### PR TITLE
Fix TRG symmetric block-sector collapse via pairwise contraction

### DIFF
--- a/src/tenax/algorithms/hotrg.py
+++ b/src/tenax/algorithms/hotrg.py
@@ -79,7 +79,7 @@ def hotrg(
         raise TypeError(f"hotrg() requires a Tensor, got {type(tensor).__name__}")
 
     T = tensor
-    log_norm_total = jnp.zeros((), dtype=T.todense().dtype)
+    log_norm_total = jnp.zeros((), dtype=T.dtype)
 
     for step in range(config.num_steps):
         if config.direction_order == "alternating":

--- a/src/tenax/algorithms/trg.py
+++ b/src/tenax/algorithms/trg.py
@@ -79,7 +79,7 @@ def trg(
         raise TypeError(f"trg() requires a Tensor, got {type(tensor).__name__}")
 
     T = tensor
-    log_norm_total = jnp.zeros((), dtype=T.todense().dtype)
+    log_norm_total = jnp.zeros((), dtype=T.dtype)
 
     for step in range(config.num_steps):
         T, log_norm = _trg_step(T, config.max_bond_dim, config.svd_trunc_err)
@@ -156,7 +156,13 @@ def _trg_step(
     F2 = F2.relabel("k", "K")  # (K, down, right)
     F4 = F4.relabel("m", "M")  # (M, down, left)
 
-    T_new = contract(F3, F1, F4, F2, output_labels=("m", "M", "k", "K"))
+    # Pairwise contraction avoids _contract_symmetric limitation where
+    # different tensor pairs share different contracted bonds.
+    top = contract(F3, F1)  # contracts "up"; result: (right, m, left, k)
+    bottom = contract(F4, F2)  # contracts "down"; result: (M, left, K, right)
+    T_new = contract(
+        top, bottom, output_labels=("m", "M", "k", "K")
+    )  # contracts left, right
     T_new = T_new.relabels({"m": "up", "M": "down", "k": "left", "K": "right"})
 
     # --- Normalize ---

--- a/tests/test_hotrg.py
+++ b/tests/test_hotrg.py
@@ -286,6 +286,20 @@ class TestHOTRGSymmetric:
         result = hotrg(tensor, config)
         assert jnp.isfinite(result)
 
+    def test_symmetric_hotrg_preserves_blocks(self):
+        """HOTRG should not collapse Z₂ block sectors during coarse-graining."""
+        tensor = compute_ising_tensor(beta=0.3, symmetric=True)
+        initial_blocks = tensor.n_blocks
+        assert initial_blocks == 8  # sanity check
+
+        T = tensor
+        for _ in range(3):
+            T, _ = _hotrg_step_horizontal(T, max_bond_dim=8)
+            assert isinstance(T, SymmetricTensor)
+            assert T.n_blocks >= initial_blocks, (
+                f"Block count collapsed from {initial_blocks} to {T.n_blocks}"
+            )
+
     def test_symmetric_hotrg_matches_exact(self):
         """Symmetric HOTRG at beta=0.3 should match exact free energy within 1%."""
         beta = 0.3

--- a/tests/test_trg.py
+++ b/tests/test_trg.py
@@ -381,6 +381,20 @@ class TestTRGSymmetric:
             f"Symmetric TRG log(Z)/N={result_sym:.8f}"
         )
 
+    def test_symmetric_trg_preserves_blocks(self):
+        """TRG should not collapse Z₂ block sectors during coarse-graining."""
+        tensor = compute_ising_tensor(beta=0.3, symmetric=True)
+        initial_blocks = tensor.n_blocks
+        assert initial_blocks == 8  # sanity check
+
+        T = tensor
+        for _ in range(3):
+            T, _ = _trg_step(T, max_bond_dim=8, svd_trunc_err=None)
+            assert isinstance(T, SymmetricTensor)
+            assert T.n_blocks >= initial_blocks, (
+                f"Block count collapsed from {initial_blocks} to {T.n_blocks}"
+            )
+
     def test_symmetric_trg_matches_exact(self):
         """Symmetric TRG at beta=0.3 should match exact free energy within 2%."""
         beta = 0.3


### PR DESCRIPTION
## Summary
- Replace single 4-tensor `contract(F3, F1, F4, F2)` in `_trg_step` with staged pairwise contractions to avoid `_contract_symmetric` limitation where different tensor pairs sharing different bonds causes block intersection to collapse (Z₂ tensors dropped from 8 blocks to 1)
- Fix unnecessary `T.todense().dtype` → `T.dtype` in both TRG and HOTRG
- Add block-preservation regression tests for both algorithms

## Test plan
- [x] New `test_symmetric_trg_preserves_blocks` passes (8 blocks maintained across 3 steps)
- [x] New `test_symmetric_hotrg_preserves_blocks` passes
- [x] All 64 TRG/HOTRG tests pass
- [x] All 307 core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)