### PR TITLE
ci: add id-token permission for PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,8 @@ jobs:
     name: Publish to TestPyPI
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     environment:
       name: testpypi
       url: https://test.pypi.org/p/tenax-tn
@@ -53,6 +55,8 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     environment:
       name: pypi
       url: https://pypi.org/p/tenax-tn


### PR DESCRIPTION
## Summary
Add `permissions: id-token: write` to both `publish-testpypi` and `publish-pypi` jobs in the publish workflow.

The `pypa/gh-action-pypi-publish` action uses OIDC trusted publishing by default, which requires this permission. Without it, the `ACTIONS_ID_TOKEN_REQUEST_TOKEN` env var is unset and the publish fails with "missing or insufficient OIDC token permissions".

## Test plan
- [ ] CI passes
- [ ] Next tag push triggers successful PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)