### PR TITLE
chore: bump to v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.4.1 (2026-04-04)
+
+### Improvements
+
+- **GMRES diagonal scaling preconditioner** for faster implicit diff backward
+  pass in iPEPS AD optimization (#231)
+- **Fix TensorIndex API calls** for sector-based refactor (#234)
+- **Remove xfail** from `test_ad_d2_chi_scaling` — chi-scaling now works
+  correctly with L-BFGS optimizer and fresh CTM line search
+
 ## v0.4.0 (2026-04-03)
 
 ### New Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tenax-tn"
-version = "0.4.0"
+version = "0.4.1"
 description = "JAX-based tensor network library with symmetry-aware block-sparse tensors"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/tenax/__init__.py
+++ b/src/tenax/__init__.py
@@ -155,7 +155,7 @@ from tenax.linalg import eigh, qr, rsvd, svd
 from tenax.network.netfile import NetworkBlueprint, from_netfile
 from tenax.network.network import TensorNetwork, build_mps, build_peps
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __all__ = [
     # Version

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -806,9 +806,6 @@ class TestHeisenbergBenchmark:
         assert E_gs > -0.80, f"AD D=2 E/site={E_gs:.6f}, unphysically low"
 
     @pytest.mark.slow
-    @pytest.mark.xfail(
-        reason="AD still exploits underconverged CTM at chi=8 despite warm-start; needs larger min chi"
-    )
     def test_ad_d2_chi_scaling(self, heisenberg_gate):
         """Energy should improve (decrease) with increasing chi at fixed D=2."""
         su_config = iPEPSConfig(


### PR DESCRIPTION
## Summary
- Bump version to 0.4.1 (v0.4.0 PyPI artifacts can't be re-uploaded)
- Add CHANGELOG entry for v0.4.1 (GMRES preconditioner #231, TensorIndex fix #234)
- Remove xfail from `test_ad_d2_chi_scaling` — chi-scaling passes with L-BFGS + fresh CTM line search

## Test plan
- [x] `test_ad_d2_chi_scaling` passes (XPASS confirmed)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)