### PR TITLE
feat: add progress logging for iPEPS AD optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ config = iPEPSConfig(
     ctm=CTMConfig(chi=16, max_iter=50),
     gs_num_steps=200,
     gs_learning_rate=1e-3,
+    gs_verbose=True,      # print per-step AD progress
+    gs_log_interval=10,   # print every 10 steps
     su_init=True,
 )
 A_opt, env, E_gs = optimize_gs_ad(gate, None, config)

--- a/docs/guide/algorithms/ad_excitations.md
+++ b/docs/guide/algorithms/ad_excitations.md
@@ -115,6 +115,8 @@ config = iPEPSConfig(
     ctm=CTMConfig(chi=16, max_iter=50),
     gs_num_steps=200,
     gs_learning_rate=1e-3,
+    gs_verbose=True,
+    gs_log_interval=10,
 )
 A_opt, env, E_gs = optimize_gs_ad(H_bond, A_init=None, config=config)
 ```

--- a/docs/guide/algorithms/ipeps.md
+++ b/docs/guide/algorithms/ipeps.md
@@ -181,9 +181,13 @@ config = iPEPSConfig(
     gs_optimizer="adam",
     gs_learning_rate=1e-3,
     gs_num_steps=200,
+    gs_verbose=True,      # print optimization progress
+    gs_log_interval=10,   # print every 10 AD steps
 )
 A_opt, env, E_gs = optimize_gs_ad(H_bond, A_init=None, config=config)
 ```
+
+Set ``gs_verbose=False`` (default) to disable console output.
 
 #### Simple update initialization
 

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -45,6 +45,10 @@ class iPEPSConfig:
                                tensor via simple update (``ipeps()``) instead of
                                random initialization.  Ignored when ``A_init``
                                is provided explicitly.
+        gs_verbose:            If True, print AD optimization progress.
+        gs_log_interval:       Print every N AD steps when ``gs_verbose`` is
+                               enabled. The first and final steps are always
+                               logged.
     """
 
     max_bond_dim: int = 2
@@ -59,6 +63,8 @@ class iPEPSConfig:
     gs_learning_rate: float = 1e-3
     gs_num_steps: int = 200
     gs_conv_tol: float = 1e-8
+    gs_verbose: bool = False
+    gs_log_interval: int = 10
     su_init: bool = False
 
 

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -5,6 +5,8 @@ Extracts optimize_gs_ad and related helpers from ipeps.py.
 
 from __future__ import annotations
 
+import math
+
 import jax
 import jax.numpy as jnp
 
@@ -17,6 +19,34 @@ from tenax.algorithms.ipeps_rdm import (
     compute_energy_ctm_2site,
 )
 from tenax.core.tensor import Tensor
+
+
+def _should_log_step(step: int, num_steps: int, interval: int) -> bool:
+    if step == 0 or step == num_steps - 1:
+        return True
+    return (step + 1) % interval == 0
+
+
+def _log_ad_step(
+    backend: str,
+    step: int,
+    num_steps: int,
+    energy: float,
+    delta_energy: float,
+    best_energy: float,
+) -> None:
+    delta_str = "N/A" if not math.isfinite(delta_energy) else f"{delta_energy:.3e}"
+    print(
+        f"[iPEPS-AD:{backend}] step {step + 1}/{num_steps} "
+        f"E={energy:.10f} dE={delta_str} E_best={best_energy:.10f}"
+    )
+
+
+def _log_ad_converged(backend: str, step: int, delta_energy: float, tol: float) -> None:
+    print(
+        f"[iPEPS-AD:{backend}] converged at step {step + 1} "
+        f"(dE={delta_energy:.3e} < tol={tol:.3e})"
+    )
 
 
 def optimize_gs_ad(
@@ -48,6 +78,9 @@ def optimize_gs_ad(
         For 1-site Tensor: ``(A_opt, env, E_gs)`` where A_opt is Tensor, env is CTMTensorEnv
         For 2-site: ``((A_opt, B_opt), (env_A, env_B), E_gs)``
     """
+    if config.gs_log_interval < 1:
+        raise ValueError(f"gs_log_interval must be >= 1, got {config.gs_log_interval}")
+
     if config.unit_cell == "2site":
         return _optimize_gs_ad_2site(hamiltonian_gate, A_init, config)
 
