### PR TITLE
ci: publish sdist only + bump to v0.4.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,8 @@ jobs:
         with:
           version: "latest"
 
-      - name: Build wheel and sdist
-        run: uv build
+      - name: Build sdist
+        run: uv build --sdist
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## v0.4.2 (2026-04-05)
+## v0.4.3 (2026-04-05)
 
 ### Improvements
 
-- **Fix PyPI publish workflow** — add attestation permissions and update
-  GitHub Actions to Node.js 24 (#258)
+- **Fix PyPI publish** — build sdist only (Cython wheel is platform-specific
+  and rejected by PyPI); add attestation permissions; update Actions to
+  Node.js 24 (#258, #260)
 
 ## v0.4.1 (2026-04-04)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tenax-tn"
-version = "0.4.2"
+version = "0.4.3"
 description = "JAX-based tensor network library with symmetry-aware block-sparse tensors"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/tenax/__init__.py
+++ b/src/tenax/__init__.py
@@ -155,7 +155,7 @@ from tenax.linalg import eigh, qr, rsvd, svd
 from tenax.network.netfile import NetworkBlueprint, from_netfile
 from tenax.network.network import TensorNetwork, build_mps, build_peps
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 __all__ = [
     # Version


### PR DESCRIPTION
## Summary
- Build sdist only in publish workflow (Cython wheel is platform-specific, rejected by PyPI)
- Bump to v0.4.3

## Test Plan
- [ ] CI passes
- [ ] After merge, tag v0.4.3 → publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)