### PR TITLE
fix: correct hatch-cython src config to find .pyx files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ Issues = "https://github.com/tenax-lab/tenax/issues"
 dev = ["tenax-tn[dev]"]
 
 [tool.hatch.build.hooks.cython]
-src = "src"
+src = "tenax"
 # Required by scipy cython_blas for zdotc/cdotc/zdotu/cdotu return values.
 # Without this, complex dot products use wrong calling convention on some BLAS.
 define_macros = [["CYTHON_CCOMPLEX", "0"]]


### PR DESCRIPTION
## Summary
- Root cause of all publish failures since v0.4.0: hatch-cython's `src` option is the **package directory name**, not the source root
- With `src = "src"`, hatch-cython globbed `./src/tenax-tn/**/*.pyx` (using the project name) — finding zero files
- Should be `src = "tenax"` → globs `./src/tenax/**/*.pyx` → finds `_cython_blas.pyx`
- Without the compiled extension, `auditwheel` (Linux) and `delocate` (macOS) both fail: "no ELF/arm64 binary found"

## Test plan
- [ ] CI passes (core tests verify the Cython BLAS extension works)
- [ ] After merge, manually trigger the publish workflow — wheels should now contain the compiled `.so`
- [ ] `auditwheel`/`delocate` should succeed since the native binary is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)