### PR TITLE
feat: add heisenberg_gate() and widen ipeps gate to Tensor

### DIFF
--- a/examples/heisenberg_ipeps_ad.py
+++ b/examples/heisenberg_ipeps_ad.py
@@ -29,21 +29,7 @@ import jax.numpy as jnp
 
 jax.config.update("jax_enable_x64", True)
 
-from tenax import CTMConfig, iPEPSConfig, optimize_gs_ad
-
-# ---------------------------------------------------------------------------
-# Hamiltonian
-# ---------------------------------------------------------------------------
-
-
-def heisenberg_gate(dtype=jnp.float64) -> jnp.ndarray:
-    """Build the 2-site Heisenberg gate H = Sz*Sz + 0.5*(S+S- + S-S+)."""
-    Sz = jnp.array([[0.5, 0.0], [0.0, -0.5]], dtype=dtype)
-    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=dtype)
-    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]], dtype=dtype)
-    H = jnp.kron(Sz, Sz) + 0.5 * (jnp.kron(Sp, Sm) + jnp.kron(Sm, Sp))
-    return H.reshape(2, 2, 2, 2)
-
+from tenax import CTMConfig, heisenberg_gate, iPEPSConfig, optimize_gs_ad
 
 # ---------------------------------------------------------------------------
 # Run AD optimization

--- a/examples/heisenberg_ipeps_excitations.py
+++ b/examples/heisenberg_ipeps_excitations.py
@@ -37,24 +37,11 @@ from tenax import (
     ExcitationConfig,
     ExcitationResult,
     compute_excitations,
+    heisenberg_gate,
     iPEPSConfig,
     make_momentum_path,
     optimize_gs_ad,
 )
-
-# ---------------------------------------------------------------------------
-# Hamiltonian
-# ---------------------------------------------------------------------------
-
-
-def heisenberg_gate(dtype=jnp.float64) -> jnp.ndarray:
-    """Build the 2-site Heisenberg gate H = Sz*Sz + 0.5*(S+S- + S-S+)."""
-    Sz = jnp.array([[0.5, 0.0], [0.0, -0.5]], dtype=dtype)
-    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=dtype)
-    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]], dtype=dtype)
-    H = jnp.kron(Sz, Sz) + 0.5 * (jnp.kron(Sp, Sm) + jnp.kron(Sm, Sp))
-    return H.reshape(2, 2, 2, 2)
-
 
 # ---------------------------------------------------------------------------
 # Ground state optimization

--- a/examples/heisenberg_ipeps_su.py
+++ b/examples/heisenberg_ipeps_su.py
@@ -26,25 +26,10 @@ from __future__ import annotations
 import time
 
 import jax
-import jax.numpy as jnp
 
 jax.config.update("jax_enable_x64", True)
 
-from tenax import CTMConfig, ipeps, iPEPSConfig
-
-# ---------------------------------------------------------------------------
-# Hamiltonian
-# ---------------------------------------------------------------------------
-
-
-def heisenberg_gate(dtype=jnp.float64) -> jnp.ndarray:
-    """Build the 2-site Heisenberg gate H = Sz*Sz + 0.5*(S+S- + S-S+)."""
-    Sz = jnp.array([[0.5, 0.0], [0.0, -0.5]], dtype=dtype)
-    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=dtype)
-    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]], dtype=dtype)
-    H = jnp.kron(Sz, Sz) + 0.5 * (jnp.kron(Sp, Sm) + jnp.kron(Sm, Sp))
-    return H.reshape(2, 2, 2, 2)
-
+from tenax import CTMConfig, heisenberg_gate, ipeps, iPEPSConfig
 
 # ---------------------------------------------------------------------------
 # Run simple update
