### PR TITLE
Document tensor display and fix excitation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The name **Tenax** combines **Ten**sor network + J**ax**, and is also Latin for 
 - **Polymorphic tensor arithmetic** — `+`, `-`, `*`, `-T`, `max_abs`, `inner()`, `conj()`, `dagger()`, `bar()` work identically on `DenseTensor` and `SymmetricTensor`, enabling algorithm code that is agnostic to the underlying storage
 - **Block-sparse SVD, QR, and eigh** — native symmetry-aware decompositions in `tenax.linalg` for `SymmetricTensor`
 - **Extensible symmetry system** — non-Abelian symmetry interface for future SU(2) support
+- **Tensor display** — ASCII box repr for `DenseTensor` and `SymmetricTensor` showing legs, dimensions, charges, and block stats; `TensorNetwork.to_mermaid()` for Mermaid diagram export
 - **Benchmark suite** — CLI-driven performance benchmarks for all algorithms across CPU, CUDA, TPU, and Metal backends
 
 ## Installation

--- a/docs/guide/algorithms/ad_excitations.md
+++ b/docs/guide/algorithms/ad_excitations.md
@@ -156,10 +156,7 @@ solved after projecting out the null space of $N$.
 import numpy as np
 from tenax import ExcitationConfig, compute_excitations, make_momentum_path
 
-config = ExcitationConfig(
-    num_excitations=3,
-    null_space_tol=1e-3,
-)
+config = ExcitationConfig(num_excitations=3)
 
 momenta = make_momentum_path("brillouin", num_points=20)
 result = compute_excitations(A_opt, env, H_bond, E_gs, momenta, config)

--- a/docs/guide/core_concepts.md
+++ b/docs/guide/core_concepts.md
@@ -180,6 +180,41 @@ t_bar  = tensor.bar()      # conjugate + flip flows (no charge dual)
 For trivial (zero) charges, `dagger()` and `bar()` produce the same dense
 result. They differ only when charges are nontrivial.
 
+### Tensor display
+
+Printing a tensor shows an ASCII box diagram with legs extending left (IN)
+and right (OUT), along with dimension and dtype information:
+
+```python
+print(tensor)
+```
+
+```
+          ┌──────────┐
+phys (2) ──▶┤ Dense    │
+          │ float64  │
+          └──────────┘
+```
+
+For `SymmetricTensor`, the display also shows the symmetry type, block
+count, and charge degeneracy for each leg:
+
+```python
+print(st)
+```
+
+```
+           ┌───────────────┐
+left (3) ──▶┤ Symmetric     ├◀── right (3)
+           │ U(1) 3 blk    │
+           │ float64       │
+           └───────────────┘
+ charges: left{-1:1, 0:1, 1:1} right{-1:1, 0:1, 1:1}
+```
+
+The charge summary `{q: count}` shows how many basis states carry each
+quantum number. For example, `{-1:1, 0:1, 1:1}` means one state per sector.
+
 ### Relabeling
 
 Labels are the key to contraction. Use `relabel` and `relabels` to rename

--- a/docs/guide/tensor_networks.md
+++ b/docs/guide/tensor_networks.md
@@ -111,3 +111,30 @@ Label convention for PEPS site tensors:
 - Horizontal bond (column j to j+1 in row i): `h{i}_{j}_{j+1}`
 - Vertical bond (row i to i+1 in column j): `v{i}_{i+1}_{j}`
 - Physical leg at (i, j): `p{i}_{j}`
+
+## Mermaid diagram export
+
+`TensorNetwork.to_mermaid()` returns a [Mermaid](https://mermaid.js.org/)
+graph string for visualization. Contracted edges are shown as solid lines
+with bond labels; open (free) legs are shown as dangling circle nodes.
+
+```python
+tn = TensorNetwork(name="MPS")
+tn.add_node("A", tensor_A)
+tn.add_node("B", tensor_B)
+tn.connect("A", "bond", "B", "bond")
+
+print(tn.to_mermaid())
+```
+
+```
+graph LR
+  A["A (2,3)"]
+  B["B (3,4)"]
+  A ---|bond| B
+  A -.- A_phys(("phys"))
+  B -.- B_phys(("phys"))
+```
+
+Paste the output into any Mermaid renderer (GitHub markdown, Mermaid Live
+Editor, or VS Code preview) to get an interactive diagram.


### PR DESCRIPTION
## Summary
- Add ASCII box repr documentation to `core_concepts.md` (DenseTensor and SymmetricTensor display)
- Add `TensorNetwork.to_mermaid()` documentation to `tensor_networks.md`
- Add "Tensor display" feature to `README.md` features list
- Fix `ad_excitations.md`: remove explicit `null_space_tol=1e-3` — default is now `1e-2` since PR #78

## Test plan
- [ ] CI passes (docs-only changes, no code modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)