### PR TITLE
Fix core-to-algorithms dependency inversion

### DIFF
--- a/src/tenax/algorithms/_tensor_utils.py
+++ b/src/tenax/algorithms/_tensor_utils.py
@@ -10,57 +10,13 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from tenax.core._tensor_utils import (  # noqa: F401 -- re-export for backward compat
+    _scale_bond_axis_symmetric,
+    scale_bond_axis,
+)
 from tenax.core.index import FlowDirection, FuseInfo, Label, TensorIndex
 from tenax.core.symmetry import BaseSymmetry
 from tenax.core.tensor import BlockKey, DenseTensor, SymmetricTensor, Tensor
-
-
-def scale_bond_axis(T: Tensor, label: Label, scale: jax.Array) -> Tensor:
-    """Scale a tensor along a labeled axis by a diagonal vector.
-
-    For DenseTensor: broadcasts scale along the named axis.
-    For SymmetricTensor: delegates to block-wise scaling.
-
-    Args:
-        T:     Input tensor.
-        label: Label of the axis to scale along.
-        scale: 1D JAX array of length matching the axis dimension.
-
-    Returns:
-        New tensor with the specified axis scaled.
-    """
-    labels = T.labels()
-    axis = labels.index(label)
-
-    if isinstance(T, SymmetricTensor):
-        return _scale_bond_axis_symmetric(T, axis, scale)
-
-    # DenseTensor path
-    data = T.todense()
-    shape = [1] * T.ndim
-    shape[axis] = data.shape[axis]
-    return DenseTensor(data * scale.reshape(shape), T.indices)
-
-
-def _scale_bond_axis_symmetric(
-    T: SymmetricTensor, axis: int, scale: jax.Array
-) -> SymmetricTensor:
-    """Block-wise scaling for SymmetricTensor (same logic as fermionic_ipeps)."""
-    new_blocks = {}
-    idx = T.indices[axis]
-    for key, block in T.blocks.items():
-        charge_val = key[axis]
-        positions = np.where(idx.charges == charge_val)[0]
-        block_size = block.shape[axis]
-        scale_slice = scale[positions[:block_size]]
-        shape = [1] * T.ndim
-        shape[axis] = block_size
-        new_blocks[key] = block * scale_slice.reshape(shape)
-
-    obj = object.__new__(SymmetricTensor)
-    obj._indices = T._indices
-    obj._init_flat_buffer(new_blocks)
-    return obj
 
 
 def max_abs_normalize(T: Tensor) -> tuple[Tensor, jax.Array]:

--- a/src/tenax/core/_tensor_utils.py
+++ b/src/tenax/core/_tensor_utils.py
@@ -1,0 +1,61 @@
+"""Core tensor utilities.
+
+Functions here work polymorphically on both DenseTensor and SymmetricTensor
+via the Tensor protocol and depend only on tenax.core.
+"""
+
+from __future__ import annotations
+
+import jax
+import numpy as np
+
+from tenax.core.index import Label
+from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+
+
+def scale_bond_axis(T: Tensor, label: Label, scale: jax.Array) -> Tensor:
+    """Scale a tensor along a labeled axis by a diagonal vector.
+
+    For DenseTensor: broadcasts scale along the named axis.
+    For SymmetricTensor: delegates to block-wise scaling.
+
+    Args:
+        T:     Input tensor.
+        label: Label of the axis to scale along.
+        scale: 1D JAX array of length matching the axis dimension.
+
+    Returns:
+        New tensor with the specified axis scaled.
+    """
+    labels = T.labels()
+    axis = labels.index(label)
+
+    if isinstance(T, SymmetricTensor):
+        return _scale_bond_axis_symmetric(T, axis, scale)
+
+    # DenseTensor path
+    data = T.todense()
+    shape = [1] * T.ndim
+    shape[axis] = data.shape[axis]
+    return DenseTensor(data * scale.reshape(shape), T.indices)
+
+
+def _scale_bond_axis_symmetric(
+    T: SymmetricTensor, axis: int, scale: jax.Array
+) -> SymmetricTensor:
+    """Block-wise scaling for SymmetricTensor (same logic as fermionic_ipeps)."""
+    new_blocks = {}
+    idx = T.indices[axis]
+    for key, block in T.blocks.items():
+        charge_val = key[axis]
+        positions = np.where(idx.charges == charge_val)[0]
+        block_size = block.shape[axis]
+        scale_slice = scale[positions[:block_size]]
+        shape = [1] * T.ndim
+        shape[axis] = block_size
+        new_blocks[key] = block * scale_slice.reshape(shape)
+
+    obj = object.__new__(SymmetricTensor)
+    obj._indices = T._indices
+    obj._init_flat_buffer(new_blocks)
+    return obj

--- a/src/tenax/core/mps.py
+++ b/src/tenax/core/mps.py
@@ -10,8 +10,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from tenax.algorithms._tensor_utils import scale_bond_axis
 from tenax.contraction.contractor import contract
+from tenax.core._tensor_utils import scale_bond_axis
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
 from tenax.linalg import qr, svd


### PR DESCRIPTION
## Summary
- Moved `scale_bond_axis` and `_scale_bond_axis_symmetric` from `tenax.algorithms._tensor_utils` to a new `tenax.core._tensor_utils` module, since these functions only depend on core types
- Updated `core/mps.py` to import from the new core location instead of algorithms
- Kept a re-export in `algorithms/_tensor_utils.py` so all existing algorithm code continues to work unchanged

## Test plan
- [x] `uv run pytest -m core -x -q` passes (688 tests)
- [x] Backward-compatible import from `tenax.algorithms._tensor_utils` verified

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)