### PR TITLE
fix: add missing test files to pytest marker map

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,10 @@ _FILE_MARKERS = {
     "test_ctm_paired.py": "algorithm",
     "test_rsvd.py": "core",
     "test_cbe.py": "algorithm",
+    "test_lattice.py": "core",
+    "test_linalg.py": "core",
+    "test_observables.py": "algorithm",
+    "test_cbe_validation.py": "algorithm",
 }
 
 


### PR DESCRIPTION
## Summary
- Add 4 unmapped test files to `_FILE_MARKERS` in `conftest.py` so they run under `pytest -m core` or `pytest -m algorithm`
  - `test_lattice.py` → `core`
  - `test_linalg.py` → `core` (contains API export checks that catch import breakage)
  - `test_observables.py` → `algorithm`
  - `test_cbe_validation.py` → `algorithm`

Split from #161 — the DMRG canonicalization piece was already merged in #160 and will be reworked separately per review feedback.

## Test plan
- [ ] `pytest -m core` collects tests from `test_lattice.py` and `test_linalg.py`
- [ ] `pytest -m algorithm` collects tests from `test_observables.py` and `test_cbe_validation.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)