### PR TITLE
Add standalone JAX QR dispatch benchmarks

### DIFF
--- a/codex-benchmark/POLARON_RESULTS.md
+++ b/codex-benchmark/POLARON_RESULTS.md
@@ -77,6 +77,8 @@ Times are in milliseconds and are means over the 3 recorded trials.
 - `loop_dispatch_then_sync` consistently beats `loop_sync_each`, which is
   evidence that repeated independent `jnp.linalg.qr` calls are dispatched
   asynchronously enough for device work to overlap with later host submission.
+- The single-GPU overlap is real but modest; it is not the same thing as an
+  explicit sector scheduler.
 - `batched_vmap_jit` is excellent for small matrices (`128`), roughly
   break-even by `256`, and dramatically worse for `512` and `1024`.
 - The catastrophic `1024`-size `batched_vmap_jit` result is not mainly compile

--- a/codex-benchmark/README.md
+++ b/codex-benchmark/README.md
@@ -8,13 +8,14 @@ The main questions are whether:
 - each QR call blocks immediately,
 - work is enqueued asynchronously and synchronized later, or
 - a batched form such as `vmap` changes the behavior materially,
-- and whether explicit two-GPU splitting helps when the workload is large enough.
+- and whether explicit multi-device splitting helps when the workload is large enough.
 
 ## Files
 
 - `qr_dispatch_benchmark.py`: benchmark script
 - `qr_size_sweep.py`: size sweep wrapper around the QR benchmark
 - `POLARON_RESULTS.md`: informational notes and observed results from a dual-V100 workstation
+- `RYZEN_RESULTS.md`: informational notes and observed results from an 8-device CPU run
 
 ## Run
 
@@ -33,6 +34,10 @@ Example with larger inputs:
   --trials 5
 ```
 
+If you request `--dtype float64`, the script enables JAX x64 mode before input
+creation so the benchmark actually runs `float64` kernels rather than silently
+downcasting to `float32`.
+
 To separate first-call JIT compile+run from steady-state execution for the
 batched `vmap` path:
 
@@ -50,6 +55,8 @@ batched `vmap` path:
 - `loop_sync_each`: do one QR and force readiness on every iteration
 - `loop_dispatch_then_sync`: dispatch all QRs in a Python loop, then synchronize once
 - `batched_vmap_jit`: compile one batched QR over a stack of matrices
+- `split_N_devices_dispatch_then_sync`: split the batch across the first `N`
+  visible JAX devices on the active backend and interleave submissions
 - `two_gpu_split_dispatch_then_sync`: split the batch across two pre-placed GPU
   batches and interleave submissions across the two devices
 
@@ -69,7 +76,69 @@ The issue phase is not pure enqueue cost. Device work may already be running
 while Python is still issuing later QR calls. The tail-wait time is only the
 unfinished remainder at the point where the explicit synchronization begins.
 
-## Optional Two-GPU Mode
+Input generation starts on the host with NumPy. Device-resident arrays are only
+materialized when a benchmark mode actually needs them, which avoids allocating
+the full batch on a single default GPU before a split-device run.
+
+## Optional Multi-Device Modes
+
+If the machine has multiple visible JAX devices on the active backend, you can
+ask the benchmark to split the batch across the first `N` devices:
+
+```bash
+.venv/bin/python codex-benchmark/qr_dispatch_benchmark.py \
+  --num-matrices 64 \
+  --matrix-size 512 \
+  --trials 5 \
+  --warmup 2 \
+  --split-devices 4
+```
+
+If the full batch would not fit on one default device, use `--split-only` so
+the script never materializes the whole workload on a single device just to run
+the single-device baseline modes:
+
+```bash
+.venv/bin/python codex-benchmark/qr_dispatch_benchmark.py \
+  --num-matrices 64 \
+  --matrix-size 2048 \
+  --trials 5 \
+  --warmup 1 \
+  --split-devices 2 \
+  --split-only
+```
+
+This is useful on both GPU and CPU, with one important caveat:
+
+- `--split-devices N` compares `N` visible JAX devices, not necessarily `N`
+  host CPU threads.
+
+For CPU runs, JAX device count is configured before startup. For example:
+
+```bash
+JAX_PLATFORMS=cpu JAX_NUM_CPU_DEVICES=1 \
+  .venv/bin/python codex-benchmark/qr_dispatch_benchmark.py \
+  --num-matrices 64 \
+  --matrix-size 512 \
+  --trials 3
+```
+
+versus:
+
+```bash
+JAX_PLATFORMS=cpu JAX_NUM_CPU_DEVICES=8 \
+  .venv/bin/python codex-benchmark/qr_dispatch_benchmark.py \
+  --num-matrices 64 \
+  --matrix-size 512 \
+  --trials 3 \
+  --split-devices 8
+```
+
+This measures one visible JAX CPU device versus a workload explicitly split
+across eight visible JAX CPU devices. It does not isolate single-thread versus
+many-thread execution within one CPU device.
+
+### Two-GPU Alias
 
 If the machine has at least two visible JAX GPU devices, you can ask the
 benchmark to split the batch across the first two GPUs:
@@ -83,8 +152,9 @@ benchmark to split the batch across the first two GPUs:
   --two-gpu-split
 ```
 
