### PR TITLE
Add website, docs, and PyPI links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tenax
 
+[Website](https://tenax-lab.github.io) | [Docs](https://tenax.readthedocs.io) | [PyPI](https://pypi.org/project/tenax-tn/)
+
 A JAX-based tensor network library with symmetry-aware block-sparse tensors and label-based contraction.
 
 The name **Tenax** combines **Ten**sor network + J**ax**, and is also Latin for "holding fast" — reflecting how tensor networks bind indices together through contraction.


### PR DESCRIPTION
## Summary

- Add a link bar at the top of README.md with Website, Docs, and PyPI links

## Test plan

- [x] Docs-only change — no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)