### PR TITLE
docs: update AD guide and changelog for CTM refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@
 
 ### Improvements
 
+- **iPEPS CTM: non-trivial U(1) charges** — `SymmetricTensor` iPEPS with
+  non-trivial charge sectors now work through the full CTM pipeline (#180)
+  - Fixed `_flip_leg_flow` to dual charges + remap block keys
+  - Standard and multisite CTM sweeps pass `base_charges` for stable projector truncation
+- **Block-sparse gauge fix for CTM AD** — replaced `todense()`/`from_dense()`
+  round-trip with direct `tenax.linalg.qr` + `contract`, giving cleaner
+  gradients and closing the energy quality gap between dense and Tensor
+  AD paths (#182)
+- **Unified AD on Tensor protocol** — removed legacy dense AD paths
+  (`ctm_converge`, `ctm_converge_2site`); all optimization now uses
+  `ctm_tensor_converge` / `ctm_tensor_converge_2site` with `DenseTensor`
+  or `SymmetricTensor` (#183)
 - Eliminated ~23 boundary special-case code paths across DMRG, TDVP,
   observables, and CBE
 - Deleted `_pad_boundary_symmetric` / `_unpad_boundary_symmetric` functions

--- a/docs/guide/algorithms/ad_excitations.md
+++ b/docs/guide/algorithms/ad_excitations.md
@@ -57,7 +57,7 @@ The full backward pass assembles five terms:
 | 4 | $(I - UU^\dagger)\,\bar{U}\,\text{diag}(1/s)\,V_h$ | Truncation correction from $\bar{U}$ |
 | 5 | $U\,\text{diag}(1/s)\,\bar{V}_h\,(I - VV^\dagger)$ | Truncation correction from $\bar{V}_h$ |
 
-### 2. CTM fixed-point differentiation (`ctm_converge`)
+### 2. CTM fixed-point differentiation (`ctm_tensor_converge`)
 
 Instead of backpropagating through all CTM iterations (storing
 $O(\text{max\_iter})$ intermediate environments), we use **implicit
@@ -85,14 +85,15 @@ $$
 \bar{A} = \frac{\partial f}{\partial A}^T \lambda
 $$
 
-### 3. Gauge fixing (`_gauge_fix_ctm`)
+### 3. Gauge fixing (`_gauge_fix_ctm_tensor`)
 
 CTM environments have a gauge ambiguity -- the fixed point is only unique
 up to invertible transformations on bond indices. Without fixing this,
 element-wise convergence fails and the implicit differentiation equation is
 ill-defined.
 
-The fix applies **QR decomposition** to each corner after every CTM step:
+The fix applies **QR decomposition** (via ``tenax.linalg.qr``, block-sparse
+for ``SymmetricTensor``) to each corner after every CTM step:
 
 $$
 C = QR \quad\Longrightarrow\quad C_{\text{new}} = R, \quad
@@ -100,7 +101,9 @@ Q^\dagger \text{ absorbed into adjacent edge tensors}
 $$
 
 The R factor from QR has a unique sign convention (positive diagonal),
-giving a unique fixed point.
+giving a unique fixed point. Using block-sparse QR directly on ``Tensor``
+objects avoids ``todense()``/``from_dense()`` round-trips, giving cleaner
+gradients during AD.
 
 ## AD Ground State Optimization
 
@@ -122,7 +125,7 @@ A_opt, env, E_gs = optimize_gs_ad(H_bond, A_init=None, config=config)
 ```
 
 The gradient flows through the full CTM + energy pipeline: the
-`ctm_converge` custom VJP handles implicit differentiation, and
+`ctm_tensor_converge` custom VJP handles implicit differentiation, and
 `truncated_svd_ad` handles SVD stability.
 
 ## Excitation Spectrum


### PR DESCRIPTION
## Summary

- Update `ad_excitations.md`: `ctm_converge` → `ctm_tensor_converge`, `_gauge_fix_ctm` → `_gauge_fix_ctm_tensor`, document block-sparse QR gauge fix
- Update `CHANGELOG.md`: add entries for PRs #180 (CTM U(1) charges), #182 (block-sparse gauge fix), #183 (legacy AD removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)