### PR TITLE
Fix Sphinx exclude, connect_by_shared_label atomicity, build_peps validation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ source_suffix = {
     ".rst": "restructuredtext",
     ".md": "markdown",
 }
-exclude_patterns = ["_build"]
+exclude_patterns = ["_build", "plans"]
 
 # Suppress third-party deprecation warnings during build
 warnings.filterwarnings(


### PR DESCRIPTION
## Summary
- **Sphinx**: Adds `"plans"` to `exclude_patterns` in `docs/conf.py` so `docs/plans/*.md` don't trigger toctree warnings
- **P1: connect_by_shared_label atomicity** — validates all shared labels before connecting any, so the network is not left partially mutated on failure
- **P2: build_peps grid validation** — validates that `tensors` grid matches `Lx`/`Ly` upfront instead of crashing with `IndexError` or silently dropping tensors

## Test plan
- [x] 21 regression tests pass
- [x] 394 core tests pass
- [x] Docs build should pass (Sphinx exclude fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)