### PR TITLE
Fix tensor display alignment and update doc examples

### DIFF
--- a/docs/guide/core_concepts.md
+++ b/docs/guide/core_concepts.md
@@ -182,38 +182,40 @@ result. They differ only when charges are nontrivial.
 
 ### Tensor display
 
-Printing a tensor shows an ASCII box diagram with legs extending left (IN)
-and right (OUT), along with dimension and dtype information:
+Printing a tensor shows an ASCII box diagram with IN legs on the left
+(`──>`) and OUT legs on the right (`<──`):
 
 ```python
-print(tensor)
+print(tensor)  # DenseTensor with 2 IN legs + 1 OUT leg
 ```
 
 ```
-          ┌──────────┐
-phys (2) ──▶┤ Dense    │
-          │ float64  │
-          └──────────┘
+            ┌─────────┐
+phys (2) ──>┤ Dense   ├<── right (3)
+left (4) ──>┤ float64 │
+            └─────────┘
 ```
 
 For `SymmetricTensor`, the display also shows the symmetry type, block
-count, and charge degeneracy for each leg:
+statistics, and charge degeneracy for each leg:
 
 ```python
-print(st)
+print(st)  # SymmetricTensor with 2 IN legs + 2 OUT legs
 ```
 
 ```
-           ┌───────────────┐
-left (3) ──▶┤ Symmetric     ├◀── right (3)
-           │ U(1) 3 blk    │
-           │ float64       │
-           └───────────────┘
- charges: left{-1:1, 0:1, 1:1} right{-1:1, 0:1, 1:1}
+            ┌──────────────┐
+left (3) ──>┤ Symmetric    ├<── right (3)
+phys (2) ──>┤ U(1) float64 ├<── top (4)
+            │ 14blk nnz=14 │
+            └──────────────┘
+ charges: left{-1:1, 0:1, 1:1} phys{-1:1, 1:1}
+          right{-1:1, 0:1, 1:1} top{-1:1, 0:1, 1:1, 2:1}
 ```
 
 The charge summary `{q: count}` shows how many basis states carry each
-quantum number. For example, `{-1:1, 0:1, 1:1}` means one state per sector.
+quantum number. For example, `{-1:1, 0:1, 1:1}` means one state per
+charge sector.
 
 ### Relabeling
 

--- a/src/tenax/core/tensor.py
+++ b/src/tenax/core/tensor.py
@@ -57,8 +57,8 @@ def _tensor_box_repr(
     ]
 
     # Format leg strings
-    in_strs = [f"{lbl} ({dim}) ──▶" for lbl, dim in in_legs]
-    out_strs = [f"◀── {lbl} ({dim})" for lbl, dim in out_legs]
+    in_strs = [f"{lbl} ({dim}) ──>" for lbl, dim in in_legs]
+    out_strs = [f"<── {lbl} ({dim})" for lbl, dim in out_legs]
 
     # Box content: type name + info lines
     box_content = [type_name] + info_lines

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -123,7 +123,7 @@ class TestDenseTensor:
     def test_repr(self, small_dense_matrix):
         r = repr(small_dense_matrix)
         assert "Dense" in r
-        assert "──▶" in r
+        assert "──>" in r
 
     def test_dtype(self, u1, u1_charges_3, rng):
         data = jax.random.normal(rng, (3,), dtype=jnp.float64)


### PR DESCRIPTION
## Summary
- Replace `▶`/`◀` (double-width in many terminal fonts) with `>`/`<` for correct column alignment in ASCII box repr
- Update `core_concepts.md` examples with real multi-leg tensor output (2 IN + 1 OUT for Dense, 2 IN + 2 OUT for Symmetric)

## Test plan
- [x] repr tests pass locally
- [ ] CI required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)