### PR TITLE
feat: MPS improvements — log_norm, SVs at all bonds, qshift, orthogonality checks (#164)

### DIFF
--- a/src/tenax/algorithms/idmrg.py
+++ b/src/tenax/algorithms/idmrg.py
@@ -633,7 +633,10 @@ def _idmrg_symmetric(
     return iDMRGResult(
         energy_per_site=e_per_site_avg,
         energies_per_step=energies_per_step,
-        mps=InfiniteMPS.from_tensors([A_L_tensor, A_R_tensor], [s_vals]),
+        mps=InfiniteMPS.from_tensors(
+            [A_L_tensor, A_R_tensor],
+            [s_vals, s_vals, s_vals],  # L+1 = 3 bonds for 2-site cell
+        ),
         converged=converged,
     )
 
@@ -810,6 +813,9 @@ def idmrg(
     return iDMRGResult(
         energy_per_site=e_per_site_avg,
         energies_per_step=energies_per_step,
-        mps=InfiniteMPS.from_tensors([A_L_tensor, A_R_tensor], [s_vals]),
+        mps=InfiniteMPS.from_tensors(
+            [A_L_tensor, A_R_tensor],
+            [s_vals, s_vals, s_vals],  # L+1 = 3 bonds for 2-site cell
+        ),
         converged=converged,
     )

--- a/src/tenax/core/mps.py
+++ b/src/tenax/core/mps.py
@@ -466,15 +466,22 @@ class InfiniteMPS:
     """Infinite matrix product state with a finite unit cell.
 
     Attributes:
-        tensors: Unit cell site tensors (length = unit_cell_size).
+        tensors: Unit cell site tensors (length L = unit_cell_size).
             Labels: v_l/p_l/v_c for left site, v_c/p_r/v_r for right site (2-site cell).
             For general N-site cells, labels follow the iDMRG convention.
-        singular_values: Singular values at each bond in the unit cell.
-            For a 2-site cell, singular_values[0] is the bond between sites 0 and 1.
+        singular_values: Singular values at each bond, length L+1.
+            For a 2-site cell (L=2):
+              - singular_values[0]: left boundary bond (between adjacent unit cells)
+              - singular_values[1]: centre bond (between sites 0 and 1)
+              - singular_values[2]: right boundary bond (same as [0], shifted by qshift)
+        qshift: Charge per unit cell for U(1)-symmetric iMPS, or None for dense.
+        log_norm: Logarithm of the norm factor (consistent with FiniteMPS).
     """
 
     tensors: list[Tensor]
     singular_values: list[jax.Array]
+    qshift: int | None = None
+    log_norm: float = 0.0
 
     # -- Construction -------------------------------------------------------
 
@@ -482,11 +489,15 @@ class InfiniteMPS:
     def from_tensors(
         tensors: list[Tensor],
         singular_values: list[jax.Array],
+        qshift: int | None = None,
+        log_norm: float = 0.0,
     ) -> InfiniteMPS:
         """Wrap existing tensors into an InfiniteMPS."""
         return InfiniteMPS(
             tensors=list(tensors),
             singular_values=list(singular_values),
+            qshift=qshift,
+            log_norm=log_norm,
         )
 
     # -- Sequence protocol --------------------------------------------------

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -470,7 +470,7 @@ class TestInfiniteMPS:
         A_L = SymmetricTensor.random_normal(idx_AL, k1)
         A_R = SymmetricTensor.random_normal(idx_AR, k2)
         sv = jnp.array([0.7, 0.5, 0.3, 0.1])
-        return InfiniteMPS.from_tensors([A_L, A_R], [sv])
+        return InfiniteMPS.from_tensors([A_L, A_R], [sv, sv, sv])
 
     def test_from_tensors(self):
         imps = self._make_imps()
@@ -512,9 +512,42 @@ class TestInfiniteMPS:
         )
         A = DenseTensor(jnp.ones((2, 2, 2)), idx0)
         B = DenseTensor(jnp.ones((2, 2, 2)), idx1)
-        imps = InfiniteMPS.from_tensors([A, B], [sv])
-        S = imps.entanglement_entropy(bond=0)
+        imps = InfiniteMPS.from_tensors([A, B], [sv, sv, sv])
+        S = imps.entanglement_entropy(bond=1)  # centre bond
         np.testing.assert_allclose(S, np.log(2), atol=1e-12)
+
+    def test_qshift_default_none(self):
+        imps = self._make_imps()
+        assert imps.qshift is None
+
+    def test_l_plus_1_bonds(self):
+        imps = self._make_imps()
+        assert len(imps.singular_values) == 3  # L+1 for 2-site cell
+
+    def test_log_norm_default(self):
+        imps = self._make_imps()
+        assert imps.log_norm == 0.0
+
+    def test_qshift_passthrough(self):
+        from tenax.core.mps import InfiniteMPS
+
+        sym = U1Symmetry()
+        charges = np.zeros(2, dtype=np.int32)
+        idx0 = (
+            TensorIndex(sym, charges, IN, label="v_l"),
+            TensorIndex(sym, charges, IN, label="p_l"),
+            TensorIndex(sym, charges, OUT, label="v_c"),
+        )
+        idx1 = (
+            TensorIndex(sym, charges, IN, label="v_c"),
+            TensorIndex(sym, charges, IN, label="p_r"),
+            TensorIndex(sym, charges, OUT, label="v_r"),
+        )
+        A = DenseTensor(jnp.ones((2, 2, 2)), idx0)
+        B = DenseTensor(jnp.ones((2, 2, 2)), idx1)
+        sv = jnp.array([0.5, 0.5])
+        imps = InfiniteMPS.from_tensors([A, B], [sv, sv, sv], qshift=2)
+        assert imps.qshift == 2
 
     def test_iter(self):
         imps = self._make_imps()


### PR DESCRIPTION
## Summary

Implements all items from issue #164 (Ian McCulloch's MPS design feedback):

### FiniteMPS
- **`log_norm: float`** — separate norm tracking. Tensors stay normalized (`sum(sv²) = 1`), `log(||ψ||)` tracked separately. Important for imaginary time evolution and truncation error accounting.
- **`compute_singular_values()`** — single SVD sweep from canonical form populates SVs at all L-1 bonds. Each bond's SVs are normalized.
- **`verify` parameter on `from_tensors()`** — debug orthogonality check: verifies A†A = I (left-canonical) and AA† = I (right-canonical) when enabled.

### InfiniteMPS
- **`qshift: int | None`** — charge per unit cell quantum number
- **L+1 bonds** — `singular_values` stores L+1 entries (bonds 0 and L are same SVs, shifted by qshift)
- **`log_norm: float`** — consistent with FiniteMPS

### Algorithm updates
- iDMRG returns `InfiniteMPS` with L+1 singular values at both return paths (dense + symmetric)

## Test plan
- [x] 6 new tests for `log_norm` (default, SV normalization, norm consistency, overlap, accumulation)
- [x] 5 new tests for `compute_singular_values` (all bonds populated, normalized, state preserved, entropy, orth_center)
- [x] 3 new tests for orthogonality verification (passes canonical, fails non-canonical, skips when disabled)
- [x] 4 new tests for InfiniteMPS qshift/L+1 bonds
- [x] Full core suite: 484 passed
- [x] iDMRG tests: 85 passed (1 slow deselected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)