### PR TITLE
Update docs for tenax.linalg API (svd, qr, eigh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The name **Tenax** combines **Ten**sor network + J**ax**, and is also Latin for 
 - **Split-CTMRG** — ket/bra-separated CTM environment tensors for O(χ³D³) projector cost instead of O(χ³D⁶); works with both `DenseTensor` and `SymmetricTensor` via the Tensor protocol (Naumann et al., arXiv:2502.10298)
 - **Quasiparticle excitations** — iPEPS excitation spectra at arbitrary Brillouin-zone momenta (Ponsioen et al. 2022)
 - **Polymorphic tensor arithmetic** — `+`, `-`, `*`, `-T`, `max_abs`, `inner()`, `conj()`, `dagger()`, `bar()` work identically on `DenseTensor` and `SymmetricTensor`, enabling algorithm code that is agnostic to the underlying storage
-- **Block-sparse SVD and QR** — native symmetry-aware decompositions for `SymmetricTensor`
+- **Block-sparse SVD, QR, and eigh** — native symmetry-aware decompositions in `tenax.linalg` for `SymmetricTensor`
 - **Extensible symmetry system** — non-Abelian symmetry interface for future SU(2) support
 - **Benchmark suite** — CLI-driven performance benchmarks for all algorithms across CPU, CUDA, TPU, and Metal backends
 

--- a/docs/api/contraction.rst
+++ b/docs/api/contraction.rst
@@ -2,5 +2,12 @@ Contraction Engine
 ==================
 
 .. automodule:: tenax.contraction.contractor
-   :members: contract, contract_with_subscripts, truncated_svd, qr_decompose
+   :members: contract, contract_with_subscripts
+   :show-inheritance:
+
+Linear Algebra (Decompositions)
+===============================
+
+.. automodule:: tenax.linalg
+   :members: svd, qr, eigh
    :show-inheritance:

--- a/docs/contraction_semantics.md
+++ b/docs/contraction_semantics.md
@@ -84,13 +84,13 @@ strings receive independent cache entries.
 
 ---
 
-## `truncated_svd(tensor, left_labels, right_labels, ...)`
+## `svd(tensor, left_labels, right_labels, ...)`
 
 SVD splits a tensor into `U, S, Vh, S_full` with an optional truncation of
 singular values:
 
 ```python
-U, S, Vh, S_full = truncated_svd(
+U, S, Vh, S_full = svd(
     theta,
     left_labels=["v0_1", "p0"],
     right_labels=["p1", "v1_2"],
@@ -110,12 +110,27 @@ U, S, Vh, S_full = truncated_svd(
 contains all singular values before truncation, useful for computing truncation
 error without a second SVD.
 
+> The legacy name `truncated_svd` is still available for backward compatibility.
+
 ---
 
-## `qr_decompose(tensor, left_labels, right_labels, new_bond_label)`
+## `qr(tensor, left_labels, right_labels, new_bond_label)`
 
 Thin QR decomposition. The orthogonality column of `Q` corresponds to
 `left_labels`; `R` carries `right_labels`. Used in MPS right-canonicalization.
+
+> The legacy name `qr_decompose` is still available for backward compatibility.
+
+---
+
+## `eigh(tensor, left_labels, right_labels, ...)`
+
+Hermitian eigendecomposition. Reshapes the tensor into a square matrix
+(left_labels vs right_labels), computes `jnp.linalg.eigh`, and returns
+eigenvectors as a Tensor with labels `(left_labels..., new_bond_label)`.
+
+Eigenvalues are sorted in descending order. `max_eigenvalues` keeps only
+the top-k. Dispatches to a block-sparse path for `SymmetricTensor`.
 
 ---
 

--- a/docs/guide/algorithms/ipeps.md
+++ b/docs/guide/algorithms/ipeps.md
@@ -248,5 +248,5 @@ print(f"Energy per site: {energy:.6f}")
 
 The `spinless_fermion_gate()` builds $H = -t \sum (c^\dagger_i c_j + \text{h.c.}) + V \sum n_i n_j$
 as a `SymmetricTensor` with `FermionParity` charges. The simple update uses
-`contract()` and `truncated_svd()` which automatically compute Koszul
+`contract()` and `svd()` which automatically compute Koszul
 signs at every leg crossing. Energy is evaluated via dense CTM fallback.

--- a/docs/guide/contraction.md
+++ b/docs/guide/contraction.md
@@ -1,4 +1,4 @@
-# Contraction, SVD, and QR
+# Contraction and Decompositions
 
 The contraction engine translates label-based tensor operations into optimised
 einsum calls executed by JAX.
@@ -45,16 +45,19 @@ C = contract(A, B, optimize="greedy")     # faster for large networks
 C = contract(A, B, optimize="optimal")    # brute-force optimal
 ```
 
-## Truncated SVD
+Decompositions live in `tenax.linalg` and are re-exported from top-level
+`tenax`.
 
-`truncated_svd` decomposes a tensor into U, s, V^dagger with truncation:
+## SVD
+
+`svd` decomposes a tensor into U, s, V^dagger with truncation:
 
 ```python
-from tenax import truncated_svd
+from tenax import svd
 
 # Split tensor T with legs ("left", "phys", "right") along the cut
 # left_labels vs right_labels
-U, s, Vh, s_full = truncated_svd(
+U, s, Vh, s_full = svd(
     T,
     left_labels=["left", "phys"],
     right_labels=["right"],
@@ -76,15 +79,18 @@ Parameters controlling truncation:
 Both dense and symmetric tensors are supported. For `SymmetricTensor`,
 the SVD is performed block-by-block within each charge sector.
 
+> The legacy name `truncated_svd` is still available for backward
+> compatibility.
+
 ## QR decomposition
 
-`qr_decompose` splits a tensor into an orthogonal factor Q and an upper-
+`qr` splits a tensor into an orthogonal factor Q and an upper-
 triangular factor R:
 
 ```python
-from tenax import qr_decompose
+from tenax import qr
 
-Q, R = qr_decompose(
+Q, R = qr(
     T,
     left_labels=["left", "phys"],
     right_labels=["right"],
@@ -96,6 +102,31 @@ Q, R = qr_decompose(
 
 QR is cheaper than SVD and is useful for canonicalising MPS tensors
 during DMRG sweeps.
+
+> The legacy name `qr_decompose` is still available for backward
+> compatibility.
+
+## Eigendecomposition (eigh)
+
+`eigh` eigendecomposes a Hermitian tensor, returning eigenvectors and
+eigenvalues sorted in descending order:
+
+```python
+from tenax import eigh
+
+V, eigenvalues = eigh(
+    T,
+    left_labels=["left", "phys"],
+    right_labels=["right"],
+    new_bond_label="bond",
+    max_eigenvalues=16,
+)
+# V has legs ("left", "phys", "bond")
+# eigenvalues is a 1D JAX array (descending order)
+```
+
+Like SVD and QR, `eigh` dispatches to a block-sparse path for
+`SymmetricTensor`.
 
 ## Lower-level API
 


### PR DESCRIPTION
## Summary
- Update all doc pages to use canonical `svd`/`qr` names instead of `truncated_svd`/`qr_decompose`, with legacy-name notes
- Add `eigh` sections to guide and semantics docs
- Split `docs/api/contraction.rst` into contraction engine + `tenax.linalg` automodule
- Update README feature bullet to mention `eigh` and `tenax.linalg`
- Fix `truncated_svd()` → `svd()` in iPEPS docs

## Test plan
- [x] `cd docs && make html` builds with no errors or warnings
- [ ] Verify rendered HTML for new eigh sections and updated imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)