-The two-GPU mode pre-places the split inputs onto the two devices once before
-warmup/trials. The timed region measures QR dispatch and completion, not
+The two-GPU mode is just a compatibility alias for `--split-devices 2`. Split
+inputs are prepared directly from host memory and placed onto the target devices
+before warmup/trials. The timed region measures QR dispatch and completion, not
 repeated host-to-device transfer cost on every trial.
 
 Behavior by machine type:

--- a/codex-benchmark/RYZEN_RESULTS.md
+++ b/codex-benchmark/RYZEN_RESULTS.md
@@ -1,0 +1,46 @@
+# Ryzen CPU Results
+
+This file records benchmark results collected on `ryzen` for discussion with
+the Tenax developers. It is an informational note for the benchmark PR.
+
+## Machine Summary
+
+- host: `ryzen`
+- backend: `cpu`
+- visible JAX CPU devices: `8`
+- JAX: `0.9.1`
+
+## Command
+
+```bash
+JAX_PLATFORMS=cpu JAX_NUM_CPU_DEVICES=8 \
+  .venv/bin/python codex-benchmark/qr_dispatch_benchmark.py \
+  --num-matrices 64 \
+  --matrix-size 512 \
+  --trials 3 \
+  --split-devices 8
+```
+
+## Results
+
+Times are in milliseconds and are means over the 3 recorded trials.
+
+| mode | issue | tail_wait | total |
+|---|---:|---:|---:|
+| `loop_sync_each` | 40.639 | 658.954 | 703.772 |
+| `loop_dispatch_then_sync` | 838.357 | 50.499 | 888.919 |
+| `batched_vmap_jit` | 0.025 | 386.108 | 386.309 |
+| `split_8_devices_dispatch_then_sync` | 89.943 | 33.446 | 123.544 |
+
+## Observations
+
+- The explicit 8-device split is dramatically faster than the one-device looped
+  paths for this case.
+- On this CPU setup, `loop_dispatch_then_sync` is actually worse than
+  `loop_sync_each`, which is a useful reminder that JAX's async overlap story is
+  backend-dependent and should not be assumed to help on CPU the way it helped
+  on the V100 GPU runs.
+- `batched_vmap_jit` remains much better than the one-device looped modes, but
+  it is still far behind the explicit 8-device split.
+- This benchmark is comparing multiple visible JAX CPU devices, not a pure
+  single-thread versus many-thread study inside one CPU device.

--- a/codex-benchmark/qr_dispatch_benchmark.py
+++ b/codex-benchmark/qr_dispatch_benchmark.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 
 @dataclass
@@ -29,6 +30,7 @@ def device_summary() -> dict[str, str]:
         "platforms": ",".join(platforms),
         "devices": str(devices),
         "primary_device": str(devices[0]) if devices else "none",
+        "x64_enabled": str(jax.config.x64_enabled),
     }
 
 
