### PR TITLE
fix: reject non-tuple initial_peps in 2-site iPEPS (closes #165)

### DIFF
--- a/src/tenax/algorithms/ipeps.py
+++ b/src/tenax/algorithms/ipeps.py
@@ -119,9 +119,15 @@ def ipeps(
         (energy_per_site, optimized_peps, ctm_environment)
     """
     if config.unit_cell == "2site":
-        init_2site = None
-        if isinstance(initial_peps, tuple):
+        if initial_peps is None:
+            init_2site = None
+        elif isinstance(initial_peps, tuple):
             init_2site = initial_peps
+        else:
+            raise TypeError(
+                f"ipeps() with unit_cell='2site' requires initial_peps to be "
+                f"a tuple of two arrays or None, got {type(initial_peps).__name__}"
+            )
         return _ipeps_2site(hamiltonian_gate, init_2site, config)
 
     # Dispatch Tensor-protocol path (DenseTensor / SymmetricTensor)

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -722,6 +722,19 @@ class TestIPEPS2Site:
         energy, _, _ = ipeps(heisenberg_gate, (A, B), config)
         assert jnp.isfinite(energy)
 
+    def test_2site_rejects_non_tuple_initial_peps(self, heisenberg_gate):
+        """2-site iPEPS should raise TypeError for non-tuple initial_peps."""
+        config = iPEPSConfig(
+            max_bond_dim=2,
+            num_imaginary_steps=1,
+            dt=0.1,
+            ctm=CTMConfig(chi=4, max_iter=1),
+            unit_cell="2site",
+        )
+        bad_input = jax.random.normal(jax.random.PRNGKey(0), (2, 2, 2, 2, 2))
+        with pytest.raises(TypeError, match="tuple.*None"):
+            ipeps(heisenberg_gate, bad_input, config)
+
 
 class TestQRProjectors:
     """Tests for QR-based CTMRG projectors (Phase 1)."""


### PR DESCRIPTION
## Summary
- **P2 fix**: `ipeps()` with `unit_cell="2site"` now raises `TypeError` for non-tuple `initial_peps` instead of silently falling back to random init
- P0 (rsvd import) and P1 (marker gaps) were already resolved in #162/#163

## Test plan
- [x] `test_2site_rejects_non_tuple_initial_peps` — verifies TypeError with clear message
- [x] Existing `test_2site_with_initial_peps` still passes (tuple input accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)