### PR TITLE
feat: add Controlled Bond Expansion (CBE) for 1-site DMRG/TDVP

### DIFF
--- a/src/tenax/__init__.py
+++ b/src/tenax/__init__.py
@@ -60,6 +60,7 @@ from tenax.algorithms.auto_mpo import (
     spin_half_ops,
     spin_one_ops,
 )
+from tenax.algorithms.cbe import expand_bond
 from tenax.algorithms.dmrg import (
     DMRGConfig,
     DMRGResult,
@@ -187,6 +188,8 @@ __all__ = [
     "rsvd",
     "qr",
     "eigh",
+    # CBE
+    "expand_bond",
     # AutoMPO
     "AutoMPO",
     "HamiltonianTerm",

--- a/src/tenax/algorithms/cbe.py
+++ b/src/tenax/algorithms/cbe.py
@@ -1,0 +1,211 @@
+"""Controlled Bond Expansion (CBE) for MPS bond dimension growth.
+
+Implements the McCulloch-Osborne CBE algorithm (arXiv:2403.00562) which
+expands the right bond of a left-canonical MPS site tensor by adding
+orthogonal columns discovered via randomized sketching.
+
+The key idea: instead of blindly adding random directions to the bond space,
+we apply the two-site Hamiltonian to random probes and project out the
+existing bond space, capturing directions that the Hamiltonian would mix in.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from tenax.core.index import TensorIndex
+from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+
+
+def expand_bond(
+    site: Tensor,
+    matvec_2site: Callable[[jax.Array, tuple[int, ...]], jax.Array],
+    right_tensor: Tensor,
+    k: int = 4,
+    oversampling: int = 5,
+    key: jax.Array | None = None,
+) -> Tensor:
+    """Expand the right bond of a left-canonical site tensor by k vectors.
+
+    Uses the McCulloch-Osborne CBE algorithm: sketch random 2-site vectors
+    through the Hamiltonian matvec, project out the existing column space,
+    and QR-orthogonalize to get new bond directions.
+
+    Args:
+        site:           Left-canonical MPS site tensor with 3 legs
+                        (left, phys, right).
+        matvec_2site:   Function ``f(v_flat, theta_shape) -> result_flat``
+                        applying the 2-site effective Hamiltonian.
+                        ``theta_shape = (chi_l, d, d2, chi_rr)``.
+        right_tensor:   Right neighbor MPS site tensor with 3 legs,
+                        sharing the right bond label with ``site``.
+        k:              Number of new bond vectors to add.
+        oversampling:   Extra sketch vectors for numerical stability.
+        key:            JAX PRNG key. Uses PRNGKey(0) if None.
+
+    Returns:
+        Expanded site tensor with right bond dimension increased by k.
+    """
+    if key is None:
+        key = jax.random.PRNGKey(0)
+
+    is_symmetric = isinstance(site, SymmetricTensor)
+
+    # Extract dense arrays
+    site_data = site.todense()
+    right_data = right_tensor.todense()
+
+    # Dimensions: site is (chi_l, d, chi_r), right is (chi_r, d2, chi_rr)
+    chi_l, d, chi_r = site_data.shape
+    _, d2, chi_rr = right_data.shape
+
+    # Determine dtype
+    use_complex = jnp.iscomplexobj(site_data) or jnp.iscomplexobj(right_data)
+    dtype = site_data.dtype
+
+    # Number of sketch columns (clamp if right space is small)
+    sketch_cols = min(k + oversampling, d2 * chi_rr)
+
+    # theta_shape for 2-site tensor
+    theta_shape = (chi_l, d, d2, chi_rr)
+
+    # Step 1: Sketch
+    # Generate random Omega in (chi_r, d2, chi_rr, sketch_cols) to form
+    # 2-site vectors theta_j[a,s,t,b] = A[a,s,c] * Omega[c,t,b,j]
+    # Apply matvec_2site to each, then contract right legs with random Psi
+    # to project back to left-site space.
+    key1, key2, key3, key4 = jax.random.split(key, 4)
+
+    if use_complex:
+        omega = (
+            jax.random.normal(
+                key1, (chi_r, d2 * chi_rr, sketch_cols), dtype=jnp.float64
+            )
+            + 1j
+            * jax.random.normal(
+                key2, (chi_r, d2 * chi_rr, sketch_cols), dtype=jnp.float64
+            )
+        ).astype(dtype)
+        psi = (
+            jax.random.normal(key3, (d2 * chi_rr, sketch_cols), dtype=jnp.float64)
+            + 1j
+            * jax.random.normal(key4, (d2 * chi_rr, sketch_cols), dtype=jnp.float64)
+        ).astype(dtype)
+    else:
+        omega = jax.random.normal(key1, (chi_r, d2 * chi_rr, sketch_cols), dtype=dtype)
+        psi = jax.random.normal(key3, (d2 * chi_rr, sketch_cols), dtype=dtype)
+
+    # A_mat: site reshaped to (chi_l*d, chi_r)
+    A_mat = site_data.reshape(chi_l * d, chi_r)
+
+    # Build Y of shape (chi_l*d, sketch_cols)
+    Y = _cbe_sketch(
+        A_mat,
+        matvec_2site,
+        theta_shape,
+        omega,
+        psi,
+        chi_l,
+        d,
+        chi_r,
+        d2,
+        chi_rr,
+        sketch_cols,
+        dtype,
+    )
+
+    # Step 2: Project out existing column space: Y_perp = (I - A A^dagger) Y
+    Y_perp = Y - A_mat @ (A_mat.conj().T @ Y)
+
+    # Step 3: QR factorization, take first k columns
+    Q, _ = jnp.linalg.qr(Y_perp)
+    Q_k = Q[:, :k]
+
+    # Step 4: Expand: A_expanded = [A_mat | Q_k]
+    A_expanded = jnp.concatenate([A_mat, Q_k], axis=1)
+    expanded_data = A_expanded.reshape(chi_l, d, chi_r + k)
+
+    # Build output tensor with proper indices
+    return _build_expanded_tensor(site, expanded_data, chi_r, k, is_symmetric)
+
+
+def _cbe_sketch(
+    A_mat: jax.Array,
+    matvec_2site: Callable,
+    theta_shape: tuple[int, ...],
+    omega: jax.Array,
+    psi: jax.Array,
+    chi_l: int,
+    d: int,
+    chi_r: int,
+    d2: int,
+    chi_rr: int,
+    sketch_cols: int,
+    dtype: Any,
+) -> jax.Array:
+    """Perform the CBE sketch: apply H to random 2-site probes and project back.
+
+    For each sketch column j:
+    1. Form 2-site vector theta_j[a,s,t,b] = A[a,s,c] * Omega[c,(t,b),j]
+    2. Apply matvec_2site to get H @ theta_j
+    3. Contract result with psi_j on the right (d2*chi_rr) legs
+    """
+    Y = jnp.zeros((chi_l * d, sketch_cols), dtype=dtype)
+
+    for j in range(sketch_cols):
+        # Omega_j has shape (chi_r, d2*chi_rr), reshape to (chi_r, d2, chi_rr)
+        omega_j = omega[:, :, j].reshape(chi_r, d2, chi_rr)
+
+        # theta_j[a,s,t,b] = A[a,s,c] * Omega_j[c,t,b]
+        A_3d = A_mat.reshape(chi_l, d, chi_r)
+        theta_j = jnp.einsum("asc,ctb->astb", A_3d, omega_j)
+        theta_flat = theta_j.reshape(-1)
+
+        # Apply 2-site matvec
+        result_flat = matvec_2site(theta_flat, theta_shape)
+        result = result_flat.reshape(chi_l * d, d2 * chi_rr)
+
+        # Contract with psi_j on right legs to get left-space vector
+        psi_j = psi[:, j]
+        y_j = result @ psi_j.conj()
+
+        Y = Y.at[:, j].set(y_j)
+
+    return Y
+
+
+def _build_expanded_tensor(
+    site: Tensor,
+    expanded_data: jax.Array,
+    chi_r: int,
+    k: int,
+    is_symmetric: bool,
+) -> Tensor:
+    """Build the expanded tensor with proper indices."""
+    old_indices = site.indices
+
+    # Find the right (OUT) bond index -- last leg
+    right_idx = old_indices[-1]
+
+    # Build new right index with expanded dimension
+    new_charges = np.zeros(chi_r + k, dtype=np.int32)
+    new_charges[:chi_r] = right_idx.charges
+
+    new_right_idx = TensorIndex(
+        symmetry=right_idx.symmetry,
+        charges=new_charges,
+        flow=right_idx.flow,
+        label=right_idx.label,
+    )
+
+    new_indices = old_indices[:-1] + (new_right_idx,)
+
+    if is_symmetric:
+        return SymmetricTensor.from_dense(expanded_data, new_indices, tol=1e-10)
+    else:
+        return DenseTensor(expanded_data, new_indices)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ _FILE_MARKERS = {
     "test_ctm_tensor_c4v.py": "algorithm",
     "test_ctm_paired.py": "algorithm",
     "test_rsvd.py": "core",
+    "test_cbe.py": "algorithm",
 }
 
 

--- a/tests/test_cbe.py
+++ b/tests/test_cbe.py
@@ -1,0 +1,242 @@
+"""Tests for Controlled Bond Expansion (CBE) algorithm."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tenax import (
+    DMRGConfig,
+    build_mpo_heisenberg,
+    build_random_symmetric_mps,
+    dmrg,
+)
+from tenax.algorithms.cbe import expand_bond
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import U1Symmetry
+from tenax.core.tensor import DenseTensor
+
+
+def _make_left_canonical_site(chi_l, d, chi_r, key, dtype=jnp.float64):
+    """Create a left-canonical DenseTensor site with 3 legs."""
+    sym = U1Symmetry()
+    charges_l = np.zeros(chi_l, dtype=np.int32)
+    charges_d = np.zeros(d, dtype=np.int32)
+    charges_r = np.zeros(chi_r, dtype=np.int32)
+
+    data = jax.random.normal(key, (chi_l, d, chi_r), dtype=dtype)
+    mat = data.reshape(chi_l * d, chi_r)
+    q, _ = jnp.linalg.qr(mat)
+    q = q[:, :chi_r]
+    data_lc = q.reshape(chi_l, d, chi_r)
+
+    indices = (
+        TensorIndex(sym, charges_l, FlowDirection.IN, label="left"),
+        TensorIndex(sym, charges_d, FlowDirection.IN, label="phys"),
+        TensorIndex(sym, charges_r, FlowDirection.OUT, label="right"),
+    )
+    return DenseTensor(data_lc, indices)
+
+
+def _make_right_tensor(chi_r, d2, chi_rr, key, dtype=jnp.float64):
+    """Create a DenseTensor for the right neighbor site."""
+    sym = U1Symmetry()
+    charges_r = np.zeros(chi_r, dtype=np.int32)
+    charges_d2 = np.zeros(d2, dtype=np.int32)
+    charges_rr = np.zeros(chi_rr, dtype=np.int32)
+
+    data = jax.random.normal(key, (chi_r, d2, chi_rr), dtype=dtype)
+
+    indices = (
+        TensorIndex(sym, charges_r, FlowDirection.IN, label="right"),
+        TensorIndex(sym, charges_d2, FlowDirection.IN, label="phys2"),
+        TensorIndex(sym, charges_rr, FlowDirection.OUT, label="right2"),
+    )
+    return DenseTensor(data, indices)
+
+
+def _make_random_hermitian_matvec(theta_shape, key):
+    """Create a random Hermitian matvec that mixes all directions.
+
+    Returns a matvec function f(v_flat, shape) -> result_flat where the
+    linear operator is a random symmetric matrix, ensuring that the CBE
+    sketch produces vectors outside the original column space.
+    """
+    n = 1
+    for s in theta_shape:
+        n *= s
+    # Random symmetric matrix
+    M = jax.random.normal(key, (n, n))
+    M = (M + M.T) / 2.0
+
+    def matvec(v_flat, shape):
+        return M @ v_flat
+
+    return matvec
+
+
+class TestExpandedShape:
+    """Test that expand_bond produces the correct output shape."""
+
+    def test_expanded_shape(self):
+        key = jax.random.PRNGKey(0)
+        k1, k2, k3 = jax.random.split(key, 3)
+        chi_l, d, chi_r = 4, 2, 3
+        d2, chi_rr = 2, 5
+        k = 4
+
+        site = _make_left_canonical_site(chi_l, d, chi_r, k1)
+        right = _make_right_tensor(chi_r, d2, chi_rr, k2)
+        theta_shape = (chi_l, d, d2, chi_rr)
+        matvec = _make_random_hermitian_matvec(theta_shape, k3)
+
+        result = expand_bond(
+            site, matvec, right, k=k, oversampling=3, key=jax.random.PRNGKey(42)
+        )
+        dense = result.todense()
+        assert dense.shape == (chi_l, d, chi_r + k), (
+            f"Expected shape {(chi_l, d, chi_r + k)}, got {dense.shape}"
+        )
+
+    def test_expanded_shape_small_k(self):
+        key = jax.random.PRNGKey(1)
+        k1, k2, k3 = jax.random.split(key, 3)
+        chi_l, d, chi_r = 3, 2, 2
+        d2, chi_rr = 2, 3
+        k = 2
+
+        site = _make_left_canonical_site(chi_l, d, chi_r, k1)
+        right = _make_right_tensor(chi_r, d2, chi_rr, k2)
+        theta_shape = (chi_l, d, d2, chi_rr)
+        matvec = _make_random_hermitian_matvec(theta_shape, k3)
+
+        result = expand_bond(
+            site, matvec, right, k=k, oversampling=2, key=jax.random.PRNGKey(42)
+        )
+        dense = result.todense()
+        assert dense.shape == (chi_l, d, chi_r + k)
+
+
+class TestExpansionOrthogonal:
+    """Test that expansion columns are orthogonal to original site columns."""
+
+    def test_expansion_orthogonal_to_original(self):
+        key = jax.random.PRNGKey(10)
+        k1, k2, k3 = jax.random.split(key, 3)
+        chi_l, d, chi_r = 6, 2, 4
+        d2, chi_rr = 2, 5
+        k = 3
+
+        site = _make_left_canonical_site(chi_l, d, chi_r, k1)
+        right = _make_right_tensor(chi_r, d2, chi_rr, k2)
+        theta_shape = (chi_l, d, d2, chi_rr)
+        matvec = _make_random_hermitian_matvec(theta_shape, k3)
+
+        result = expand_bond(
+            site, matvec, right, k=k, oversampling=3, key=jax.random.PRNGKey(42)
+        )
+        dense = result.todense()
+        A_mat = site.todense().reshape(chi_l * d, chi_r)
+        new_cols = dense.reshape(chi_l * d, chi_r + k)[:, chi_r:]
+
+        # A_mat^dagger @ new_cols should be approximately zero
+        overlap = A_mat.conj().T @ new_cols
+        assert jnp.allclose(overlap, 0.0, atol=1e-10), (
+            f"Overlap between original and new columns too large: "
+            f"{float(jnp.max(jnp.abs(overlap)))}"
+        )
+
+
+class TestComplexTensors:
+    """Test that CBE works with complex-valued tensors."""
+
+    def test_complex_tensors(self):
+        key = jax.random.PRNGKey(20)
+        k1, k2, k3, k4, k5 = jax.random.split(key, 5)
+        chi_l, d, chi_r = 4, 2, 3
+        d2, chi_rr = 2, 4
+        k = 2
+
+        # Build complex site tensor (left-canonical)
+        sym = U1Symmetry()
+        charges_l = np.zeros(chi_l, dtype=np.int32)
+        charges_d = np.zeros(d, dtype=np.int32)
+        charges_r = np.zeros(chi_r, dtype=np.int32)
+
+        re = jax.random.normal(k1, (chi_l, d, chi_r))
+        im = jax.random.normal(k2, (chi_l, d, chi_r))
+        data = re + 1j * im
+        mat = data.reshape(chi_l * d, chi_r)
+        q, _ = jnp.linalg.qr(mat)
+        q = q[:, :chi_r]
+        data_lc = q.reshape(chi_l, d, chi_r)
+
+        indices = (
+            TensorIndex(sym, charges_l, FlowDirection.IN, label="left"),
+            TensorIndex(sym, charges_d, FlowDirection.IN, label="phys"),
+            TensorIndex(sym, charges_r, FlowDirection.OUT, label="right"),
+        )
+        site = DenseTensor(data_lc, indices)
+        right = _make_right_tensor(chi_r, d2, chi_rr, k3, dtype=jnp.complex128)
+
+        # Complex Hermitian matvec
+        n = chi_l * d * d2 * chi_rr
+        M = jax.random.normal(k4, (n, n)) + 1j * jax.random.normal(k5, (n, n))
+        M = (M + M.conj().T) / 2.0
+
+        def matvec(v_flat, shape):
+            return M @ v_flat
+
+        result = expand_bond(
+            site, matvec, right, k=k, oversampling=3, key=jax.random.PRNGKey(99)
+        )
+        dense = result.todense()
+
+        # Check shape
+        assert dense.shape == (chi_l, d, chi_r + k)
+
+        # Check orthogonality
+        A_mat = data_lc.reshape(chi_l * d, chi_r)
+        new_cols = dense.reshape(chi_l * d, chi_r + k)[:, chi_r:]
+        overlap = A_mat.conj().T @ new_cols
+        assert jnp.allclose(overlap, 0.0, atol=1e-10), (
+            f"Complex overlap too large: {float(jnp.max(jnp.abs(overlap)))}"
+        )
+
+        # Check dtype preserved
+        assert jnp.iscomplexobj(dense)
+
+
+class TestEnergyImprovement:
+    """Integration test: 2-site DMRG gives lower energy than 1-site."""
+
+    def test_energy_improves_with_expansion(self):
+        L = 6
+        mpo = build_mpo_heisenberg(L)
+
+        # 1-site DMRG with small bond dim
+        mps = build_random_symmetric_mps(L, bond_dim=4, seed=0)
+        config_1site = DMRGConfig(
+            max_bond_dim=4,
+            num_sweeps=5,
+            two_site=False,
+            verbose=False,
+        )
+        result_1site = dmrg(mpo, mps, config_1site)
+        E_1site = result_1site.energy
+
+        # 2-site DMRG with larger bond dim (more variational freedom)
+        mps2 = build_random_symmetric_mps(L, bond_dim=4, seed=0)
+        config_2site = DMRGConfig(
+            max_bond_dim=6,
+            num_sweeps=10,
+            two_site=True,
+            verbose=False,
+        )
+        result_2site = dmrg(mpo, mps2, config_2site)
+        E_2site = result_2site.energy
+
+        # 2-site should achieve lower or equal energy
+        assert E_2site <= E_1site + 1e-8, (
+            f"2-site energy {E_2site} should be <= 1-site energy {E_1site}"
+        )


### PR DESCRIPTION
## Summary
Add `expand_bond()` implementing Controlled Bond Expansion (McCulloch-Osborne, arXiv:2403.00562). Enables bond dimension growth in 1-site DMRG/TDVP at O(dwkD²) cost instead of O(dwD³) for 2-site methods.

- Sketch-based expansion: `H_2site @ (A ⊗ Ω)`, project out current basis, QR
- DenseTensor and SymmetricTensor support (SymmetricTensor via dense round-trip)
- Complex tensor support for TDVP real-time evolution

Resolves #152 (partial — standalone function only, config integration in follow-up)

## Test plan
- [x] Expanded tensor has correct shape `(chi_l, d, chi_r + k)`
- [x] Expansion vectors orthogonal to original columns
- [x] Complex tensor support
- [x] Integration test: 2-site DMRG gives lower energy than 1-site (validates test setup)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)