@@ -101,6 +134,7 @@ def optimize_gs_ad(
     best_energy = float("inf")
     best_A = A
     prev_energy = float("inf")
+    log_interval = config.gs_log_interval
 
     for step in range(config.gs_num_steps):
         energy_val, grads = jax.value_and_grad(loss_fn)(A)
@@ -110,8 +144,34 @@ def optimize_gs_ad(
             best_energy = energy_float
             best_A = A
 
+        delta_energy = abs(energy_float - prev_energy)
+        logged = False
+        if config.gs_verbose and _should_log_step(
+            step, config.gs_num_steps, log_interval
+        ):
+            _log_ad_step(
+                "1site-dense",
+                step,
+                config.gs_num_steps,
+                energy_float,
+                delta_energy,
+                best_energy,
+            )
+            logged = True
+
         # Check convergence
-        if abs(energy_float - prev_energy) < config.gs_conv_tol:
+        if delta_energy < config.gs_conv_tol:
+            if config.gs_verbose:
+                if not logged:
+                    _log_ad_step(
+                        "1site-dense",
+                        step,
+                        config.gs_num_steps,
+                        energy_float,
+                        delta_energy,
+                        best_energy,
+                    )
+                _log_ad_converged("1site-dense", step, delta_energy, config.gs_conv_tol)
             break
         prev_energy = energy_float
 
@@ -125,6 +185,8 @@ def optimize_gs_ad(
     env_tuple = ctm_converge(A_final, config_tuple)
     env = CTMEnvironment(*env_tuple)
     E_gs = float(compute_energy_ctm(A_final, env, gate, d_phys))
+    if config.gs_verbose:
+        print(f"[iPEPS-AD:1site-dense] final E={E_gs:.10f}")
 
     return A_final, env, E_gs
 
@@ -175,6 +237,7 @@ def _optimize_gs_ad_tensor(
     best_energy = float("inf")
     best_A = A
     prev_energy = float("inf")
+    log_interval = config.gs_log_interval
 
     for step in range(config.gs_num_steps):
         energy_val, grads = jax.value_and_grad(loss_fn)(A)
@@ -184,7 +247,35 @@ def _optimize_gs_ad_tensor(
             best_energy = energy_float
             best_A = A
 
-        if abs(energy_float - prev_energy) < config.gs_conv_tol:
+        delta_energy = abs(energy_float - prev_energy)
+        logged = False
+        if config.gs_verbose and _should_log_step(
+            step, config.gs_num_steps, log_interval
+        ):
+            _log_ad_step(
+                "1site-tensor",
+                step,
+                config.gs_num_steps,
+                energy_float,
+                delta_energy,
+                best_energy,
+            )
+            logged = True
+
+        if delta_energy < config.gs_conv_tol:
+            if config.gs_verbose:
+                if not logged:
+                    _log_ad_step(
+                        "1site-tensor",
+                        step,
+                        config.gs_num_steps,
+                        energy_float,
+                        delta_energy,
+                        best_energy,
+                    )
+                _log_ad_converged(
+                    "1site-tensor", step, delta_energy, config.gs_conv_tol
+                )
             break
         prev_energy = energy_float
 
@@ -196,6 +287,8 @@ def _optimize_gs_ad_tensor(
     env_leaves = ctm_tensor_converge(A_final, config_tuple)
     env = jax.tree.unflatten(env_treedef, env_leaves)
     E_gs = float(compute_energy_ctm_tensor(A_final, env, gate, d_phys))
+    if config.gs_verbose:
+        print(f"[iPEPS-AD:1site-tensor] final E={E_gs:.10f}")
 
     return A_final, env, E_gs
 
@@ -279,6 +372,7 @@ def _optimize_gs_ad_2site(
     best_energy = float("inf")
     best_params = params
     prev_energy = float("inf")
+    log_interval = config.gs_log_interval
 
     for step in range(config.gs_num_steps):
         energy_val, grads = jax.value_and_grad(loss_fn)(params)
@@ -288,7 +382,33 @@ def _optimize_gs_ad_2site(
             best_energy = energy_float
             best_params = params
 
-        if abs(energy_float - prev_energy) < config.gs_conv_tol:
+        delta_energy = abs(energy_float - prev_energy)
+        logged = False
+        if config.gs_verbose and _should_log_step(
+            step, config.gs_num_steps, log_interval
+        ):
+            _log_ad_step(
+                "2site-dense",
+                step,
+                config.gs_num_steps,
+                energy_float,
+                delta_energy,
+                best_energy,
+            )
+            logged = True
+
+        if delta_energy < config.gs_conv_tol:
+            if config.gs_verbose:
+                if not logged:
+                    _log_ad_step(
+                        "2site-dense",
+                        step,
+                        config.gs_num_steps,
+                        energy_float,
+                        delta_energy,
+                        best_energy,
+                    )
+                _log_ad_converged("2site-dense", step, delta_energy, config.gs_conv_tol)
             break
         prev_energy = energy_float
 
@@ -309,6 +429,8 @@ def _optimize_gs_ad_2site(
     env_A = CTMEnvironment(*env_tuple[:8])
     env_B = CTMEnvironment(*env_tuple[8:])
     E_gs = float(compute_energy_ctm_2site(A_final, B_final, env_A, env_B, gate, d_phys))
+    if config.gs_verbose:
+        print(f"[iPEPS-AD:2site-dense] final E={E_gs:.10f}")
 
     return (A_final, B_final), (env_A, env_B), E_gs
 
@@ -368,8 +490,9 @@ def _optimize_gs_ad_tensor_2site(
     best_energy = float("inf")
     best_params = params
     prev_energy = float("inf")
+    log_interval = config.gs_log_interval
 
-    for _ in range(config.gs_num_steps):
+    for step in range(config.gs_num_steps):
         energy_val, grads = jax.value_and_grad(loss_fn)(params)
         energy_float = float(energy_val)
 
@@ -377,7 +500,35 @@ def _optimize_gs_ad_tensor_2site(
             best_energy = energy_float
             best_params = params
 
-        if abs(energy_float - prev_energy) < config.gs_conv_tol:
+        delta_energy = abs(energy_float - prev_energy)
+        logged = False
+        if config.gs_verbose and _should_log_step(
+            step, config.gs_num_steps, log_interval
+        ):
+            _log_ad_step(
+                "2site-tensor",
+                step,
+                config.gs_num_steps,
+                energy_float,
+                delta_energy,
+                best_energy,
+            )
+            logged = True
+
+        if delta_energy < config.gs_conv_tol:
+            if config.gs_verbose:
+                if not logged:
+                    _log_ad_step(
+                        "2site-tensor",
+                        step,
+                        config.gs_num_steps,
+                        energy_float,
+                        delta_energy,
+                        best_energy,
+                    )
+                _log_ad_converged(
+                    "2site-tensor", step, delta_energy, config.gs_conv_tol
+                )
             break
         prev_energy = energy_float
 
@@ -399,5 +550,7 @@ def _optimize_gs_ad_tensor_2site(
     E_gs = float(
         compute_energy_ctm_tensor_2site(A_final, B_final, env_A, env_B, gate, d_phys)
     )
+    if config.gs_verbose:
+        print(f"[iPEPS-AD:2site-tensor] final E={E_gs:.10f}")
 
     return (A_final, B_final), (env_A, env_B), E_gs

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -60,6 +60,8 @@ class TestIPEPSConfig:
         assert cfg.dt == 0.01
         assert cfg.ctm is not None
         assert isinstance(cfg.ctm, CTMConfig)
+        assert cfg.gs_verbose is False
+        assert cfg.gs_log_interval == 10
 
     def test_custom_values(self):
         cfg = iPEPSConfig(max_bond_dim=4, num_imaginary_steps=50, dt=0.05)
@@ -839,6 +841,38 @@ class TestOptimizeGsAd2Site:
         result = optimize_gs_ad(heisenberg_gate, None, config)
         _, _, E_gs = result
         assert np.isfinite(E_gs)
+
+
+class TestOptimizeGsAdLogging:
+    """Tests for AD optimization progress logging."""
+
+    @pytest.fixture
+    def heisenberg_gate(self):
+        d = 2
+        Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+        Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+        Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+        H = jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+        return H.reshape(d, d, d, d)
+
+    def test_invalid_log_interval_raises(self, heisenberg_gate):
+        config = iPEPSConfig(gs_log_interval=0)
+        with pytest.raises(ValueError, match="gs_log_interval"):
+            optimize_gs_ad(heisenberg_gate, None, config)
+
+    def test_verbose_prints_progress(self, heisenberg_gate, capsys):
+        config = iPEPSConfig(
+            max_bond_dim=2,
+            ctm=CTMConfig(chi=4, max_iter=5),
+            gs_num_steps=2,
+            gs_learning_rate=1e-3,
+            gs_verbose=True,
+            gs_log_interval=1,
+        )
+        optimize_gs_ad(heisenberg_gate, None, config)
+        out = capsys.readouterr().out
+        assert "[iPEPS-AD:1site-dense] step 1/2" in out
+        assert "[iPEPS-AD:1site-dense] final E=" in out
 
 
 class TestOptimizeGsAdDenseOnly:


### PR DESCRIPTION
## Summary
- add AD optimization progress controls to iPEPSConfig via gs_verbose and gs_log_interval
- print step energy (E), energy delta (dE), and best-so-far energy (E_best) across all optimize_gs_ad backends (1-site/2-site, dense/tensor)
- validate gs_log_interval >= 1 and raise ValueError otherwise
- add tests for defaults, validation, and emitted progress output
- document the new options in README and iPEPS/AD docs

## Validation
- uv run ruff check src/tenax/algorithms/ipeps_config.py src/tenax/algorithms/ipeps_optimize.py tests/test_ipeps.py
- uv run pytest tests/test_ipeps.py -k OptimizeGsAdLogging or IPEPSConfig or test_2site_ad_runs or test_optimize_gs_ad_symmetric_runs