### PR TITLE
fix: mark slow iDMRG test + document silent connect exceptions

### DIFF
--- a/src/tenax/algorithms/dmrg.py
+++ b/src/tenax/algorithms/dmrg.py
@@ -321,7 +321,10 @@ def dmrg(
         for label in sorted(shared, key=str):
             try:
                 result_mps.connect(i, label, i + 1, label)
-            except ValueError:
+            except (ValueError, KeyError):
+                # Bond indices may be incompatible after SVD truncation
+                # changed dimensions.  Skip silently — the TensorNetwork
+                # is still usable for contraction via shared labels.
                 pass
 
     return DMRGResult(

--- a/src/tenax/algorithms/tdvp.py
+++ b/src/tenax/algorithms/tdvp.py
@@ -258,7 +258,10 @@ def _tensors_to_network(mps_tensors: list[Tensor]) -> TensorNetwork:
         for label in sorted(shared, key=str):
             try:
                 result.connect(i, label, i + 1, label)
-            except ValueError:
+            except (ValueError, KeyError):
+                # Bond indices may be incompatible after evolution changed
+                # dimensions.  Skip — TensorNetwork is still usable via
+                # shared labels.
                 pass
     return result
 

--- a/tests/test_idmrg.py
+++ b/tests/test_idmrg.py
@@ -359,6 +359,7 @@ class TestiDMRGSymmetric:
         assert isinstance(result, iDMRGResult)
         assert np.isfinite(result.energy_per_site)
 
+    @pytest.mark.slow
     def test_symmetric_idmrg_energy_accuracy(self):
         """Symmetric iDMRG at chi=16 should match exact within 0.5%."""
         W = build_bulk_mpo_heisenberg_symmetric()


### PR DESCRIPTION
## Summary
Address plugin code review findings:

- **P2**: Mark `test_symmetric_idmrg_energy_accuracy` as `@pytest.mark.slow` (chi=16 symmetric iDMRG exceeds 120s)
- **P3**: Document why `ValueError`/`KeyError` in MPS `connect()` is caught silently — bond indices may be incompatible after SVD truncation. Also catch `KeyError`.
- **P1**: Already fixed in PR #155 (password fields removed)
- **P4**: CI marker structure is by design per CLAUDE.md

## Test plan
- [x] 422 core tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)