### PR TITLE
Add block-sparse QR projector for symmetric CTM

### DIFF
--- a/src/tenax/algorithms/_ctm_tensor.py
+++ b/src/tenax/algorithms/_ctm_tensor.py
@@ -103,7 +103,6 @@ def _eigh_projector_symmetric(
     fused_pos = C1g.labels().index("fused")
     col_pos = 1 - fused_pos  # the other leg
     fused_idx = C1g.indices[fused_pos]
-    sym = fused_idx.symmetry
 
     # Group blocks by fused charge for each corner
     def _group_by_fused(Cg: SymmetricTensor) -> dict[int, list[tuple[int, jax.Array]]]:
@@ -182,10 +181,32 @@ def _eigh_projector_symmetric(
         V_q = jax.lax.stop_gradient(V_q)
         proj_blocks[(fq, fq)] = V_q
 
+    return _build_symmetric_projector(
+        proj_blocks, chi_new_charges, fused_idx, C1g.dtype
+    )
+
+
+def _build_symmetric_projector(
+    proj_blocks: dict[tuple[int, ...], jax.Array],
+    chi_new_charges: list[int],
+    fused_idx: TensorIndex,
+    dtype: jnp.dtype,
+) -> SymmetricTensor:
+    """Assemble a projector SymmetricTensor from per-sector blocks.
+
+    Args:
+        proj_blocks: Map ``(fq, fq) -> V_q`` of eigenvector blocks.
+        chi_new_charges: Flat list of chi_new charges (one per kept vector).
+        fused_idx: The fused TensorIndex (row index of the projector).
+        dtype: Data type for the output tensor.
+
+    Returns:
+        SymmetricTensor with indices ``(fused_idx, chi_new_idx)``.
+    """
+    sym = fused_idx.symmetry
     chi_new_idx = TensorIndex(
         sym, np.array(chi_new_charges, dtype=np.int32), OUT, label="chi_new"
     )
-    # Construct SymmetricTensor directly — blocks already satisfy conservation.
     obj = object.__new__(SymmetricTensor)
     obj._indices = (fused_idx, chi_new_idx)
     sorted_keys = sorted(proj_blocks.keys())
@@ -193,7 +214,7 @@ def _eigh_projector_symmetric(
         flat_parts = [proj_blocks[k].ravel() for k in sorted_keys]
         obj._data = jnp.concatenate(flat_parts)
     else:
-        obj._data = jnp.zeros(0, dtype=C1g.dtype)
+        obj._data = jnp.zeros(0, dtype=dtype)
     obj._block_keys = tuple(sorted_keys)
     shapes = [proj_blocks[k].shape for k in sorted_keys]
     obj._block_shapes = tuple(shapes)
@@ -207,6 +228,116 @@ def _eigh_projector_symmetric(
         offset += size
     obj._block_offsets = tuple(offsets)
     return obj
+
+
+def _qr_projector_symmetric(
+    C1g: SymmetricTensor,
+    C4g: SymmetricTensor,
+    chi: int,
+) -> SymmetricTensor:
+    r"""Block-sparse projector via per-sector QR + small eigh.
+
+    For each charge sector *q* of the ``fused`` leg, concatenates the
+    column-blocks from both grown corners to form :math:`M_q`, then
+    QR-factors :math:`M_q = Q_q R_q`.  The reduced eigenproblem
+    :math:`R_q R_q^\dagger` is cheaper than the full
+    :math:`\rho_q = M_q M_q^\dagger` when the column dimension is small.
+
+    Eigenvalues are merged across sectors and globally truncated to *chi*.
+
+    Args:
+        C1g: Grown corner SymmetricTensor ``(fused, col1)``.
+        C4g: Grown corner SymmetricTensor ``(fused, col2)``.
+        chi: Target bond dimension.
+
+    Returns:
+        Projector ``P`` with labels ``(fused, chi_new)``, flows ``(IN, OUT)``.
+    """
+    fused_pos = C1g.labels().index("fused")
+    col_pos = 1 - fused_pos
+    fused_idx = C1g.indices[fused_pos]
+
+    # Group blocks by fused charge for each corner
+    def _group_by_fused(
+        Cg: SymmetricTensor,
+    ) -> dict[int, list[tuple[int, jax.Array]]]:
+        grouped: dict[int, list[tuple[int, jax.Array]]] = {}
+        for key, block in Cg.blocks.items():
+            fq = int(key[fused_pos])
+            cq = int(key[col_pos])
+            grouped.setdefault(fq, []).append((cq, block))
+        return grouped
+
+    c1_groups = _group_by_fused(C1g)
+    c4_groups = _group_by_fused(C4g)
+    all_fused_charges = sorted(set(c1_groups.keys()) | set(c4_groups.keys()))
+
+    charges_arr = np.asarray(fused_idx.charges)
+    charge_rows: dict[int, np.ndarray] = {}
+    for fq in all_fused_charges:
+        charge_rows[fq] = np.where(charges_arr == fq)[0]
+
+    # Per-sector QR + small eigh
+    sector_results: dict[int, tuple[jax.Array, jax.Array]] = {}  # fq -> (P_q, eigvals)
+
+    for fq in all_fused_charges:
+        fused_dim = int(len(charge_rows.get(fq, [])))
+        if fused_dim == 0:
+            continue
+
+        # Collect column blocks from both corners for this fused charge
+        col_blocks: list[jax.Array] = []
+        for entries in [c1_groups.get(fq, []), c4_groups.get(fq, [])]:
+            for _cq, block in entries:
+                if fused_pos == 0:
+                    col_blocks.append(block.reshape(fused_dim, -1))
+                else:
+                    col_blocks.append(block.reshape(-1, fused_dim).T)
+
+        if not col_blocks:
+            continue
+
+        M_q = jnp.concatenate(col_blocks, axis=1)  # (fused_dim, total_col)
+        Q_q, R_q = jnp.linalg.qr(M_q)
+
+        rho_small = R_q @ R_q.conj().T
+        rho_small = 0.5 * (rho_small + rho_small.conj().T)
+        eigvals, eigvecs = jnp.linalg.eigh(rho_small)
+
+        # P_q = Q @ eigvecs maps from reduced space back to fused space
+        P_q = Q_q @ eigvecs  # (fused_dim, min(fused_dim, total_col))
+        sector_results[fq] = (P_q, eigvals)
+
+    # Global truncation across sectors
+    all_eig_pairs: list[tuple[float, int, int]] = []
+    for fq, (_, eigvals) in sector_results.items():
+        for i, val in enumerate(np.array(eigvals)):
+            all_eig_pairs.append((float(val), fq, i))
+
+    all_eig_pairs.sort(key=lambda x: (-x[0], -x[2]))
+    n_keep = min(chi, len(all_eig_pairs))
+
+    sector_keep: dict[int, list[int]] = {}
+    for _, fq, idx in all_eig_pairs[:n_keep]:
+        sector_keep.setdefault(fq, []).append(idx)
+
+    # Build projector blocks
+    chi_new_charges: list[int] = []
+    proj_blocks: dict[tuple[int, ...], jax.Array] = {}
+
+    for fq in sorted(sector_keep.keys()):
+        keep_indices = sorted(sector_keep[fq], reverse=True)
+        n_q = len(keep_indices)
+        chi_new_charges.extend([fq] * n_q)
+
+        P_q, _ = sector_results[fq]
+        V_q = P_q[:, keep_indices]  # (fused_dim, n_q)
+        V_q = jax.lax.stop_gradient(V_q)
+        proj_blocks[(fq, fq)] = V_q
+
+    return _build_symmetric_projector(
+        proj_blocks, chi_new_charges, fused_idx, C1g.dtype
+    )
 
 
 def _compute_projector_tensor(
@@ -225,8 +356,8 @@ def _compute_projector_tensor(
     ``[C1g, C4g]`` to reduce to a small ``(2*col, 2*col)`` eigenproblem,
     following the approach in arXiv:2505.00494.
 
-    For SymmetricTensor inputs with ``"eigh"``, uses block-sparse eigh
-    (per charge sector) to avoid dense round-trip.
+    For SymmetricTensor inputs (both ``"eigh"`` and ``"qr"``), uses
+    per-charge-sector decomposition to avoid dense round-trip.
 
     Args:
         C1g: Grown corner with labels ``(fused, <col1>)``.
@@ -246,8 +377,17 @@ def _compute_projector_tensor(
             f"Unknown projector_method={projector_method!r}; expected 'eigh' or 'qr'."
         )
 
-    # --- QR path: densify → QR → small eigh ---
+    # --- QR path ---
     if projector_method == "qr":
+        # Block-sparse QR for SymmetricTensor (non-tracer)
+        if isinstance(C1g, SymmetricTensor) and isinstance(C4g, SymmetricTensor):
+            has_tracers = isinstance(C1g._data, jax.core.Tracer) or isinstance(
+                C4g._data, jax.core.Tracer
+            )
+            if not has_tracers and C1g.n_blocks > 0 and C4g.n_blocks > 0:
+                return _qr_projector_symmetric(C1g, C4g, chi)
+
+        # Dense QR fallback
         C1g_dense = C1g.todense()
         C4g_dense = C4g.todense()
 

--- a/tests/test_ctm_tensor.py
+++ b/tests/test_ctm_tensor.py
@@ -555,17 +555,13 @@ class TestQRProjectorMethod:
 
 
 class TestProjectorSymmetric:
-    def test_projector_symmetric_matches_dense(self, small_peps_symmetric):
-        """Block-sparse projector matches dense projector output."""
+    @staticmethod
+    def _build_grown_corners(A, chi):
+        """Build grown corners from a symmetric iPEPS tensor (left move)."""
         from tenax.contraction.contractor import contract
 
-        A = small_peps_symmetric
-        chi = 4
-
-        _build_double_layer_tensor(A)  # ensure it doesn't error
         env = initialize_ctm_tensor_env(A, chi)
 
-        # Build grown corners like a left move
         C1_r = env.C1.relabel("c1_r", "t1_l")
         C1g = contract(C1_r, env.T1)
         C1g = _fuse_pair_by_label(C1g, "c1_d", "u2", "fused", FlowDirection.IN)
@@ -574,8 +570,18 @@ class TestProjectorSymmetric:
         C4g = contract(C4_u, env.T3)
         C4g = _fuse_pair_by_label(C4g, "c4_r", "d2", "fused", FlowDirection.IN)
 
+        return C1g, C4g
+
+    def test_projector_symmetric_matches_dense(self, small_peps_symmetric):
+        """Block-sparse eigh projector matches dense projector output."""
+        A = small_peps_symmetric
+        chi = 4
+
+        _build_double_layer_tensor(A)  # ensure it doesn't error
+        C1g, C4g = self._build_grown_corners(A, chi)
+
         # Compute projector via symmetric path
-        P_sym = _compute_projector_tensor(C1g, C4g, chi)
+        P_sym = _compute_projector_tensor(C1g, C4g, chi, projector_method="eigh")
 
         # Dense reference
         C1g_d = C1g.todense()
@@ -592,3 +598,37 @@ class TestProjectorSymmetric:
         proj_sym = P_sym_d @ P_sym_d.T
         proj_ref = P_ref @ P_ref.T
         np.testing.assert_allclose(proj_sym, proj_ref, atol=1e-10)
+
+    def test_qr_projector_symmetric_matches_eigh(self, small_peps_symmetric):
+        """Block-sparse QR projector subspace matches eigh projector subspace."""
+        A = small_peps_symmetric
+        chi = 4
+
+        C1g, C4g = self._build_grown_corners(A, chi)
+
+        P_eigh = _compute_projector_tensor(C1g, C4g, chi, projector_method="eigh")
+        P_qr = _compute_projector_tensor(C1g, C4g, chi, projector_method="qr")
+
+        # Both should be SymmetricTensor
+        assert isinstance(P_eigh, SymmetricTensor)
+        assert isinstance(P_qr, SymmetricTensor)
+
+        # Projection matrices should span the same subspace
+        Pe = P_eigh.todense()
+        Pq = P_qr.todense()
+        proj_eigh = Pe @ Pe.T
+        proj_qr = Pq @ Pq.T
+        np.testing.assert_allclose(proj_qr, proj_eigh, atol=1e-10)
+
+    def test_ctm_tensor_qr_symmetric_converges(self, small_peps_symmetric):
+        """CTM with QR projector converges for symmetric tensors."""
+        env = ctm_tensor(
+            small_peps_symmetric,
+            chi=4,
+            max_iter=20,
+            conv_tol=1e-6,
+            projector_method="qr",
+            qr_warmup_steps=3,
+        )
+        for field in env:
+            assert jnp.all(jnp.isfinite(field.todense()))


### PR DESCRIPTION
## Summary

- **Layer 3**: Add `_qr_projector_symmetric` — per-sector QR + small eigh for SymmetricTensor, mirroring the existing `_eigh_projector_symmetric`. The QR path now avoids `todense()` and assigns correct per-sector `chi_new` charges
- **Refactor**: Extract `_build_symmetric_projector` helper shared by both eigh and QR paths, eliminating duplicated block-assembly code
- **Layer 4 (convergence)**: Intentionally kept as-is — `todense()` on chi×chi corner is negligible cost

### Remaining `todense()` calls
- Convergence check (chi×chi corner SVD) — negligible, kept
- Dense eigh fallback (AD/tracer path) — can't sort tracers for global truncation
- Energy bridge functions — requires polymorphic `compute_energy_ctm`, larger scope

## Test plan

- [x] `test_qr_projector_symmetric_matches_eigh` — subspace match between QR and eigh projectors
- [x] `test_ctm_tensor_qr_symmetric_converges` — QR CTM converges for symmetric tensors
- [x] All 50 CTM + integration tests pass
- [x] All 359 core tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)