### PR TITLE
perf: flat buffer storage for SymmetricTensor

### DIFF
--- a/src/tenax/algorithms/_tensor_utils.py
+++ b/src/tenax/algorithms/_tensor_utils.py
@@ -47,7 +47,7 @@ def _scale_bond_axis_symmetric(
     """Block-wise scaling for SymmetricTensor (same logic as fermionic_ipeps)."""
     new_blocks = {}
     idx = T.indices[axis]
-    for key, block in T._blocks.items():
+    for key, block in T.blocks.items():
         charge_val = key[axis]
         positions = np.where(idx.charges == charge_val)[0]
         block_size = block.shape[axis]
@@ -58,7 +58,7 @@ def _scale_bond_axis_symmetric(
 
     obj = object.__new__(SymmetricTensor)
     obj._indices = T._indices
-    obj._blocks = new_blocks
+    obj._init_flat_buffer(new_blocks)
     return obj
 
 
@@ -279,7 +279,7 @@ def _fuse_indices_symmetric(
     # If b is not adjacent to a, we need to transpose the block first
     new_blocks: dict[BlockKey, jax.Array] = {}
 
-    for key, block in T._blocks.items():
+    for key, block in T.blocks.items():
         qa = key[a]
         qb = key[b]
         q_f, offset = offset_map[(int(qa), int(qb))]
@@ -321,7 +321,7 @@ def _fuse_indices_symmetric(
 
     obj = object.__new__(SymmetricTensor)
     obj._indices = new_indices
-    obj._blocks = new_blocks
+    obj._init_flat_buffer(new_blocks)
     return obj
 
 

--- a/src/tenax/algorithms/dmrg.py
+++ b/src/tenax/algorithms/dmrg.py
@@ -938,17 +938,15 @@ def _pad_boundary_symmetric(t: SymmetricTensor, pad_left: bool) -> SymmetricTens
     if pad_left:
         trivial_idx = TensorIndex(sym, trivial_bond, FlowDirection.IN, label="_pad_l")
         new_indices = (trivial_idx,) + t.indices
-        new_blocks = {(0,) + key: arr[np.newaxis, :] for key, arr in t._blocks.items()}
+        new_blocks = {(0,) + key: arr[np.newaxis, :] for key, arr in t.blocks.items()}
     else:
         trivial_idx = TensorIndex(sym, trivial_bond, FlowDirection.OUT, label="_pad_r")
         new_indices = t.indices + (trivial_idx,)
-        new_blocks = {
-            key + (0,): arr[..., np.newaxis] for key, arr in t._blocks.items()
-        }
+        new_blocks = {key + (0,): arr[..., np.newaxis] for key, arr in t.blocks.items()}
 
     obj = object.__new__(SymmetricTensor)
     obj._indices = new_indices
-    obj._blocks = new_blocks
+    obj._init_flat_buffer(new_blocks)
     return obj
 
 
@@ -964,14 +962,14 @@ def _unpad_boundary_symmetric(t: SymmetricTensor, pad_left: bool) -> SymmetricTe
     """
     if pad_left:
         new_indices = t.indices[1:]
-        new_blocks = {key[1:]: arr[0] for key, arr in t._blocks.items()}
+        new_blocks = {key[1:]: arr[0] for key, arr in t.blocks.items()}
     else:
         new_indices = t.indices[:-1]
-        new_blocks = {key[:-1]: arr[..., 0] for key, arr in t._blocks.items()}
+        new_blocks = {key[:-1]: arr[..., 0] for key, arr in t.blocks.items()}
 
     obj = object.__new__(SymmetricTensor)
     obj._indices = new_indices
-    obj._blocks = new_blocks
+    obj._init_flat_buffer(new_blocks)
     return obj
 
 
@@ -1147,7 +1145,7 @@ def _blockwise_contract(
     # satisfy the standard conservation law for environment tensors).
     obj = object.__new__(SymmetricTensor)
     obj._indices = output_indices
-    obj._blocks = output_blocks
+    obj._init_flat_buffer(output_blocks)
     return obj
 
 

--- a/src/tenax/contraction/contractor.py
+++ b/src/tenax/contraction/contractor.py
@@ -479,7 +479,7 @@ def _contract_symmetric(
         # Non-identity target: bypass conservation validation
         obj = object.__new__(SymmetricTensor)
         obj._indices = out_indices_ordered
-        obj._blocks = output_blocks
+        obj._init_flat_buffer(output_blocks)
         return obj
     return SymmetricTensor(output_blocks, out_indices_ordered)
 

--- a/src/tenax/core/tensor.py
+++ b/src/tenax/core/tensor.py
@@ -381,11 +381,16 @@ def inner(a: Tensor, b: Tensor) -> jax.Array:
     if isinstance(a, DenseTensor) and isinstance(b, DenseTensor):
         return jnp.sum(jnp.conj(a._data) * b._data)
     if isinstance(a, SymmetricTensor) and isinstance(b, SymmetricTensor):
-        # Both must have matching block keys
+        # Fast path: identical block structure → single buffer dot
+        if a._block_keys == b._block_keys and a._block_shapes == b._block_shapes:
+            return jnp.sum(jnp.conj(a._data) * b._data)
+        # Slow path: iterate over matching keys
+        a_blocks = a.blocks
+        b_blocks = b.blocks
         total = jnp.zeros((), dtype=a.dtype)
-        for key in a._blocks:
-            if key in b._blocks:
-                total = total + jnp.sum(jnp.conj(a._blocks[key]) * b._blocks[key])
+        for key in a._block_keys:
+            if key in b_blocks:
+                total = total + jnp.sum(jnp.conj(a_blocks[key]) * b_blocks[key])
         return total
     # Mixed types: fall back to dense
     return jnp.sum(jnp.conj(a.todense()) * b.todense())
@@ -618,8 +623,29 @@ class SymmetricTensor(Tensor):
         indices: tuple[TensorIndex, ...],
     ) -> None:
         self._indices = tuple(indices)
-        self._blocks: dict[BlockKey, jax.Array] = dict(blocks)
+        self._init_flat_buffer(blocks)
         self._validate()
+
+    def _init_flat_buffer(self, blocks: dict[BlockKey, jax.Array]) -> None:
+        """Pack block arrays into a single flat 1D buffer with index metadata."""
+        sorted_keys = sorted(blocks.keys())
+        if sorted_keys:
+            flat_parts = [blocks[k].ravel() for k in sorted_keys]
+            self._data: jax.Array = jnp.concatenate(flat_parts)
+        else:
+            self._data = jnp.zeros(0, dtype=jnp.float64)
+        self._block_keys: tuple[BlockKey, ...] = tuple(sorted_keys)
+        shapes = [blocks[k].shape for k in sorted_keys]
+        self._block_shapes: tuple[tuple[int, ...], ...] = tuple(shapes)
+        offsets = []
+        offset = 0
+        for s in shapes:
+            offsets.append(offset)
+            size = 1
+            for d in s:
+                size *= d
+            offset += size
+        self._block_offsets: tuple[int, ...] = tuple(offsets)
 
     def _validate(self) -> None:
         """Verify all block keys satisfy the symmetry conservation law."""
@@ -628,7 +654,7 @@ class SymmetricTensor(Tensor):
         sym = self._indices[0].symmetry
         identity = sym.identity()
 
-        for key in self._blocks:
+        for key in self._block_keys:
             effective = [
                 np.array([int(idx.flow) * int(charge)], dtype=np.int32)
                 for idx, charge in zip(self._indices, key)
@@ -640,28 +666,54 @@ class SymmetricTensor(Tensor):
                     f"fused={fused_val}, expected identity={identity}"
                 )
 
+    def _get_block(self, idx: int) -> jax.Array:
+        """Return the block array at position idx in sorted key order."""
+        offset = self._block_offsets[idx]
+        shape = self._block_shapes[idx]
+        size = 1
+        for d in shape:
+            size *= d
+        return self._data[offset : offset + size].reshape(shape)
+
     # --- Pytree interface ---
 
     def tree_flatten(
         self,
-    ) -> tuple[list[jax.Array], tuple[list[BlockKey], tuple[TensorIndex, ...]]]:
-        # Sort keys for deterministic ordering
-        keys = sorted(self._blocks.keys())
-        arrays = [self._blocks[k] for k in keys]
-        return arrays, (keys, self._indices)
+    ) -> tuple[
+        list[jax.Array],
+        tuple[
+            tuple[BlockKey, ...],
+            tuple[tuple[int, ...], ...],
+            tuple[int, ...],
+            tuple[TensorIndex, ...],
+        ],
+    ]:
+        # Single leaf: the flat data buffer
+        return [self._data], (
+            self._block_keys,
+            self._block_shapes,
+            self._block_offsets,
+            self._indices,
+        )
 
     @classmethod
     def tree_unflatten(
         cls,
-        aux: tuple[list[BlockKey], tuple[TensorIndex, ...]],
+        aux: tuple[
+            tuple[BlockKey, ...],
+            tuple[tuple[int, ...], ...],
+            tuple[int, ...],
+            tuple[TensorIndex, ...],
+        ],
         children: list[jax.Array],
     ) -> SymmetricTensor:
-        keys, indices = aux
-        blocks = dict(zip(keys, children))
-        # Skip validation (keys are already validated at construction time)
+        block_keys, block_shapes, block_offsets, indices = aux
         obj = object.__new__(cls)
+        obj._data = children[0]
+        obj._block_keys = block_keys
+        obj._block_shapes = block_shapes
+        obj._block_offsets = block_offsets
         obj._indices = indices
-        obj._blocks = blocks
         return obj
 
     # --- Factory methods ---
@@ -695,7 +747,7 @@ class SymmetricTensor(Tensor):
             # which would fail standard validation. Bypass it.
             obj = object.__new__(cls)
             obj._indices = tuple(indices)
-            obj._blocks = dict(blocks)
+            obj._init_flat_buffer(dict(blocks))
             return obj
         return cls(blocks, indices)
 
@@ -736,7 +788,7 @@ class SymmetricTensor(Tensor):
             # which would fail standard validation. Bypass it.
             obj = object.__new__(cls)
             obj._indices = tuple(indices)
-            obj._blocks = dict(blocks)
+            obj._init_flat_buffer(dict(blocks))
             return obj
         return cls(blocks, indices)
 
@@ -816,19 +868,20 @@ class SymmetricTensor(Tensor):
 
     @property
     def dtype(self) -> Any:
-        if not self._blocks:
-            return jnp.float64
-        return next(iter(self._blocks.values())).dtype
+        return self._data.dtype if self._data.size > 0 else jnp.float64
 
     @property
     def n_blocks(self) -> int:
         """Number of non-empty charge sectors."""
-        return len(self._blocks)
+        return len(self._block_keys)
 
     @property
     def blocks(self) -> dict[BlockKey, jax.Array]:
-        """Read-only view of the block dict."""
-        return self._blocks
+        """Reconstruct block dict from flat buffer (compatibility layer)."""
+        return {
+            self._block_keys[i]: self._get_block(i)
+            for i in range(len(self._block_keys))
+        }
 
     def todense(self) -> jax.Array:
         """Materialize the full dense tensor (for testing/debugging only).
@@ -839,13 +892,13 @@ class SymmetricTensor(Tensor):
             Dense JAX array of shape tuple(idx.dim for idx in indices).
         """
         shape = tuple(idx.dim for idx in self._indices)
-        if not self._blocks:
+        if self.n_blocks == 0:
             return jnp.zeros(shape, dtype=self.dtype)
 
         # Start from zeros and scatter blocks using JAX-compatible ops
         # so that todense() works under JAX tracing (e.g. inside jax.grad).
         result = jnp.zeros(shape, dtype=self.dtype)
-        for key, block in self._blocks.items():
+        for key, block in self.blocks.items():
             masks, _ = _block_slices(self._indices, key)
             idx_arrays = [np.where(m)[0] for m in masks]
             grid = np.ix_(*idx_arrays)
@@ -854,11 +907,13 @@ class SymmetricTensor(Tensor):
         return result
 
     def conj(self) -> SymmetricTensor:
-        """Return conjugate tensor (conjugate all block arrays)."""
-        new_blocks = {k: jnp.conj(v) for k, v in self._blocks.items()}
+        """Return conjugate tensor (single flat buffer op)."""
         obj = object.__new__(SymmetricTensor)
+        obj._data = jnp.conj(self._data)
+        obj._block_keys = self._block_keys
+        obj._block_shapes = self._block_shapes
+        obj._block_offsets = self._block_offsets
         obj._indices = self._indices
-        obj._blocks = new_blocks
         return obj
 
     def dagger(self) -> SymmetricTensor:
@@ -876,7 +931,7 @@ class SymmetricTensor(Tensor):
         sym = self._indices[0].symmetry if self._indices else None
         new_indices = tuple(idx.dual() for idx in self._indices)
         new_blocks: dict[BlockKey, jax.Array] = {}
-        for key, block in self._blocks.items():
+        for key, block in self.blocks.items():
             new_key = (
                 tuple(int(sym.dual(np.array([q]))[0]) for q in key) if sym else key
             )
@@ -890,16 +945,18 @@ class SymmetricTensor(Tensor):
             new_blocks[new_key] = val
         obj = object.__new__(SymmetricTensor)
         obj._indices = new_indices
-        obj._blocks = new_blocks
+        obj._init_flat_buffer(new_blocks)
         return obj
 
     def bar(self) -> SymmetricTensor:
         """Element-wise conjugate with flipped flows. No charge dual, no twist."""
         new_indices = tuple(idx.flip_flow() for idx in self._indices)
-        new_blocks = {k: jnp.conj(v) for k, v in self._blocks.items()}
         obj = object.__new__(SymmetricTensor)
+        obj._data = jnp.conj(self._data)
+        obj._block_keys = self._block_keys
+        obj._block_shapes = self._block_shapes
+        obj._block_offsets = self._block_offsets
         obj._indices = new_indices
-        obj._blocks = new_blocks
         return obj
 
     def transpose(self, axes: tuple[int, ...]) -> SymmetricTensor:
@@ -919,7 +976,7 @@ class SymmetricTensor(Tensor):
         is_ferm = sym is not None and sym.is_fermionic
 
         new_blocks: dict[BlockKey, jax.Array] = {}
-        for key, block in self._blocks.items():
+        for key, block in self.blocks.items():
             new_key = tuple(key[i] for i in axes)
             transposed = jnp.transpose(block, axes)
             if is_ferm:
@@ -930,19 +987,21 @@ class SymmetricTensor(Tensor):
             new_blocks[new_key] = transposed
         obj = object.__new__(SymmetricTensor)
         obj._indices = new_indices
-        obj._blocks = new_blocks
+        obj._init_flat_buffer(new_blocks)
         return obj
 
     def norm(self) -> jax.Array:
         """Frobenius norm across all blocks."""
-        if not self._blocks:
+        if self.n_blocks == 0:
             return jnp.zeros((), dtype=self.dtype)
-        sq_norms = [jnp.sum(jnp.abs(v) ** 2) for v in self._blocks.values()]
-        return jnp.sqrt(sum(sq_norms))
+        return jnp.sqrt(jnp.sum(jnp.abs(self._data) ** 2))
 
     def block_shapes(self) -> dict[BlockKey, tuple[int, ...]]:
         """Return the shape of each stored block."""
-        return {k: v.shape for k, v in self._blocks.items()}
+        return {
+            self._block_keys[i]: self._block_shapes[i]
+            for i in range(len(self._block_keys))
+        }
 
     def relabel(self, old: Label, new: Label) -> SymmetricTensor:
         """Return a copy with one leg label renamed.
@@ -971,7 +1030,10 @@ class SymmetricTensor(Tensor):
             )
         obj = object.__new__(SymmetricTensor)
         obj._indices = tuple(new_indices)
-        obj._blocks = self._blocks
+        obj._data = self._data
+        obj._block_keys = self._block_keys
+        obj._block_shapes = self._block_shapes
+        obj._block_offsets = self._block_offsets
         return obj
 
     def relabels(self, mapping: dict[Label, Label]) -> SymmetricTensor:
@@ -990,14 +1052,19 @@ class SymmetricTensor(Tensor):
         )
         obj = object.__new__(SymmetricTensor)
         obj._indices = new_indices
-        obj._blocks = self._blocks
+        obj._data = self._data
+        obj._block_keys = self._block_keys
+        obj._block_shapes = self._block_shapes
+        obj._block_offsets = self._block_offsets
         return obj
 
     def __mul__(self, scalar: float) -> SymmetricTensor:
-        new_blocks = {k: v * scalar for k, v in self._blocks.items()}
         obj = object.__new__(SymmetricTensor)
         obj._indices = self._indices
-        obj._blocks = new_blocks
+        obj._data = self._data * scalar
+        obj._block_keys = self._block_keys
+        obj._block_shapes = self._block_shapes
+        obj._block_offsets = self._block_offsets
         return obj
 
     def __rmul__(self, scalar: float) -> SymmetricTensor:
@@ -1009,19 +1076,33 @@ class SymmetricTensor(Tensor):
                 f"Cannot add SymmetricTensor and {type(other).__name__}; "
                 f"convert to matching type first."
             )
-        # Union of block keys: add where both exist, copy where only one exists
+        # Fast path: identical block structure → single buffer add
+        if (
+            self._block_keys == other._block_keys
+            and self._block_shapes == other._block_shapes
+        ):
+            obj = object.__new__(SymmetricTensor)
+            obj._data = self._data + other._data
+            obj._block_keys = self._block_keys
+            obj._block_shapes = self._block_shapes
+            obj._block_offsets = self._block_offsets
+            obj._indices = self._indices
+            return obj
+        # Slow path: union of block keys
+        self_blocks = self.blocks
+        other_blocks = other.blocks
         new_blocks: dict[BlockKey, jax.Array] = {}
-        all_keys = set(self._blocks.keys()) | set(other._blocks.keys())
+        all_keys = set(self._block_keys) | set(other._block_keys)
         for key in all_keys:
-            if key in self._blocks and key in other._blocks:
-                new_blocks[key] = self._blocks[key] + other._blocks[key]
-            elif key in self._blocks:
-                new_blocks[key] = self._blocks[key]
+            if key in self_blocks and key in other_blocks:
+                new_blocks[key] = self_blocks[key] + other_blocks[key]
+            elif key in self_blocks:
+                new_blocks[key] = self_blocks[key]
             else:
-                new_blocks[key] = other._blocks[key]
+                new_blocks[key] = other_blocks[key]
         obj = object.__new__(SymmetricTensor)
         obj._indices = self._indices
-        obj._blocks = new_blocks
+        obj._init_flat_buffer(new_blocks)
         return obj
 
     def __sub__(self, other: Tensor) -> SymmetricTensor:
@@ -1035,12 +1116,12 @@ class SymmetricTensor(Tensor):
         return self.__mul__(-1.0)
 
     def max_abs(self) -> jax.Array:
-        if not self._blocks:
+        if self.n_blocks == 0:
             return jnp.zeros((), dtype=self.dtype)
-        return jnp.max(jnp.stack([jnp.max(jnp.abs(v)) for v in self._blocks.values()]))
+        return jnp.max(jnp.abs(self._data))
 
     def __repr__(self) -> str:
-        total_elements = sum(v.size for v in self._blocks.values())
+        total_elements = int(self._data.size)
         sym_name = self._indices[0].symmetry.__class__.__name__ if self._indices else ""
         # Short symmetry label: U1Symmetry -> U(1), ZnSymmetry(3) -> Z(3)
         sym = self._indices[0].symmetry if self._indices else None

--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -322,10 +322,10 @@ def _truncated_svd_symmetric(
         # Bypass validation for non-identity targets
         U_tensor = object.__new__(SymmetricTensor)
         U_tensor._indices = U_indices
-        U_tensor._blocks = U_blocks
+        U_tensor._init_flat_buffer(U_blocks)
         Vh_tensor = object.__new__(SymmetricTensor)
         Vh_tensor._indices = Vh_indices
-        Vh_tensor._blocks = Vh_blocks
+        Vh_tensor._init_flat_buffer(Vh_blocks)
     else:
         U_tensor = SymmetricTensor(U_blocks, U_indices)
         Vh_tensor = SymmetricTensor(Vh_blocks, Vh_indices)

--- a/tests/test_dmrg.py
+++ b/tests/test_dmrg.py
@@ -563,7 +563,7 @@ class TestSymmetricBlockSparseDMRG:
         # Pad right: (v0, p0, p1) → (v0, p0, p1, _pad_r)
         padded = _pad_boundary_symmetric(t_3d, pad_left=False)
         assert padded.ndim == 4
-        for key, arr in padded._blocks.items():
+        for key, arr in padded.blocks.items():
             assert arr.shape == (2, 2, 2, 1), f"Expected (2,2,2,1) but got {arr.shape}"
 
         # Unpad right: (v0, p0, p1, _pad_r) → (v0, p0, p1)

--- a/tests/test_integration_regression.py
+++ b/tests/test_integration_regression.py
@@ -170,7 +170,7 @@ class TestBlockPreservation:
 
         chi, chi_I = 4, 2
         env = initialize_split_ctm_tensor_env(A, chi, chi_I)
-        init_blocks = min(len(t._blocks) for t in env)
+        init_blocks = min(t.n_blocks for t in env)
 
         for _ in range(5):
             env = _split_ctm_tensor_sweep(env, A, chi, chi_I, True)
@@ -179,8 +179,8 @@ class TestBlockPreservation:
             assert isinstance(t, SymmetricTensor), (
                 "Env tensor lost SymmetricTensor type after split CTM sweeps"
             )
-            assert len(t._blocks) >= init_blocks, (
-                f"Block count dropped from {init_blocks} to {len(t._blocks)}: "
+            assert t.n_blocks >= init_blocks, (
+                f"Block count dropped from {init_blocks} to {t.n_blocks}: "
                 f"charge sectors collapsed"
             )
 

--- a/tests/test_split_ctm_tensor.py
+++ b/tests/test_split_ctm_tensor.py
@@ -397,7 +397,7 @@ class TestSplitCTMSymmetric:
         chi, chi_I = 4, 2
         env = initialize_split_ctm_tensor_env(A, chi, chi_I)
         # Check initial block count
-        init_blocks = len(env.C1._blocks)
+        init_blocks = env.C1.n_blocks
         # Run 3 sweeps
         for _ in range(3):
             env = _split_ctm_tensor_sweep(env, A, chi, chi_I, True)
@@ -406,7 +406,7 @@ class TestSplitCTMSymmetric:
             assert isinstance(t, SymmetricTensor), (
                 f"Expected SymmetricTensor, got {type(t)}"
             )
-            assert len(t._blocks) >= init_blocks, (
-                f"Block count dropped from {init_blocks} to {len(t._blocks)}: "
+            assert t.n_blocks >= init_blocks, (
+                f"Block count dropped from {init_blocks} to {t.n_blocks}: "
                 f"charge sectors collapsed"
             )

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -227,6 +227,15 @@ class TestSymmetricTensorCreation:
         with pytest.raises(ValueError):
             SymmetricTensor.from_dense(dense, indices)
 
+    def test_flat_buffer_storage(self, u1_sym_tensor_2leg):
+        """SymmetricTensor stores data in a single flat buffer."""
+        t = u1_sym_tensor_2leg
+        assert hasattr(t, "_data"), "Expected flat buffer _data attribute"
+        assert isinstance(t._data, jax.Array), "_data should be a jax.Array"
+        assert t._data.ndim == 1, "_data should be 1D"
+        total = sum(v.size for v in t.blocks.values())
+        assert t._data.size == total
+
 
 class TestSymmetricTensorOperations:
     def test_todense_shape(self, u1_sym_tensor_2leg):


### PR DESCRIPTION
## Summary

- Replace `dict[BlockKey, jax.Array]` internal storage with a single contiguous 1D `jax.Array` flat buffer
- Reduce JAX pytree leaves from N (one per block) to 1, improving JIT compilation and gradient propagation
- Element-wise ops (`conj`, `bar`, `mul`, `neg`, `norm`, `max_abs`, `inner_product`, `__add__`) operate directly on the flat buffer when block structure matches — no per-block iteration
- Static index metadata (`_block_keys`, `_block_shapes`, `_block_offsets`) stored as pytree aux data
- Backward-compatible `.blocks` property reconstructs the dict on-the-fly for external callers (contraction, SVD, DMRG)
- All `._blocks` direct access across the codebase migrated to use `.blocks` property or `_from_blocks_bypass()`

## Test plan

- [x] 736 non-slow tests pass (0 failures)
- [x] New `test_flat_buffer_storage` verifies 1D buffer structure
- [x] JIT and grad pytree tests pass with single-leaf structure
- [x] iPEPS AD optimization tests pass (JAX tracing through `tree_unflatten`)
- [x] Ruff lint and format clean
- [ ] CI: Python 3.11, 3.12, macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)