### PR TITLE
Fix PRR 7, 013237 attribution and add Liao et al. PRX 2019 reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A JAX-based tensor network library with symmetry-aware block-sparse tensors and 
 - **Network class** — graph-based tensor network container with contraction caching
 - **Algorithms** — DMRG, TRG, HOTRG, iPEPS (simple update & AD optimization), quasiparticle excitations
 - **AutoMPO** — build Hamiltonian MPOs from symbolic operator descriptions (custom couplings, NNN, arbitrary spin)
-- **AD-based iPEPS optimization** — gradient optimization via implicit differentiation through CTM fixed point (Lootens et al. PRR 7, 013237)
+- **AD-based iPEPS optimization** — gradient optimization via implicit differentiation through CTM fixed point (Francuz et al. PRR 7, 013237)
 - **Quasiparticle excitations** — iPEPS excitation spectra at arbitrary Brillouin-zone momenta (Ponsioen et al. 2022)
 - **Block-sparse SVD and QR** — native symmetry-aware decompositions for `SymmetricTensor`
 - **Extensible symmetry system** — non-Abelian symmetry interface for future SU(2) support
@@ -145,7 +145,7 @@ gate = jnp.einsum("ij,kl->ikjl", Sz, Sz) \
      + 0.5 * (jnp.einsum("ij,kl->ikjl", Sp, Sm)
              + jnp.einsum("ij,kl->ikjl", Sm, Sp))
 
