### PR TITLE
fix: codebase health review — 9 bug fixes

### DIFF
--- a/src/tenax/algorithms/ad_utils.py
+++ b/src/tenax/algorithms/ad_utils.py
@@ -16,6 +16,7 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax.scipy.sparse.linalg import gmres as jax_gmres
 
 from tenax.algorithms._ctm_tensor import (
@@ -260,7 +261,7 @@ def truncated_svd_symmetric_ad(
 
     # Determine symmetry from input (if available)
     sym = M.indices[0].symmetry
-    bond_charges = jnp.zeros(k, dtype=jnp.int32)
+    bond_charges = np.zeros(k, dtype=np.int32)
     bond_out = TensorIndex.from_charges(
         sym, bond_charges, FlowDirection.OUT, label=new_bond_label
     )
@@ -303,7 +304,7 @@ def _config_from_tuple(config_tuple: tuple):
     pm_int = config_tuple[4] if len(config_tuple) > 4 else 0
     min_iter = config_tuple[5] if len(config_tuple) > 5 else 10
     ad_regularize_svd = bool(config_tuple[6]) if len(config_tuple) > 6 else True
-    gmres_precondition = bool(config_tuple[7]) if len(config_tuple) > 7 else True
+    gmres_precondition = bool(config_tuple[7]) if len(config_tuple) > 7 else False
     ad_bwd_int = config_tuple[8] if len(config_tuple) > 8 else 0
     ad_backward_method = {0: "vjp", 1: "gmres"}.get(ad_bwd_int, "vjp")
     return CTMConfig(
@@ -609,14 +610,14 @@ def _ctm_tensor_converge_bwd(neighbors, config_tuple, residuals, g):
         lam = g
 
         for _ in range(max_fp_iter):
+            lam_prev = lam
             Jt_lam = vjp_env_fn(lam)[0]
             lam = tuple(ji + gi for ji, gi in zip(Jt_lam, g))
 
             # Check if lam is diverging — stop early if so
             lam_norm = sum(float(jnp.sum(li**2)) for li in lam) ** 0.5
             if not math.isfinite(lam_norm) or lam_norm > 1e15:
-                # Revert to last good lam
-                lam = tuple(li - ji for li, ji in zip(lam, Jt_lam))
+                lam = lam_prev
                 break
 
             # Check convergence: |J^T lam| should decrease
@@ -683,8 +684,6 @@ def _ctm_tensor_multisite_fixed_point(site_tensors, neighbors, config, envs_init
             if c in prev_svs:
                 if float(_ctm_sv_diff_local(sv, prev_svs[c])) >= config.conv_tol:
                     converged = False
-                    prev_svs[c] = sv
-                    break
             else:
                 converged = False
             prev_svs[c] = sv

--- a/src/tenax/algorithms/dmrg.py
+++ b/src/tenax/algorithms/dmrg.py
@@ -1582,8 +1582,10 @@ def _lanczos_solve_tensor(
             w = w - basis[-2] * betas[-1]
 
         # Full reorthogonalization against all previous basis vectors.
+        # inner(q, w) = <q|w> is real for Hermitian operators; take .real
+        # to avoid imaginary-part noise corrupting the reorthogonalization.
         for q in basis:
-            w = w - q * float(inner(q, w))
+            w = w - q * float(inner(q, w).real)
 
         beta_val = float(w.norm())
         betas.append(beta_val)

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -39,8 +39,8 @@ def _build_optimizer(config: iPEPSConfig):
         )
     elif name == "lbfgs":
         return optax.chain(
-            optax.clip_by_global_norm(config.gs_max_grad_norm),
             optax.scale_by_lbfgs(memory_size=10),
+            optax.clip_by_global_norm(config.gs_max_grad_norm),
             optax.scale(-1.0),
         )
     elif name == "cg":

--- a/src/tenax/algorithms/tdvp.py
+++ b/src/tenax/algorithms/tdvp.py
@@ -314,7 +314,7 @@ def _build_boundary_left_env(
 ) -> DenseTensor:
     """Build left boundary environment with explicit MPS/MPO boundary dims."""
     env = jnp.zeros((chi_mps, chi_mpo, chi_mps), dtype=dtype)
-    env = env.at[:, 0, :].set(jnp.eye(chi_mps, dtype=dtype))
+    env = env.at[:, -1, :].set(jnp.eye(chi_mps, dtype=dtype))
 
     sym = U1Symmetry()
     mps_bond = np.zeros(chi_mps, dtype=np.int32)

--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -979,6 +979,11 @@ def _eigh_symmetric(
 
     grouped = _group_blocks_by_bond_charge(tensor, left_axes, right_axes)
 
+    # Check if fermionic signs are needed for leg reordering
+    sym = tensor.indices[0].symmetry
+    is_fermionic = sym.is_fermionic
+    decomp_perm = tuple(left_axes + right_axes)
+
     # Per-sector eigh results: (eigvecs, eigvals, left_subkeys, left_row_sizes)
     sector_results: dict[
         int,
@@ -1027,6 +1032,20 @@ def _eigh_symmetric(
             row_start = sum(left_row_sizes[:li])
             col_start = sum(right_col_sizes[:ri])
             flat_block = block.reshape(left_row_sizes[li], right_col_sizes[ri])
+            # Apply Koszul sign for leg reordering (original -> left+right)
+            if is_fermionic:
+                full_key = [0] * len(tensor.indices)
+                for ax, ch in zip(left_axes, lk):
+                    full_key[ax] = ch
+                for ax, ch in zip(right_axes, rk):
+                    full_key[ax] = ch
+                parities = tuple(
+                    int(sym.parity(np.array([full_key[i]]))[0])
+                    for i in range(len(full_key))
+                )
+                ksign = _koszul_sign(parities, decomp_perm)
+                if ksign < 0:
+                    flat_block = -flat_block
             matrix = matrix.at[
                 row_start : row_start + left_row_sizes[li],
                 col_start : col_start + right_col_sizes[ri],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,9 @@ _FILE_MARKERS = {
     "test_jit_sweep.py": "core",
     "test_padded_linalg.py": "core",
     "test_lanczos_np.py": "algorithm",
+    "test_block_array.py": "core",
+    "test_dmrg3s.py": "algorithm",
+    "test_dmrg_cython.py": "algorithm",
 }
 
 


### PR DESCRIPTION
## Summary

Systematic codebase health review of `main` identified and fixes 9 bugs across core and algorithm modules:

### Critical / High
- **linalg**: `_eigh_symmetric` was missing Koszul signs for fermionic tensors — all other decompositions (SVD, QR, rSVD) apply them. Fermionic CTM projectors via `eigh` had wrong signs. (#241)
- **ad_utils**: `jnp.zeros` passed to `TensorIndex.from_charges` would crash under `jax.jit`/`jax.grad` with `ConcretizationTypeError`. Changed to `np.zeros`. (#242)
- **ad_utils**: `_config_from_tuple` defaulted `gmres_precondition` to `True`, but `CTMConfig` defaults to `False` (disabled in #238 for broken gradients). Old config tuples would silently re-enable it. (#243)

### Medium
- **ad_utils**: Iterative VJP rollback on divergence reverted to initial `g` instead of last good `lam_prev`. (#244)
- **ad_utils**: Multisite CTM convergence `break` skipped `prev_svs` updates for remaining sites, risking false convergence. (#245)
- **tdvp**: Left boundary env set identity at MPO channel 0 ("done") instead of last channel ("vacuum") — wrong for `chi_mpo > 1`. (#246)
- **ipeps_optimize**: L-BFGS had `clip_by_global_norm` before `scale_by_lbfgs`, breaking the secant equation. Moved clip after curvature. (#247)

### Low
- **dmrg**: Lanczos `_lanczos_solve_tensor` reorthogonalization used `float(inner(q,w))` which drops imaginary part for complex tensors. Now uses `.real`. (#249)
- **conftest**: `test_block_array`, `test_dmrg3s`, `test_dmrg_cython` were missing from `_FILE_MARKERS` and never ran in CI. (#251)

### Issues created but not fixed here (need investigation)
- #248: `best_A` tracking — verified correct on re-inspection
- #250: Wilson fermion cross-mass term sign/phase — needs physics verification
- #252: Test coverage gaps for GMRES backward, L-BFGS/CG, symmetric TDVP

## Test plan
- [x] `pytest -m core` — 685 passed (2 pre-existing failures excluded: Metal backend, jit_sweep)
- [x] `test_ad_utils.py` — all pass
- [x] `test_linalg.py` — all pass
- [x] `test_tdvp.py` — all pass
- [x] `test_trg.py` — all pass
- [x] Pre-commit hooks (ruff, ruff format) pass

🤖 Generated with [Claude Code](https://claude.ai/code)