### PR TITLE
Fix broken GitHub URLs and stale copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ print(z3.fuse(np.array([1, 2], dtype=np.int32),
 
 ```bash
 # Clone and install with dev dependencies
-git clone https://github.com/yjkao/TN-Jax
+git clone https://github.com/yingjerkao/TN-Jax
 cd TN-Jax
 uv sync --all-extras --dev
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 import warnings
 
 project = "TN-Jax"
-copyright = "2024, TN-Jax Contributors"
+copyright = "2025, TN-Jax Contributors"
 author = "TN-Jax Contributors"
 release = "0.1.0"
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -15,7 +15,7 @@ pip install tnjax
 
 ```bash
 # Clone the repository
-git clone https://github.com/yjkao/TN-Jax.git
+git clone https://github.com/yingjerkao/TN-Jax.git
 cd TN-Jax
 
 # Install in development mode with all extras

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,9 @@ docs = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yjkao/TN-Jax"
-Repository = "https://github.com/yjkao/TN-Jax"
-Issues = "https://github.com/yjkao/TN-Jax/issues"
+Homepage = "https://github.com/yingjerkao/TN-Jax"
+Repository = "https://github.com/yingjerkao/TN-Jax"
+Issues = "https://github.com/yingjerkao/TN-Jax/issues"
 
 [tool.uv]
 dev-dependencies = ["tnjax[dev]"]


### PR DESCRIPTION
## Summary
- Fix all repository URLs from `yjkao/TN-Jax` (404) to `yingjerkao/TN-Jax` in `pyproject.toml`, `README.md`, and `docs/guide/installation.md`
- Update copyright year in `docs/conf.py` from 2024 to 2025

## Test plan
- [x] `grep -r 'yjkao' .` returns no hits in source files
- [x] `uv run ruff check src/` passes
- [x] `uv run pytest tests/ -v` — all 315 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)