### PR TITLE
Refactor: move ad_utils lazy imports to top-level

### DIFF
--- a/src/tenax/algorithms/ad_utils.py
+++ b/src/tenax/algorithms/ad_utils.py
@@ -12,13 +12,38 @@ Implements the solutions from Francuz et al., Phys. Rev. Research 7, 013237
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
+from jax.scipy.sparse.linalg import gmres as jax_gmres
 
-if TYPE_CHECKING:
-    from tenax.algorithms.ipeps_config import CTMConfig, CTMEnvironment
+from tenax.algorithms._ctm_tensor import (
+    CHECKERBOARD_NEIGHBORS,
+    CTMTensorEnv,
+    _build_double_layer_tensor,
+    _ctm_tensor_sweep,
+    _ctm_tensor_sweep_multisite,
+    initialize_ctm_tensor_env,
+)
+from tenax.algorithms._ctm_tensor import (
+    _ctm_sv_diff as _ctm_sv_diff_tensor,
+)
+from tenax.algorithms._split_ctm_tensor import (
+    _split_ctm_tensor_sweep,
+    ctm_split_tensor,
+)
+from tenax.algorithms.ipeps_config import CTMConfig, CTMEnvironment
+from tenax.algorithms.ipeps_ctm import (
+    _build_double_layer,
+    _ctm_2site_sweep,
+    _ctm_bottom_move,
+    _ctm_left_move,
+    _ctm_right_move,
+    _ctm_top_move,
+    _initialize_ctm_env,
+    _renormalize_env,
+)
+from tenax.core.tensor import SymmetricTensor
 
 # ---------------------------------------------------------------------------
 # 1. Truncated SVD with stable backward pass
@@ -137,19 +162,7 @@ truncated_svd_ad.defvjp(_truncated_svd_ad_fwd, _truncated_svd_ad_bwd)
 
 
 def _ctm_step(A: jax.Array, env: CTMEnvironment, config: CTMConfig) -> CTMEnvironment:
-    """One full CTM iteration (left, right, top, bottom moves + renormalize).
-
-    Imports CTM move functions from ipeps module to avoid circular imports.
-    """
-    from tenax.algorithms.ipeps_ctm import (
-        _build_double_layer,
-        _ctm_bottom_move,
-        _ctm_left_move,
-        _ctm_right_move,
-        _ctm_top_move,
-        _renormalize_env,
-    )
-
+    """One full CTM iteration (left, right, top, bottom moves + renormalize)."""
     a = _build_double_layer(A)
     if a.ndim == 8:
         D = a.shape[0]
@@ -176,15 +189,13 @@ def _env_to_flat(env: CTMEnvironment) -> jax.Array:
 
 def _flat_to_env(flat: jax.Array, env_template: CTMEnvironment) -> CTMEnvironment:
     """Reconstruct CTMEnvironment from a flat array using template shapes."""
-    from tenax.algorithms.ipeps_config import CTMEnvironment as CTMEnv
-
     arrays = []
     offset = 0
     for t in env_template:
         size = t.size
         arrays.append(flat[offset : offset + size].reshape(t.shape))
         offset += size
-    return CTMEnv(*arrays)
+    return CTMEnvironment(*arrays)
 
 
 def _gauge_fix_ctm(env: CTMEnvironment) -> CTMEnvironment:
@@ -197,8 +208,6 @@ def _gauge_fix_ctm(env: CTMEnvironment) -> CTMEnvironment:
     and the corresponding Q factors are absorbed into the adjacent edge
     tensors. This removes the gauge freedom in the CTM environment.
     """
-    from tenax.algorithms.ipeps_config import CTMEnvironment as CTMEnv
-
     C1, C2, C3, C4, T1, T2, T3, T4 = env
 
     # C1 = Q1 @ R1 -> C1_new = R1, T1_new = Q1^H @ T1, T4_new = Q1^H @ T4
@@ -226,7 +235,7 @@ def _gauge_fix_ctm(env: CTMEnvironment) -> CTMEnvironment:
     T3_new = jnp.einsum("ab,bdc->adc", Q4.conj().T, T3_new)
     T4_new = jnp.einsum("adb,bc->adc", T4_new, Q4)
 
-    return CTMEnv(C1_new, C2_new, C3_new, C4_new, T1_new, T2_new, T3_new, T4_new)
+    return CTMEnvironment(C1_new, C2_new, C3_new, C4_new, T1_new, T2_new, T3_new, T4_new)
 
 
 def ctm_fixed_point(
@@ -260,11 +269,6 @@ def _ctm_fixed_point_impl(
     initial_env: CTMEnvironment | None = None,
 ) -> CTMEnvironment:
     """Implementation of CTM with custom VJP for implicit differentiation."""
-    from tenax.algorithms.ipeps_ctm import (
-        _build_double_layer,
-        _initialize_ctm_env,
-    )
-
     a = _build_double_layer(A)
     if a.ndim == 8:
         D_phys = a.shape[0]
@@ -311,8 +315,6 @@ def _config_to_tuple(config) -> tuple:
 
 def _config_from_tuple(config_tuple: tuple):
     """Reconstruct CTMConfig from a packed tuple."""
-    from tenax.algorithms.ipeps_config import CTMConfig
-
     pm_int = config_tuple[4] if len(config_tuple) > 4 else 0
     return CTMConfig(
         chi=config_tuple[0],
@@ -366,8 +368,6 @@ def _ctm_converge_bwd(
     013237), where J = d(ctm_step)/d(env) is the Jacobian of one CTM step.
     Then ``dA = d(ctm_step)/dA^T @ lambda``.
     """
-    from tenax.algorithms.ipeps_config import CTMEnvironment
-
     A, env_tuple = residuals
     config = _config_from_tuple(config_tuple)
 