@@ -43,11 +45,20 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--dtype", choices=("float32", "float64"), default="float32")
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument(
+        "--split-devices",
+        type=int,
+        default=0,
+        help=(
+            "If at least this many visible JAX devices are present on the active "
+            "backend, split the workload across the first N devices and interleave "
+            "QR submissions."
+        ),
+    )
+    parser.add_argument(
         "--two-gpu-split",
         action="store_true",
         help=(
-            "If two or more GPU devices are available, split the workload across "
-            "the first two GPUs and benchmark concurrent dispatch."
+            "Compatibility alias for --split-devices 2 on GPU."
         ),
     )
     parser.add_argument(
@@ -58,17 +69,30 @@ def parse_args() -> argparse.Namespace:
             "second call for the vmap QR path."
         ),
     )
+    parser.add_argument(
+        "--split-only",
+        action="store_true",
+        help=(
+            "When a split-device benchmark is requested, run only the split mode. "
+            "This avoids materializing the full batch on a single default device."
+        ),
+    )
     return parser.parse_args()
 
 
 def make_inputs(
     num_matrices: int, matrix_size: int, dtype_name: str, seed: int
-) -> jax.Array:
-    dtype = getattr(jnp, dtype_name)
-    key = jax.random.PRNGKey(seed)
-    return jax.random.normal(
-        key, (num_matrices, matrix_size, matrix_size), dtype=dtype
-    )
+) -> np.ndarray:
+    dtype = getattr(np, dtype_name)
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal(
+        (num_matrices, matrix_size, matrix_size)
+    ).astype(dtype, copy=False)
+
+
+def configure_precision(dtype_name: str) -> None:
+    if dtype_name == "float64" and not jax.config.x64_enabled:
+        jax.config.update("jax_enable_x64", True)
 
 
 def _checksum_terms(q: jax.Array, r: jax.Array) -> jax.Array:
@@ -197,79 +221,118 @@ def has_two_gpu_devices() -> bool:
     return len(gpus) >= 2
 
 
-def prepare_two_gpu_split_inputs(mats: jax.Array) -> tuple[jax.Array, jax.Array]:
-    gpu_devices = [device for device in jax.devices() if device.platform == "gpu"]
-    if len(gpu_devices) < 2:
-        raise RuntimeError("two_gpu_split benchmark requires at least two GPU devices")
+def visible_devices(platform: str | None = None) -> list[jax.Device]:
+    devices = jax.devices()
+    if platform is None:
+        return devices
+    return [device for device in devices if device.platform == platform]
 
