### PR TITLE
fix: re-export _compute_projector_tensor from CTM shims

### DIFF
--- a/src/tenax/algorithms/_ctm_tensor.py
+++ b/src/tenax/algorithms/_ctm_tensor.py
@@ -1,5 +1,8 @@
 """Standard CTM with Tensor protocol — re-export shim."""
 
+from tenax.algorithms._ctm_projector import (
+    _compute_projector_tensor as _compute_projector_tensor,  # noqa: F401
+)
 from tenax.algorithms._ctm_tensor_convergence import *  # noqa: F401,F403
 from tenax.algorithms._ctm_tensor_energy import *  # noqa: F401,F403
 from tenax.algorithms._ctm_tensor_init import *  # noqa: F401,F403

--- a/src/tenax/algorithms/_split_ctm_tensor.py
+++ b/src/tenax/algorithms/_split_ctm_tensor.py
@@ -1,5 +1,8 @@
 """Split CTM with Tensor protocol — re-export shim."""
 
+from tenax.algorithms._ctm_projector import (
+    _compute_projector_tensor as _compute_projector_tensor,  # noqa: F401
+)
 from tenax.algorithms._split_ctm_tensor_convergence import *  # noqa: F401,F403
 from tenax.algorithms._split_ctm_tensor_energy import *  # noqa: F401,F403
 from tenax.algorithms._split_ctm_tensor_init import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- Re-export `_compute_projector_tensor` from `_ctm_tensor` and `_split_ctm_tensor` shims
- Addresses PR #125 review comments about broken backward-compatible import paths

## Test plan
- [ ] `from tenax.algorithms._ctm_tensor import _compute_projector_tensor` works
- [ ] `from tenax.algorithms._split_ctm_tensor import _compute_projector_tensor` works
- [ ] All 46 CTM tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)