### PR TITLE
fix: update Sphinx autodoc paths for iPEPS submodules

### DIFF
--- a/docs/api/algorithms.rst
+++ b/docs/api/algorithms.rst
@@ -60,27 +60,27 @@ HOTRG
 iPEPS
 -----
 
-.. autoclass:: tenax.algorithms.ipeps.iPEPSConfig
+.. autoclass:: tenax.algorithms.ipeps_config.iPEPSConfig
    :members:
    :no-index:
 
-.. autoclass:: tenax.algorithms.ipeps.CTMConfig
+.. autoclass:: tenax.algorithms.ipeps_config.CTMConfig
    :members:
    :no-index:
 
-.. autoclass:: tenax.algorithms.ipeps.CTMEnvironment
+.. autoclass:: tenax.algorithms.ipeps_config.CTMEnvironment
    :members:
    :no-index:
 
 .. autofunction:: tenax.algorithms.ipeps.ipeps
 
-.. autofunction:: tenax.algorithms.ipeps.ctm
+.. autofunction:: tenax.algorithms.ipeps_ctm.ctm
 
-.. autofunction:: tenax.algorithms.ipeps.ctm_2site
+.. autofunction:: tenax.algorithms.ipeps_ctm.ctm_2site
 
-.. autofunction:: tenax.algorithms.ipeps.compute_energy_ctm_2site
+.. autofunction:: tenax.algorithms.ipeps_rdm.compute_energy_ctm_2site
 
-.. autofunction:: tenax.algorithms.ipeps.optimize_gs_ad
+.. autofunction:: tenax.algorithms.ipeps_optimize.optimize_gs_ad
 
 AD Utilities
 ------------


### PR DESCRIPTION
## Summary
- Fix 2 Sphinx autodoc warnings (treated as errors in CI) after the iPEPS refactoring
- `CTMConfig` → `tenax.algorithms.ipeps_config.CTMConfig`
- `optimize_gs_ad` → `tenax.algorithms.ipeps_optimize.optimize_gs_ad`
- Also updates `ctm`, `ctm_2site`, `compute_energy_ctm_2site` to canonical submodule paths

## Test plan
- [x] Local `sphinx-build -W` passes with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)