### PR TITLE
fix: correct plugin install commands in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,8 @@ generates per-algorithm PNG charts grouped by size and backend. See
 Tenax has an official [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin with 18 domain-specific skills covering DMRG, iPEPS, TRG, fermionic PEPS, AutoMPO, migration guides, and more. Install it with:
 
 ```bash
-claude plugin add tenax-lab/tenax-toolkit
+claude plugin marketplace add tenax-lab/tenax-toolkit
+claude plugin install tenax-toolkit
 ```
 
 Once installed, Claude can guide you through tensor network calculations with Tenax-specific code examples and troubleshooting. See the [documentation](https://tenax.readthedocs.io/en/latest/guide/claude_code.html) for details.

--- a/docs/guide/claude_code.md
+++ b/docs/guide/claude_code.md
@@ -8,10 +8,12 @@ Tenax-specific code examples and troubleshooting.
 
 ## Installing the plugin
 
-In any terminal with Claude Code available, run:
+In any terminal with Claude Code available, first add the Tenax marketplace
+(one-time setup), then install the plugin:
 
 ```bash
-claude plugin add tenax-lab/tenax-toolkit
+claude plugin marketplace add tenax-lab/tenax-toolkit
+claude plugin install tenax-toolkit
 ```
 
 This installs all Tenax skills into your Claude Code session. No API keys


### PR DESCRIPTION
## Summary
Fix the plugin installation instructions in both `docs/guide/claude_code.md` and `README.md`.

The correct two-step process is:
```bash
claude plugin marketplace add tenax-lab/tenax-toolkit  # add marketplace (one-time)
claude plugin install tenax-toolkit                     # install by plugin name
```

Previously documented as `claude plugin add tenax-lab/tenax-toolkit` which doesn't work.

## Test plan
- [x] Verified correct commands work locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)