-    split = mats.shape[0] // 2
-    if split == 0 or split == mats.shape[0]:
-        raise ValueError(
-            "two_gpu_split benchmark requires at least two matrices so the workload "
-            "can be split across devices"
+
+def has_at_least_n_devices(n: int, platform: str | None = None) -> bool:
+    return len(visible_devices(platform)) >= n
+
+
+def prepare_device_split_inputs(
+    mats: Any, num_devices: int, platform: str | None = None
+) -> tuple[jax.Array, ...]:
+    target_devices = visible_devices(platform)
+    if len(target_devices) < num_devices:
+        platform_msg = f" on platform '{platform}'" if platform else ""
+        raise RuntimeError(
+            f"split benchmark requires at least {num_devices} visible devices"
+            f"{platform_msg}"
         )
 
-    d0, d1 = gpu_devices[:2]
-    host_mats_0 = mats[:split]
-    host_mats_1 = mats[split:]
+    if mats.shape[0] < num_devices:
+        raise ValueError(
+            "split benchmark requires at least as many matrices as devices so the "
+            "workload can be partitioned across devices"
+        )
 
-    with jax.default_device(d0):
-        mats_0 = jax.device_put(host_mats_0, d0)
-    with jax.default_device(d1):
-        mats_1 = jax.device_put(host_mats_1, d1)
-    return mats_0, mats_1
+    selected_devices = target_devices[:num_devices]
+    device_batches = []
+    start = 0
+    total = mats.shape[0]
+    for offset, device in enumerate(selected_devices):
+        remaining = total - start
+        devices_left = len(selected_devices) - offset
+        batch_size = remaining // devices_left
+        host_batch = mats[start : start + batch_size]
+        start += batch_size
+        with jax.default_device(device):
+            device_batches.append(jax.device_put(host_batch, device))
+    return tuple(device_batches)
+
+
+def prepare_two_gpu_split_inputs(mats: jax.Array) -> tuple[jax.Array, jax.Array]:
+    device_batches = prepare_device_split_inputs(mats, num_devices=2, platform="gpu")
+    return device_batches[0], device_batches[1]
+
+
+def _is_device_batch_tuple(mats: Any) -> bool:
+    return isinstance(mats, tuple) and all(hasattr(batch, "shape") for batch in mats)
+
+
+def bench_multi_device_split_dispatch_then_sync(
+    mats: Any,
+    num_devices: int | None = None,
+    platform: str | None = None,
+    name: str | None = None,
+) -> Timing:
+    """Dispatch independent QR calls across pre-placed device batches.
+
+    Inputs are expected to already live on distinct devices if this function is
+    used from the timed benchmark path. Calls are interleaved across the
+    device-resident batches so the host alternates submissions rather than
+    draining one device fully before touching the next.
+    """
+    if _is_device_batch_tuple(mats):
+        device_batches = mats
+    else:
+        if num_devices is None:
+            raise ValueError("num_devices is required when mats are not pre-split")
+        device_batches = prepare_device_split_inputs(mats, num_devices, platform)
+
+    mode_name = name or f"split_{len(device_batches)}_devices_dispatch_then_sync"
+
+    start = time.perf_counter()
+
+    dispatch_start = time.perf_counter()
+    outputs_by_device = [[] for _ in device_batches]
+    max_len = max(batch.shape[0] for batch in device_batches)
+    for i in range(max_len):
+        for device_index, batch in enumerate(device_batches):
+            if i < batch.shape[0]:
+                q, r = jnp.linalg.qr(batch[i])
+                outputs_by_device[device_index].append(_checksum_terms(q, r))
+    dispatch_end = time.perf_counter()
+
+    sync_start = time.perf_counter()
+    stacked_outputs = []
+    for device_outputs in outputs_by_device:
+        stacked = jnp.stack(device_outputs)
+        stacked_outputs.append(jax.block_until_ready(stacked))
+    sync_end = time.perf_counter()
+
+    checksum = sum(float(jnp.sum(stacked)) for stacked in stacked_outputs)
+    total_s = time.perf_counter() - start
+    return Timing(
+        name=mode_name,
+        issue_phase_s=dispatch_end - dispatch_start,
+        tail_wait_s=sync_end - sync_start,
+        total_s=total_s,
+        checksum=checksum,
+    )
 
 
 def bench_two_gpu_split_dispatch_then_sync(
     mats: Any,
 ) -> Timing:
-    """Dispatch independent QR calls across two pre-placed GPU batches.
-
-    Inputs are expected to already live on distinct devices if this function is
-    used from the timed benchmark path. Calls are interleaved across the two
-    device-resident batches so the host alternates submissions to ``cuda:0`` and
-    ``cuda:1`` rather than draining one device fully before touching the other.
-    """
-    if (
-        isinstance(mats, tuple)
-        and len(mats) == 2
-        and hasattr(mats[0], "shape")
-        and hasattr(mats[1], "shape")
-    ):
-        mats_0, mats_1 = mats
-    else:
-        mats_0, mats_1 = prepare_two_gpu_split_inputs(mats)
-
-    start = time.perf_counter()
-
-    dispatch_start = time.perf_counter()
-    outputs_0 = []
-    outputs_1 = []
-    max_len = max(mats_0.shape[0], mats_1.shape[0])
-    for i in range(max_len):
-        if i < mats_0.shape[0]:
-            q0, r0 = jnp.linalg.qr(mats_0[i])
-            outputs_0.append(_checksum_terms(q0, r0))
-        if i < mats_1.shape[0]:
-            q1, r1 = jnp.linalg.qr(mats_1[i])
-            outputs_1.append(_checksum_terms(q1, r1))
-    dispatch_end = time.perf_counter()
-
-    sync_start = time.perf_counter()
-    stacked_0 = jnp.stack(outputs_0)
-    stacked_1 = jnp.stack(outputs_1)
-    stacked_0 = jax.block_until_ready(stacked_0)
-    stacked_1 = jax.block_until_ready(stacked_1)
-    sync_end = time.perf_counter()
-
-    checksum = float(jnp.sum(stacked_0)) + float(jnp.sum(stacked_1))
-    total_s = time.perf_counter() - start
-    return Timing(
+    return bench_multi_device_split_dispatch_then_sync(
+        mats,
+        num_devices=2,
+        platform="gpu",
         name="two_gpu_split_dispatch_then_sync",
-        issue_phase_s=dispatch_end - dispatch_start,
-        tail_wait_s=sync_end - sync_start,
-        total_s=total_s,
-        checksum=checksum,
     )
 
 
@@ -300,9 +363,13 @@ def summarize(results: list[Timing]) -> None:
 
 def main() -> None:
     args = parse_args()
-    mats = make_inputs(args.num_matrices, args.matrix_size, args.dtype, args.seed)
+    configure_precision(args.dtype)
+    host_mats = make_inputs(args.num_matrices, args.matrix_size, args.dtype, args.seed)
     summary = device_summary()
-    two_gpu_inputs = None
+    mats: jax.Array | None = None
+    split_inputs = None
+    split_benchmark: Callable[[Any], Timing] | None = None
+    split_only = False
 
     print("JAX QR dispatch benchmark")
     print("-------------------------")
@@ -311,8 +378,9 @@ def main() -> None:
     print(f"platforms    : {summary['platforms']}")
     print(f"device count : {summary['device_count']}")
     print(f"primary dev  : {summary['primary_device']}")
-    print(f"shape        : {mats.shape}")
-    print(f"dtype        : {mats.dtype}")
+    print(f"x64 enabled  : {summary['x64_enabled']}")
+    print(f"shape        : {host_mats.shape}")
+    print(f"dtype        : {host_mats.dtype}")
     print(f"trials       : {args.trials}")
     print(f"warmup       : {args.warmup}")
     print(f"all devices  : {summary['devices']}")
@@ -323,11 +391,44 @@ def main() -> None:
         bench_vmap_jit,
     ]
 
+    requested_split_devices = args.split_devices
     if args.two_gpu_split:
-        if has_two_gpu_devices():
-            two_gpu_inputs = prepare_two_gpu_split_inputs(mats)
-            benchmarks.append(bench_two_gpu_split_dispatch_then_sync)
+        requested_split_devices = max(requested_split_devices, 2)
+
+    if requested_split_devices > 1:
+        if has_at_least_n_devices(requested_split_devices):
+            split_inputs = prepare_device_split_inputs(
+                host_mats, requested_split_devices
+            )
+
+            def run_split(prepared_inputs: Any) -> Timing:
+                return bench_multi_device_split_dispatch_then_sync(
+                    prepared_inputs,
+                    name=(
+                        "two_gpu_split_dispatch_then_sync"
+                        if args.two_gpu_split and requested_split_devices == 2
+                        else f"split_{requested_split_devices}_devices_dispatch_then_sync"
+                    ),
+                )
+
+            split_benchmark = run_split
+            benchmarks.append(split_benchmark)
+            split_only = args.split_only
         else:
+            print(
+                "note         : "
+                f"--split-devices {requested_split_devices} requested, but fewer "
+                "visible devices were found"
+            )
+
+    if args.split_only and split_benchmark is None:
+        print("note         : --split-only requested without an active split benchmark")
+
+    if split_only:
+        benchmarks = [split_benchmark]
+
+    if args.two_gpu_split:
+        if not has_two_gpu_devices():
             print("note         : --two-gpu-split requested, but fewer than two GPUs found")
 
     compile_benchmarks: list = []
@@ -336,12 +437,16 @@ def main() -> None:
             bench_vmap_jit_compile_and_first_call,
             bench_vmap_jit_second_call,
         ]
