### PR TITLE
Fix publish: decouple PyPI from TestPyPI, skip existing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,10 +47,11 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          skip-existing: true
 
   publish-pypi:
     name: Publish to PyPI
-    needs: publish-testpypi
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: pypi


### PR DESCRIPTION
## Summary
- PyPI publish depends only on build, not TestPyPI (so TestPyPI failure doesn't block PyPI)
- TestPyPI uses `skip-existing: true` to handle re-tags gracefully

## Test plan
- [x] Re-tag after merge to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)