### PR TITLE
Remove private re-exports from ipeps.py

### DIFF
--- a/src/tenax/algorithms/ipeps.py
+++ b/src/tenax/algorithms/ipeps.py
@@ -24,75 +24,22 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from tenax.algorithms.ipeps_config import (
-    CTMConfig,  # noqa: F401
-    CTMEnvironment,
-    SplitCTMEnvironment,  # noqa: F401
-    iPEPSConfig,
-)
-from tenax.algorithms.ipeps_ctm import (
-    _build_double_layer,  # noqa: F401
-    _ctm_2site_sweep,  # noqa: F401
-    _ctm_bottom_move,  # noqa: F401
-    _ctm_bottom_move_2site,  # noqa: F401
-    _ctm_left_move,  # noqa: F401
-    _ctm_left_move_2site,  # noqa: F401
-    _ctm_move,  # noqa: F401
-    _ctm_move_eigh,  # noqa: F401
-    _ctm_move_qr,  # noqa: F401
-    _ctm_right_move,  # noqa: F401
-    _ctm_right_move_2site,  # noqa: F401
-    _ctm_sv_diff,  # noqa: F401
-    _ctm_sweep,  # noqa: F401
-    _ctm_top_move,  # noqa: F401
-    _ctm_top_move_2site,  # noqa: F401
-    _initialize_ctm_env,  # noqa: F401
-    _initialize_split_ctm_env,  # noqa: F401
-    _renormalize_env,  # noqa: F401
-    _split_ctm_move,  # noqa: F401
-    _split_ctm_projector,  # noqa: F401
-    _split_ctm_sweep,  # noqa: F401
-    _split_env_to_standard,  # noqa: F401
-    _svd_split_edge,  # noqa: F401
-    ctm,
-    ctm_2site,
-    ctm_split,  # noqa: F401
-)
-from tenax.algorithms.ipeps_optimize import (
-    _optimize_gs_ad_2site,  # noqa: F401
-    _optimize_gs_ad_tensor,  # noqa: F401
-    _optimize_gs_ad_tensor_2site,  # noqa: F401
-    optimize_gs_ad,  # noqa: F401
-)
-from tenax.algorithms.ipeps_rdm import (
-    _build_double_layer_open,  # noqa: F401
-    _rdm1x2,  # noqa: F401
-    _rdm1x2_2site,  # noqa: F401
-    _rdm2x1,  # noqa: F401
-    _rdm2x1_2site,  # noqa: F401
-    compute_energy_ctm,
-    compute_energy_ctm_2site,
-    compute_energy_split_ctm,  # noqa: F401
-)
+from tenax.algorithms.ipeps_config import CTMEnvironment, iPEPSConfig
+from tenax.algorithms.ipeps_ctm import ctm, ctm_2site
+from tenax.algorithms.ipeps_rdm import compute_energy_ctm, compute_energy_ctm_2site
 from tenax.algorithms.ipeps_simple_update import (
     _absorb_lambdas_tensor,
     _make_trotter_gate_tensor,
     _simple_update_1x1,
-    _simple_update_2site_bond,  # noqa: F401
     _simple_update_2site_horizontal,
     _simple_update_2site_vertical,
-    _simple_update_3leg,  # noqa: F401
-    _simple_update_bond,  # noqa: F401
-    _simple_update_horizontal,  # noqa: F401
     _simple_update_horizontal_tensor,
-    _simple_update_vertical,  # noqa: F401
     _simple_update_vertical_tensor,
 )
-from tenax.contraction.contractor import contract, truncated_svd  # noqa: F401
 from tenax.core import EPS
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.symmetry import U1Symmetry
-from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor  # noqa: F401
+from tenax.core.tensor import DenseTensor, Tensor
 from tenax.network.network import TensorNetwork
 
 

--- a/tests/test_ad_utils.py
+++ b/tests/test_ad_utils.py
@@ -20,7 +20,8 @@ from tenax.algorithms.ad_utils import (
     ctm_converge,
     truncated_svd_ad,
 )
