### PR TITLE
fix: Codex review fixes (complex dot, docs, dead preconditioner)

### DIFF
--- a/docs/guide/algorithms/ipeps.md
+++ b/docs/guide/algorithms/ipeps.md
@@ -240,7 +240,7 @@ config = iPEPSConfig(
     gs_line_search_max_steps=8,
     su_init=True,
 )
-A_opt, env, E_gs = optimize_gs_ad(gate, None, config)
+A_opt, env, E_gs = optimize_gs_ad(H_bond, None, config)
 ```
 
 For Adam, a **cosine learning rate schedule** (lr → lr/10) is automatically
@@ -260,7 +260,7 @@ config = iPEPSConfig(
     gs_learning_rate=1e-3,
     gs_num_steps=50,
 )
-A_opt, env, E_gs = optimize_gs_ad(gate, None, config)
+A_opt, env, E_gs = optimize_gs_ad(H_bond, None, config)
 ```
 
 ```{warning}

--- a/src/tenax/algorithms/ad_utils.py
+++ b/src/tenax/algorithms/ad_utils.py
@@ -563,19 +563,12 @@ def _ctm_tensor_converge_bwd(neighbors, config_tuple, residuals, g):
         Jt_v = vjp_fn(v)[0]
         return tuple(vi - ji for vi, ji in zip(v, Jt_v))
 
-    # Diagonal scaling preconditioner: normalize by env tensor norms so that
-    # corners (chi×chi) and edges (chi×D²×chi) are on comparable scales.
-    # Nearly free to apply (element-wise multiply, no VJP needed).
+    # Preconditioner slot for GMRES.  The diagonal scaling approach
+    # (env norms) used wrong space — env_leaves are forward tensors while
+    # the GMRES vectors live in cotangent space.  Neumann series (I + J^T)
+    # also diverges with truncated GMRES.  Left as None until a proper
+    # approximation of (I - J^T)^{-1} is implemented.
     precond = None
-    if config.gmres_precondition:
-        inv_norms = tuple(
-            1.0 / jnp.maximum(jnp.sqrt(jnp.sum(e**2)), 1e-12) for e in env_leaves
-        )
-
-        def apply_diag_precond(v):
-            return tuple(vi * si for vi, si in zip(v, inv_norms))
-
-        precond = apply_diag_precond
 
     max_fp_iter = min(config.max_iter, 50)
     lam, info = jax_gmres(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -61,10 +61,12 @@ def _use_line_search(config: iPEPSConfig) -> bool:
 
 
 def _tree_dot(a, b) -> float:
-    """Compute dot product between two pytrees of arrays."""
+    """Compute real dot product between two pytrees of arrays."""
     leaves_a = jax.tree.leaves(a)
     leaves_b = jax.tree.leaves(b)
-    return float(sum(jnp.sum(la * lb) for la, lb in zip(leaves_a, leaves_b)))
+    return float(
+        jnp.real(sum(jnp.sum(jnp.conj(la) * lb) for la, lb in zip(leaves_a, leaves_b)))
+    )
 
 
 def _tree_scale(tree, alpha: float):

--- a/tests/test_ad_utils.py
+++ b/tests/test_ad_utils.py
@@ -354,11 +354,8 @@ class TestGMRESBackward:
         assert jnp.all(jnp.isfinite(grad.todense())), "Preconditioned GMRES: NaN/Inf"
         assert grad.norm() > 1e-15, "Preconditioned GMRES: gradient is all zeros"
 
-    @pytest.mark.xfail(
-        reason="Diagonal preconditioner produces divergent gradients; needs investigation"
-    )
     def test_gmres_preconditioned_matches_unpreconditioned(self):
-        """Preconditioned and unpreconditioned GMRES must agree on gradients."""
+        """With preconditioner disabled (no-op), both paths must agree."""
         A = _make_dense_tensor(jax.random.PRNGKey(55))
         gate = jnp.diag(jnp.array([0.25, -0.25, -0.25, 0.25])).reshape(2, 2, 2, 2)
 


### PR DESCRIPTION
## Summary
Addresses Codex review comments from PRs #235, #236, and removes dead preconditioner code from #231/#238.

- **`_tree_dot` Hermitian fix (P1):** `sum(la * lb)` → `Re(sum(conj(la) * lb))` for complex tensor correctness in CG beta and Armijo line search
- **iPEPS guide docs fix (P2):** `gate` → `H_bond` in optimizer and explicit AD examples (variable is defined as `H_bond` in the guide)
- **Dead preconditioner removal:** Remove the diagonal scaling `if config.gmres_precondition:` branch (used env norms in cotangent space — fundamentally wrong). Keep `precond = None` with explanatory comment.
- **Remove xfail:** Preconditioner matching test now trivially passes (both paths unpreconditioned)

## Test plan
- [x] Core tests pass (618 passed)
- [x] AD utils tests pass (23 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)