### PR TITLE
fix: best_A tracking edge case + tests for uncovered paths

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -408,12 +408,27 @@ def _optimize_gs_ad_tensor(
             A = optax.apply_updates(A, direction)
             A = A * (1.0 / (A.norm() + 1e-10))
 
-    A_final = best_A * (1.0 / (best_A.norm() + 1e-10))
-    env_leaves = ctm_tensor_converge(
-        {(0, 0): A_final}, prev_env_leaves, SINGLE_SITE_NEIGHBORS, config_tuple
+    # Check if the final post-update A is better than best_A (the last
+    # iteration's line-search result is not evaluated inside the loop).
+    A_norm = A * (1.0 / (A.norm() + 1e-10))
+    env_leaves_final = ctm_tensor_converge(
+        {(0, 0): A_norm}, prev_env_leaves, SINGLE_SITE_NEIGHBORS, config_tuple
     )
-    env = jax.tree.unflatten(env_treedef, env_leaves)
-    E_gs = float(compute_energy_ctm_tensor(A_final, env, gate, d_phys))
+    env_final = jax.tree.unflatten(env_treedef, env_leaves_final)
+    E_final = float(compute_energy_ctm_tensor(A_norm, env_final, gate, d_phys))
+    if E_final < best_energy:
+        best_A = A
+        best_energy = E_final
+
+    A_final = best_A * (1.0 / (best_A.norm() + 1e-10))
+    if best_A is A:
+        env, E_gs = env_final, E_final
+    else:
+        env_leaves = ctm_tensor_converge(
+            {(0, 0): A_final}, prev_env_leaves, SINGLE_SITE_NEIGHBORS, config_tuple
+        )
+        env = jax.tree.unflatten(env_treedef, env_leaves)
+        E_gs = float(compute_energy_ctm_tensor(A_final, env, gate, d_phys))
     if config.gs_verbose:
         print(f"[iPEPS-AD:1site-tensor] final E={E_gs:.10f}", flush=True)
 
@@ -674,27 +689,56 @@ def _optimize_gs_ad_tensor_2site(
             params = optax.apply_updates(params, direction)
             params = _normalize_params(params)
 
-    # Re-evaluate best params with fresh CTM to get accurate energy
-    A_final, B_final = _normalize_params(best_params)
-    site_tensors = {(0, 0): A_final, (1, 0): B_final}
-    fresh_env_leaves = ctm_tensor_converge(
-        site_tensors,
-        best_env_leaves or prev_env_leaves,
+    # Check if the final post-update params are better than best_params
+    # (the last iteration's line-search result is not evaluated inside the loop).
+    A_last, B_last = _normalize_params(params)
+    site_last = {(0, 0): A_last, (1, 0): B_last}
+    last_env_leaves = ctm_tensor_converge(
+        site_last,
+        prev_env_leaves,
         CHECKERBOARD_NEIGHBORS,
         config_tuple,
     )
-    env_A = jax.tree.unflatten(env_treedef, fresh_env_leaves[:n_env_leaves])
-    env_B = jax.tree.unflatten(env_treedef, fresh_env_leaves[n_env_leaves:])
-    E_gs = float(
+    env_A_last = jax.tree.unflatten(env_treedef, last_env_leaves[:n_env_leaves])
+    env_B_last = jax.tree.unflatten(env_treedef, last_env_leaves[n_env_leaves:])
+    E_last = float(
         compute_energy_ctm_tensor_2site(
-            A_final,
-            B_final,
-            env_A,
-            env_B,
+            A_last,
+            B_last,
+            env_A_last,
+            env_B_last,
             gate,
             d_phys,
         )
     )
+    if E_last < best_energy:
+        best_params = params
+        best_env_leaves = last_env_leaves
+
+    # Re-evaluate best params with fresh CTM to get accurate energy
+    A_final, B_final = _normalize_params(best_params)
+    if best_params is params:
+        env_A, env_B, E_gs = env_A_last, env_B_last, E_last
+    else:
+        site_tensors = {(0, 0): A_final, (1, 0): B_final}
+        fresh_env_leaves = ctm_tensor_converge(
+            site_tensors,
+            best_env_leaves or prev_env_leaves,
+            CHECKERBOARD_NEIGHBORS,
+            config_tuple,
+        )
+        env_A = jax.tree.unflatten(env_treedef, fresh_env_leaves[:n_env_leaves])
+        env_B = jax.tree.unflatten(env_treedef, fresh_env_leaves[n_env_leaves:])
+        E_gs = float(
+            compute_energy_ctm_tensor_2site(
+                A_final,
+                B_final,
+                env_A,
+                env_B,
+                gate,
+                d_phys,
+            )
+        )
     if config.gs_verbose:
         print(f"[iPEPS-AD:2site-tensor] final E={E_gs:.10f}", flush=True)
 

--- a/tests/test_ad_utils.py
+++ b/tests/test_ad_utils.py
@@ -406,6 +406,63 @@ class TestGMRESBackward:
         assert grad.norm() > 1e-15, "No-precond GMRES: gradient is all zeros"
 
 
+class TestGMRESBackwardPath:
+    """Verify the GMRES backward branch (ad_backward_method='gmres') is exercised."""
+
+    def test_gmres_path_finite_gradient(self):
+        """GMRES backward path should produce finite, nonzero gradients."""
+        A = _make_dense_tensor(jax.random.PRNGKey(42))
+        config = CTMConfig(
+            chi=4, max_iter=10, conv_tol=1e-6, ad_backward_method="gmres"
+        )
+        config_tuple = _config_to_tuple(config)
+        gate = jnp.diag(jnp.array([0.25, -0.25, -0.25, 0.25])).reshape(2, 2, 2, 2)
+
+        def energy_fn(A_in):
+            A_norm = A_in * (1.0 / (A_in.norm() + 1e-10))
+            env_leaves = ctm_tensor_converge(
+                {(0, 0): A_norm}, None, SINGLE_SITE_NEIGHBORS, config_tuple
+            )
+            env = jax.tree.unflatten(
+                jax.tree.structure(initialize_ctm_tensor_env(A_in, 4)),
+                list(env_leaves),
+            )
+            return compute_energy_ctm_tensor(A_norm, env, gate)
+
+        grad = jax.grad(energy_fn)(A)
+        assert jnp.all(jnp.isfinite(grad.todense())), "GMRES path: NaN/Inf"
+        assert grad.norm() > 1e-15, "GMRES path: gradient is all zeros"
+
+    def test_gmres_path_agrees_with_vjp(self):
+        """GMRES and VJP backward paths should produce similar gradients."""
+        A = _make_dense_tensor(jax.random.PRNGKey(55))
+        gate = jnp.diag(jnp.array([0.25, -0.25, -0.25, 0.25])).reshape(2, 2, 2, 2)
+
+        def _grad_with(method: str):
+            config = CTMConfig(
+                chi=4, max_iter=10, conv_tol=1e-6, ad_backward_method=method
+            )
+            ct = _config_to_tuple(config)
+
+            def energy_fn(A_in):
+                A_norm = A_in * (1.0 / (A_in.norm() + 1e-10))
+                env_leaves = ctm_tensor_converge(
+                    {(0, 0): A_norm}, None, SINGLE_SITE_NEIGHBORS, ct
+                )
+                env = jax.tree.unflatten(
+                    jax.tree.structure(initialize_ctm_tensor_env(A_in, 4)),
+                    list(env_leaves),
+                )
+                return compute_energy_ctm_tensor(A_norm, env, gate)
+
+            return jax.grad(energy_fn)(A)
+
+        grad_gmres = _grad_with("gmres")
+        grad_vjp = _grad_with("vjp")
+        diff = float(jnp.max(jnp.abs(grad_gmres.todense() - grad_vjp.todense())))
+        assert diff < 5e-2, f"GMRES vs VJP gradient diff = {diff}"
+
+
 class TestSvdSectorBackward:
     """Tests for the factored _svd_sector_backward function."""
 

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -913,6 +913,42 @@ class TestOptimizeGsAdDenseOnly:
         assert np.isfinite(E_gs)
 
 
+class TestOptimizeGsAdOptimizers:
+    """Verify L-BFGS and CG optimizer paths run correctly."""
+
+    @pytest.fixture
+    def heisenberg_gate(self):
+        d = 2
+        Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+        Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+        Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+        H = jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+        return H.reshape(d, d, d, d)
+
+    def test_lbfgs_optimizer_runs(self, heisenberg_gate):
+        """L-BFGS optimizer with line search should produce finite energy."""
+        config = iPEPSConfig(
+            max_bond_dim=2,
+            ctm=CTMConfig(chi=4, max_iter=5),
+            gs_optimizer="lbfgs",
+            gs_num_steps=3,
+            gs_line_search=True,
+        )
+        _, _, E_gs = optimize_gs_ad(heisenberg_gate, None, config)
+        assert np.isfinite(E_gs)
+
+    def test_cg_optimizer_runs(self, heisenberg_gate):
+        """CG optimizer should produce finite energy (covers PR beta path)."""
+        config = iPEPSConfig(
+            max_bond_dim=2,
+            ctm=CTMConfig(chi=4, max_iter=5),
+            gs_optimizer="cg",
+            gs_num_steps=3,
+        )
+        _, _, E_gs = optimize_gs_ad(heisenberg_gate, None, config)
+        assert np.isfinite(E_gs)
+
+
 class TestADSymmetric:
     """Tests for full block-sparse AD pipeline with SymmetricTensor."""
 

--- a/tests/test_tdvp.py
+++ b/tests/test_tdvp.py
@@ -231,3 +231,28 @@ class TestTDVPComplexTime:
         np.testing.assert_allclose(
             result_real.energies, result_complex.energies, atol=1e-10
         )
+
+
+class TestTDVPSymmetric:
+    """Verify TDVP works with symmetric (SymmetricTensor) MPO."""
+
+    def test_1site_tdvp_symmetric_mpo(self):
+        """TDVP with a symmetric MPO should produce decreasing energy."""
+        from tenax.core.mps import FiniteMPS
+
+        L, chi = 4, 4
+        terms = []
+        for i in range(L - 1):
+            terms.append((1.0, "Sz", i, "Sz", i + 1))
+            terms.append((0.5, "Sp", i, "Sm", i + 1))
+            terms.append((0.5, "Sm", i, "Sp", i + 1))
+        mpo_sym = build_auto_mpo(terms, L=L, symmetric=True)
+        mps = FiniteMPS.random(L, d=2, chi=chi, key=jax.random.PRNGKey(42))
+
+        cfg = TDVPConfig(mode="1site", dt=0.05, time_type="imaginary", num_steps=2)
+        result = tdvp(mps, mpo_sym, cfg)
+
+        assert len(result.energies) == 3  # initial + 2 steps
+        assert all(np.isfinite(e) for e in result.energies)
+        # Imaginary time should lower energy
+        assert result.energies[-1] <= result.energies[0] + 1e-6


### PR DESCRIPTION
## Summary

Follow-up to PR #253 (squash-merged with only the first commit). This contains the second commit that was pushed after auto-merge triggered.

- **Fix #248**: After the optimizer loop in both 1-site and 2-site `optimize_gs_ad`, evaluate the final post-update A against `best_energy`. Previously, the last-iteration line-search improvement was permanently lost.
- **Fix #252**: Add 5 targeted tests for previously uncovered code paths:
  - GMRES backward path (`ad_backward_method="gmres"`) — finite gradient + GMRES-vs-VJP agreement
  - L-BFGS optimizer path
  - CG optimizer path (covers Polak-Ribiere beta)
  - Symmetric (SymmetricTensor) MPO through TDVP

## Test plan
- [x] All 5 new tests pass on CPU
- [x] Existing test_ad_utils, test_ipeps, test_tdvp all pass
- [x] Pre-commit hooks (ruff, ruff format) pass

🤖 Generated with [Claude Code](https://claude.ai/code)