-# AD ground-state optimization (Lootens et al. PRR 7, 013237)
+# AD ground-state optimization (Francuz et al. PRR 7, 013237)
 config = iPEPSConfig(
     max_bond_dim=2,
     ctm=CTMConfig(chi=16, max_iter=50),
@@ -207,7 +207,8 @@ The generated HTML is in `docs/_build/html/`.
 
 ## References
 
-- T. Lootens, B. Vanhecke, F. Verstraete, *PRR* **7**, 013237 (2025) — AD-based iPEPS ground-state optimization
+- H.-J. Liao, J.-G. Liu, L. Wang, T. Xiang, *Phys. Rev. X* **9**, 031041 (2019) — AD-based iPEPS ground-state optimization
+- A. Francuz, N. Schuch, B. Vanhecke, *PRR* **7**, 013237 (2025) — Stable AD through CTM (SVD regularization, truncation correction, implicit differentiation)
 - L. Ponsioen, F. F. Assaad, P. Corboz, *SciPost Phys.* **12**, 006 (2022) — Quasiparticle excitations for iPEPS
 
 ## License

--- a/docs/guide/algorithms/ad_excitations.md
+++ b/docs/guide/algorithms/ad_excitations.md
@@ -4,7 +4,7 @@ TN-Jax implements the quasiparticle excitation method from
 [Ponsioen, Assaad & Corboz, SciPost Phys. 12, 006 (2022)](https://scipost.org/10.21468/SciPostPhys.12.1.006),
 using JAX automatic differentiation to construct the effective Hamiltonian
 and norm matrices. The stable AD infrastructure follows
-[Lootens et al., Phys. Rev. Research 7, 013237 (2025)](https://journals.aps.org/prresearch/abstract/10.1103/PhysRevResearch.7.013237).
+[Francuz et al., Phys. Rev. Research 7, 013237 (2025)](https://journals.aps.org/prresearch/abstract/10.1103/PhysRevResearch.7.013237).
 
 ## Stable AD Infrastructure
 
@@ -30,7 +30,7 @@ This smoothly approaches $1/(s_i^2 - s_j^2)$ when singular values are
 well-separated but stays finite when they are degenerate. The diagonal is
 zeroed (gauge freedom).
 
-**Truncation correction** (Lootens et al., the dominant error source) adds
+**Truncation correction** (Francuz et al., the dominant error source) adds
 two terms to the backward pass:
 
 $$
@@ -181,5 +181,5 @@ Each RDM variant specifies which tensor appears in the ket and bra layers:
 
 - Ponsioen, Assaad & Corboz, *SciPost Phys.* **12**, 006 (2022) --
   AD excitations method
-- Lootens et al., *Phys. Rev. Research* **7**, 013237 (2025) --
+- Francuz et al., *Phys. Rev. Research* **7**, 013237 (2025) --
   Stable AD of CTM (custom SVD VJP, implicit differentiation, gauge fixing)

--- a/src/tnjax/algorithms/ad_utils.py
+++ b/src/tnjax/algorithms/ad_utils.py
@@ -1,6 +1,6 @@
 """Stable automatic differentiation utilities for iPEPS.
 
-Implements the solutions from Lootens et al., Phys. Rev. Research 7, 013237
+Implements the solutions from Francuz et al., Phys. Rev. Research 7, 013237
 (2025) for stable AD through CTM:
 
 1. Custom truncated SVD with Lorentzian regularization for degenerate singular
@@ -68,11 +68,11 @@ def _truncated_svd_ad_bwd(
 ) -> tuple[jax.Array]:
     """Backward pass with Lorentzian regularization and truncation term.
 
-    Implements the stable SVD adjoint from Lootens et al. PRR 7, 013237:
+    Implements the stable SVD adjoint from Francuz et al. PRR 7, 013237:
     - Lorentzian broadening ``s_i^2 - s_j^2 / ((s_i^2-s_j^2)^2 + eps^2)``
       prevents divergences from degenerate singular values.
     - Full truncation correction accounts for coupling between kept and
-      discarded subspaces (the dominant error source identified by Lootens
+      discarded subspaces (the dominant error source identified by Francuz
       et al.).
     """
     U_full, s_full, Vh_full, M, k = residuals
@@ -107,7 +107,7 @@ def _truncated_svd_ad_bwd(
     proj_U_perp = jnp.eye(M.shape[0]) - U @ U.conj().T
     proj_V_perp = jnp.eye(M.shape[1]) - V @ V.conj().T
 
-    # Assemble gradient (Wan & Narayanan 2023 / Lootens et al.):
+    # Assemble gradient (Wan & Narayanan 2023 / Francuz et al.):
     dM = jnp.zeros_like(M)
 
     # 1. Diagonal part from ds
@@ -190,7 +190,7 @@ def _gauge_fix_ctm(env: CTMEnvironment) -> CTMEnvironment:
     """Fix gauge of CTM tensors via QR decomposition of corners.
 
     Ensures unique element-wise convergence needed for fixed-point
-    implicit differentiation (Lootens et al. PRR 7, 013237).
+    implicit differentiation (Francuz et al. PRR 7, 013237).
 
     Each corner C is replaced by R from its QR decomposition (C = Q R),
     and the corresponding Q factors are absorbed into the adjacent edge
@@ -345,7 +345,7 @@ def _ctm_converge_bwd(
 ) -> tuple[jax.Array]:
     """Backward pass via implicit differentiation of CTM fixed point.
 
-    Solves ``(I - J^T) lambda = g`` using GMRES (Lootens et al. PRR 7,
+    Solves ``(I - J^T) lambda = g`` using GMRES (Francuz et al. PRR 7,
     013237), where J = d(ctm_step)/d(env) is the Jacobian of one CTM step.
     Then ``dA = d(ctm_step)/dA^T @ lambda``.
     """
@@ -368,7 +368,7 @@ def _ctm_converge_bwd(
         env_out = _gauge_fix_ctm(env_out)
         return tuple(env_out)
 
-    # Solve (I - J_env^T) lambda = g via GMRES (Lootens et al. PRR 7, 013237).
+    # Solve (I - J_env^T) lambda = g via GMRES (Francuz et al. PRR 7, 013237).
     # GMRES converges superlinearly (Krylov acceleration) and directly
     # monitors the residual norm, unlike the Neumann series which converges
     # only geometrically with rate equal to the spectral radius.

--- a/src/tnjax/algorithms/ipeps.py
+++ b/src/tnjax/algorithms/ipeps.py
@@ -983,7 +983,7 @@ def optimize_gs_ad(
     """AD-based ground state optimization of iPEPS.
 
     Uses automatic differentiation through the CTM fixed-point equation
-    (Lootens et al. PRR 7, 013237) to compute exact gradients of the
+    (Francuz et al. PRR 7, 013237) to compute exact gradients of the
     energy with respect to the site tensor A, then optimizes with optax.
 
     Args:


### PR DESCRIPTION
## Summary
- Fix incorrect author attribution for PRR 7, 013237 (2025): Francuz, Schuch & Vanhecke, not Lootens, Vanhecke & Verstraete
- Update description from "AD-based iPEPS ground-state optimization" to "Stable AD through CTM" to better reflect the paper's contribution
- Add Liao, Liu, Wang & Xiang, PRX 9, 031041 (2019) as the original AD-based iPEPS optimization reference

## Test plan
- [ ] Verify no remaining "Lootens" references in codebase
- [ ] Check updated references render correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)