### PR TITLE
Add site-generic Tensor-protocol CTM for 2-site AD iPEPS

### DIFF
--- a/src/tenax/__init__.py
+++ b/src/tenax/__init__.py
@@ -40,7 +40,9 @@ jax.config.update("jax_enable_x64", True)
 from tenax.algorithms._ctm_tensor import (
     CTMTensorEnv,
     compute_energy_ctm_tensor,
+    compute_energy_ctm_tensor_2site,
     ctm_tensor,
+    ctm_tensor_2site,
 )
 from tenax.algorithms._split_ctm_tensor import (
     SplitCTMTensorEnv,
@@ -205,7 +207,9 @@ __all__ = [
     # Standard CTM (Tensor protocol)
     "CTMTensorEnv",
     "ctm_tensor",
+    "ctm_tensor_2site",
     "compute_energy_ctm_tensor",
+    "compute_energy_ctm_tensor_2site",
     # Split CTM (Tensor protocol)
     "SplitCTMTensorEnv",
     "ctm_split_tensor",

--- a/src/tenax/algorithms/_ctm_tensor.py
+++ b/src/tenax/algorithms/_ctm_tensor.py
@@ -363,12 +363,17 @@ def _wrap_standard_edge_dense(
 
 
 def _ctm_tensor_move_left(
-    env: CTMTensorEnv,
+    env_self: CTMTensorEnv,
+    env_neighbor: CTMTensorEnv,
     a: Tensor,
     chi: int,
     projector_method: str = "eigh",
 ) -> CTMTensorEnv:
     """Left move: updates C1, T4, C4.
+
+    Corners (C1, C4) from env_self, perpendicular edges (T1, T3) from
+    env_neighbor, parallel edge (T4) from env_self, double-layer ``a``
+    from neighbor site.
 
     Dense reference: C1g = einsum('ab,buc->auc', C1, T1)
                      C4g = einsum('gh,hdi->gdi', C4, T3)
@@ -376,20 +381,18 @@ def _ctm_tensor_move_left(
     """
     D2 = a.indices[0].dim
 
-    # C1(c1_d=a, c1_r=b) · T1(t1_l=b, u2, t1_r=c) → contract b: c1_r ↔ t1_l
-    C1_r = env.C1.relabel("c1_r", "t1_l")
-    C1g = contract(C1_r, env.T1)  # (c1_d, u2, t1_r)
+    # C1(self) · T1(neighbor)
+    C1_r = env_self.C1.relabel("c1_r", "t1_l")
+    C1g = contract(C1_r, env_neighbor.T1)  # (c1_d, u2, t1_r)
     C1g = _fuse_pair_by_label(C1g, "c1_d", "u2", "fused", IN)  # (fused, t1_r)
 
-    # C4(c4_r=g, c4_u=h) · T3(t3_r=h, d2, t3_l) → contract h: c4_u ↔ t3_r
-    C4_u = env.C4.relabel("c4_u", "t3_r")
-    C4g = contract(C4_u, env.T3)  # (c4_r, d2, t3_l)
+    # C4(self) · T3(neighbor)
+    C4_u = env_self.C4.relabel("c4_u", "t3_r")
+    C4g = contract(C4_u, env_neighbor.T3)  # (c4_r, d2, t3_l)
     C4g = _fuse_pair_by_label(C4g, "c4_r", "d2", "fused", IN)  # (fused, t3_l)
 
-    # T4(t4_d=a, l2, t4_u=g) · a(u2, d2, l2, r2) → contract l2
-    # Dense result (a,u,g,d,r), transpose(0,1,4,2,3)→(a,u,r,g,d)
-    # reshape → (a*u, r, g*d) = fuse(t4_d,u2), r2, fuse(t4_u,d2)
-    T4_with_a = contract(env.T4, a)
+    # T4(self) · a(neighbor)
+    T4_with_a = contract(env_self.T4, a)
     T4g = _fuse_pair_by_label(T4_with_a, "t4_d", "u2", "fl", IN)
     T4g = _fuse_pair_by_label(T4g, "t4_u", "d2", "fr", IN)
     T4g_dense = T4g.todense()
@@ -416,8 +419,8 @@ def _ctm_tensor_move_left(
         C1_new_dense,
         "c1_d",
         "c1_r",
-        env.C1.indices[0],
-        env.C1.indices[1],
+        env_self.C1.indices[0],
+        env_self.C1.indices[1],
         chi,
         symmetric=_sym,
         base_charges=_c1_q,
@@ -426,21 +429,21 @@ def _ctm_tensor_move_left(
         C4_new_dense,
         "c4_r",
         "c4_u",
-        env.C4.indices[0],
-        env.C4.indices[1],
+        env_self.C4.indices[0],
+        env_self.C4.indices[1],
         chi,
         symmetric=_sym,
         base_charges=_c4_q,
     )
 
     _t4_chi_q = a.indices[1].charges if _sym else None
-    _t4_D2_q = env.T4.indices[1].charges if _sym else None
+    _t4_D2_q = env_self.T4.indices[1].charges if _sym else None
     T4_new = _wrap_standard_edge_dense(
         T4_new_dense,
         "t4_d",
         "l2",
         "t4_u",
-        env.T4.indices,
+        env_self.T4.indices,
         chi,
         D2,
         symmetric=_sym,
@@ -448,16 +451,21 @@ def _ctm_tensor_move_left(
         base_D2_charges=_t4_D2_q,
     )
 
-    return env._replace(C1=C1_new, C4=C4_new, T4=T4_new)
+    return env_self._replace(C1=C1_new, C4=C4_new, T4=T4_new)
 
 
 def _ctm_tensor_move_right(
-    env: CTMTensorEnv,
+    env_self: CTMTensorEnv,
+    env_neighbor: CTMTensorEnv,
     a: Tensor,
     chi: int,
     projector_method: str = "eigh",
 ) -> CTMTensorEnv:
     """Right move: updates C2, T2, C3.
+
+    Corners (C2, C3) from env_self, perpendicular edges (T1, T3) from
+    env_neighbor, parallel edge (T2) from env_self, double-layer ``a``
+    from neighbor site.
 
     Dense reference: C2g = einsum('ce,buc->eub', C2, T1)
                      C3g = einsum('im,hdi->mdh', C3, T3)
@@ -465,20 +473,18 @@ def _ctm_tensor_move_right(
     """
     D2 = a.indices[0].dim
 
-    # C2(c2_l=c, c2_d=e) · T1(t1_l=b, u2, t1_r=c) → contract c: c2_l ↔ t1_r
-    C2_l = env.C2.relabel("c2_l", "t1_r")
-    C2g = contract(C2_l, env.T1)  # (c2_d, t1_l, u2)
+    # C2(self) · T1(neighbor)
+    C2_l = env_self.C2.relabel("c2_l", "t1_r")
+    C2g = contract(C2_l, env_neighbor.T1)  # (c2_d, t1_l, u2)
     C2g = _fuse_pair_by_label(C2g, "c2_d", "u2", "fused", IN)  # (fused, t1_l)
 
-    # C3(c3_u=i, c3_l=m) · T3(t3_r=h, d2, t3_l=i) → contract i: c3_u ↔ t3_l
-    C3_u = env.C3.relabel("c3_u", "t3_l")
-    C3g = contract(C3_u, env.T3)  # (c3_l, t3_r, d2)
+    # C3(self) · T3(neighbor)
+    C3_u = env_self.C3.relabel("c3_u", "t3_l")
+    C3g = contract(C3_u, env_neighbor.T3)  # (c3_l, t3_r, d2)
     C3g = _fuse_pair_by_label(C3g, "c3_l", "d2", "fused", IN)  # (fused, t3_r)
 
-    # T2(t2_u=e, r2, t2_d=m) · a(u2, d2, l2, r2) → contract r2
-    # Dense result (e,u,m,d,l), transpose(0,1,4,2,3)→(e,u,l,m,d)
-    # reshape → (e*u, l, m*d) = fuse(t2_u,u2), l2, fuse(t2_d,d2)
-    T2_with_a = contract(env.T2, a)
+    # T2(self) · a(neighbor)
+    T2_with_a = contract(env_self.T2, a)
     T2g = _fuse_pair_by_label(T2_with_a, "t2_u", "u2", "fl", IN)
     T2g = _fuse_pair_by_label(T2g, "t2_d", "d2", "fr", IN)
     T2g_dense = T2g.todense()
@@ -502,8 +508,8 @@ def _ctm_tensor_move_right(
         C2_new_dense,
         "c2_l",
         "c2_d",
-        env.C2.indices[0],
-        env.C2.indices[1],
+        env_self.C2.indices[0],
+        env_self.C2.indices[1],
         chi,
         symmetric=_sym,
         base_charges=_c2_q,
@@ -512,21 +518,21 @@ def _ctm_tensor_move_right(
         C3_new_dense,
         "c3_u",
         "c3_l",
-        env.C3.indices[0],
-        env.C3.indices[1],
+        env_self.C3.indices[0],
+        env_self.C3.indices[1],
         chi,
         symmetric=_sym,
         base_charges=_c3_q,
     )
 
     _t2_chi_q = a.indices[0].charges if _sym else None
-    _t2_D2_q = env.T2.indices[1].charges if _sym else None
+    _t2_D2_q = env_self.T2.indices[1].charges if _sym else None
     T2_new = _wrap_standard_edge_dense(
         T2_new_dense,
         "t2_u",
         "r2",
         "t2_d",
-        env.T2.indices,
+        env_self.T2.indices,
         chi,
         D2,
         symmetric=_sym,
@@ -534,16 +540,21 @@ def _ctm_tensor_move_right(
         base_D2_charges=_t2_D2_q,
     )
 
-    return env._replace(C2=C2_new, C3=C3_new, T2=T2_new)
+    return env_self._replace(C2=C2_new, C3=C3_new, T2=T2_new)
 
 
 def _ctm_tensor_move_top(
-    env: CTMTensorEnv,
+    env_self: CTMTensorEnv,
+    env_neighbor: CTMTensorEnv,
     a: Tensor,
     chi: int,
     projector_method: str = "eigh",
 ) -> CTMTensorEnv:
     """Top move: updates C1, T1, C2.
+
+    Corners (C1, C2) from env_self, perpendicular edges (T4, T2) from
+    env_neighbor, parallel edge (T1) from env_self, double-layer ``a``
+    from neighbor site.
 
     Dense reference: C1g = einsum('ab,alg->blg', C1, T4)
                      C2g = einsum('ce,erm->crm', C2, T2)
@@ -551,20 +562,18 @@ def _ctm_tensor_move_top(
     """
     D2 = a.indices[0].dim
 
-    # C1(c1_d=a, c1_r=b) · T4(t4_d=a, l2, t4_u) → contract a: c1_d ↔ t4_d
-    C1_d = env.C1.relabel("c1_d", "t4_d")
-    C1g = contract(C1_d, env.T4)  # (c1_r, l2, t4_u)
+    # C1(self) · T4(neighbor)
+    C1_d = env_self.C1.relabel("c1_d", "t4_d")
+    C1g = contract(C1_d, env_neighbor.T4)  # (c1_r, l2, t4_u)
     C1g = _fuse_pair_by_label(C1g, "c1_r", "l2", "fused", IN)  # (fused, t4_u)
 
-    # C2(c2_l=c, c2_d=e) · T2(t2_u=e, r2, t2_d) → contract e: c2_d ↔ t2_u
-    C2_d = env.C2.relabel("c2_d", "t2_u")
-    C2g = contract(C2_d, env.T2)  # (c2_l, r2, t2_d)
+    # C2(self) · T2(neighbor)
+    C2_d = env_self.C2.relabel("c2_d", "t2_u")
+    C2g = contract(C2_d, env_neighbor.T2)  # (c2_l, r2, t2_d)
     C2g = _fuse_pair_by_label(C2g, "c2_l", "r2", "fused", IN)  # (fused, t2_d)
 
-    # T1(t1_l=b, u2, t1_r=c) · a(u2, d2, l2, r2) → contract u2
-    # Dense result (b,c,d,l,r), transpose(0,3,2,1,4)→(b,l,d,c,r)
-    # reshape → (b*l, d, c*r) = fuse(t1_l,l2), d2, fuse(t1_r,r2)
-    T1_with_a = contract(env.T1, a)
+    # T1(self) · a(neighbor)
+    T1_with_a = contract(env_self.T1, a)
     T1g = _fuse_pair_by_label(T1_with_a, "t1_l", "l2", "fl", IN)
     T1g = _fuse_pair_by_label(T1g, "t1_r", "r2", "fr", IN)
     T1g_dense = T1g.todense()
@@ -588,8 +597,8 @@ def _ctm_tensor_move_top(
         C1_new_dense,
         "c1_d",
         "c1_r",
-        env.C1.indices[0],
-        env.C1.indices[1],
+        env_self.C1.indices[0],
+        env_self.C1.indices[1],
         chi,
         symmetric=_sym,
         base_charges=_c1_q,
@@ -598,21 +607,21 @@ def _ctm_tensor_move_top(
         C2_new_dense,
         "c2_l",
         "c2_d",
-        env.C2.indices[0],
-        env.C2.indices[1],
+        env_self.C2.indices[0],
+        env_self.C2.indices[1],
         chi,
         symmetric=_sym,
         base_charges=_c2_q,
     )
 
     _t1_chi_q = a.indices[3].charges if _sym else None
-    _t1_D2_q = env.T1.indices[1].charges if _sym else None
+    _t1_D2_q = env_self.T1.indices[1].charges if _sym else None
     T1_new = _wrap_standard_edge_dense(
         T1_new_dense,
         "t1_l",
         "u2",
         "t1_r",
-        env.T1.indices,
+        env_self.T1.indices,
         chi,
         D2,
         symmetric=_sym,
@@ -620,16 +629,21 @@ def _ctm_tensor_move_top(
         base_D2_charges=_t1_D2_q,
     )
 
-    return env._replace(C1=C1_new, C2=C2_new, T1=T1_new)
+    return env_self._replace(C1=C1_new, C2=C2_new, T1=T1_new)
 
 
 def _ctm_tensor_move_bottom(
-    env: CTMTensorEnv,
+    env_self: CTMTensorEnv,
+    env_neighbor: CTMTensorEnv,
     a: Tensor,
     chi: int,
     projector_method: str = "eigh",
 ) -> CTMTensorEnv:
     """Bottom move: updates C4, T3, C3.
+
+    Corners (C4, C3) from env_self, perpendicular edges (T4, T2) from
+    env_neighbor, parallel edge (T3) from env_self, double-layer ``a``
+    from neighbor site.
 
     Dense reference: C4g = einsum('gh,alg->hal', C4, T4).transpose(0,2,1)
                      C3g = einsum('im,erm->ire', C3, T2)
@@ -637,21 +651,18 @@ def _ctm_tensor_move_bottom(
     """
     D2 = a.indices[0].dim
 
-    # C4(c4_r=g, c4_u=h) · T4(t4_d=a, l2, t4_u=g) → contract g: c4_r ↔ t4_u
-    C4_r = env.C4.relabel("c4_r", "t4_u")
-    C4g = contract(C4_r, env.T4)  # (c4_u, t4_d, l2)
-    # Dense: result (h,a,l) transposed to (h,l,a), reshape → fuse(c4_u, l2), t4_d
+    # C4(self) · T4(neighbor)
+    C4_r = env_self.C4.relabel("c4_r", "t4_u")
+    C4g = contract(C4_r, env_neighbor.T4)  # (c4_u, t4_d, l2)
     C4g = _fuse_pair_by_label(C4g, "c4_u", "l2", "fused", IN)  # (fused, t4_d)
 
-    # C3(c3_u=i, c3_l=m) · T2(t2_u=e, r2, t2_d=m) → contract m: c3_l ↔ t2_d
-    C3_l = env.C3.relabel("c3_l", "t2_d")
-    C3g = contract(C3_l, env.T2)  # (c3_u, t2_u, r2)
+    # C3(self) · T2(neighbor)
+    C3_l = env_self.C3.relabel("c3_l", "t2_d")
+    C3g = contract(C3_l, env_neighbor.T2)  # (c3_u, t2_u, r2)
     C3g = _fuse_pair_by_label(C3g, "c3_u", "r2", "fused", IN)  # (fused, t2_u)
 
-    # T3(t3_r=h, d2, t3_l=i) · a(u2, d2, l2, r2) → contract d2
-    # Dense result (h,i,u,l,r), transpose(0,3,2,1,4)→(h,l,u,i,r)
-    # reshape → (h*l, u, i*r) = fuse(t3_r,l2), u2, fuse(t3_l,r2)
-    T3_with_a = contract(env.T3, a)
+    # T3(self) · a(neighbor)
+    T3_with_a = contract(env_self.T3, a)
     T3g = _fuse_pair_by_label(T3_with_a, "t3_r", "l2", "fl", IN)
     T3g = _fuse_pair_by_label(T3g, "t3_l", "r2", "fr", IN)
     T3g_dense = T3g.todense()
@@ -675,8 +686,8 @@ def _ctm_tensor_move_bottom(
         C4_new_dense,
         "c4_r",
         "c4_u",
-        env.C4.indices[0],
-        env.C4.indices[1],
+        env_self.C4.indices[0],
+        env_self.C4.indices[1],
         chi,
         symmetric=_sym,
         base_charges=_c4_q,
@@ -685,21 +696,21 @@ def _ctm_tensor_move_bottom(
         C3_new_dense,
         "c3_u",
         "c3_l",
-        env.C3.indices[0],
-        env.C3.indices[1],
+        env_self.C3.indices[0],
+        env_self.C3.indices[1],
         chi,
         symmetric=_sym,
         base_charges=_c3_q,
     )
 
     _t3_chi_q = a.indices[3].charges if _sym else None
-    _t3_D2_q = env.T3.indices[1].charges if _sym else None
+    _t3_D2_q = env_self.T3.indices[1].charges if _sym else None
     T3_new = _wrap_standard_edge_dense(
         T3_new_dense,
         "t3_r",
         "d2",
         "t3_l",
-        env.T3.indices,
+        env_self.T3.indices,
         chi,
         D2,
         symmetric=_sym,
@@ -707,7 +718,7 @@ def _ctm_tensor_move_bottom(
         base_D2_charges=_t3_D2_q,
     )
 
-    return env._replace(C4=C4_new, C3=C3_new, T3=T3_new)
+    return env_self._replace(C4=C4_new, C3=C3_new, T3=T3_new)
 
 
 # ------------------------------------------------------------------ #
@@ -752,13 +763,56 @@ def _ctm_tensor_sweep(
     projector_method: str = "eigh",
 ) -> CTMTensorEnv:
     """One full CTM sweep: left, right, top, bottom + optional renormalize."""
-    env = _ctm_tensor_move_left(env, a, chi, projector_method)
-    env = _ctm_tensor_move_right(env, a, chi, projector_method)
-    env = _ctm_tensor_move_top(env, a, chi, projector_method)
-    env = _ctm_tensor_move_bottom(env, a, chi, projector_method)
+    env = _ctm_tensor_move_left(env, env, a, chi, projector_method)
+    env = _ctm_tensor_move_right(env, env, a, chi, projector_method)
+    env = _ctm_tensor_move_top(env, env, a, chi, projector_method)
+    env = _ctm_tensor_move_bottom(env, env, a, chi, projector_method)
     if renormalize:
         env = _renormalize_tensor_env(env)
     return env
+
+
+# ------------------------------------------------------------------ #
+# Neighbor maps for unit cell topologies                              #
+# ------------------------------------------------------------------ #
+
+Coord = tuple[int, int]
+
+SINGLE_SITE_NEIGHBORS: dict[Coord, dict[str, Coord]] = {
+    (0, 0): {"left": (0, 0), "right": (0, 0), "top": (0, 0), "bottom": (0, 0)},
+}
+
+CHECKERBOARD_NEIGHBORS: dict[Coord, dict[str, Coord]] = {
+    (0, 0): {"left": (1, 0), "right": (1, 0), "top": (1, 0), "bottom": (1, 0)},
+    (1, 0): {"left": (0, 0), "right": (0, 0), "top": (0, 0), "bottom": (0, 0)},
+}
+
+_DIRECTION_MOVES = [
+    ("left", _ctm_tensor_move_left),
+    ("right", _ctm_tensor_move_right),
+    ("top", _ctm_tensor_move_top),
+    ("bottom", _ctm_tensor_move_bottom),
+]
+
+
+def _ctm_tensor_sweep_multisite(
+    envs: dict[Coord, CTMTensorEnv],
+    double_layers: dict[Coord, Tensor],
+    neighbors: dict[Coord, dict[str, Coord]],
+    chi: int,
+    renormalize: bool,
+    projector_method: str = "eigh",
+) -> dict[Coord, CTMTensorEnv]:
+    """One full multisite CTM sweep over all sites and directions."""
+    for direction, move_fn in _DIRECTION_MOVES:
+        for coord in sorted(envs.keys()):
+            nb = neighbors[coord][direction]
+            envs[coord] = move_fn(
+                envs[coord], envs[nb], double_layers[nb], chi, projector_method
+            )
+    if renormalize:
+        envs = {c: _renormalize_tensor_env(e) for c, e in envs.items()}
+    return envs
 
 
 # ------------------------------------------------------------------ #
@@ -816,6 +870,88 @@ def ctm_tensor(
     return env
 
 
+def _ctm_tensor_multisite(
+    site_tensors: dict[Coord, Tensor],
+    neighbors: dict[Coord, dict[str, Coord]],
+    chi: int,
+    max_iter: int = 100,
+    conv_tol: float = 1e-8,
+    renormalize: bool = True,
+    projector_method: str = "eigh",
+) -> dict[Coord, CTMTensorEnv]:
+    """Run multisite CTM to convergence using the Tensor protocol.
+
+    Args:
+        site_tensors: Map from coordinate to iPEPS site tensor.
+        neighbors:    Map from coordinate to direction→neighbor coordinate.
+        chi:          Environment bond dimension.
+        max_iter:     Maximum CTM iterations.
+        conv_tol:     Convergence tolerance on corner singular values.
+        renormalize:  Renormalize environment at each step.
+        projector_method: ``"eigh"`` or ``"qr"``.
+
+    Returns:
+        Dict mapping coordinates to converged CTMTensorEnv.
+    """
+    double_layers = {c: _build_double_layer_tensor(A) for c, A in site_tensors.items()}
+    envs = {c: initialize_ctm_tensor_env(A, chi) for c, A in site_tensors.items()}
+
+    prev_svs: dict[Coord, jax.Array] = {}
+    for _ in range(max_iter):
+        envs = _ctm_tensor_sweep_multisite(
+            envs, double_layers, neighbors, chi, renormalize, projector_method
+        )
+        converged = True
+        for c in sorted(envs):
+            sv = jnp.linalg.svd(envs[c].C1.todense(), compute_uv=False)
+            if c in prev_svs:
+                if float(_ctm_sv_diff(sv, prev_svs[c])) >= conv_tol:
+                    converged = False
+            else:
+                converged = False
+            prev_svs[c] = sv
+        if converged:
+            break
+
+    return envs
+
+
+def ctm_tensor_2site(
+    A: Tensor,
+    B: Tensor,
+    chi: int,
+    max_iter: int = 100,
+    conv_tol: float = 1e-8,
+    renormalize: bool = True,
+    projector_method: str = "eigh",
+) -> tuple[CTMTensorEnv, CTMTensorEnv]:
+    """Run 2-site checkerboard CTM to convergence using the Tensor protocol.
+
+    Args:
+        A:   Site tensor for sublattice A (DenseTensor or SymmetricTensor)
+             with 5 legs ``(u, d, l, r, phys)``.
+        B:   Site tensor for sublattice B.
+        chi: Environment bond dimension.
+        max_iter:     Maximum CTM iterations.
+        conv_tol:     Convergence tolerance on corner singular values.
+        renormalize:  Renormalize environment at each step.
+        projector_method: ``"eigh"`` or ``"qr"``.
+
+    Returns:
+        ``(env_A, env_B)`` — converged CTMTensorEnv for each sublattice.
+    """
+    envs = _ctm_tensor_multisite(
+        {(0, 0): A, (1, 0): B},
+        CHECKERBOARD_NEIGHBORS,
+        chi,
+        max_iter,
+        conv_tol,
+        renormalize,
+        projector_method,
+    )
+    return envs[(0, 0)], envs[(1, 0)]
+
+
 # ------------------------------------------------------------------ #
 # RDMs + energy                                                        #
 # ------------------------------------------------------------------ #
@@ -870,3 +1006,43 @@ def compute_energy_ctm_tensor(
 
     std_env = _env_to_dense_standard(env)
     return compute_energy_ctm(A_dense, std_env, H, d)
+
+
+def compute_energy_ctm_tensor_2site(
+    A: Tensor,
+    B: Tensor,
+    env_A: CTMTensorEnv,
+    env_B: CTMTensorEnv,
+    hamiltonian_gate: Tensor | jax.Array,
+    d: int | None = None,
+) -> jax.Array:
+    """Compute energy per site for a 2-site checkerboard iPEPS.
+
+    Converts to dense and delegates to ``compute_energy_ctm_2site``.
+
+    Args:
+        A:                Site tensor for sublattice A.
+        B:                Site tensor for sublattice B.
+        env_A:            Converged CTMTensorEnv for sublattice A.
+        env_B:            Converged CTMTensorEnv for sublattice B.
+        hamiltonian_gate: 2-site Hamiltonian gate.
+        d:                Physical dimension (inferred from A if None).
+
+    Returns:
+        Scalar energy per site.
+    """
+    from tenax.algorithms.ipeps import compute_energy_ctm_2site
+
+    A_d = A.todense()
+    B_d = B.todense()
+    if d is None:
+        d = A_d.shape[-1]
+
+    if isinstance(hamiltonian_gate, Tensor):
+        H = hamiltonian_gate.todense().reshape(d, d, d, d)
+    else:
+        H = hamiltonian_gate.reshape(d, d, d, d)
+
+    std_env_A = _env_to_dense_standard(env_A)
+    std_env_B = _env_to_dense_standard(env_B)
+    return compute_energy_ctm_2site(A_d, B_d, std_env_A, std_env_B, H, d)

--- a/src/tenax/algorithms/ad_utils.py
+++ b/src/tenax/algorithms/ad_utils.py
@@ -294,6 +294,18 @@ def _ctm_fixed_point_impl(
     return env
 
 
+def _config_to_tuple(config) -> tuple:
+    """Pack CTMConfig into a hashable tuple for JAX tracing."""
+    _pm_map = {"eigh": 0, "qr": 1}
+    return (
+        config.chi,
+        config.max_iter,
+        config.conv_tol,
+        int(config.renormalize),
+        _pm_map.get(config.projector_method, 0),
+    )
+
+
 def _config_from_tuple(config_tuple: tuple):
     """Reconstruct CTMConfig from a packed tuple."""
     from tenax.algorithms.ipeps import CTMConfig
@@ -576,7 +588,358 @@ ctm_converge_2site.defvjp(_ctm_converge_2site_fwd, _ctm_converge_2site_bwd)
 
 
 # ---------------------------------------------------------------------------
-# 5. Split CTM (Tensor protocol) fixed-point implicit differentiation
+# 5. Standard CTM (Tensor protocol) fixed-point implicit differentiation
+# ---------------------------------------------------------------------------
+
+
+def _gauge_fix_ctm_tensor(env):
+    """Fix gauge of CTMTensorEnv via QR decomposition of corners.
+
+    Converts to dense arrays, applies the standard QR gauge fix,
+    then wraps results back into Tensor objects.  All operations
+    (``todense()``, dense QR/einsum, ``from_dense()``) are differentiable.
+    """
+    from tenax.algorithms._ctm_tensor import CTMTensorEnv
+    from tenax.algorithms.ipeps import CTMEnvironment
+    from tenax.core.tensor import SymmetricTensor
+
+    # todense() is differentiable (jnp scatter)
+    C1, C2, C3, C4 = (c.todense() for c in (env.C1, env.C2, env.C3, env.C4))
+    T1, T2, T3, T4 = (t.todense() for t in (env.T1, env.T2, env.T3, env.T4))
+
+    # Standard QR gauge fix on dense arrays
+    dense_env = CTMEnvironment(C1, C2, C3, C4, T1, T2, T3, T4)
+    fixed = _gauge_fix_ctm(dense_env)
+
+    # Wrap back into Tensor objects preserving original index structure
+    def _wrap(data, original):
+        if isinstance(original, SymmetricTensor):
+            return SymmetricTensor.from_dense(data, original.indices, tol=float("inf"))
+        return type(original)(data, original.indices)
+
+    return CTMTensorEnv(
+        C1=_wrap(fixed.C1, env.C1),
+        C2=_wrap(fixed.C2, env.C2),
+        C3=_wrap(fixed.C3, env.C3),
+        C4=_wrap(fixed.C4, env.C4),
+        T1=_wrap(fixed.T1, env.T1),
+        T2=_wrap(fixed.T2, env.T2),
+        T3=_wrap(fixed.T3, env.T3),
+        T4=_wrap(fixed.T4, env.T4),
+    )
+
+
+def _ctm_tensor_step(
+    A_leaves: tuple[jax.Array, ...],
+    env_leaves: tuple[jax.Array, ...],
+    chi: int,
+    renormalize: bool,
+    projector_method: str,
+    A_treedef,
+    env_treedef,
+) -> tuple[jax.Array, ...]:
+    """One CTM tensor sweep + gauge fix, mapping flat leaves to flat leaves."""
+    from tenax.algorithms._ctm_tensor import (
+        _build_double_layer_tensor,
+        _ctm_tensor_sweep,
+    )
+
+    A = jax.tree.unflatten(A_treedef, A_leaves)
+    env = jax.tree.unflatten(env_treedef, list(env_leaves))
+
+    a = _build_double_layer_tensor(A)
+    env_new = _ctm_tensor_sweep(env, a, chi, renormalize, projector_method)
+    env_new = _gauge_fix_ctm_tensor(env_new)
+
+    return tuple(jax.tree.leaves(env_new))
+
+
+def _ctm_tensor_fixed_point_impl(A, config):
+    """Run standard Tensor-protocol CTM to convergence with gauge fixing."""
+    from tenax.algorithms._ctm_tensor import (
+        _build_double_layer_tensor,
+        _ctm_tensor_sweep,
+        initialize_ctm_tensor_env,
+    )
+
+    a = _build_double_layer_tensor(A)
+    env = initialize_ctm_tensor_env(A, config.chi)
+
+    prev_sv = None
+    for _ in range(config.max_iter):
+        env = _ctm_tensor_sweep(
+            env, a, config.chi, config.renormalize, config.projector_method
+        )
+        env = _gauge_fix_ctm_tensor(env)
+
+        current_sv = jnp.linalg.svd(env.C1.todense(), compute_uv=False)
+        if prev_sv is not None:
+            diff = _ctm_sv_diff_local(current_sv, prev_sv)
+            if float(diff) < config.conv_tol:
+                break
+        prev_sv = current_sv
+
+    return env
+
+
+def _ctm_sv_diff_local(sv_new, sv_old):
+    """Compute max abs diff between normalized SVs (local helper)."""
+    sv1 = sv_new / (jnp.sum(sv_new) + 1e-15)
+    sv2 = sv_old / (jnp.sum(sv_old) + 1e-15)
+    return jnp.max(jnp.abs(sv1 - sv2))
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(1,))
+def ctm_tensor_converge(
+    A,
+    config_tuple: tuple,
+) -> tuple[jax.Array, ...]:
+    """Standard Tensor-protocol CTM with implicit differentiation.
+
+    Args:
+        A:            iPEPS site tensor (DenseTensor or SymmetricTensor).
+        config_tuple: CTMConfig fields packed as tuple for JAX tracing.
+
+    Returns:
+        Flat tuple of environment pytree leaf arrays.
+    """
+    config = _config_from_tuple(config_tuple)
+    env = _ctm_tensor_fixed_point_impl(A, config)
+    return tuple(jax.tree.leaves(env))
+
+
+def _ctm_tensor_converge_fwd(A, config_tuple):
+    """Forward pass — run Tensor CTM, cache A and env for backward."""
+    config = _config_from_tuple(config_tuple)
+    env = _ctm_tensor_fixed_point_impl(A, config)
+    env_leaves = tuple(jax.tree.leaves(env))
+    residuals = (A, env)
+    return env_leaves, residuals
+
+
+def _ctm_tensor_converge_bwd(config_tuple, residuals, g):
+    """Backward pass via implicit differentiation of Tensor CTM fixed point."""
+    A, env = residuals
+    config = _config_from_tuple(config_tuple)
+
+    A_treedef = jax.tree.structure(A)
+    env_treedef = jax.tree.structure(env)
+    env_leaves = tuple(jax.tree.leaves(env))
+
+    def step_fn(A_in, env_in_leaves):
+        return _ctm_tensor_step(
+            tuple(jax.tree.leaves(A_in)),
+            env_in_leaves,
+            config.chi,
+            config.renormalize,
+            config.projector_method,
+            A_treedef,
+            env_treedef,
+        )
+
+    from jax.scipy.sparse.linalg import gmres as jax_gmres
+
+    def apply_I_minus_Jt(v):
+        _, vjp_fn = jax.vjp(lambda e: step_fn(A, e), env_leaves)
+        Jt_v = vjp_fn(v)[0]
+        return tuple(vi - ji for vi, ji in zip(v, Jt_v))
+
+    max_fp_iter = min(config.max_iter, 50)
+    lam, info = jax_gmres(
+        apply_I_minus_Jt,
+        g,
+        x0=g,
+        tol=config.conv_tol,
+        maxiter=max_fp_iter,
+    )
+
+    _, vjp_A_fn = jax.vjp(lambda a: step_fn(a, env_leaves), A)
+    dA = vjp_A_fn(lam)[0]
+
+    return (dA,)
+
+
+ctm_tensor_converge.defvjp(_ctm_tensor_converge_fwd, _ctm_tensor_converge_bwd)
+
+
+# ---------------------------------------------------------------------------
+# 5b. 2-site Tensor-protocol CTM fixed-point implicit differentiation
+# ---------------------------------------------------------------------------
+
+
+def _ctm_tensor_multisite_fixed_point(site_tensors, neighbors, config):
+    """Run multisite Tensor-protocol CTM to convergence with gauge fixing."""
+    from tenax.algorithms._ctm_tensor import (
+        _build_double_layer_tensor,
+        _ctm_tensor_sweep_multisite,
+        initialize_ctm_tensor_env,
+    )
+
+    double_layers = {c: _build_double_layer_tensor(A) for c, A in site_tensors.items()}
+    envs = {
+        c: initialize_ctm_tensor_env(A, config.chi) for c, A in site_tensors.items()
+    }
+
+    prev_svs = {}
+    for _ in range(config.max_iter):
+        envs = _ctm_tensor_sweep_multisite(
+            envs,
+            double_layers,
+            neighbors,
+            config.chi,
+            config.renormalize,
+            config.projector_method,
+        )
+        envs = {c: _gauge_fix_ctm_tensor(e) for c, e in envs.items()}
+
+        converged = True
+        for c in sorted(envs):
+            sv = jnp.linalg.svd(envs[c].C1.todense(), compute_uv=False)
+            if c in prev_svs:
+                if float(_ctm_sv_diff_local(sv, prev_svs[c])) >= config.conv_tol:
+                    converged = False
+            else:
+                converged = False
+            prev_svs[c] = sv
+        if converged:
+            break
+
+    return envs
+
+
+def _ctm_tensor_step_2site(
+    A_leaves,
+    B_leaves,
+    env_leaves,
+    chi,
+    renormalize,
+    projector_method,
+    A_treedef,
+    B_treedef,
+    env_A_treedef,
+    n_env_A_leaves,
+):
+    """One 2-site CTM tensor sweep + gauge fix, flat leaves → flat leaves."""
+    from tenax.algorithms._ctm_tensor import (
+        CHECKERBOARD_NEIGHBORS,
+        _build_double_layer_tensor,
+        _ctm_tensor_sweep_multisite,
+    )
+
+    A = jax.tree.unflatten(A_treedef, A_leaves)
+    B = jax.tree.unflatten(B_treedef, B_leaves)
+    env_A = jax.tree.unflatten(env_A_treedef, list(env_leaves[:n_env_A_leaves]))
+    env_B = jax.tree.unflatten(env_A_treedef, list(env_leaves[n_env_A_leaves:]))
+
+    double_layers = {
+        (0, 0): _build_double_layer_tensor(A),
+        (1, 0): _build_double_layer_tensor(B),
+    }
+    envs = {(0, 0): env_A, (1, 0): env_B}
+    envs = _ctm_tensor_sweep_multisite(
+        envs, double_layers, CHECKERBOARD_NEIGHBORS, chi, renormalize, projector_method
+    )
+    envs = {c: _gauge_fix_ctm_tensor(e) for c, e in envs.items()}
+
+    return tuple(jax.tree.leaves(envs[(0, 0)])) + tuple(jax.tree.leaves(envs[(1, 0)]))
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(2,))
+def ctm_tensor_converge_2site(
+    A,
+    B,
+    config_tuple: tuple,
+) -> tuple[jax.Array, ...]:
+    """2-site Tensor-protocol CTM with implicit differentiation.
+
+    Args:
+        A:            iPEPS site tensor A (DenseTensor or SymmetricTensor).
+        B:            iPEPS site tensor B.
+        config_tuple: CTMConfig fields packed as tuple for JAX tracing.
+
+    Returns:
+        Flat tuple ``(*env_A_leaves, *env_B_leaves)``.
+    """
+    from tenax.algorithms._ctm_tensor import CHECKERBOARD_NEIGHBORS
+
+    config = _config_from_tuple(config_tuple)
+    envs = _ctm_tensor_multisite_fixed_point(
+        {(0, 0): A, (1, 0): B}, CHECKERBOARD_NEIGHBORS, config
+    )
+    return tuple(jax.tree.leaves(envs[(0, 0)])) + tuple(jax.tree.leaves(envs[(1, 0)]))
+
+
+def _ctm_tensor_converge_2site_fwd(A, B, config_tuple):
+    """Forward pass — run 2-site Tensor CTM, cache A, B, envs."""
+    from tenax.algorithms._ctm_tensor import CHECKERBOARD_NEIGHBORS
+
+    config = _config_from_tuple(config_tuple)
+    envs = _ctm_tensor_multisite_fixed_point(
+        {(0, 0): A, (1, 0): B}, CHECKERBOARD_NEIGHBORS, config
+    )
+    env_A, env_B = envs[(0, 0)], envs[(1, 0)]
+    out = tuple(jax.tree.leaves(env_A)) + tuple(jax.tree.leaves(env_B))
+    residuals = (A, B, env_A, env_B)
+    return out, residuals
+
+
+def _ctm_tensor_converge_2site_bwd(config_tuple, residuals, g):
+    """Backward pass via implicit differentiation of 2-site Tensor CTM."""
+    A, B, env_A, env_B = residuals
+    config = _config_from_tuple(config_tuple)
+
+    A_treedef = jax.tree.structure(A)
+    B_treedef = jax.tree.structure(B)
+    env_A_treedef = jax.tree.structure(env_A)
+
+    env_A_leaves = tuple(jax.tree.leaves(env_A))
+    env_B_leaves = tuple(jax.tree.leaves(env_B))
+    n_env_A_leaves = len(env_A_leaves)
+    env_leaves = env_A_leaves + env_B_leaves
+
+    def step_fn(A_in, B_in, env_in_leaves):
+        return _ctm_tensor_step_2site(
+            tuple(jax.tree.leaves(A_in)),
+            tuple(jax.tree.leaves(B_in)),
+            env_in_leaves,
+            config.chi,
+            config.renormalize,
+            config.projector_method,
+            A_treedef,
+            B_treedef,
+            env_A_treedef,
+            n_env_A_leaves,
+        )
+
+    from jax.scipy.sparse.linalg import gmres as jax_gmres
+
+    def apply_I_minus_Jt(v):
+        _, vjp_fn = jax.vjp(lambda e: step_fn(A, B, e), env_leaves)
+        Jt_v = vjp_fn(v)[0]
+        return tuple(vi - ji for vi, ji in zip(v, Jt_v))
+
+    max_fp_iter = min(config.max_iter, 50)
+    lam, info = jax_gmres(
+        apply_I_minus_Jt,
+        g,
+        x0=g,
+        tol=config.conv_tol,
+        maxiter=max_fp_iter,
+    )
+
+    _, vjp_AB_fn = jax.vjp(lambda a, b: step_fn(a, b, env_leaves), A, B)
+    dA, dB = vjp_AB_fn(lam)
+
+    return (dA, dB)
+
+
+ctm_tensor_converge_2site.defvjp(
+    _ctm_tensor_converge_2site_fwd, _ctm_tensor_converge_2site_bwd
+)
+
+
+# ---------------------------------------------------------------------------
+# 6. Split CTM (Tensor protocol) fixed-point implicit differentiation
 # ---------------------------------------------------------------------------
 
 

--- a/src/tenax/algorithms/ipeps.py
+++ b/src/tenax/algorithms/ipeps.py
@@ -30,7 +30,7 @@ import numpy as np
 from tenax.core import EPS
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.symmetry import U1Symmetry
-from tenax.core.tensor import DenseTensor
+from tenax.core.tensor import DenseTensor, Tensor
 from tenax.network.network import TensorNetwork
 
 
@@ -2293,11 +2293,16 @@ def optimize_gs_ad(
         config:           iPEPSConfig with AD optimization settings.
 
     Returns:
-        For 1-site: ``(A_opt, env, E_gs)``
+        For 1-site dense:  ``(A_opt, env, E_gs)``
+        For 1-site Tensor: ``(A_opt, env, E_gs)`` where A_opt is Tensor, env is CTMTensorEnv
         For 2-site: ``((A_opt, B_opt), (env_A, env_B), E_gs)``
     """
     if config.unit_cell == "2site":
         return _optimize_gs_ad_2site(hamiltonian_gate, A_init, config)
+
+    # Dispatch: Tensor-protocol path vs dense path
+    if isinstance(A_init, Tensor):
+        return _optimize_gs_ad_tensor(hamiltonian_gate, A_init, config)
 
     import optax
 
@@ -2376,20 +2381,88 @@ def optimize_gs_ad(
     return A_final, env, E_gs
 
 
+def _optimize_gs_ad_tensor(
+    hamiltonian_gate: jax.Array,
+    A_init: Tensor,
+    config: iPEPSConfig,
+):
+    """AD-based ground state optimization for Tensor-protocol iPEPS (1-site).
+
+    Uses ``ctm_tensor_converge`` with implicit differentiation through
+    the standard Tensor-protocol CTM.
+    """
+    import optax
+
+    from tenax.algorithms._ctm_tensor import (
+        compute_energy_ctm_tensor,
+        initialize_ctm_tensor_env,
+    )
+    from tenax.algorithms.ad_utils import _config_to_tuple, ctm_tensor_converge
+
+    gate = jnp.array(hamiltonian_gate)
+    d_phys = gate.shape[0]
+
+    A = A_init
+    A = A * (1.0 / (A.norm() + 1e-10))
+
+    config_tuple = _config_to_tuple(config.ctm)
+
+    _env_template = initialize_ctm_tensor_env(A, config.ctm.chi)
+    env_treedef = jax.tree.structure(_env_template)
+
+    def loss_fn(A_param):
+        A_norm = A_param * (1.0 / (A_param.norm() + 1e-10))
+        env_leaves = ctm_tensor_converge(A_norm, config_tuple)
+        env = jax.tree.unflatten(env_treedef, env_leaves)
+        energy = compute_energy_ctm_tensor(A_norm, env, gate, d_phys)
+        return energy
+
+    optimizer = optax.adam(config.gs_learning_rate)
+    opt_state = optimizer.init(A)
+
+    best_energy = float("inf")
+    best_A = A
+    prev_energy = float("inf")
+
+    for _ in range(config.gs_num_steps):
+        energy_val, grads = jax.value_and_grad(loss_fn)(A)
+        energy_float = float(energy_val)
+
+        if energy_float < best_energy:
+            best_energy = energy_float
+            best_A = A
+
+        if abs(energy_float - prev_energy) < config.gs_conv_tol:
+            break
+        prev_energy = energy_float
+
+        updates, opt_state = optimizer.update(grads, opt_state, A)
+        A = optax.apply_updates(A, updates)
+        A = A * (1.0 / (A.norm() + 1e-10))
+
+    A_final = best_A * (1.0 / (best_A.norm() + 1e-10))
+    env_leaves = ctm_tensor_converge(A_final, config_tuple)
+    env = jax.tree.unflatten(env_treedef, env_leaves)
+    E_gs = float(compute_energy_ctm_tensor(A_final, env, gate, d_phys))
+
+    return A_final, env, E_gs
+
+
 def _optimize_gs_ad_2site(
     hamiltonian_gate: jax.Array,
-    AB_init: tuple[jax.Array, jax.Array] | None,
+    AB_init: tuple[jax.Array, jax.Array] | tuple[Tensor, Tensor] | None,
     config: iPEPSConfig,
-) -> tuple[
-    tuple[jax.Array, jax.Array],
-    tuple[CTMEnvironment, CTMEnvironment],
-    float,
-]:
+):
     """AD-based ground state optimization for 2-site iPEPS unit cell.
 
     Uses implicit differentiation through the 2-site CTM fixed point
     to compute gradients of energy w.r.t. both site tensors (A, B).
+
+    Accepts dense ``jax.Array`` or Tensor-protocol objects.
     """
+    if isinstance(AB_init, tuple) and any(isinstance(t, Tensor) for t in AB_init):
+        return _optimize_gs_ad_tensor_2site(hamiltonian_gate, AB_init, config)
+
     import optax
 
     from tenax.algorithms.ad_utils import ctm_converge_2site
@@ -2484,5 +2557,91 @@ def _optimize_gs_ad_2site(
     env_A = CTMEnvironment(*env_tuple[:8])
     env_B = CTMEnvironment(*env_tuple[8:])
     E_gs = float(compute_energy_ctm_2site(A_final, B_final, env_A, env_B, gate, d_phys))
+
+    return (A_final, B_final), (env_A, env_B), E_gs
+
+
+def _optimize_gs_ad_tensor_2site(
+    hamiltonian_gate: jax.Array,
+    AB_init: tuple[Tensor, Tensor],
+    config: iPEPSConfig,
+):
+    """AD-based ground state optimization for 2-site Tensor-protocol iPEPS.
+
+    Uses ``ctm_tensor_converge_2site`` with implicit differentiation through
+    the 2-site Tensor-protocol CTM.
+    """
+    import optax
+
+    from tenax.algorithms._ctm_tensor import (
+        compute_energy_ctm_tensor_2site,
+        initialize_ctm_tensor_env,
+    )
+    from tenax.algorithms.ad_utils import _config_to_tuple, ctm_tensor_converge_2site
+
+    gate = jnp.array(hamiltonian_gate)
+    d_phys = gate.shape[0]
+
+    A, B = AB_init
+    A = A * (1.0 / (A.norm() + 1e-10))
+    B = B * (1.0 / (B.norm() + 1e-10))
+
+    config_tuple = _config_to_tuple(config.ctm)
+
+    # Get env treedef from a template
+    _env_template = initialize_ctm_tensor_env(A, config.ctm.chi)
+    env_treedef = jax.tree.structure(_env_template)
+    n_env_leaves = len(jax.tree.leaves(_env_template))
+
+    def loss_fn(params):
+        A_p, B_p = params
+        A_norm = A_p * (1.0 / (A_p.norm() + 1e-10))
+        B_norm = B_p * (1.0 / (B_p.norm() + 1e-10))
+        env_leaves = ctm_tensor_converge_2site(A_norm, B_norm, config_tuple)
+        env_A = jax.tree.unflatten(env_treedef, env_leaves[:n_env_leaves])
+        env_B = jax.tree.unflatten(env_treedef, env_leaves[n_env_leaves:])
+        energy = compute_energy_ctm_tensor_2site(
+            A_norm, B_norm, env_A, env_B, gate, d_phys
+        )
+        return energy
+
+    params = (A, B)
+    optimizer = optax.adam(config.gs_learning_rate)
+    opt_state = optimizer.init(params)
+
+    best_energy = float("inf")
+    best_params = params
+    prev_energy = float("inf")
+
+    for _ in range(config.gs_num_steps):
+        energy_val, grads = jax.value_and_grad(loss_fn)(params)
+        energy_float = float(energy_val)
+
+        if energy_float < best_energy:
+            best_energy = energy_float
+            best_params = params
+
+        if abs(energy_float - prev_energy) < config.gs_conv_tol:
+            break
+        prev_energy = energy_float
+
+        updates, opt_state = optimizer.update(grads, opt_state, params)
+        params = optax.apply_updates(params, updates)
+        A_p, B_p = params
+        params = (
+            A_p * (1.0 / (A_p.norm() + 1e-10)),
+            B_p * (1.0 / (B_p.norm() + 1e-10)),
+        )
+
+    # Final CTM environment
+    A_final, B_final = best_params
+    A_final = A_final * (1.0 / (A_final.norm() + 1e-10))
+    B_final = B_final * (1.0 / (B_final.norm() + 1e-10))
+    env_leaves = ctm_tensor_converge_2site(A_final, B_final, config_tuple)
+    env_A = jax.tree.unflatten(env_treedef, env_leaves[:n_env_leaves])
+    env_B = jax.tree.unflatten(env_treedef, env_leaves[n_env_leaves:])
+    E_gs = float(
+        compute_energy_ctm_tensor_2site(A_final, B_final, env_A, env_B, gate, d_phys)
+    )
 
     return (A_final, B_final), (env_A, env_B), E_gs

--- a/src/tenax/core/tensor.py
+++ b/src/tenax/core/tensor.py
@@ -372,7 +372,12 @@ class DenseTensor(Tensor):
         aux: tuple[TensorIndex, ...],
         children: tuple[jax.Array],
     ) -> DenseTensor:
-        return cls(children[0], aux)
+        # Bypass validation for JAX-internal dummy objects (e.g., custom_vjp
+        # backward pass creates object() placeholders to probe pytree structure).
+        obj = object.__new__(cls)
+        obj._data = children[0]
+        obj._indices = tuple(aux)
+        return obj
 
     # --- Tensor interface ---
 

--- a/tests/test_ctm_tensor.py
+++ b/tests/test_ctm_tensor.py
@@ -13,14 +13,18 @@ from tenax.algorithms._ctm_tensor import (
     _build_double_layer_tensor,
     _ctm_tensor_sweep,
     compute_energy_ctm_tensor,
+    compute_energy_ctm_tensor_2site,
     ctm_tensor,
+    ctm_tensor_2site,
     initialize_ctm_tensor_env,
 )
 from tenax.algorithms.ipeps import (
     CTMConfig,
     _build_double_layer,
     compute_energy_ctm,
+    compute_energy_ctm_2site,
     ctm,
+    ctm_2site,
 )
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.symmetry import FermionParity, U1Symmetry
@@ -323,3 +327,128 @@ class TestFermionicIntegration:
         energy, A_opt, env = fpeps(H, config)
         assert isinstance(env, CTMTensorEnv)
         assert np.isfinite(energy)
+
+
+# ------------------------------------------------------------------ #
+# 2-site CTM tests                                                     #
+# ------------------------------------------------------------------ #
+
+
+@pytest.fixture
+def small_peps_pair_dense():
+    """Two random DenseTensor iPEPS site tensors for 2-site unit cell."""
+    D, d = 2, 2
+    sym = U1Symmetry()
+    charges = np.zeros(D, dtype=np.int32)
+    phys_charges = np.zeros(d, dtype=np.int32)
+
+    def _make(seed):
+        key = jax.random.PRNGKey(seed)
+        data = jax.random.normal(key, (D, D, D, D, d))
+        data = data / (jnp.linalg.norm(data) + 1e-10)
+        indices = (
+            TensorIndex(sym, charges.copy(), FlowDirection.OUT, label="u"),
+            TensorIndex(sym, charges.copy(), FlowDirection.IN, label="d"),
+            TensorIndex(sym, charges.copy(), FlowDirection.OUT, label="l"),
+            TensorIndex(sym, charges.copy(), FlowDirection.IN, label="r"),
+            TensorIndex(sym, phys_charges.copy(), FlowDirection.IN, label="phys"),
+        )
+        return DenseTensor(data, indices)
+
+    return _make(42), _make(123)
+
+
+@pytest.fixture
+def small_peps_pair_symmetric():
+    """Two random SymmetricTensor iPEPS site tensors (trivial U(1) charges)."""
+    D, d = 2, 2
+    sym = U1Symmetry()
+    charges = np.zeros(D, dtype=np.int32)
+    phys_charges = np.zeros(d, dtype=np.int32)
+
+    def _make(seed):
+        key = jax.random.PRNGKey(seed)
+        data = jax.random.normal(key, (D, D, D, D, d))
+        indices = (
+            TensorIndex(sym, charges.copy(), FlowDirection.OUT, label="u"),
+            TensorIndex(sym, charges.copy(), FlowDirection.IN, label="d"),
+            TensorIndex(sym, charges.copy(), FlowDirection.OUT, label="l"),
+            TensorIndex(sym, charges.copy(), FlowDirection.IN, label="r"),
+            TensorIndex(sym, phys_charges.copy(), FlowDirection.IN, label="phys"),
+        )
+        return SymmetricTensor.from_dense(data, indices)
+
+    return _make(99), _make(200)
+
+
+class TestTwoSiteCTM:
+    def test_2site_dense_converges(self, small_peps_pair_dense):
+        """2-site DenseTensor CTM converges (finite env after max_iter)."""
+        A, B = small_peps_pair_dense
+        env_A, env_B = ctm_tensor_2site(A, B, chi=4, max_iter=20, conv_tol=1e-6)
+        for field in env_A:
+            assert jnp.all(jnp.isfinite(field.todense()))
+        for field in env_B:
+            assert jnp.all(jnp.isfinite(field.todense()))
+
+    def test_2site_dense_matches_legacy(self, small_peps_pair_dense, heisenberg_gate):
+        """2-site DenseTensor CTM energy matches legacy dense CTM energy."""
+        A, B = small_peps_pair_dense
+        chi = 6
+        A_raw, B_raw = A.todense(), B.todense()
+
+        # Legacy dense CTM
+        cfg = CTMConfig(chi=chi, max_iter=50, conv_tol=1e-8)
+        env_A_leg, env_B_leg = ctm_2site(A_raw, B_raw, cfg)
+        E_legacy = float(
+            compute_energy_ctm_2site(
+                A_raw, B_raw, env_A_leg, env_B_leg, heisenberg_gate, d=2
+            )
+        )
+
+        # Tensor-protocol 2-site CTM
+        env_A, env_B = ctm_tensor_2site(A, B, chi=chi, max_iter=50, conv_tol=1e-8)
+        E_tensor = float(
+            compute_energy_ctm_tensor_2site(A, B, env_A, env_B, heisenberg_gate, d=2)
+        )
+
+        np.testing.assert_allclose(E_tensor, E_legacy, atol=1e-4)
+
+    def test_2site_symmetric_converges(self, small_peps_pair_symmetric):
+        """2-site SymmetricTensor CTM converges."""
+        A, B = small_peps_pair_symmetric
+        env_A, env_B = ctm_tensor_2site(A, B, chi=4, max_iter=20, conv_tol=1e-6)
+        for field in env_A:
+            assert jnp.all(jnp.isfinite(field.todense()))
+        for field in env_B:
+            assert jnp.all(jnp.isfinite(field.todense()))
+
+    def test_2site_symmetric_energy_matches_dense(
+        self, small_peps_pair_symmetric, heisenberg_gate
+    ):
+        """2-site SymmetricTensor energy matches DenseTensor result."""
+        A_sym, B_sym = small_peps_pair_symmetric
+        chi = 6
+
+        A_dense = DenseTensor(A_sym.todense(), A_sym.indices)
+        B_dense = DenseTensor(B_sym.todense(), B_sym.indices)
+
+        env_Ad, env_Bd = ctm_tensor_2site(
+            A_dense, B_dense, chi=chi, max_iter=40, conv_tol=1e-8
+        )
+        E_dense = float(
+            compute_energy_ctm_tensor_2site(
+                A_dense, B_dense, env_Ad, env_Bd, heisenberg_gate, d=2
+            )
+        )
+
+        env_As, env_Bs = ctm_tensor_2site(
+            A_sym, B_sym, chi=chi, max_iter=40, conv_tol=1e-8
+        )
+        E_sym = float(
+            compute_energy_ctm_tensor_2site(
+                A_sym, B_sym, env_As, env_Bs, heisenberg_gate, d=2
+            )
+        )
+
+        np.testing.assert_allclose(E_sym, E_dense, atol=1e-4)


### PR DESCRIPTION
## Summary
- Generalize Tensor-protocol CTM moves to `(env_self, env_neighbor, a_neighbor)` pattern, enabling both 1-site and 2-site checkerboard unit cells with a single code path
- Add `ctm_tensor_2site()`, `compute_energy_ctm_tensor_2site()` public API and `ctm_tensor_converge`/`ctm_tensor_converge_2site` with `@jax.custom_vjp` for implicit differentiation
- Add `_optimize_gs_ad_tensor` and `_optimize_gs_ad_tensor_2site` for Tensor-protocol AD optimization dispatch in `optimize_gs_ad()`
- Fix `DenseTensor.tree_unflatten` to bypass validation for JAX-internal dummy objects (needed for `custom_vjp` backward pass probing)

## Test plan
- [x] All 18 existing 1-site CTM tensor tests pass (regression)
- [x] 4 new 2-site tests: convergence, energy match vs legacy, symmetric convergence, symmetric energy match
- [x] 307 core tests pass
- [x] 325 algorithm tests pass
- [x] 8 integration regression tests pass
- [x] Manual verification: `jax.value_and_grad` through `ctm_tensor_converge_2site` produces finite gradients for both sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)