-from tenax.algorithms.ipeps import CTMConfig, CTMEnvironment, ctm
+from tenax.algorithms.ipeps_config import CTMConfig, CTMEnvironment
+from tenax.algorithms.ipeps_ctm import ctm
 
 
 class TestTruncatedSVDADForward:
@@ -210,7 +211,7 @@ class TestCTMFixedPointGradient:
             A_norm = A_in / (jnp.linalg.norm(A_in) + 1e-10)
             env_tuple = ctm_converge(A_norm, config_tuple)
             env = CTMEnvironment(*env_tuple)
-            from tenax.algorithms.ipeps import compute_energy_ctm
+            from tenax.algorithms.ipeps_rdm import compute_energy_ctm
 
             return compute_energy_ctm(A_norm, env, gate, d)
 
@@ -275,7 +276,7 @@ class TestGMRESBackward:
             A_norm = A_in / (jnp.linalg.norm(A_in) + 1e-10)
             env_tuple = ctm_converge(A_norm, config_tuple)
             env = CTMEnvironment(*env_tuple)
-            from tenax.algorithms.ipeps import compute_energy_ctm
+            from tenax.algorithms.ipeps_rdm import compute_energy_ctm
 
             return compute_energy_ctm(A_norm, env, gate, d)
 
@@ -297,7 +298,7 @@ class TestGMRESBackward:
             A_norm = A_in / (jnp.linalg.norm(A_in) + 1e-10)
             env_tuple = ctm_converge(A_norm, config_tuple)
             env = CTMEnvironment(*env_tuple)
-            from tenax.algorithms.ipeps import compute_energy_ctm
+            from tenax.algorithms.ipeps_rdm import compute_energy_ctm
 
             return compute_energy_ctm(A_norm, env, gate, d)
 

--- a/tests/test_ctm_tensor.py
+++ b/tests/test_ctm_tensor.py
@@ -22,7 +22,7 @@ from tenax.algorithms._ctm_tensor import (
     ctm_tensor_2site,
     initialize_ctm_tensor_env,
 )
