### PR TITLE
ci: fix Codecov v5 coverage input key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
 
   test-full:
@@ -86,7 +86,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
 
   test-no-cython:


### PR DESCRIPTION
## Summary
- replace deprecated/invalid Codecov input `file:` with `files:` in CI workflow
- apply fix to both coverage upload steps (core tests and full tests)
- removes current post-merge CI annotations: `Unexpected input(s) 'file'`

## Testing
- not run locally (workflow-only change)
