### PR TITLE
fix(docs): ctm_converge → ctm_tensor_converge in API docs

### DIFF
--- a/docs/api/algorithms.rst
+++ b/docs/api/algorithms.rst
@@ -112,7 +112,7 @@ AD Utilities
 
 .. autofunction:: tenax.algorithms.ad_utils.truncated_svd_ad
 
-.. autofunction:: tenax.algorithms.ad_utils.ctm_converge
+.. autofunction:: tenax.algorithms.ad_utils.ctm_tensor_converge
 
 iPEPS Excitations
 -----------------


### PR DESCRIPTION
Follow-up to #183 — the Sphinx autofunction reference wasn't updated.