### PR TITLE
fix: proper 1-site DMRG with QR canonicalization

### DIFF
--- a/src/tenax/algorithms/dmrg.py
+++ b/src/tenax/algorithms/dmrg.py
@@ -172,6 +172,46 @@ def dmrg(
     if config.target_charge is not None and use_symmetric:
         validate_mps_sector(mps_tensors, config.target_charge)
 
+    # Right-canonicalize MPS before building environments (1-site mode).
+    # The L→R sweep needs right environments built from right-canonical MPS.
+    if not config.two_site:
+        # Right-canonicalize: RQ from site L-1 down to site 1.
+        # For boundary sites where RQ would change bond dim, just
+        # normalize to unit Frobenius norm and absorb the norm factor
+        # into the previous site.
+        for _i in range(L - 1, 0, -1):
+            q, l_mat = _rq_right_canonical(mps_tensors[_i])
+            if l_mat is not None:
+                mps_tensors[_i] = q
+                _absorb_l_into_prev(l_mat, mps_tensors, _i - 1)
+            else:
+                # Boundary: normalize tensor to unit norm, absorb
+                # the norm factor into the previous site as a scalar.
+                _td = mps_tensors[_i].todense()
+                _n = float(jnp.linalg.norm(_td))
+                if _n > 1e-15:
+                    mps_tensors[_i] = DenseTensor(_td / _n, mps_tensors[_i].indices)
+                    # Scale previous site by _n
+                    _pv = mps_tensors[_i - 1].todense()
+                    mps_tensors[_i - 1] = DenseTensor(
+                        _pv * _n, mps_tensors[_i - 1].indices
+                    )
+        # Compute MPS norm and normalize via site 0
+        _env = jnp.array([[1.0]])
+        for _t in mps_tensors:
+            _d = _t.todense()
+            if _d.ndim == 2:
+                _d = (
+                    _d[jnp.newaxis, :]
+                    if _d.shape[0] < _d.shape[1]
+                    else _d[:, :, jnp.newaxis]
+                )
+            _env = jnp.einsum("ab,apc,bpd->cd", _env, _d, jnp.conj(_d))
+        _nrm = float(jnp.sqrt(jnp.abs(_env.ravel()[0])))
+        if _nrm > 1e-15 and abs(_nrm - 1.0) > 1e-10:
+            _t0 = mps_tensors[0].todense()
+            mps_tensors[0] = DenseTensor(_t0 / _nrm, mps_tensors[0].indices)
+
     # Build left environments (L[i] = trivial for i=0)
     left_envs = _build_left_environments_list(mps_tensors, mpo_tensors, L, ops)
     right_envs = _build_right_environments_list(mps_tensors, mpo_tensors, L, ops)
@@ -209,6 +249,12 @@ def dmrg(
 
         # Rebuild left environments from updated MPS before left-to-right sweep
         if sweep > 0:
+            # After R→L, site 0 has accumulated L factors. Normalize.
+            if not config.two_site:
+                _t0 = mps_tensors[0].todense()
+                _n0 = float(jnp.linalg.norm(_t0))
+                if _n0 > 1e-15 and abs(_n0 - 1.0) > 1e-10:
+                    mps_tensors[0] = DenseTensor(_t0 / _n0, mps_tensors[0].indices)
             left_envs = _build_left_environments_list(mps_tensors, mpo_tensors, L, ops)
 
         # Left-to-right sweep
@@ -246,8 +292,28 @@ def dmrg(
                     config,
                 )
                 energy = float(e)
-                mps_tensors[i] = new_site
-                left_envs[i + 1] = ops.update_left_env(l_env, new_site, mpo_tensors[i])
+
+                # QR + absorb R + build env (atomic step for 1-site)
+                q_site, r_mat = _qr_left_canonical(new_site)
+                if r_mat is not None:
+                    mps_tensors[i] = q_site
+                    _absorb_r_into_next(r_mat, mps_tensors, i + 1)
+                    left_envs[i + 1] = ops.update_left_env(
+                        l_env, q_site, mpo_tensors[i]
+                    )
+                else:
+                    mps_tensors[i] = new_site
+                    left_envs[i + 1] = ops.update_left_env(
+                        l_env, new_site, mpo_tensors[i]
+                    )
+
+        # After L→R, site L-1 has accumulated R factors. Normalize it
+        # so right environments are built from a unit-norm MPS.
+        if not config.two_site:
+            _tL = mps_tensors[L - 1].todense()
+            _nL = float(jnp.linalg.norm(_tL))
+            if _nL > 1e-15 and abs(_nL - 1.0) > 1e-10:
+                mps_tensors[L - 1] = DenseTensor(_tL / _nL, mps_tensors[L - 1].indices)
 
         # Rebuild right environments from updated MPS before right-to-left sweep
         right_envs = _build_right_environments_list(mps_tensors, mpo_tensors, L, ops)
@@ -289,8 +355,19 @@ def dmrg(
                     config,
                 )
                 energy = float(e)
-                mps_tensors[i] = new_site
-                right_envs[i] = ops.update_right_env(r1_env, new_site, mpo_tensors[i])
+
+                # RQ + absorb L + build env (atomic step for 1-site)
+                q_site, l_mat = _rq_right_canonical(new_site)
+                if l_mat is not None:
+                    mps_tensors[i] = q_site
+                    if i > 0:
+                        _absorb_l_into_prev(l_mat, mps_tensors, i - 1)
+                    right_envs[i] = ops.update_right_env(r1_env, q_site, mpo_tensors[i])
+                else:
+                    mps_tensors[i] = new_site
+                    right_envs[i] = ops.update_right_env(
+                        r1_env, new_site, mpo_tensors[i]
+                    )
 
         energies_per_sweep.append(energy)
         if config.verbose:
@@ -334,6 +411,98 @@ def dmrg(
         truncation_errors=truncation_errors,
         converged=converged,
     )
+
+
+def _qr_left_canonical(
+    site: Tensor,
+) -> tuple[Tensor, jax.Array | None]:
+    """QR-decompose site tensor to left-canonical form.
+
+    Returns (Q_tensor, R_matrix) where Q is left-canonical.
+    Returns (site, None) if QR would change bond dimensions
+    (e.g., at boundary sites where chi_l*d < chi_r).
+    """
+    data = site.todense()
+    ndim = data.ndim
+    if ndim == 2:
+        lbl = site.labels()[0]
+        is_lb = isinstance(lbl, str) and lbl.startswith("p")
+        data = data[jnp.newaxis, :] if is_lb else data[:, :, jnp.newaxis]
+
+    cl, dd, cr = data.shape
+    if cl * dd < cr:
+        return site, None  # fat matrix — QR would change chi_r
+
+    mat = data.reshape(cl * dd, cr)
+    Qm, Rm = jnp.linalg.qr(mat)
+    q_3d = Qm.reshape(cl, dd, cr)
+
+    if ndim == 2:
+        q_store = q_3d[0] if is_lb else q_3d[:, :, 0]
+    else:
+        q_store = q_3d
+
+    return DenseTensor(q_store, site.indices), Rm
+
+
+def _rq_right_canonical(
+    site: Tensor,
+) -> tuple[Tensor, jax.Array | None]:
+    """RQ-decompose site tensor to right-canonical form.
+
+    Returns (Q_tensor, L_matrix) where Q is right-canonical.
+    Returns (site, None) if RQ would change bond dimensions.
+    """
+    data = site.todense()
+    ndim = data.ndim
+    if ndim == 2:
+        lbl = site.labels()[0]
+        is_lb = isinstance(lbl, str) and lbl.startswith("p")
+        data = data[jnp.newaxis, :] if is_lb else data[:, :, jnp.newaxis]
+
+    cl, dd, cr = data.shape
+    if dd * cr < cl:
+        return site, None  # RQ would change chi_l
+
+    mat = data.reshape(cl, dd * cr)
+    Qt, Rt = jnp.linalg.qr(mat.T)
+    q_3d = Qt.T.reshape(cl, dd, cr)
+    Lm = Rt.T  # (cl, cl)
+
+    if ndim == 2:
+        q_store = q_3d[0] if is_lb else q_3d[:, :, 0]
+    else:
+        q_store = q_3d
+
+    return DenseTensor(q_store, site.indices), Lm
+
+
+def _absorb_r_into_next(R: jax.Array, mps_tensors: list[Tensor], next_idx: int) -> None:
+    """Absorb R matrix into site next_idx (in-place)."""
+    nb = mps_tensors[next_idx].todense()
+    nd = nb.ndim
+    if nd == 2:
+        lbl = mps_tensors[next_idx].labels()[0]
+        is_lb = isinstance(lbl, str) and lbl.startswith("p")
+        nb = nb[jnp.newaxis, :] if is_lb else nb[:, :, jnp.newaxis]
+    nb_new = jnp.einsum("ij,jpk->ipk", R, nb)
+    if nd == 2:
+        nb_new = nb_new[0] if is_lb else nb_new[:, :, 0]
+    mps_tensors[next_idx] = DenseTensor(nb_new, mps_tensors[next_idx].indices)
+
+
+def _absorb_l_into_prev(L: jax.Array, mps_tensors: list[Tensor], prev_idx: int) -> None:
+    """Absorb L matrix into site prev_idx (in-place)."""
+    pv = mps_tensors[prev_idx].todense()
+    nd = pv.ndim
+    if nd == 2:
+        lbl = mps_tensors[prev_idx].labels()[0]
+        is_lb = isinstance(lbl, str) and lbl.startswith("p")
+        pv = pv[jnp.newaxis, :] if is_lb else pv[:, :, jnp.newaxis]
+    pv_new = jnp.einsum("ijk,kl->ijl", pv, L)
+    if nd == 2:
+        pv_new = pv_new[0] if is_lb else pv_new[:, :, 0]
+    mps_tensors[prev_idx] = DenseTensor(pv_new, mps_tensors[prev_idx].indices)
 
 
 def _right_canonicalize(mps_tensors: list[Tensor]) -> list[Tensor]:


### PR DESCRIPTION
## Summary

Fix 1-site DMRG to properly maintain canonical form during sweeps via atomic QR + R-absorption + environment update.

### Changes
- **Pre-sweep right-canonicalization**: RQ from right to left, normalize boundary sites, normalize MPS norm via site 0
- **In-sweep QR (L→R)**: After Lanczos at site i, QR → store Q → absorb R into site i+1 → build left_env[i+1] from Q
- **In-sweep RQ (R→L)**: After Lanczos at site i, RQ → store Q → absorb L into site i-1 → build right_env[i] from Q  
- **Boundary normalization**: Normalize site L-1 after L→R and site 0 after R→L to prevent norm drift

### Results (L=6 Heisenberg, chi=4)
| Method | Before | After |
|--------|--------|-------|
| 1-site from scratch | E = -0.34 | E = -2.08 |
| 2-site (reference) | E = -2.49 | E = -2.49 (unchanged) |

### New helper functions
- \`_qr_left_canonical(site)\` → \`(Q_tensor, R_matrix)\`
- \`_rq_right_canonical(site)\` → \`(Q_tensor, L_matrix)\`
- \`_absorb_r_into_next(R, mps, idx)\`
- \`_absorb_l_into_prev(L, mps, idx)\`

Fixes #159

## Test plan
- [x] 1-site from scratch: E=-2.08 (was -0.34)
- [x] 2-site not broken: E=-2.49
- [x] 422 core tests pass
- [x] No energy halving per sweep
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)