+    if split_only:
+        compile_benchmarks = []
 
     for _ in range(args.warmup):
         for benchmark in benchmarks:
-            if benchmark is bench_two_gpu_split_dispatch_then_sync and two_gpu_inputs:
-                benchmark(two_gpu_inputs)
+            if split_benchmark is not None and benchmark is split_benchmark and split_inputs:
+                benchmark(split_inputs)
             else:
+                if mats is None:
+                    mats = jax.device_put(host_mats)
                 benchmark(mats)
 
     results: list[Timing] = []
@@ -353,9 +458,11 @@ def main() -> None:
         )
         print("-" * 76)
         for benchmark in benchmarks + compile_benchmarks:
-            if benchmark is bench_two_gpu_split_dispatch_then_sync and two_gpu_inputs:
-                result = benchmark(two_gpu_inputs)
+            if split_benchmark is not None and benchmark is split_benchmark and split_inputs:
+                result = benchmark(split_inputs)
             else:
+                if mats is None:
+                    mats = jax.device_put(host_mats)
                 result = benchmark(mats)
             results.append(result)
             print(

--- a/codex-benchmark/qr_size_sweep.py
+++ b/codex-benchmark/qr_size_sweep.py
@@ -8,14 +8,18 @@ import jax
 from qr_dispatch_benchmark import (
     Timing,
     bench_loop_dispatch_then_sync,
+    bench_multi_device_split_dispatch_then_sync,
     bench_loop_sync_each,
     bench_two_gpu_split_dispatch_then_sync,
     bench_vmap_jit_compile_and_first_call,
     bench_vmap_jit_second_call,
     bench_vmap_jit,
+    configure_precision,
     device_summary,
+    has_at_least_n_devices,
     has_two_gpu_devices,
     make_inputs,
+    prepare_device_split_inputs,
     prepare_two_gpu_split_inputs,
 )
 
@@ -32,8 +36,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--warmup", type=int, default=1)
     parser.add_argument("--dtype", choices=("float32", "float64"), default="float32")
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--split-devices", type=int, default=0)
     parser.add_argument("--two-gpu-split", action="store_true")
     parser.add_argument("--include-vmap-compile", action="store_true")
+    parser.add_argument("--split-only", action="store_true")
     return parser.parse_args()
 
 
@@ -47,21 +53,45 @@ def summarize_mode(timings: list[Timing]) -> tuple[float, float, float]:
 
 def main() -> None:
     args = parse_args()
+    configure_precision(args.dtype)
     summary = device_summary()
+    requested_split_devices = args.split_devices
+    if args.two_gpu_split:
+        requested_split_devices = max(requested_split_devices, 2)
+
+    use_split_devices = requested_split_devices > 1 and has_at_least_n_devices(
+        requested_split_devices
+    )
     use_two_gpu_split = args.two_gpu_split and has_two_gpu_devices()
+    split_only = args.split_only and use_split_devices
     benchmarks = [
         bench_loop_sync_each,
         bench_loop_dispatch_then_sync,
         bench_vmap_jit,
     ]
+    split_benchmark = None
     compile_benchmarks = []
-    if use_two_gpu_split:
-        benchmarks.append(bench_two_gpu_split_dispatch_then_sync)
+    if use_split_devices:
+        if args.two_gpu_split and requested_split_devices == 2:
+            split_benchmark = bench_two_gpu_split_dispatch_then_sync
+        else:
+            def run_split(prepared_inputs):
+                return bench_multi_device_split_dispatch_then_sync(
+                    prepared_inputs,
+                    name=f"split_{requested_split_devices}_devices_dispatch_then_sync",
+                )
+
+            split_benchmark = run_split
+        benchmarks.append(split_benchmark)
+    if split_only:
+        benchmarks = [split_benchmark]
     if args.include_vmap_compile:
         compile_benchmarks = [
             bench_vmap_jit_compile_and_first_call,
             bench_vmap_jit_second_call,
         ]
+    if split_only:
+        compile_benchmarks = []
 
     print("QR size sweep")
     print("-------------")
@@ -70,31 +100,52 @@ def main() -> None:
     print(f"platforms    : {summary['platforms']}")
     print(f"device count : {summary['device_count']}")
     print(f"primary dev  : {summary['primary_device']}")
+    print(f"x64 enabled  : {summary['x64_enabled']}")
     print(f"all devices  : {summary['devices']}")
     print(f"num_matrices : {args.num_matrices}")
     print(f"sizes        : {args.sizes}")
     print(f"trials       : {args.trials}")
     print(f"warmup       : {args.warmup}")
     print(f"dtype        : {args.dtype}")
+    if args.split_devices > 1 and not use_split_devices:
+        print(
+            "note         : "
+            f"--split-devices {args.split_devices} requested, but fewer visible "
+            "devices were found"
+        )
+    if args.two_gpu_split and not use_two_gpu_split:
+        print("note         : --two-gpu-split requested, but fewer than two GPUs found")
+    if args.split_only and not use_split_devices:
+        print("note         : --split-only requested without an active split benchmark")
 
     for size in args.sizes:
-        mats = make_inputs(args.num_matrices, size, args.dtype, args.seed)
-        two_gpu_inputs = None
-        if use_two_gpu_split:
-            two_gpu_inputs = prepare_two_gpu_split_inputs(mats)
+        host_mats = make_inputs(args.num_matrices, size, args.dtype, args.seed)
+        mats = None
+        split_inputs = None
+        if use_split_devices:
+            if args.two_gpu_split and requested_split_devices == 2:
+                split_inputs = prepare_two_gpu_split_inputs(host_mats)
+            else:
+                split_inputs = prepare_device_split_inputs(
+                    host_mats, requested_split_devices
+                )
         for _ in range(args.warmup):
             for benchmark in benchmarks:
-                if benchmark is bench_two_gpu_split_dispatch_then_sync and two_gpu_inputs:
-                    benchmark(two_gpu_inputs)
+                if split_benchmark is not None and benchmark is split_benchmark and split_inputs:
+                    benchmark(split_inputs)
                 else:
+                    if mats is None:
+                        mats = jax.device_put(host_mats)
                     benchmark(mats)
 
         per_mode: dict[str, list[Timing]] = {}
         for _ in range(args.trials):
             for benchmark in benchmarks + compile_benchmarks:
-                if benchmark is bench_two_gpu_split_dispatch_then_sync and two_gpu_inputs:
-                    result = benchmark(two_gpu_inputs)
+                if split_benchmark is not None and benchmark is split_benchmark and split_inputs:
+                    result = benchmark(split_inputs)
                 else:
+                    if mats is None:
+                        mats = jax.device_put(host_mats)
                     result = benchmark(mats)
                 per_mode.setdefault(result.name, []).append(result)
 


### PR DESCRIPTION
## Summary

This adds a small standalone benchmark directory for probing how repeated
independent `jnp.linalg.qr` calls behave under JAX. The goal is not to add a
Tenax benchmark suite, but to capture backend behavior that may be useful when
thinking about dense per-sector linear algebra under symmetry.

This PR is intended as informational and should not be merged,
though something similar could potentially be developed into a Tenax benchmark
in the future.

The added files are informational:

- `codex-benchmark/qr_dispatch_benchmark.py`
- `codex-benchmark/qr_size_sweep.py`
- `codex-benchmark/POLARON_RESULTS.md`
- `codex-benchmark/RYZEN_RESULTS.md`
- `codex-benchmark/README.md`

## What The Benchmark Measures

- per-call sync in a Python loop
- looped dispatch followed by one final sync
- batched `vmap(jnp.linalg.qr)` under `jax.jit`
- optional first-call vs second-call timing for the batched path (measures the jit overhead)
- optional multi-device split across  visible JAX CPU or GPU devices

The scripts report:

- issue-phase time
- tail-wait time
- total time

## Why This May Be Interesting For Tenax

These results do not directly measure Tenax algorithms, but they do say
something about how a JAX dense backend may behave for workloads resembling
independent symmetry-sector factorizations:

- repeated independent QR calls are asynchronous enough to beat sync-each loops
- batched `vmap` is not uniformly better; for large matrices it can be much worse
- explicit two-GPU splitting can help, but only with pre-placement and a sensible
  host submission pattern

## Notes

- This is intentionally standalone and not wired into Tenax's benchmark/test
  infrastructure.
- `POLARON_RESULTS.md` show the results of this benchmark on a 2-GPU (2x V100) workstation
- `RYZEN_RESULTS.md` show the results of this benchmark on 8 CPU cores (ignore the hostname, it is actually an Intel i7-12700KF), which shows quite a good speedup, indicating that looping over symmery-sectors could get a useful speedup from JAX.
