### PR TITLE
fix(dmrg,idmrg): address post-226 solver/config bugs

### DIFF
--- a/src/tenax/algorithms/dmrg.py
+++ b/src/tenax/algorithms/dmrg.py
@@ -236,6 +236,16 @@ def dmrg(
             "subspace_expansion=True requires two_site=False. "
             "DMRG3S enrichment is a 1-site algorithm."
         )
+    if config.num_states != 1:
+        raise NotImplementedError(
+            "DMRGConfig.num_states>1 is not implemented yet. "
+            "Only single-state (ground-state) targeting is currently supported."
+        )
+    if config.noise != 0.0:
+        raise NotImplementedError(
+            "DMRGConfig.noise is not implemented yet. Set noise=0.0."
+        )
+
     L = hamiltonian.n_nodes()
     if L < 2:
         raise ValueError(

--- a/src/tenax/algorithms/idmrg.py
+++ b/src/tenax/algorithms/idmrg.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from tenax.algorithms.dmrg import (
     _blockwise_contract,
-    _lanczos_solve_jit,
+    _lanczos_solve,
     _lanczos_solve_tensor,
     _precompute_block_plan,
     _update_left_env_symmetric,
@@ -872,8 +872,8 @@ def _idmrg_sweep(
         def matvec(v: jax.Array) -> jax.Array:
             return _idmrg_matvec_jit(v, _ts, _le, W, W, _re)
 
-        E_total, theta_opt_flat = _lanczos_solve_jit(
-            matvec, theta_flat, config.lanczos_max_iter
+        E_total, theta_opt_flat = _lanczos_solve(
+            matvec, theta_flat, config.lanczos_max_iter, config.lanczos_tol
         )
         E_total = float(E_total)
         theta_opt = theta_opt_flat.reshape(theta_shape)
@@ -930,8 +930,8 @@ def _idmrg_sweep(
     def _matvec_init(v: jax.Array) -> jax.Array:
         return _idmrg_matvec_jit(v, _ts, _le, W, W, _re)
 
-    E_total, theta_opt_flat = _lanczos_solve_jit(
-        _matvec_init, theta.ravel(), config.lanczos_max_iter
+    E_total, theta_opt_flat = _lanczos_solve(
+        _matvec_init, theta.ravel(), config.lanczos_max_iter, config.lanczos_tol
     )
     E_total = float(E_total)
     theta_opt = theta_opt_flat.reshape(theta_shape)
@@ -980,8 +980,8 @@ def _idmrg_sweep(
         def matvec(v: jax.Array) -> jax.Array:
             return _idmrg_matvec_jit(v, _ts, _le, W, W, _re)
 
-        E_total, theta_opt_flat = _lanczos_solve_jit(
-            matvec, theta_flat, config.lanczos_max_iter
+        E_total, theta_opt_flat = _lanczos_solve(
+            matvec, theta_flat, config.lanczos_max_iter, config.lanczos_tol
         )
         E_total = float(E_total)
         theta_opt = theta_opt_flat.reshape(theta_shape)
@@ -1040,6 +1040,35 @@ def _idmrg_sweep(
                 f"e/site={e_per_site:.10f}, chi={n_keep}",
                 flush=True,
             )
+
+        # ---- Periodic orthogonalization (configurable interval) ----
+        if (
+            config.orthogonalize_interval > 0
+            and (sweep + 1) % config.orthogonalize_interval == 0
+            and chi_env > 1
+            and A_L.shape[0] == A_L.shape[2]
+        ):
+            A_L_np, A_R_np, s_np = _orthogonalize_unit_cell_dense(
+                np.array(A_L),
+                np.array(A_R),
+                np.array(s_center),
+                tol=config.arnoldi_tol,
+            )
+            A_L = jnp.array(A_L_np)
+            A_R = jnp.array(A_R_np)
+            s_center = jnp.array(s_np)
+            L_env = jnp.array(
+                _solve_left_env_fixedpoint_dense(np.array(A_L), np.array(W))
+            )
+            R_env = jnp.array(
+                _solve_right_env_fixedpoint_dense(np.array(A_R), np.array(W))
+            )
+
+            if config.verbose:
+                print(
+                    f"  Applied periodic orthogonalization at sweep {sweep + 1}",
+                    flush=True,
+                )
 
         # ---- Check convergence ----
         if len(energies_per_step) >= 2:
@@ -1397,8 +1426,8 @@ def _idmrg_1site_sweep(
         def matvec_2site(v: jax.Array) -> jax.Array:
             return _idmrg_matvec_jit(v, _ts, _le, W, W, _re)
 
-        E_total, theta_opt_flat = _lanczos_solve_jit(
-            matvec_2site, theta_flat, config.lanczos_max_iter
+        E_total, theta_opt_flat = _lanczos_solve(
+            matvec_2site, theta_flat, config.lanczos_max_iter, config.lanczos_tol
         )
         E_total = float(E_total)
         theta_opt = theta_opt_flat.reshape(theta_shape)
@@ -1477,6 +1506,35 @@ def _idmrg_1site_sweep(
                 f"e/site={e_per_site:.10f}, chi={n_keep}",
                 flush=True,
             )
+
+        # ---- Periodic orthogonalization (configurable interval) ----
+        if (
+            config.orthogonalize_interval > 0
+            and (sweep + 1) % config.orthogonalize_interval == 0
+            and chi_env > 1
+            and A_L.shape[0] == A_L.shape[2]
+        ):
+            A_L_np, A_R_np, s_np = _orthogonalize_unit_cell_dense(
+                np.array(A_L),
+                np.array(A_R),
+                np.array(s_center),
+                tol=config.arnoldi_tol,
+            )
+            A_L = jnp.array(A_L_np)
+            A_R = jnp.array(A_R_np)
+            s_center = jnp.array(s_np)
+            L_env = jnp.array(
+                _solve_left_env_fixedpoint_dense(np.array(A_L), np.array(W))
+            )
+            R_env = jnp.array(
+                _solve_right_env_fixedpoint_dense(np.array(A_R), np.array(W))
+            )
+
+            if config.verbose:
+                print(
+                    f"  Applied periodic orthogonalization at sweep {sweep + 1}",
+                    flush=True,
+                )
 
         # ---- Check convergence ----
         if len(energies_per_step) >= 2:

--- a/tests/test_dmrg.py
+++ b/tests/test_dmrg.py
@@ -220,6 +220,36 @@ class TestDMRGRun:
             assert final <= initial + 0.5, "Energy should not increase significantly"
 
 
+class TestDMRGUnsupportedOptions:
+    def test_num_states_gt_one_raises(self):
+        """num_states>1 is public but currently unsupported."""
+        L = 4
+        mpo = _densify_tensor_network(build_mpo_heisenberg(L))
+        mps = build_random_mps(L, physical_dim=2, bond_dim=4, seed=0)
+        config = DMRGConfig(
+            max_bond_dim=4,
+            num_sweeps=1,
+            lanczos_max_iter=5,
+            num_states=2,
+        )
+        with pytest.raises(NotImplementedError, match="num_states"):
+            dmrg(mpo, mps, config)
+
+    def test_noise_nonzero_raises(self):
+        """noise is public but currently unsupported."""
+        L = 4
+        mpo = _densify_tensor_network(build_mpo_heisenberg(L))
+        mps = build_random_mps(L, physical_dim=2, bond_dim=4, seed=0)
+        config = DMRGConfig(
+            max_bond_dim=4,
+            num_sweeps=1,
+            lanczos_max_iter=5,
+            noise=1e-3,
+        )
+        with pytest.raises(NotImplementedError, match="noise"):
+            dmrg(mpo, mps, config)
+
+
 def _build_heisenberg_matrix(L: int, Jz: float = 1.0, Jxy: float = 1.0) -> np.ndarray:
     """Build the L-site Heisenberg Hamiltonian matrix (OBC) using Kronecker products.
 

--- a/tests/test_idmrg.py
+++ b/tests/test_idmrg.py
@@ -1,5 +1,6 @@
 """Tests for the iDMRG algorithm."""
 
+import importlib
 import math
 
 import jax
@@ -144,6 +145,38 @@ class TestiDMRGRun:
         cfg = iDMRGConfig(max_bond_dim=8, max_iterations=5, lanczos_max_iter=10)
         result = idmrg(W, cfg)
         assert isinstance(result, iDMRGResult)
+
+    def test_dense_two_site_uses_tolerance_aware_lanczos(self, monkeypatch):
+        """Dense 2-site path should route through tol-aware Lanczos."""
+        idmrg_mod = importlib.import_module("tenax.algorithms.idmrg")
+
+        W = build_bulk_mpo_heisenberg(dtype=jnp.float64)
+        cfg = iDMRGConfig(
+            max_bond_dim=4,
+            max_iterations=2,
+            lanczos_max_iter=6,
+            lanczos_tol=1e-5,
+            convergence_tol=0.0,
+        )
+
+        seen_tols: list[float] = []
+        orig_lanczos = idmrg_mod._lanczos_solve
+
+        def _record_lanczos(matvec, initial_vector, num_steps, tol):
+            seen_tols.append(float(tol))
+            return orig_lanczos(matvec, initial_vector, num_steps, tol)
+
+        def _forbid_jit(*args, **kwargs):
+            raise AssertionError("dense iDMRG should not call _lanczos_solve_jit")
+
+        monkeypatch.setattr(idmrg_mod, "_lanczos_solve", _record_lanczos)
+        if hasattr(idmrg_mod, "_lanczos_solve_jit"):
+            monkeypatch.setattr(idmrg_mod, "_lanczos_solve_jit", _forbid_jit)
+
+        result = idmrg(W, cfg, dtype=jnp.float64)
+        assert np.isfinite(result.energy_per_site)
+        assert seen_tols
+        assert all(np.isclose(tol, cfg.lanczos_tol) for tol in seen_tols)
 
     def test_dense_two_site_raises_clear_error_on_bond_shrink(self):
         """Aggressive svd_trunc_err should raise a clear validation error."""
@@ -534,6 +567,30 @@ class TestOrthogonalization:
             TL_I, np.eye(chi), atol=1e-6, err_msg="T_L(I) != I after orthogonalization"
         )
 
+    def test_orthogonalize_interval_applies_periodically_two_site(self, monkeypatch):
+        """orthogonalize_interval should trigger multiple in-loop calls."""
+        idmrg_mod = importlib.import_module("tenax.algorithms.idmrg")
+        W = build_bulk_mpo_heisenberg(dtype=jnp.float64)
+        call_count = 0
+
+        def _count_only(A_L, A_R, s_vals, tol=1e-12):
+            nonlocal call_count
+            call_count += 1
+            return A_L, A_R, s_vals
+
+        monkeypatch.setattr(idmrg_mod, "_orthogonalize_unit_cell_dense", _count_only)
+
+        cfg = iDMRGConfig(
+            max_bond_dim=8,
+            max_iterations=5,
+            lanczos_max_iter=8,
+            convergence_tol=0.0,
+            orthogonalize_interval=2,
+        )
+        result = idmrg(W, cfg, dtype=jnp.float64)
+        assert np.isfinite(result.energy_per_site)
+        assert call_count >= 2
+
 
 # ---------------------------------------------------------------------------
 # 1-site iDMRG with DMRG3S
@@ -601,6 +658,64 @@ class TestiDMRG1Site:
         # Default
         cfg2 = iDMRGConfig()
         assert cfg2.mixing_factor == 0.05
+
+    def test_1site_uses_tolerance_aware_lanczos(self, monkeypatch):
+        """Dense 1-site path should route through tol-aware Lanczos."""
+        idmrg_mod = importlib.import_module("tenax.algorithms.idmrg")
+
+        W = build_bulk_mpo_heisenberg(dtype=jnp.float64)
+        cfg = iDMRGConfig(
+            max_bond_dim=4,
+            max_iterations=2,
+            two_site=False,
+            lanczos_max_iter=6,
+            lanczos_tol=1e-6,
+            convergence_tol=0.0,
+        )
+
+        seen_tols: list[float] = []
+        orig_lanczos = idmrg_mod._lanczos_solve
+
+        def _record_lanczos(matvec, initial_vector, num_steps, tol):
+            seen_tols.append(float(tol))
+            return orig_lanczos(matvec, initial_vector, num_steps, tol)
+
+        def _forbid_jit(*args, **kwargs):
+            raise AssertionError("dense iDMRG should not call _lanczos_solve_jit")
+
+        monkeypatch.setattr(idmrg_mod, "_lanczos_solve", _record_lanczos)
+        if hasattr(idmrg_mod, "_lanczos_solve_jit"):
+            monkeypatch.setattr(idmrg_mod, "_lanczos_solve_jit", _forbid_jit)
+
+        result = idmrg(W, cfg, dtype=jnp.float64)
+        assert np.isfinite(result.energy_per_site)
+        assert seen_tols
+        assert all(np.isclose(tol, cfg.lanczos_tol) for tol in seen_tols)
+
+    def test_orthogonalize_interval_applies_periodically_one_site(self, monkeypatch):
+        """1-site orthogonalize_interval should trigger in-loop orthogonalization."""
+        idmrg_mod = importlib.import_module("tenax.algorithms.idmrg")
+        W = build_bulk_mpo_heisenberg(dtype=jnp.float64)
+        call_count = 0
+
+        def _count_only(A_L, A_R, s_vals, tol=1e-12):
+            nonlocal call_count
+            call_count += 1
+            return A_L, A_R, s_vals
+
+        monkeypatch.setattr(idmrg_mod, "_orthogonalize_unit_cell_dense", _count_only)
+
+        cfg = iDMRGConfig(
+            max_bond_dim=8,
+            max_iterations=5,
+            two_site=False,
+            lanczos_max_iter=8,
+            convergence_tol=0.0,
+            orthogonalize_interval=2,
+        )
+        result = idmrg(W, cfg, dtype=jnp.float64)
+        assert np.isfinite(result.energy_per_site)
+        assert call_count >= 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix dense iDMRG Lanczos tolerance handling: dense 2-site and 1-site paths now honor `iDMRGConfig.lanczos_tol`
- implement periodic `orthogonalize_interval` behavior in dense iDMRG (2-site and 1-site), with environment re-sync after each orthogonalization step
- reject currently unsupported DMRG config options early (`DMRGConfig.num_states != 1`, `DMRGConfig.noise != 0.0`) instead of silently no-op
- keep existing fixes for dense phase-3 bond-shrink validation and explicit GMRES failure handling

## Details
- `src/tenax/algorithms/idmrg.py`
  - switch dense Lanczos calls from `_lanczos_solve_jit` (fixed-iteration, no tol) to `_lanczos_solve(..., config.lanczos_tol)`
  - add periodic orthogonalization checks at sweep intervals (`(sweep + 1) % orthogonalize_interval == 0`) in both dense 2-site and 1-site loops
  - after periodic orthogonalization, recompute fixed-point left/right environments to keep sweep state consistent
- `src/tenax/algorithms/dmrg.py`
  - add explicit `NotImplementedError` guards for `num_states` and `noise` unsupported values

## Tests
- added regression tests in:
  - `tests/test_idmrg.py`
    - dense 2-site and 1-site paths use tolerance-aware Lanczos
    - `orthogonalize_interval` triggers multiple periodic calls in 2-site and 1-site modes
  - `tests/test_dmrg.py`
    - `num_states > 1` raises `NotImplementedError`
    - `noise != 0.0` raises `NotImplementedError`
- local verification:
  - `uv run pytest -q tests/test_idmrg.py::TestiDMRGRun::test_dense_two_site_uses_tolerance_aware_lanczos tests/test_idmrg.py::TestOrthogonalization::test_orthogonalize_interval_applies_periodically_two_site tests/test_idmrg.py::TestiDMRG1Site::test_1site_uses_tolerance_aware_lanczos tests/test_idmrg.py::TestiDMRG1Site::test_orthogonalize_interval_applies_periodically_one_site tests/test_dmrg.py::TestDMRGUnsupportedOptions::test_num_states_gt_one_raises tests/test_dmrg.py::TestDMRGUnsupportedOptions::test_noise_nonzero_raises`
  - `uv run pytest -q tests/test_idmrg.py tests/test_dmrg.py`

Closes #219
Closes #220
Closes #221
Closes #222
Closes #223