### PR TITLE
Fix _solve_excitations shape contract violation

### DIFF
--- a/src/tenax/algorithms/ipeps_excitations.py
+++ b/src/tenax/algorithms/ipeps_excitations.py
@@ -584,9 +584,12 @@ def _solve_excitations(
     H_tilde = 0.5 * (H_tilde + H_tilde.conj().T)
     eigvals = np.linalg.eigvalsh(H_tilde)
 
-    # Return the lowest excitation energies
-    n_ret = min(num_excitations, len(eigvals))
-    return eigvals[:n_ret]
+    # Always return exactly num_excitations values (pad with zeros if the
+    # safe subspace is smaller than num_excitations).
+    result = np.zeros(num_excitations)
+    n_fill = min(num_excitations, len(eigvals))
+    result[:n_fill] = eigvals[:n_fill]
+    return result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_solve_excitations()` could return fewer than `num_excitations` values when the safe subspace is smaller than requested, breaking the documented `(num_k, num_excitations)` shape of `ExcitationResult.energies`
- Pad with zeros to always return exactly `num_excitations` values, consistent with the three early-return paths that already do this

## Test plan
- [x] `TestSolveExcitations` unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)