### PR TITLE
fix: code review — krylov JIT note + unit_cell validation

### DIFF
--- a/src/tenax/algorithms/_krylov.py
+++ b/src/tenax/algorithms/_krylov.py
@@ -34,6 +34,11 @@ def krylov_expm(
 
     Returns:
         The vector ``exp(dt * A) @ v``.
+
+    Note:
+        This function is **not JIT-safe** — it uses ``float()`` for
+        convergence checks, matching the pattern in ``_lanczos_solve``.
+        Call it from a Python loop, not inside ``jax.jit``.
     """
     norm_v = jnp.linalg.norm(v)
 

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -67,6 +67,13 @@ class iPEPSConfig:
     gs_log_interval: int = 10
     su_init: bool = False
 
+    def __post_init__(self):
+        valid_unit_cells = {"1x1", "2site"}
+        if self.unit_cell not in valid_unit_cells:
+            raise ValueError(
+                f"unit_cell must be one of {valid_unit_cells}, got {self.unit_cell!r}"
+            )
+
 
 class CTMEnvironment(NamedTuple):
     """The 8 CTM environment tensors (4 corners + 4 edge tensors).


### PR DESCRIPTION
## Summary
Address findings from `docs/plans/2026-03-17-code-review.md`:

- **P1**: `krylov_expm` not JIT-safe — added docstring note. Intentional design matching `_lanczos_solve` pattern; both use Python `float()` for convergence checks. Will address JIT-safety when needed for compiled pipelines.
- **P2**: Invalid `unit_cell` values silently select 1-site path — added `__post_init__` validation to `iPEPSConfig` that raises `ValueError` for values not in `{"1x1", "2site"}`.
- **P3**: `test_krylov.py` missing from CI markers — already fixed in PR #141.

## Test plan
- [x] `iPEPSConfig(unit_cell="2Site")` raises `ValueError`
- [x] `iPEPSConfig(unit_cell="1x1")` and `iPEPSConfig(unit_cell="2site")` work
- [x] 415 core tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)