### PR TITLE
Update installation docs for PyPI availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,39 +29,28 @@ The name **Tenax** combines **Ten**sor network + J**ax**, and is also Latin for 
 
 ## Installation
 
-> **Note:** The PyPI package (`tenax-tn`) is not yet available. Install from source using the instructions below.
+```bash
+pip install tenax-tn
+```
+
+With hardware acceleration:
+
+```bash
+pip install tenax-tn[cuda13]   # NVIDIA GPU (CUDA 13, recommended)
+pip install tenax-tn[cuda12]   # NVIDIA GPU (CUDA 12)
+pip install tenax-tn[tpu]      # Google Cloud TPU
+pip install tenax-tn[metal]    # Apple Silicon GPU (experimental)
+```
+
+### From source
 
 ```bash
 git clone https://github.com/tenax-lab/tenax.git
 cd tenax
-
-# With uv (recommended)
-uv sync --all-extras --dev
-
-# Or with pip
-pip install -e .
+uv sync --all-extras --dev     # or: pip install -e ".[dev]"
 ```
 
-### Hardware acceleration
-
-Tenax uses JAX as its backend. To enable GPU or TPU acceleration, install
-the appropriate JAX variant **before** installing Tenax:
-
-```bash
-# NVIDIA GPU (CUDA 13, recommended)
-pip install -U "jax[cuda13]"
-
-# NVIDIA GPU (CUDA 12)
-pip install -U "jax[cuda12]"
-
-# Google Cloud TPU
-pip install -U "jax[tpu]"
-
-# Apple Silicon GPU (macOS only, experimental)
-pip install jax-metal
-```
-
-See the [JAX installation guide](https://docs.jax.dev/en/latest/installation.html) for the latest accelerator options.
+See the [JAX installation guide](https://docs.jax.dev/en/latest/installation.html) for more accelerator options.
 
 ## Quick Start
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -5,9 +5,22 @@
 - Python 3.11 or 3.12
 - A working JAX installation (CPU or GPU)
 
-## Install from source
+## Install from PyPI
 
-> **Note:** The PyPI package (`tenax-tn`) is not yet available. Install from source using the instructions below.
+```bash
+pip install tenax-tn
+```
+
+With hardware acceleration:
+
+```bash
+pip install tenax-tn[cuda13]   # NVIDIA GPU (CUDA 13, recommended)
+pip install tenax-tn[cuda12]   # NVIDIA GPU (CUDA 12)
+pip install tenax-tn[tpu]      # Google Cloud TPU
+pip install tenax-tn[metal]    # Apple Silicon GPU (experimental)
+```
+
+## Install from source
 
 ### With uv (recommended)
 


### PR DESCRIPTION
## Summary
- README and docs now show `pip install tenax-tn` as the primary install method
- Hardware acceleration extras documented inline (`tenax-tn[cuda13]`, etc.)
- Source install moved to secondary section

## Test plan
- [x] Docs build should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)