### PR TITLE
ci: add workflow to sync skills to tenax-toolkit

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,0 +1,45 @@
+name: Sync skills to tenax-toolkit
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.claude/skills/**'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: tenax-lab/tenax-toolkit
+          token: ${{ secrets.PLUGIN_REPO_TOKEN }}
+          path: plugin-repo
+
+      - name: Sync skills
+        run: |
+          rm -rf plugin-repo/skills/
+          cp -r .claude/skills plugin-repo/skills/
+
+      - name: Create PR if changed
+        working-directory: plugin-repo
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+            echo "No changes to sync"
+            exit 0
+          fi
+          BRANCH="sync-skills-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          git add skills/
+          git commit -m "chore: sync skills from tenax main"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: sync skills from tenax" \
+            --body "Auto-synced from [tenax main](https://github.com/tenax-lab/tenax)." \
+            --repo tenax-lab/tenax-toolkit
+        env:
+          GH_TOKEN: ${{ secrets.PLUGIN_REPO_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ docs/_build/
 
 # Worktrees
 .worktrees/
+plugin/


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that syncs `.claude/skills/**` to the new `tenax-lab/tenax-toolkit` plugin repo
- Triggers on pushes to `main` that modify skill files
- Opens a PR in `tenax-toolkit` with the updated skills
- Add `plugin/` to `.gitignore` (local plugin checkout)

## Setup required

Add a `PLUGIN_REPO_TOKEN` secret to this repo — a fine-grained PAT with write access to `tenax-lab/tenax-toolkit` (contents + pull requests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)