@@ -384,8 +384,6 @@ def _ctm_converge_bwd(
     # GMRES converges superlinearly (Krylov acceleration) and directly
     # monitors the residual norm, unlike the Neumann series which converges
     # only geometrically with rate equal to the spectral radius.
-    from jax.scipy.sparse.linalg import gmres as jax_gmres
-
     def apply_I_minus_Jt(v):
         """Apply (I - J_env^T) to vector v (a tuple of arrays)."""
         _, vjp_fn = jax.vjp(lambda e: step_fn(A, e), env_tuple)
@@ -425,13 +423,7 @@ def _ctm_step_2site(
 ) -> tuple[CTMEnvironment, CTMEnvironment]:
     """One full 2-site CTM iteration + gauge fixing.
 
-    Imports 2-site CTM sweep from ipeps module to avoid circular imports.
     """
-    from tenax.algorithms.ipeps_ctm import (
-        _build_double_layer,
-        _ctm_2site_sweep,
-    )
-
     a_A = _build_double_layer(A)
     a_B = _build_double_layer(B)
     if a_A.ndim == 8:
@@ -453,11 +445,6 @@ def _ctm_2site_fixed_point_impl(
     config: CTMConfig,
 ) -> tuple[CTMEnvironment, CTMEnvironment]:
     """Run 2-site CTM to convergence with gauge fixing."""
-    from tenax.algorithms.ipeps_ctm import (
-        _build_double_layer,
-        _initialize_ctm_env,
-    )
-
     a_A = _build_double_layer(A)
     a_B = _build_double_layer(B)
     if a_A.ndim == 8:
@@ -541,8 +528,6 @@ def _ctm_converge_2site_bwd(
     Solves ``(I - J^T) lambda = g`` using GMRES where the state vector
     spans both sublattice environments ``(env_A, env_B)``.
     """
-    from tenax.algorithms.ipeps_config import CTMEnvironment
-
     A, B, env_flat = residuals
     config = _config_from_tuple(config_tuple)
 
@@ -562,8 +547,6 @@ def _ctm_converge_2site_bwd(
 
     env_combined = env_A_tuple + env_B_tuple
     g_combined = g_A + g_B
-
-    from jax.scipy.sparse.linalg import gmres as jax_gmres
 
     def apply_I_minus_Jt(v):
         _, vjp_fn = jax.vjp(lambda e: step_fn(A, B, e), env_combined)
@@ -601,10 +584,6 @@ def _gauge_fix_ctm_tensor(env):
     then wraps results back into Tensor objects.  All operations
     (``todense()``, dense QR/einsum, ``from_dense()``) are differentiable.
     """
-    from tenax.algorithms._ctm_tensor import CTMTensorEnv
-    from tenax.algorithms.ipeps_config import CTMEnvironment
-    from tenax.core.tensor import SymmetricTensor
-
     # todense() is differentiable (jnp scatter)
     C1, C2, C3, C4 = (c.todense() for c in (env.C1, env.C2, env.C3, env.C4))
     T1, T2, T3, T4 = (t.todense() for t in (env.T1, env.T2, env.T3, env.T4))
@@ -641,11 +620,6 @@ def _ctm_tensor_step(
     env_treedef,
 ) -> tuple[jax.Array, ...]:
     """One CTM tensor sweep + gauge fix, mapping flat leaves to flat leaves."""
-    from tenax.algorithms._ctm_tensor import (
-        _build_double_layer_tensor,
-        _ctm_tensor_sweep,
-    )
-
     A = jax.tree.unflatten(A_treedef, A_leaves)
     env = jax.tree.unflatten(env_treedef, list(env_leaves))
 
@@ -658,12 +632,6 @@ def _ctm_tensor_step(
 
 def _ctm_tensor_fixed_point_impl(A, config):
     """Run standard Tensor-protocol CTM to convergence with gauge fixing."""
-    from tenax.algorithms._ctm_tensor import (
-        _build_double_layer_tensor,
-        _ctm_tensor_sweep,
-        initialize_ctm_tensor_env,
-    )
-
     a = _build_double_layer_tensor(A)
     env = initialize_ctm_tensor_env(A, config.chi)
 
@@ -686,9 +654,7 @@ def _ctm_tensor_fixed_point_impl(A, config):
 
 def _ctm_sv_diff_local(sv_new, sv_old):
     """Compute max abs diff between normalized SVs."""
-    from tenax.algorithms._ctm_tensor import _ctm_sv_diff
-
-    return _ctm_sv_diff(sv_new, sv_old)
+    return _ctm_sv_diff_tensor(sv_new, sv_old)
 
 
 @partial(jax.custom_vjp, nondiff_argnums=(1,))
@@ -739,8 +705,6 @@ def _ctm_tensor_converge_bwd(config_tuple, residuals, g):
             env_treedef,
         )
 
-    from jax.scipy.sparse.linalg import gmres as jax_gmres
-
     def apply_I_minus_Jt(v):
         _, vjp_fn = jax.vjp(lambda e: step_fn(A, e), env_leaves)
         Jt_v = vjp_fn(v)[0]
@@ -771,12 +735,6 @@ ctm_tensor_converge.defvjp(_ctm_tensor_converge_fwd, _ctm_tensor_converge_bwd)
 
 def _ctm_tensor_multisite_fixed_point(site_tensors, neighbors, config):
     """Run multisite Tensor-protocol CTM to convergence with gauge fixing."""
-    from tenax.algorithms._ctm_tensor import (
-        _build_double_layer_tensor,
-        _ctm_tensor_sweep_multisite,
-        initialize_ctm_tensor_env,
-    )
-
     double_layers = {c: _build_double_layer_tensor(A) for c, A in site_tensors.items()}
     envs = {
         c: initialize_ctm_tensor_env(A, config.chi) for c, A in site_tensors.items()
@@ -829,12 +787,6 @@ def _ctm_tensor_step_2site(
     If *double_layers* is provided, it is used directly (avoids redundant
     recomputation when A/B are constant, e.g. in the GMRES backward pass).
     """
-    from tenax.algorithms._ctm_tensor import (
-        CHECKERBOARD_NEIGHBORS,
-        _build_double_layer_tensor,
-        _ctm_tensor_sweep_multisite,
-    )
-
     A = jax.tree.unflatten(A_treedef, A_leaves)
     B = jax.tree.unflatten(B_treedef, B_leaves)
     env_A = jax.tree.unflatten(env_A_treedef, list(env_leaves[:n_env_A_leaves]))
@@ -870,8 +822,6 @@ def ctm_tensor_converge_2site(
     Returns:
         Flat tuple ``(*env_A_leaves, *env_B_leaves)``.
     """
-    from tenax.algorithms._ctm_tensor import CHECKERBOARD_NEIGHBORS
-
     config = _config_from_tuple(config_tuple)
     envs = _ctm_tensor_multisite_fixed_point(
         {(0, 0): A, (1, 0): B}, CHECKERBOARD_NEIGHBORS, config
@@ -881,8 +831,6 @@ def ctm_tensor_converge_2site(
 
 def _ctm_tensor_converge_2site_fwd(A, B, config_tuple):
     """Forward pass — run 2-site Tensor CTM, cache A, B, envs."""
-    from tenax.algorithms._ctm_tensor import CHECKERBOARD_NEIGHBORS
-
     config = _config_from_tuple(config_tuple)
     envs = _ctm_tensor_multisite_fixed_point(
         {(0, 0): A, (1, 0): B}, CHECKERBOARD_NEIGHBORS, config
@@ -895,8 +843,6 @@ def _ctm_tensor_converge_2site_fwd(A, B, config_tuple):
 
 def _ctm_tensor_converge_2site_bwd(config_tuple, residuals, g):
     """Backward pass via implicit differentiation of 2-site Tensor CTM."""
-    from tenax.algorithms._ctm_tensor import _build_double_layer_tensor
-
     A, B, env_A, env_B = residuals
     config = _config_from_tuple(config_tuple)
 
@@ -929,8 +875,6 @@ def _ctm_tensor_converge_2site_bwd(config_tuple, residuals, g):
             n_env_A_leaves,
             double_layers=double_layers,
         )
-
-    from jax.scipy.sparse.linalg import gmres as jax_gmres
 
     def apply_I_minus_Jt(v):
         _, vjp_fn = jax.vjp(
@@ -978,10 +922,6 @@ def _split_ctm_tensor_step(
     Reconstructs Tensor objects from flat arrays using templates,
     runs one sweep, and returns the flattened environment.
     """
-    from tenax.algorithms._split_ctm_tensor import (
-        _split_ctm_tensor_sweep,
-    )
-
     # Reconstruct A from flat
     A = jax.tree.unflatten(jax.tree.structure(A_template), (A_flat,))
 
@@ -1018,6 +958,4 @@ def ctm_split_tensor_fixed_point(
     Returns:
         Converged SplitCTMTensorEnv.
     """
-    from tenax.algorithms._split_ctm_tensor import ctm_split_tensor
-
     return ctm_split_tensor(A, chi, max_iter, conv_tol, chi_I, renormalize)


### PR DESCRIPTION
## Summary

- Move all 27 runtime-local imports in `ad_utils.py` to module-level
- No circular dependency exists — `ipeps_ctm`, `_ctm_tensor`, and `_split_ctm_tensor` never import from `ad_utils`
- Removes misleading "avoid circular imports" comments
- Net -62 lines

Addresses P3 finding: runtime/local imports used to break dependency cycles that don't exist.

## Test plan

- [x] All 411 core tests pass
- [x] Ruff linter clean (0 errors)
- [ ] CI: full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)