### PR TITLE
Fix Sphinx doc build warning in fermionic_ipeps

### DIFF
--- a/src/tenax/algorithms/fermionic_ipeps.py
+++ b/src/tenax/algorithms/fermionic_ipeps.py
@@ -60,7 +60,7 @@ def spinless_fermion_gate(config: FPEPSConfig) -> SymmetricTensor:
     """Build the 2-site Hamiltonian H = -t(c†c + h.c.) + V(n_i n_j).
 
     The Hamiltonian acts on two spinless fermion sites with local
-    Hilbert space {|0>, |1>} (empty, occupied). The fermionic
+    Hilbert space ``{|0>, |1>}`` (empty, occupied). The fermionic
     anti-commutation relations are encoded via FermionParity symmetry.
 
     Args:


### PR DESCRIPTION
## Summary
- Wrap `{|0>, |1>}` in double backticks in the `spinless_fermion_gate` docstring to prevent RST from interpreting `|` as substitution reference start-strings
- This fixes the 2 warnings that cause the "Build documentation" CI job to fail (since `-W` treats warnings as errors)

## Test plan
- [x] Local `sphinx-build -W` now succeeds with zero warnings
- [ ] CI "Build documentation" job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)