### PR TITLE
Reject L<2 in dmrg() and fix build_mps/build_peps docstrings

### DIFF
--- a/.claude/skills/tenax-tensor-ops/SKILL.md
+++ b/.claude/skills/tenax-tensor-ops/SKILL.md
@@ -221,8 +221,8 @@ result = tn.contract()  # Contract the whole network
 ```python
 from tenax import build_mps, build_peps
 
-mps = build_mps(tensors, open_boundary=True)    # 1D chain
-peps = build_peps(tensors, Lx, Ly, open_boundary=True)  # 2D grid
+mps = build_mps(tensors)                # 1D chain
+peps = build_peps(tensors, Lx, Ly)      # 2D grid
 ```
 
 ---

--- a/src/tenax/algorithms/dmrg.py
+++ b/src/tenax/algorithms/dmrg.py
@@ -142,6 +142,11 @@ def dmrg(
         DMRGResult with energy, sweep history, optimized MPS, and diagnostics.
     """
     L = hamiltonian.n_nodes()
+    if L < 2:
+        raise ValueError(
+            f"DMRG requires at least 2 sites, got L={L}. "
+            "For a single site, diagonalize the operator directly."
+        )
     mps_tensors: list[Tensor] = [initial_mps.get_tensor(i) for i in range(L)]
     mpo_tensors = [hamiltonian.get_tensor(i) for i in range(L)]
 

--- a/src/tenax/network/network.py
+++ b/src/tenax/network/network.py
@@ -622,26 +622,18 @@ class TensorNetwork:
 
 def build_mps(
     tensors: list[Tensor],
-    open_boundary: bool = True,
 ) -> TensorNetwork:
     """Build a Matrix Product State as a TensorNetwork.
 
-    Tensors are expected to have legs labeled with a convention that
-    allows adjacent tensors to share virtual bond labels. If the tensors
-    already have matching virtual bond labels (e.g., right label of site i
-    matches left label of site i+1), they will be auto-connected.
-
-    If virtual bond labels don't match, default virtual bonds are created:
-    - Site i: left="v{i-1}_{i}", phys="p{i}", right="v{i}_{i+1}"
-
-    Physical legs are not connected (they remain open).
+    Adjacent tensors are connected wherever they share a common label
+    with compatible dimensions.  Labels that appear on only one tensor
+    remain as open (dangling) legs.
 
     Args:
-        tensors:        List of site tensors [A_0, A_1, ..., A_{L-1}].
-        open_boundary:  If True, boundary virtual legs remain open.
+        tensors: List of site tensors [A_0, A_1, ..., A_{L-1}].
 
     Returns:
-        TensorNetwork with virtual bonds connected.
+        TensorNetwork with shared virtual bonds connected.
     """
     L = len(tensors)
     tn = TensorNetwork(name="MPS")
@@ -669,23 +661,17 @@ def build_peps(
     tensors: list[list[Tensor]],
     Lx: int,
     Ly: int,
-    open_boundary: bool = True,
 ) -> TensorNetwork:
     """Build a PEPS (2D tensor network) as a TensorNetwork.
 
-    Tensors are organized in a 2D grid tensors[i][j] for row i, column j.
-    Adjacent tensors are connected by shared virtual bond labels.
-
-    Convention for virtual bond labels (if not already matching):
-    - Horizontal bond (j, j+1) in row i: "h{i}_{j}_{j+1}"
-    - Vertical bond row (i, i+1) in column j: "v{i}_{i+1}_{j}"
-    - Physical leg at (i,j): "p{i}_{j}"
+    Tensors are organized in a 2D grid ``tensors[i][j]`` for row *i*,
+    column *j*.  Horizontal and vertical neighbours are connected wherever
+    they share a common label with compatible dimensions.
 
     Args:
-        tensors:       2D list [Lx][Ly] of site tensors.
-        Lx:            Number of rows.
-        Ly:            Number of columns.
-        open_boundary: If True, boundary virtual legs remain open.
+        tensors: 2D list [Lx][Ly] of site tensors.
+        Lx:      Number of rows.
+        Ly:      Number of columns.
 
     Returns:
         TensorNetwork with virtual bonds connected.

--- a/tests/test_code_review_regressions.py
+++ b/tests/test_code_review_regressions.py
@@ -477,24 +477,22 @@ class TestSymmetricTensorAddChargeValidation:
 
 
 class TestDMRGSingleSite:
-    """P1 regression: DMRG on L=1 must return correct on-site energy,
-    not the default 0.0."""
+    """P1 regression: DMRG on L=1 must reject the input instead of
+    silently returning a bogus zero energy."""
 
-    def test_dmrg_l1_returns_correct_energy(self):
+    def test_dmrg_l1_raises(self):
         from tenax.algorithms.auto_mpo import AutoMPO, spin_half_ops
         from tenax.algorithms.dmrg import DMRGConfig, build_random_mps, dmrg
 
         L = 1
-        hz = 1.0
         ops = spin_half_ops()
         auto = AutoMPO(L=L, d=2, site_ops=ops)
-        auto.add_term(hz, "Sz", 0)
+        auto.add_term(1.0, "Sz", 0)
         mpo = auto.to_mpo()
         mps = build_random_mps(L=L, physical_dim=2, bond_dim=2, seed=0)
-        config = DMRGConfig(max_bond_dim=4, num_sweeps=5, convergence_tol=1e-10)
-        result = dmrg(mpo, mps, config)
-        # Ground state of hz*Sz is E = -hz/2
-        np.testing.assert_allclose(result.energy, -hz / 2, atol=1e-8)
+        config = DMRGConfig(max_bond_dim=4, num_sweeps=5)
+        with pytest.raises(ValueError, match="at least 2 sites"):
+            dmrg(mpo, mps, config)
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary
- **P1: dmrg() L=1 guard** — `dmrg()` now raises `ValueError` for `L < 2` instead of silently returning a bogus zero energy. Single-site problems should be solved by direct diagonalization.
- **P2: build_mps/build_peps docstring mismatch** — Docstrings claimed auto-relabeling and `open_boundary` behavior that was never implemented. Fixed docstrings to accurately describe the shared-label auto-connect behavior; removed the unused `open_boundary` parameter from both functions.

## Test plan
- [x] Regression test updated to assert `ValueError` on L=1
- [x] 390 core tests pass
- [x] No callers use `open_boundary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)