### PR TITLE
fix(tests): add Cython availability guards to BLAS regression tests

### DIFF
--- a/tests/test_block_array.py
+++ b/tests/test_block_array.py
@@ -456,6 +456,13 @@ class TestCythonComplexBa:
 class TestComplexLanczosReorth:
     """Regression tests for complex reorthogonalization (issue #216 bug 2)."""
 
+    @pytest.fixture(autouse=True)
+    def require_cython(self):
+        try:
+            from tenax.contraction._cython_blas import cython_ba_inner  # noqa: F401
+        except ImportError:
+            pytest.skip("Cython BA extension not available")
+
     def test_complex_inner_preserves_imaginary(self):
         """ba_inner must return complex for complex inputs, not just real part."""
         from tenax.contraction._cython_blas import cython_ba_inner
@@ -486,6 +493,15 @@ class TestComplexLanczosReorth:
 
 class TestNonContiguousBLAS:
     """Regression tests for in-place BLAS on non-C-contiguous arrays (issue #216 bug 3)."""
+
+    @pytest.fixture(autouse=True)
+    def require_cython(self):
+        try:
+            from tenax.contraction._cython_blas import (
+                cython_ba_scale_inplace,  # noqa: F401
+            )
+        except ImportError:
+            pytest.skip("Cython BA extension not available")
 
     def test_scale_inplace_fortran_order(self):
         from tenax.contraction._cython_blas import cython_ba_scale_inplace

--- a/tests/test_dmrg_cython.py
+++ b/tests/test_dmrg_cython.py
@@ -260,6 +260,15 @@ class TestCrossValidation:
 class TestCythonLanczosReorth:
     """Verify fused reorthogonalization matches sequential approach."""
 
+    @pytest.fixture(autouse=True)
+    def require_cython(self):
+        try:
+            from tenax.contraction._cython_blas import (
+                cython_lanczos_reorth,  # noqa: F401
+            )
+        except ImportError:
+            pytest.skip("Cython BA extension not available")
+
     @staticmethod
     def _sequential_reorth(basis_blocks_list, w_blocks):
         """Reference implementation: sequential inner + axpy per basis vector."""


### PR DESCRIPTION
## Summary

Tests added in #218 import `_cython_blas` directly without checking if the Cython extension is compiled. This causes failures in the "Full tests" CI job when Cython is not available.

Adds `require_cython` autouse fixtures to:
- `TestComplexLanczosReorth` in `test_block_array.py`
- `TestNonContiguousBLAS` in `test_block_array.py`
- `TestCythonLanczosReorth` in `test_dmrg_cython.py`

## Test plan
- [ ] Tests skip cleanly when Cython is not available
- [ ] Tests pass when Cython is compiled