### PR TITLE
perf: cache SymmetricTensor.blocks — 8.5x speedup

### DIFF
--- a/src/tenax/core/tensor.py
+++ b/src/tenax/core/tensor.py
@@ -946,11 +946,21 @@ class SymmetricTensor(Tensor):
 
     @property
     def blocks(self) -> dict[BlockKey, jax.Array]:
-        """Reconstruct block dict from flat buffer (compatibility layer)."""
-        return {
-            self._block_keys[i]: self._get_block(i)
-            for i in range(len(self._block_keys))
-        }
+        """Block dict from flat buffer, cached for repeated access.
+
+        The cache is valid because ``_data`` (a JAX array) is immutable.
+        Eliminates redundant slice+reshape calls when ``blocks`` is
+        accessed multiple times (e.g. during ``_blockwise_contract``).
+        """
+        try:
+            return self._blocks_cache
+        except AttributeError:
+            cache = {
+                self._block_keys[i]: self._get_block(i)
+                for i in range(len(self._block_keys))
+            }
+            object.__setattr__(self, "_blocks_cache", cache)
+            return cache
 
     def todense(self) -> jax.Array:
         """Materialize the full dense tensor (for testing/debugging only).


### PR DESCRIPTION
## Summary

Cache the `blocks` property dict on first access. Previously rebuilt from `_get_block()` (slice+reshape) on every call — 6.9M JAX dispatch calls in a typical iDMRG run.

**Before:** 798s for chi=32, 50 sweeps (symmetric Heisenberg iDMRG)
**After:** 94s — **8.5x speedup**

One-line change: `object.__setattr__(self, "_blocks_cache", cache)` on first access. Valid because `_data` is an immutable JAX array. Preserves flat `_data` layout for future Pallas kernels.

## Test plan
- [x] 496 core tests pass
- [x] Same energy output (-0.4431111357)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)