-from tenax.algorithms.ipeps import (
+from tenax.algorithms.ipeps_ctm import (
     _build_double_layer,
     _ctm_2site_sweep,
     _ctm_sweep,

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -5,28 +5,34 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from tenax.algorithms.ipeps import (
+from tenax.algorithms.ipeps import ipeps
+from tenax.algorithms.ipeps_config import (
     CTMConfig,
     CTMEnvironment,
     SplitCTMEnvironment,
+    iPEPSConfig,
+)
+from tenax.algorithms.ipeps_ctm import (
     _build_double_layer,
-    _build_double_layer_open,
     _initialize_split_ctm_env,
-    _rdm1x2,
-    _rdm2x1,
-    _simple_update_1x1,
-    _simple_update_2site_horizontal,
-    _simple_update_2site_vertical,
     _split_env_to_standard,
-    compute_energy_ctm,
-    compute_energy_ctm_2site,
-    compute_energy_split_ctm,
     ctm,
     ctm_2site,
     ctm_split,
-    ipeps,
-    iPEPSConfig,
-    optimize_gs_ad,
+)
+from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+from tenax.algorithms.ipeps_rdm import (
+    _build_double_layer_open,
+    _rdm1x2,
+    _rdm2x1,
+    compute_energy_ctm,
+    compute_energy_ctm_2site,
+    compute_energy_split_ctm,
+)
+from tenax.algorithms.ipeps_simple_update import (
+    _simple_update_1x1,
+    _simple_update_2site_horizontal,
+    _simple_update_2site_vertical,
 )
 
 
@@ -183,7 +189,7 @@ class TestCTM:
     def test_ctm_edge_tensors_change(self, small_peps_tensor):
         """After a full CTM run, edge tensors should differ from initialization."""
         config = CTMConfig(chi=4, max_iter=10)
-        from tenax.algorithms.ipeps import _build_double_layer, _initialize_ctm_env
+        from tenax.algorithms.ipeps_ctm import _build_double_layer, _initialize_ctm_env
 
         a = _build_double_layer(small_peps_tensor)
         D = small_peps_tensor.shape[0]
@@ -1059,7 +1065,7 @@ class TestTensorSimpleUpdate:
 
     def test_horizontal_dense_tensor_runs(self):
         """Horizontal simple update works with DenseTensor."""
-        from tenax.algorithms.ipeps import (
+        from tenax.algorithms.ipeps_simple_update import (
             _make_trotter_gate_tensor,
             _simple_update_horizontal_tensor,
         )
@@ -1076,7 +1082,7 @@ class TestTensorSimpleUpdate:
 
     def test_vertical_dense_tensor_runs(self):
         """Vertical simple update works with DenseTensor."""
-        from tenax.algorithms.ipeps import (
+        from tenax.algorithms.ipeps_simple_update import (
             _make_trotter_gate_tensor,
             _simple_update_vertical_tensor,
         )
@@ -1093,7 +1099,7 @@ class TestTensorSimpleUpdate:
 
     def test_symmetric_tensor_runs(self):
         """Simple update works with SymmetricTensor."""
-        from tenax.algorithms.ipeps import (
+        from tenax.algorithms.ipeps_simple_update import (
             _make_trotter_gate_tensor,
             _simple_update_horizontal_tensor,
             _simple_update_vertical_tensor,

--- a/tests/test_ipeps_excitations.py
+++ b/tests/test_ipeps_excitations.py
@@ -8,15 +8,12 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from tenax.algorithms.ipeps import (
+from tenax.algorithms.ipeps_config import (
     CTMConfig,
     CTMEnvironment,
-    _build_double_layer_open,
-    compute_energy_ctm,
-    ctm,
     iPEPSConfig,
-    optimize_gs_ad,
 )
+from tenax.algorithms.ipeps_ctm import ctm
 from tenax.algorithms.ipeps_excitations import (
     ExcitationConfig,
     ExcitationResult,
@@ -31,6 +28,8 @@ from tenax.algorithms.ipeps_excitations import (
     compute_excitations,
     make_momentum_path,
 )
+from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+from tenax.algorithms.ipeps_rdm import _build_double_layer_open, compute_energy_ctm
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/test_split_ctm_tensor.py
+++ b/tests/test_split_ctm_tensor.py
@@ -14,7 +14,9 @@ from tenax.algorithms._split_ctm_tensor import (
     ctm_split_tensor,
     initialize_split_ctm_tensor_env,
 )
-from tenax.algorithms.ipeps import CTMConfig, compute_energy_ctm, ctm, ctm_split
+from tenax.algorithms.ipeps_config import CTMConfig
+from tenax.algorithms.ipeps_ctm import ctm, ctm_split
+from tenax.algorithms.ipeps_rdm import compute_energy_ctm
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.symmetry import U1Symmetry
 from tenax.core.tensor import DenseTensor, SymmetricTensor
@@ -204,7 +206,7 @@ class TestSplitCTMTensorEnergy:
         CTMEnvironment and verify the energy is identical.
         """
         from tenax.algorithms._split_ctm_tensor import _split_env_to_dense_standard
-        from tenax.algorithms.ipeps import CTMEnvironment
+        from tenax.algorithms.ipeps_config import CTMEnvironment
 
         d = 2
         chi = 8
@@ -233,7 +235,7 @@ class TestSplitCTMTensorEnergy:
         grown T-edge tensor as the merge + double-layer + einsum path.
         """
         from tenax.algorithms._split_ctm_tensor import _grow_edge_no_double_layer
-        from tenax.algorithms.ipeps import (
+        from tenax.algorithms.ipeps_ctm import (
             _build_double_layer,
             _initialize_split_ctm_env,
         )


### PR DESCRIPTION
## Summary

- Update all test files to import directly from ipeps submodules instead of through `ipeps.py`
- Remove 44 private symbol re-exports (`_ctm_*`, `_rdm*`, `_simple_update_*`, etc.) from `ipeps.py`
- Eliminates all `# noqa: F401` compatibility façade imports
- `ipeps.py` now only imports what it uses locally (370 lines, down from 423)

Addresses P2 finding: ipeps.py was still leaking internal API through re-exports.

## Test plan

- [x] All 411 core tests pass
- [x] Ruff linter clean (0 errors)
- [ ] CI: full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)