### PR TITLE
Make connect_by_shared_label transactional, validate builders

### DIFF
--- a/src/tenax/network/network.py
+++ b/src/tenax/network/network.py
@@ -248,12 +248,25 @@ class TensorNetwork:
                 f"(labels={sorted(labels_b)})"
             )
 
-        count = 0
-        for label in sorted(shared, key=str):
-            self.connect(node_a, label, node_b, label)
-            count += 1
+        # Validate all shared labels before mutating, so the network is
+        # not left partially connected on failure.
+        sorted_shared = sorted(shared, key=str)
+        for label in sorted_shared:
+            idx_a = self._get_index(node_a, label)
+            idx_b = self._get_index(node_b, label)
+            if not idx_a.compatible_with(idx_b):
+                raise ValueError(
+                    f"Incompatible indices on shared label {label!r}: "
+                    f"{node_a!r} (dim={idx_a.dim}, flow={idx_a.flow.name}) "
+                    f"vs {node_b!r} (dim={idx_b.dim}, flow={idx_b.flow.name})"
+                )
 
-        return count
+        # Already validated; bypass connect() to avoid re-checking.
+        for label in sorted_shared:
+            self._graph.add_edge(node_a, node_b, label_a=label, label_b=label)
+        self._invalidate_cache()
+
+        return len(sorted_shared)
 
     def disconnect(
         self,
@@ -647,12 +660,8 @@ def build_mps(
         labels_next = set(tensors[i + 1].labels())
         shared = labels_i & labels_next
 
-        if shared:
-            for label in sorted(shared, key=str):
-                try:
-                    tn.connect(i, label, i + 1, label)
-                except ValueError:
-                    pass  # incompatible dimensions, skip
+        for label in sorted(shared, key=str):
+            tn.connect(i, label, i + 1, label)
 
     return tn
 
@@ -676,6 +685,16 @@ def build_peps(
     Returns:
         TensorNetwork with virtual bonds connected.
     """
+    if len(tensors) != Lx:
+        raise ValueError(
+            f"tensors has {len(tensors)} rows but Lx={Lx}"
+        )
+    for i, row in enumerate(tensors):
+        if len(row) != Ly:
+            raise ValueError(
+                f"tensors[{i}] has {len(row)} columns but Ly={Ly}"
+            )
+
     tn = TensorNetwork(name="PEPS")
 
     # Add all nodes
@@ -690,10 +709,7 @@ def build_peps(
             labels_next = set(tensors[i][j + 1].labels())
             shared = labels_ij & labels_next
             for label in sorted(shared, key=str):
-                try:
-                    tn.connect((i, j), label, (i, j + 1), label)
-                except ValueError:
-                    pass
+                tn.connect((i, j), label, (i, j + 1), label)
 
     # Connect vertical neighbors
     for i in range(Lx - 1):
@@ -702,9 +718,6 @@ def build_peps(
             labels_next = set(tensors[i + 1][j].labels())
             shared = labels_ij & labels_next
             for label in sorted(shared, key=str):
-                try:
-                    tn.connect((i, j), label, (i + 1, j), label)
-                except ValueError:
-                    pass
+                tn.connect((i, j), label, (i + 1, j), label)
 
     return tn

--- a/tests/test_code_review_regressions.py
+++ b/tests/test_code_review_regressions.py
@@ -583,3 +583,109 @@ class TestReplaceTensorValidation:
         )
         with pytest.raises(ValueError, match="flow"):
             tn.replace_tensor("A", T1_bad)
+
+
+# ------------------------------------------------------------------ #
+# P1: connect_by_shared_label atomicity                               #
+# ------------------------------------------------------------------ #
+
+
+class TestConnectBySharedLabelAtomicity:
+    """connect_by_shared_label must not leave partial edges on failure."""
+
+    def test_no_partial_edges_on_incompatible_label(self):
+        from tenax.network.network import TensorNetwork
+
+        u1 = U1Symmetry()
+        # Tensors share labels "a" (compatible) and "b" (incompatible dim).
+        T1 = DenseTensor(
+            jnp.ones((3, 4)),
+            (
+                TensorIndex(u1, np.zeros(3, dtype=np.int32), FlowDirection.OUT, label="a"),
+                TensorIndex(u1, np.zeros(4, dtype=np.int32), FlowDirection.OUT, label="b"),
+            ),
+        )
+        T2 = DenseTensor(
+            jnp.ones((3, 5)),
+            (
+                TensorIndex(u1, np.zeros(3, dtype=np.int32), FlowDirection.IN, label="a"),
+                TensorIndex(u1, np.zeros(5, dtype=np.int32), FlowDirection.IN, label="b"),
+            ),
+        )
+        tn = TensorNetwork()
+        tn.add_node("X", T1)
+        tn.add_node("Y", T2)
+
+        with pytest.raises(ValueError, match="Incompatible"):
+            tn.connect_by_shared_label("X", "Y")
+
+        # No edges should have been created.
+        assert tn.n_edges() == 0
+
+
+# ------------------------------------------------------------------ #
+# P2: build_peps grid shape validation                                #
+# ------------------------------------------------------------------ #
+
+
+class TestBuildPepsValidation:
+    """build_peps must reject mismatched grid dimensions."""
+
+    def _make_tensor(self):
+        u1 = U1Symmetry()
+        return DenseTensor(
+            jnp.ones((2,)),
+            (TensorIndex(u1, np.zeros(2, dtype=np.int32), FlowDirection.IN, label="p"),),
+        )
+
+    def test_too_few_rows_raises(self):
+        from tenax.network.network import build_peps
+
+        T = self._make_tensor()
+        with pytest.raises(ValueError, match="rows"):
+            build_peps([[T]], 2, 1)
+
+    def test_too_few_columns_raises(self):
+        from tenax.network.network import build_peps
+
+        T = self._make_tensor()
+        with pytest.raises(ValueError, match="columns"):
+            build_peps([[T]], 1, 2)
+
+    def test_extra_columns_raises(self):
+        from tenax.network.network import build_peps
+
+        T = self._make_tensor()
+        with pytest.raises(ValueError, match="columns"):
+            build_peps([[T, T]], 1, 1)
+
+
+# ------------------------------------------------------------------ #
+# P2: build_mps / build_peps propagate incompatible-index errors      #
+# ------------------------------------------------------------------ #
+
+
+class TestBuildersPropagateBondErrors:
+    """build_mps and build_peps must not silently drop incompatible bonds."""
+
+    def test_build_mps_raises_on_incompatible_shared_label(self):
+        from tenax.network.network import build_mps
+
+        u1 = U1Symmetry()
+        A = DenseTensor(
+            jnp.ones((2, 4)),
+            (
+                TensorIndex(u1, np.zeros(2, dtype=np.int32), FlowDirection.IN, label="p0"),
+                TensorIndex(u1, np.zeros(4, dtype=np.int32), FlowDirection.OUT, label="v"),
+            ),
+        )
+        B = DenseTensor(
+            jnp.ones((5, 2)),
+            (
+                TensorIndex(u1, np.zeros(5, dtype=np.int32), FlowDirection.OUT, label="v"),
+                TensorIndex(u1, np.zeros(2, dtype=np.int32), FlowDirection.IN, label="p1"),
+            ),
+        )
+        # "v" is shared but dims 4 vs 5 are incompatible — must raise.
+        with pytest.raises(ValueError, match="Incompatible"):
+            build_mps([A, B])


### PR DESCRIPTION
## Summary
- **P1: connect_by_shared_label atomicity** — validates all shared labels before connecting any, so the network is not left partially mutated on failure
- **P2: build_peps grid validation** — validates `tensors` grid matches `Lx`/`Ly` upfront instead of `IndexError` or silent data loss
- **P2: builder error propagation** — `build_mps()` and `build_peps()` no longer silently swallow `ValueError` from incompatible shared labels; errors propagate to the caller

## Test plan
- [x] 22 regression tests pass
- [x] 395 core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)