### PR TITLE
fix: pin cibuildwheel to v3.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3
+        uses: pypa/cibuildwheel@v3.4
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3
+        uses: pypa/cibuildwheel@v3.4
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- `pypa/cibuildwheel@v3` → `@v3.4` — no `v3` major tag exists, need semver minor tag

## Test plan
- [ ] Manually trigger publish workflow — cibuildwheel should resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)