### PR TITLE
Add examples for all algorithms

### DIFF
--- a/examples/heisenberg_ipeps_ad.py
+++ b/examples/heisenberg_ipeps_ad.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""2D Heisenberg ground state via iPEPS AD optimization.
+
+Finds the ground-state energy of the spin-1/2 antiferromagnetic Heisenberg
+model on the infinite square lattice using automatic differentiation (AD)
+through the Corner Transfer Matrix (CTM) fixed-point equation.
+
+Two initialization strategies are compared:
+
+1. **Random init** — site tensor drawn from a normal distribution.
+2. **Simple update init** (``su_init=True``) — imaginary time evolution
+   provides a physically reasonable starting tensor before AD refinement.
+
+The exact ground-state energy per site is E/N ~ -0.6694 (QMC reference).
+With the small D and chi used here, the variational energy will be above
+this exact value.
+
+Usage::
+
+    uv run python examples/heisenberg_ipeps_ad.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+from tnjax import CTMConfig, iPEPSConfig, optimize_gs_ad
+
+# ---------------------------------------------------------------------------
+# Hamiltonian
+# ---------------------------------------------------------------------------
+
+
+def heisenberg_gate(dtype=jnp.float64) -> jnp.ndarray:
+    """Build the 2-site Heisenberg gate H = Sz*Sz + 0.5*(S+S- + S-S+)."""
+    Sz = jnp.array([[0.5, 0.0], [0.0, -0.5]], dtype=dtype)
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=dtype)
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]], dtype=dtype)
+    H = jnp.kron(Sz, Sz) + 0.5 * (jnp.kron(Sp, Sm) + jnp.kron(Sm, Sp))
+    return H.reshape(2, 2, 2, 2)
+
+
+# ---------------------------------------------------------------------------
+# Run AD optimization
+# ---------------------------------------------------------------------------
+
+
+def run_ad(
+    gate: jnp.ndarray,
+    D: int,
+    chi: int,
+    gs_steps: int,
+    lr: float,
+    su_init: bool,
+    su_steps: int = 200,
+    su_dt: float = 0.01,
+    A_init: jnp.ndarray | None = None,
+    label: str = "",
+):
+    """Run optimize_gs_ad and print results."""
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        num_imaginary_steps=su_steps,
+        dt=su_dt,
+        ctm=CTMConfig(chi=chi, max_iter=100),
+        gs_optimizer="adam",
+        gs_learning_rate=lr,
+        gs_num_steps=gs_steps,
+        su_init=su_init,
+    )
+
+    print(f"\n{'─' * 60}")
+    print(f"  {label}")
+    print(f"  D={D}, chi={chi}, lr={lr}, AD steps={gs_steps}")
+    if su_init:
+        print(f"  SU init: {su_steps} steps, dt={su_dt}")
+    else:
+        print("  Random initialization")
+    print(f"{'─' * 60}")
+
+    t0 = time.perf_counter()
+    A_opt, env, E_gs = optimize_gs_ad(gate, A_init, config)
+    dt = time.perf_counter() - t0
+
+    print(f"  E/site = {E_gs:.6f}")
+    print(f"  Time   = {dt:.1f}s")
+
+    return A_opt, env, E_gs
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    print("iPEPS AD ground-state optimization: 2D Heisenberg model")
+    print("H = sum_{<i,j>} S_i . S_j   (J=1, antiferromagnetic)")
+    print("Exact E/site ~ -0.6694 (QMC)")
+
+    gate = heisenberg_gate()
+
+    # --- D=2, random init ---
+    run_ad(
+        gate,
+        D=2,
+        chi=4,
+        gs_steps=20,
+        lr=1e-2,
+        su_init=False,
+        label="D=2, random init",
+    )
+
+    # --- D=2, SU init ---
+    run_ad(
+        gate,
+        D=2,
+        chi=4,
+        gs_steps=20,
+        lr=1e-2,
+        su_init=True,
+        su_steps=200,
+        su_dt=0.05,
+        label="D=2, simple update init",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/heisenberg_ipeps_excitations.py
+++ b/examples/heisenberg_ipeps_excitations.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""iPEPS excitation spectrum for the 2D Heisenberg model.
+
+Computes the quasiparticle excitation dispersion of the spin-1/2
+antiferromagnetic Heisenberg model on the infinite square lattice using
+the iPEPS excitation ansatz (Ponsioen, Assaad & Corboz, SciPost Phys. 12,
+006, 2022).
+
+The workflow is:
+
+1. Build the 2-site Heisenberg gate.
+2. Find the ground state via AD optimization (``optimize_gs_ad``, D=2, chi=16).
+3. Generate a momentum path along high-symmetry lines Gamma-X-M-Gamma.
+4. Compute excitation energies at each momentum point.
+5. Print the excitation spectrum.
+
+Note: this example is slow (~minutes) due to the ground state optimization
+followed by the excitation calculation at each k-point.
+
+Usage::
+
+    uv run python examples/heisenberg_ipeps_excitations.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+jax.config.update("jax_enable_x64", True)
+
+from tnjax import (
+    CTMConfig,
+    ExcitationConfig,
+    ExcitationResult,
+    compute_excitations,
+    iPEPSConfig,
+    make_momentum_path,
+    optimize_gs_ad,
+)
+
+# ---------------------------------------------------------------------------
+# Hamiltonian
+# ---------------------------------------------------------------------------
+
+
+def heisenberg_gate(dtype=jnp.float64) -> jnp.ndarray:
+    """Build the 2-site Heisenberg gate H = Sz*Sz + 0.5*(S+S- + S-S+)."""
+    Sz = jnp.array([[0.5, 0.0], [0.0, -0.5]], dtype=dtype)
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=dtype)
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]], dtype=dtype)
+    H = jnp.kron(Sz, Sz) + 0.5 * (jnp.kron(Sp, Sm) + jnp.kron(Sm, Sp))
+    return H.reshape(2, 2, 2, 2)
+
+
+# ---------------------------------------------------------------------------
+# Ground state optimization
+# ---------------------------------------------------------------------------
+
+
+def find_ground_state(
+    gate: jnp.ndarray,
+    D: int = 2,
+    chi: int = 16,
+    gs_steps: int = 100,
+    lr: float = 1e-3,
+) -> tuple[jnp.ndarray, object, float]:
+    """Find the iPEPS ground state using AD optimization.
+
+    Returns:
+        ``(A_opt, env, E_gs)`` -- optimized tensor, CTM environment, and
+        ground state energy per site.
+    """
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        ctm=CTMConfig(chi=chi, max_iter=60),
+        gs_optimizer="adam",
+        gs_learning_rate=lr,
+        gs_num_steps=gs_steps,
+    )
+
+    print(f"  D={D}, chi={chi}, lr={lr}, AD steps={gs_steps}")
+
+    t0 = time.perf_counter()
+    A_opt, env, E_gs = optimize_gs_ad(gate, None, config)
+    dt = time.perf_counter() - t0
+
+    print(f"  E/site = {E_gs:.6f}  (time: {dt:.1f}s)")
+    return A_opt, env, E_gs
+
+
+# ---------------------------------------------------------------------------
+# Excitation spectrum
+# ---------------------------------------------------------------------------
+
+
+def compute_spectrum(
+    A_opt: jnp.ndarray,
+    env: object,
+    gate: jnp.ndarray,
+    E_gs: float,
+    num_points: int = 12,
+    num_excitations: int = 2,
+) -> ExcitationResult:
+    """Compute excitation energies along Gamma-X-M-Gamma.
+
+    Args:
+        A_opt:            Optimized ground state tensor.
+        env:              Converged CTM environment.
+        gate:             2-site Hamiltonian gate.
+        E_gs:             Ground state energy per site.
+        num_points:       Total number of momentum points on the path.
+        num_excitations:  Number of lowest excitations per k-point.
+
+    Returns:
+        ExcitationResult with ``.energies`` and ``.momenta``.
+    """
+    momenta = make_momentum_path("brillouin", num_points=num_points)
+
+    exc_config = ExcitationConfig(
+        num_excitations=num_excitations,
+        null_space_tol=1e-2,
+    )
+
+    print(f"  Momentum path: Gamma -> X -> M -> Gamma ({len(momenta)} points)")
+    print(f"  num_excitations={num_excitations}")
+
+    t0 = time.perf_counter()
+    result = compute_excitations(A_opt, env, gate, E_gs, momenta, exc_config)
+    dt = time.perf_counter() - t0
+
+    print(f"  Excitation calculation time: {dt:.1f}s")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Print results
+# ---------------------------------------------------------------------------
+
+
+def print_spectrum(result: ExcitationResult) -> None:
+    """Print the excitation spectrum in a readable table."""
+    print(f"\n{'=' * 60}")
+    print("  Excitation Spectrum")
+    print(f"  Ground state energy: E/site = {result.ground_state_energy:.6f}")
+    print(f"{'=' * 60}")
+
+    n_k, n_exc = result.energies.shape
+    header = f"  {'kx/pi':>8s}  {'ky/pi':>8s}"
+    for i in range(n_exc):
+        header += f"  {'omega_' + str(i):>10s}"
+    print(header)
+    print(f"  {'-' * len(header.strip())}")
+
+    for ik in range(n_k):
+        kx, ky = result.momenta[ik]
+        row = f"  {kx / np.pi:8.4f}  {ky / np.pi:8.4f}"
+        for ie in range(n_exc):
+            row += f"  {result.energies[ik, ie]:10.6f}"
+        print(row)
+
+    # Highlight high-symmetry points
+    print("\n  High-symmetry excitation gaps:")
+    # Find points closest to Gamma, X, M
+    targets = {"Gamma": (0.0, 0.0), "X": (np.pi, 0.0), "M": (np.pi, np.pi)}
+    for name, (kx_t, ky_t) in targets.items():
+        dists = np.sqrt(
+            (result.momenta[:, 0] - kx_t) ** 2 + (result.momenta[:, 1] - ky_t) ** 2
+        )
+        idx = int(np.argmin(dists))
+        omega_0 = result.energies[idx, 0]
+        kx, ky = result.momenta[idx]
+        print(
+            f"    {name:>6s} (kx/pi={kx / np.pi:.3f}, ky/pi={ky / np.pi:.3f})"
+            f":  omega_0 = {omega_0:.6f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    print("iPEPS excitation spectrum: 2D Heisenberg model")
+    print("H = sum_{<i,j>} S_i . S_j   (J=1, antiferromagnetic)")
+    print("Method: Ponsioen, Assaad & Corboz, SciPost Phys. 12, 006 (2022)")
+
+    gate = heisenberg_gate()
+
+    # Step 1: Find the ground state
+    print(f"\n{'=' * 60}")
+    print("  Step 1: Ground state optimization")
+    print(f"{'=' * 60}")
+    A_opt, env, E_gs = find_ground_state(gate, D=2, chi=16, gs_steps=100, lr=1e-3)
+
+    # Step 2: Compute excitation spectrum
+    print(f"\n{'=' * 60}")
+    print("  Step 2: Excitation spectrum")
+    print(f"{'=' * 60}")
+    result = compute_spectrum(
+        A_opt,
+        env,
+        gate,
+        E_gs,
+        num_points=12,
+        num_excitations=2,
+    )
+
+    # Step 3: Print results
+    print_spectrum(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/heisenberg_ipeps_su.py
+++ b/examples/heisenberg_ipeps_su.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""2D Heisenberg ground state via iPEPS simple update.
+
+Finds the ground-state energy of the spin-1/2 antiferromagnetic Heisenberg
+model on the infinite square lattice using imaginary time evolution (simple
+update) followed by Corner Transfer Matrix (CTM) environment contraction.
+
+Two unit cells are demonstrated:
+
+1. **1x1 unit cell, D=2** -- single-site translational invariance.
+2. **2x2 unit cell, D=2** -- checkerboard (2-site) cell that can capture
+   Neel-type antiferromagnetic order.
+
+The exact ground-state energy per site is E/N ~ -0.6694 (QMC reference).
+The 1x1 unit cell gives E ~ 0.5 (product state) because a single tensor
+cannot represent the two-sublattice Neel order.  The 2x2 unit cell breaks
+this symmetry and yields a much lower energy.
+
+Usage::
+
+    uv run python examples/heisenberg_ipeps_su.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+from tnjax import CTMConfig, ipeps, iPEPSConfig
+
+# ---------------------------------------------------------------------------
+# Hamiltonian
+# ---------------------------------------------------------------------------
+
+
+def heisenberg_gate(dtype=jnp.float64) -> jnp.ndarray:
+    """Build the 2-site Heisenberg gate H = Sz*Sz + 0.5*(S+S- + S-S+)."""
+    Sz = jnp.array([[0.5, 0.0], [0.0, -0.5]], dtype=dtype)
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=dtype)
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]], dtype=dtype)
+    H = jnp.kron(Sz, Sz) + 0.5 * (jnp.kron(Sp, Sm) + jnp.kron(Sm, Sp))
+    return H.reshape(2, 2, 2, 2)
+
+
+# ---------------------------------------------------------------------------
+# Run simple update
+# ---------------------------------------------------------------------------
+
+
+def run_simple_update(
+    gate: jnp.ndarray,
+    D: int,
+    chi: int,
+    num_steps: int,
+    dt: float,
+    unit_cell: str = "1x1",
+    label: str = "",
+):
+    """Run iPEPS simple update + CTM and print results."""
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        num_imaginary_steps=num_steps,
+        dt=dt,
+        ctm=CTMConfig(chi=chi, max_iter=100),
+        unit_cell=unit_cell,
+    )
+
+    print(f"\n{'=' * 60}")
+    print(f"  {label}")
+    print(f"  D={D}, chi={chi}, unit_cell={unit_cell}")
+    print(f"  SU steps={num_steps}, dt={dt}")
+    print(f"{'=' * 60}")
+
+    t0 = time.perf_counter()
+    energy, peps, env = ipeps(gate, initial_peps=None, config=config)
+    elapsed = time.perf_counter() - t0
+
+    print(f"  E/site = {energy:.6f}")
+    print(f"  Time   = {elapsed:.1f}s")
+
+    return energy
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    print("iPEPS simple update: 2D Heisenberg model")
+    print("H = sum_{<i,j>} S_i . S_j   (J=1, antiferromagnetic)")
+    print("QMC reference: E/site ~ -0.6694")
+
+    gate = heisenberg_gate()
+
+    # --- 1x1 unit cell, D=2 ---
+    run_simple_update(
+        gate,
+        D=2,
+        chi=16,
+        num_steps=500,
+        dt=0.05,
+        unit_cell="1x1",
+        label="1x1 unit cell, D=2",
+    )
+
+    # --- 2x2 (checkerboard) unit cell, D=2 ---
+    run_simple_update(
+        gate,
+        D=2,
+        chi=16,
+        num_steps=200,
+        dt=0.3,
+        unit_cell="2site",
+        label="2x2 checkerboard unit cell, D=2",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ising_hotrg.py
+++ b/examples/ising_hotrg.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""2D classical Ising partition function via HOTRG.
+
+Computes the free energy per site of the 2D square-lattice Ising model at
+several temperatures using Higher-Order Tensor Renormalization Group (HOTRG),
+and compares against Onsager's exact solution.
+
+The Ising Hamiltonian is H = -J * sum_{<i,j>} s_i s_j with J=1 (ferromagnet).
+The critical temperature is Tc = 2 / ln(1 + sqrt(2)) ~ 2.269, corresponding
+to an inverse temperature beta_c ~ 0.4407.
+
+Reference: Xie et al., PRB 86, 045139 (2012).
+
+Usage::
+
+    uv run python examples/ising_hotrg.py
+"""
+
+from __future__ import annotations
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+from tnjax import HOTRGConfig, compute_ising_tensor, hotrg, ising_free_energy_exact
+
+# ---------------------------------------------------------------------------
+# Parameters
+# ---------------------------------------------------------------------------
+
+BETA_C = 0.4407  # approximate inverse critical temperature
+TEMPERATURES = [3.0, 2.5, 2.269, 2.0, 1.5]  # above, near, below Tc
+MAX_BOND_DIM = 16
+NUM_STEPS = 20
+
+
+# ---------------------------------------------------------------------------
+# Run HOTRG at several temperatures
+# ---------------------------------------------------------------------------
+
+
+def main():
+    print("2D Ising model: free energy via HOTRG")
+    print(f"  chi = {MAX_BOND_DIM}, HOTRG steps = {NUM_STEPS}")
+    print(f"  Tc ~ {1.0 / BETA_C:.4f}  (beta_c ~ {BETA_C})")
+    print()
+    print(
+        f"  {'T':>8s}  {'beta':>8s}  {'f_HOTRG':>14s}  {'f_exact':>14s}  {'rel_err':>12s}"
+    )
+    print(f"  {'-' * 8}  {'-' * 8}  {'-' * 14}  {'-' * 14}  {'-' * 12}")
+
+    for T in TEMPERATURES:
+        beta = 1.0 / T
+
+        # Build the initial 2x2x2x2 Boltzmann weight tensor
+        tensor = compute_ising_tensor(beta=beta)
+
+        # Run HOTRG coarse-graining
+        config = HOTRGConfig(
+            max_bond_dim=MAX_BOND_DIM,
+            num_steps=NUM_STEPS,
+            direction_order="alternating",
+        )
+        log_z_per_n = hotrg(tensor, config)
+
+        # Free energy per site: f = -T * ln(Z) / N = -ln(Z) / (N * beta)
+        f_hotrg = float(-log_z_per_n / beta)
+        f_exact = ising_free_energy_exact(beta)
+
+        rel_err = abs(f_hotrg - f_exact) / abs(f_exact)
+        print(
+            f"  {T:8.3f}  {beta:8.4f}  {f_hotrg:14.8f}  {f_exact:14.8f}  {rel_err:12.2e}"
+        )
+
+    print()
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ising_trg.py
+++ b/examples/ising_trg.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""2D classical Ising model partition function via TRG.
+
+Computes the free energy per site of the 2D classical Ising model on an
+infinite square lattice using the Tensor Renormalization Group (TRG)
+algorithm (Levin & Nave, PRL 99, 120601, 2007).
+
+Results are compared against the exact Onsager solution at several
+temperatures: above, near, and below the critical temperature
+Tc = 2 / ln(1 + sqrt(2)) ~ 2.269 (i.e. beta_c ~ 0.4407).
+
+Usage::
+
+    uv run python examples/ising_trg.py
+"""
+
+from __future__ import annotations
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import numpy as np
+
+from tnjax import TRGConfig, compute_ising_tensor, ising_free_energy_exact, trg
+
+
+def run_trg_ising(
+    beta: float,
+    max_bond_dim: int = 24,
+    num_steps: int = 20,
+) -> tuple[float, float, float]:
+    """Run TRG for the 2D Ising model at inverse temperature beta.
+
+    Args:
+        beta:          Inverse temperature 1/(k_B T).
+        max_bond_dim:  Maximum bond dimension (chi) for TRG truncation.
+        num_steps:     Number of coarse-graining iterations.
+
+    Returns:
+        Tuple of (trg_free_energy, exact_free_energy, relative_error).
+    """
+    tensor = compute_ising_tensor(beta=beta)
+    config = TRGConfig(max_bond_dim=max_bond_dim, num_steps=num_steps)
+
+    log_z_per_n = trg(tensor, config)
+    trg_free_energy = float(-log_z_per_n / beta)
+    exact_free_energy = ising_free_energy_exact(beta)
+    relative_error = abs(trg_free_energy - exact_free_energy) / abs(exact_free_energy)
+
+    return trg_free_energy, exact_free_energy, relative_error
+
+
+def main():
+    beta_c = np.log(1 + np.sqrt(2)) / 2  # ~ 0.4407
+
+    temperatures = [
+        ("High T  (T = 4.0)", 1.0 / 4.0),
+        ("Above Tc (T = 2.5)", 1.0 / 2.5),
+        ("Near Tc  (T ~ 2.27)", beta_c),
+        ("Below Tc (T = 2.0)", 1.0 / 2.0),
+        ("Low T   (T = 1.5)", 1.0 / 1.5),
+    ]
+
+    chi = 24
+    num_steps = 20
+
+    print("2D Classical Ising Model: TRG vs Onsager Exact Solution")
+    print(f"TRG parameters: chi = {chi}, num_steps = {num_steps}")
+    print(f"Critical temperature: Tc = {1.0 / beta_c:.4f}, beta_c = {beta_c:.4f}")
+    print()
+    print(
+        f"{'Label':<20s} {'beta':>8s} {'f_TRG':>14s} {'f_exact':>14s} {'rel error':>12s}"
+    )
+    print("-" * 72)
+
+    for label, beta in temperatures:
+        f_trg, f_exact, rel_err = run_trg_ising(
+            beta=beta,
+            max_bond_dim=chi,
+            num_steps=num_steps,
+        )
+        print(f"{label:<20s} {beta:8.4f} {f_trg:14.8f} {f_exact:14.8f} {rel_err:12.2e}")
+
+    print()
+    print("Note: TRG accuracy degrades near the critical point due to the")
+    print("divergent correlation length. Increasing chi improves accuracy.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ ignore = ["E501"]
 [tool.ruff.lint.per-file-ignores]
 "src/tnjax/__init__.py" = ["E402"]
 "tests/**" = ["F401", "E402"]
+"examples/**" = ["E402"]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
## Summary
- Add 5 new example scripts covering algorithms that were missing examples:
  - `heisenberg_ipeps_su.py` — iPEPS simple update (1x1 and 2-site checkerboard)
  - `heisenberg_ipeps_ad.py` — iPEPS AD optimization (random vs SU init)
  - `heisenberg_ipeps_excitations.py` — iPEPS excitation spectrum along Γ-X-M-Γ
  - `ising_trg.py` — TRG for 2D Ising, compared to Onsager exact
  - `ising_hotrg.py` — HOTRG for 2D Ising, compared to Onsager exact
- Add `examples/**` to ruff E402 ignore (imports after `jax.config.update`)

All algorithms now have runnable examples: DMRG, iDMRG, iPEPS (SU, AD, excitations), TRG, HOTRG.

## Test plan
- [x] All 5 new examples run without errors
- [x] 299 core tests pass
- [x] ruff/format pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)