### PR TITLE
Add macOS full tests and default to CPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,38 @@ jobs:
         run: uv run ruff check src/ tests/
 
       - name: Run core tests
+        env:
+          JAX_PLATFORMS: cpu
         run: |
           uv run pytest tests/ -m "core" \
+            --cov=tenax \
+            --cov-report=term-missing \
+            -v
+
+  test-full-macos:
+    name: Full tests (macOS, Python 3.12)
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-full-tests')
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run all tests
+        env:
+          JAX_PLATFORMS: cpu
+        run: |
+          uv run pytest tests/ \
             --cov=tenax \
             --cov-report=term-missing \
             -v


### PR DESCRIPTION
## Summary
- Set `JAX_PLATFORMS=cpu` on the existing `test-macos` job to avoid Metal/GPU backend issues
- Add a new `test-full-macos` job that runs the full test suite on `macos-latest` (Python 3.12) with `JAX_PLATFORMS=cpu`, triggered on push to main/dev or PRs with the `run-full-tests` label

## Test plan
- [ ] Verify both macOS jobs appear in CI
- [ ] Confirm `JAX_PLATFORMS=cpu` is set in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)