@@ -52,7 +37,7 @@ def heisenberg_gate(dtype=jnp.float64) -> jnp.ndarray:
 
 
 def run_simple_update(
-    gate: jnp.ndarray,
+    gate,
     D: int,
     chi: int,
     num_steps: int,

--- a/src/tenax/__init__.py
+++ b/src/tenax/__init__.py
@@ -81,7 +81,7 @@ from tenax.algorithms.idmrg import (
     iDMRGConfig,
     iDMRGResult,
 )
-from tenax.algorithms.ipeps import ipeps
+from tenax.algorithms.ipeps import heisenberg_gate, ipeps
 from tenax.algorithms.ipeps_config import (
     CTMConfig,
     CTMEnvironment,
@@ -210,6 +210,7 @@ __all__ = [
     "CTMConfig",
     "CTMEnvironment",
     "SplitCTMEnvironment",
+    "heisenberg_gate",
     "ipeps",
     "ctm",
     "ctm_2site",

--- a/src/tenax/algorithms/__init__.py
+++ b/src/tenax/algorithms/__init__.py
@@ -27,7 +27,7 @@ from tenax.algorithms.idmrg import (
     iDMRGConfig,
     iDMRGResult,
 )
-from tenax.algorithms.ipeps import ipeps
+from tenax.algorithms.ipeps import heisenberg_gate, ipeps
 from tenax.algorithms.ipeps_config import (
     CTMConfig,
     CTMEnvironment,
@@ -84,6 +84,7 @@ __all__ = [
     "iPEPSConfig",
     "CTMConfig",
     "CTMEnvironment",
+    "heisenberg_gate",
     "ipeps",
     "ctm",
     "ctm_2site",

--- a/src/tenax/algorithms/ipeps.py
+++ b/src/tenax/algorithms/ipeps.py
@@ -43,8 +43,29 @@ from tenax.core.tensor import DenseTensor, Tensor
 from tenax.network.network import TensorNetwork
 
 
+def heisenberg_gate(dtype=jnp.float64) -> DenseTensor:
+    """Build the 2-site Heisenberg Hamiltonian as a DenseTensor.
+
+    ``H = Sz Sz + 0.5 (S+ S- + S- S+)`` on two spin-1/2 sites, returned
+    as a 4-leg tensor with labels ``(si, sj, si_out, sj_out)``.
+    """
+    Sz = jnp.array([[0.5, 0.0], [0.0, -0.5]], dtype=dtype)
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=dtype)
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]], dtype=dtype)
+    H = jnp.kron(Sz, Sz) + 0.5 * (jnp.kron(Sp, Sm) + jnp.kron(Sm, Sp))
+    sym = U1Symmetry()
+    charges = np.zeros(2, dtype=np.int32)
+    indices = (
+        TensorIndex(sym, charges.copy(), FlowDirection.IN, label="si"),
+        TensorIndex(sym, charges.copy(), FlowDirection.IN, label="sj"),
+        TensorIndex(sym, charges.copy(), FlowDirection.OUT, label="si_out"),
+        TensorIndex(sym, charges.copy(), FlowDirection.OUT, label="sj_out"),
+    )
+    return DenseTensor(H.reshape(2, 2, 2, 2), indices)
+
+
 def ipeps(
-    hamiltonian_gate: jax.Array,
+    hamiltonian_gate: Tensor | jax.Array,
     initial_peps: TensorNetwork | jax.Array | Tensor | tuple | None,
     config: iPEPSConfig,
 ) -> tuple[float, TensorNetwork | Tensor, object]:
@@ -79,12 +100,19 @@ def ipeps(
     if isinstance(initial_peps, Tensor):
         return _ipeps_tensor(hamiltonian_gate, initial_peps, config)
 
+    # Dense path: convert gate to JAX array if needed
+    gate_arr = (
+        hamiltonian_gate.todense()
+        if isinstance(hamiltonian_gate, Tensor)
+        else jnp.array(hamiltonian_gate)
+    )
+
     # Get site tensor
     if initial_peps is None:
         # Build random initial PEPS tensor
         key = jax.random.PRNGKey(0)
         D = config.max_bond_dim
-        d_phys = hamiltonian_gate.shape[0]  # physical dimension from gate shape
+        d_phys = gate_arr.shape[0]  # physical dimension from gate shape
         A_dense = jax.random.normal(key, (D, D, D, D, d_phys))
         A_dense = A_dense / (jnp.linalg.norm(A_dense) + 1e-10)
     elif isinstance(initial_peps, jax.Array):
@@ -104,7 +132,7 @@ def ipeps(
             raise ValueError("iPEPS: could not find site tensor")
 
         A_dense = A_tensor.todense()
-    gate = jnp.array(hamiltonian_gate)
+    gate = gate_arr
 
     # Build Trotter gate: exp(-dt * H_bond)
     # Reshape gate (d,d,d,d) -> (d^2, d^2), diagonalize, exponentiate
@@ -152,7 +180,7 @@ def ipeps(
 
 
 def _ipeps_tensor(
-    hamiltonian_gate: jax.Array,
+    hamiltonian_gate: Tensor | jax.Array,
     A_init: Tensor,
     config: iPEPSConfig,
 ) -> tuple[float, Tensor, object]:
@@ -273,7 +301,7 @@ def _build_1x1_peps(A: jax.Array, d: int, D: int) -> TensorNetwork:
 
 
 def _ipeps_2site(
-    hamiltonian_gate: jax.Array,
+    hamiltonian_gate: Tensor | jax.Array,
     initial_peps: tuple[jax.Array, jax.Array] | None,
     config: iPEPSConfig,
 ) -> tuple[float, TensorNetwork, tuple[CTMEnvironment, CTMEnvironment]]:
@@ -282,7 +310,11 @@ def _ipeps_2site(
     Returns:
         (energy_per_site, peps_network, (env_A, env_B))
     """
-    gate = jnp.array(hamiltonian_gate)
+    gate = (
+        hamiltonian_gate.todense()
+        if isinstance(hamiltonian_gate, Tensor)
+        else jnp.array(hamiltonian_gate)
+    )
     d = gate.shape[0]
     D = config.max_bond_dim
 

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -20,7 +20,7 @@ from tenax.core.tensor import Tensor
 
 
 def optimize_gs_ad(
-    hamiltonian_gate: jax.Array,
+    hamiltonian_gate: jax.Array | Tensor,
     A_init: jax.Array | Tensor | tuple | None,
     config: iPEPSConfig,
 ):
@@ -60,7 +60,11 @@ def optimize_gs_ad(
     from tenax.algorithms.ad_utils import _config_to_tuple, ctm_converge
     from tenax.algorithms.ipeps import ipeps
 
-    gate = jnp.array(hamiltonian_gate)
+    gate = (
+        hamiltonian_gate.todense()
+        if isinstance(hamiltonian_gate, Tensor)
+        else jnp.array(hamiltonian_gate)
+    )
     d_phys = gate.shape[0]
     D = config.max_bond_dim
 
@@ -143,7 +147,11 @@ def _optimize_gs_ad_tensor(
     )
     from tenax.algorithms.ad_utils import _config_to_tuple, ctm_tensor_converge
 
-    gate = jnp.array(hamiltonian_gate)
+    gate = (
+        hamiltonian_gate.todense()
+        if isinstance(hamiltonian_gate, Tensor)
+        else jnp.array(hamiltonian_gate)
+    )
     d_phys = gate.shape[0]
 
     A = A_init
@@ -211,7 +219,11 @@ def _optimize_gs_ad_2site(
 
     from tenax.algorithms.ad_utils import ctm_converge_2site
 
-    gate = jnp.array(hamiltonian_gate)
+    gate = (
+        hamiltonian_gate.todense()
+        if isinstance(hamiltonian_gate, Tensor)
+        else jnp.array(hamiltonian_gate)
+    )
     d_phys = gate.shape[0]
     D = config.max_bond_dim
 
@@ -319,7 +331,11 @@ def _optimize_gs_ad_tensor_2site(
     )
     from tenax.algorithms.ad_utils import _config_to_tuple, ctm_tensor_converge_2site
 
-    gate = jnp.array(hamiltonian_gate)
+    gate = (
+        hamiltonian_gate.todense()
+        if isinstance(hamiltonian_gate, Tensor)
+        else jnp.array(hamiltonian_gate)
+    )
     d_phys = gate.shape[0]
 
     A, B = AB_init


### PR DESCRIPTION
## Summary

- Add `heisenberg_gate()` utility returning a `DenseTensor` with labeled indices `(si, sj, si_out, sj_out)`, consistent with `spinless_fermion_gate()` pattern
- Widen `hamiltonian_gate` parameter in `ipeps()` and `optimize_gs_ad()` from `jax.Array` to `Tensor | jax.Array`
- Update all 3 Heisenberg iPEPS examples to import from `tenax` instead of building raw JAX gates

## Test plan

- [x] All 126 iPEPS tests pass
- [x] `from tenax import heisenberg_gate` works and returns `DenseTensor`
- [x] Pre-commit hooks pass (ruff lint + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)