### PR TITLE
fix: address code review findings (P1/P2/P3)

### DIFF
--- a/src/tenax/algorithms/_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_ctm_tensor_convergence.py
@@ -320,6 +320,16 @@ def ctm_multisite(
     Returns:
         ``{site_name: CTMTensorEnv}`` — converged environments.
     """
+    # Validate: every lattice site must have a corresponding tensor
+    missing = set(lattice.sites) - set(site_tensors.keys())
+    if missing:
+        raise ValueError(
+            f"site_tensors is missing sites defined in lattice: {sorted(missing)}"
+        )
+    extra = set(site_tensors.keys()) - set(lattice.sites)
+    if extra:
+        raise ValueError(f"site_tensors contains sites not in lattice: {sorted(extra)}")
+
     # Map site names to coordinates: site_i -> (i, 0)
     name_to_coord: dict[str, Coord] = {
         name: (i, 0) for i, name in enumerate(lattice.sites)

--- a/src/tenax/contraction/contractor.py
+++ b/src/tenax/contraction/contractor.py
@@ -447,16 +447,13 @@ def _contract_symmetric(
                 expr = block_expr_cache[cache_key]
                 result_array = expr(*arrays, backend="jax")
             else:
-                try:
-                    expr = opt_einsum.contract_expression(
-                        subscripts,
-                        *block_shapes,
-                        optimize=optimize,
-                    )
-                    block_expr_cache[cache_key] = expr
-                    result_array = expr(*arrays, backend="jax")
-                except Exception:
-                    continue
+                expr = opt_einsum.contract_expression(
+                    subscripts,
+                    *block_shapes,
+                    optimize=optimize,
+                )
+                block_expr_cache[cache_key] = expr
+                result_array = expr(*arrays, backend="jax")
 
             # Apply fermionic sign from leg reordering
             if is_fermionic and inversion_pairs:

--- a/src/tenax/core/lattice.py
+++ b/src/tenax/core/lattice.py
@@ -7,6 +7,8 @@ functions for common lattice types used in tensor-network simulations.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
 
 __all__ = [
     "Bond",
@@ -40,12 +42,20 @@ class Lattice:
         Bonds connecting sites (may include self-bonds for single-site cells).
     neighbor_map : dict[str, dict[str, str]]
         For each site, a mapping from direction ("left", "right", "top",
-        "bottom") to the neighboring site label.
+        "bottom") to the neighboring site label.  Frozen on construction
+        via ``MappingProxyType`` to enforce immutability.
     """
 
     sites: tuple[str, ...]
     bonds: tuple[Bond, ...]
     neighbor_map: dict[str, dict[str, str]]
+
+    def __post_init__(self) -> None:
+        # Deep-freeze neighbor_map so callers cannot mutate topology.
+        frozen: Any = MappingProxyType(
+            {k: MappingProxyType(v) for k, v in self.neighbor_map.items()}
+        )
+        object.__setattr__(self, "neighbor_map", frozen)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -58,6 +58,14 @@ class TestLatticeDataclass:
         for site in lat.sites:
             assert set(lat.neighbor_map[site].keys()) == DIRECTIONS
 
+    def test_neighbor_map_is_immutable(self):
+        """neighbor_map and its inner dicts must be read-only."""
+        lat = square()
+        with pytest.raises(TypeError):
+            lat.neighbor_map["a"] = {}  # type: ignore[index]
+        with pytest.raises(TypeError):
+            lat.neighbor_map["a"]["left"] = "z"  # type: ignore[index]
+
 
 # ---------------------------------------------------------------------------
 # Factory functions
@@ -254,3 +262,22 @@ class TestCtmMultisiteIntegration:
         }
         envs = ctm_multisite(tensors, lat, chi=4, max_iter=5, conv_tol=1e-6)
         assert set(envs.keys()) == set(lat.sites)
+
+    def test_missing_site_raises(self):
+        """ctm_multisite raises ValueError when a lattice site is missing."""
+        from tenax.algorithms._ctm_tensor_convergence import ctm_multisite
+
+        lat = checkerboard()
+        A = _make_random_dense_site_tensor(jax.random.PRNGKey(0))
+        with pytest.raises(ValueError, match="missing sites.*'b'"):
+            ctm_multisite({"a": A}, lat, chi=4)
+
+    def test_extra_site_raises(self):
+        """ctm_multisite raises ValueError for sites not in lattice."""
+        from tenax.algorithms._ctm_tensor_convergence import ctm_multisite
+
+        lat = square()
+        A = _make_random_dense_site_tensor(jax.random.PRNGKey(0))
+        B = _make_random_dense_site_tensor(jax.random.PRNGKey(1))
+        with pytest.raises(ValueError, match="not in lattice.*'z'"):
+            ctm_multisite({"a": A, "z": B}, lat, chi=4)


### PR DESCRIPTION
## Summary

- **P1**: Remove silent `except Exception: continue` in symmetric contraction (`contractor.py:450`) — block-drop on opt_einsum errors now surfaces instead of silently corrupting results
- **P2**: Add upfront input validation to `ctm_multisite()` — missing/extra site tensors raise `ValueError` with clear messages
- **P3**: Deep-freeze `Lattice.neighbor_map` via `MappingProxyType` — callers can no longer mutate topology after construction

## Test plan

- [x] 411 core tests pass (no regressions from P1 change)
- [x] New test: `test_neighbor_map_is_immutable` — verifies outer and inner dicts reject mutation
- [x] New test: `test_missing_site_raises` — confirms clear error for missing site tensors
- [x] New test: `test_extra_site_raises` — confirms clear error for extra site tensors

🤖 Generated with [Claude Code](https://claude.com/claude-code)