### PR TITLE
refactor(ctm): replace wildcard re-export shims with explicit imports

### DIFF
--- a/src/tenax/__init__.py
+++ b/src/tenax/__init__.py
@@ -37,15 +37,17 @@ import jax
 
 jax.config.update("jax_enable_x64", True)
 
-from tenax.algorithms._ctm_tensor import (
-    CTMTensorEnv,
-    compute_energy_ctm_tensor,
-    compute_energy_ctm_tensor_2site,
+from tenax.algorithms._ctm_tensor_c4v import ctm_tensor_c4v
+from tenax.algorithms._ctm_tensor_convergence import (
+    ctm_multisite,
     ctm_tensor,
     ctm_tensor_2site,
-    ctm_tensor_c4v,
 )
-from tenax.algorithms._ctm_tensor_convergence import ctm_multisite
+from tenax.algorithms._ctm_tensor_energy import (
+    compute_energy_ctm_tensor,
+    compute_energy_ctm_tensor_2site,
+)
+from tenax.algorithms._ctm_tensor_init import CTMTensorEnv
 from tenax.algorithms._krylov import krylov_expm
 from tenax.algorithms._split_ctm_tensor import (
     SplitCTMTensorEnv,
@@ -101,7 +103,7 @@ from tenax.algorithms.ipeps_config import (
     SplitCTMEnvironment,
     iPEPSConfig,
 )
-from tenax.algorithms.ipeps_ctm import ctm, ctm_2site, ctm_split
+from tenax.algorithms.ipeps_ctm_convergence import ctm, ctm_2site, ctm_split
 from tenax.algorithms.ipeps_excitations import (
     ExcitationConfig,
     ExcitationResult,

--- a/src/tenax/algorithms/__init__.py
+++ b/src/tenax/algorithms/__init__.py
@@ -35,7 +35,7 @@ from tenax.algorithms.ipeps_config import (
     SplitCTMEnvironment,
     iPEPSConfig,
 )
-from tenax.algorithms.ipeps_ctm import ctm, ctm_2site, ctm_split
+from tenax.algorithms.ipeps_ctm_convergence import ctm, ctm_2site, ctm_split
 from tenax.algorithms.ipeps_excitations import (
     ExcitationConfig,
     ExcitationResult,

--- a/src/tenax/algorithms/_ctm_tensor.py
+++ b/src/tenax/algorithms/_ctm_tensor.py
@@ -1,12 +1,128 @@
-"""Standard CTM with Tensor protocol — re-export shim."""
+"""Standard CTM with Tensor protocol — public re-export shim.
 
-from tenax.algorithms._ctm_projector import (
-    _compute_projector_tensor as _compute_projector_tensor,  # noqa: F401
+Internal code should import directly from the concrete modules:
+  - ``_ctm_tensor_init``        (CTMTensorEnv, initialize_ctm_tensor_env, ...)
+  - ``_ctm_tensor_moves``       (directional moves, projector application)
+  - ``_ctm_tensor_convergence`` (ctm_tensor, ctm_tensor_2site, sweeps, ...)
+  - ``_ctm_tensor_energy``      (compute_energy_ctm_tensor, RDMs, ...)
+  - ``_ctm_tensor_c4v``         (ctm_tensor_c4v)
+  - ``_ctm_projector``          (_compute_projector_tensor)
+
+This module re-exports public names so that ``from tenax.algorithms._ctm_tensor
+import X`` keeps working for downstream / notebook code.
+"""
+
+from tenax.algorithms._ctm_projector import (  # noqa: F401
+    _compute_projector_tensor as _compute_projector_tensor,
 )
-from tenax.algorithms._ctm_tensor_c4v import (
-    ctm_tensor_c4v as ctm_tensor_c4v,  # noqa: F401
+from tenax.algorithms._ctm_tensor_c4v import (  # noqa: F401
+    ctm_tensor_c4v as ctm_tensor_c4v,
 )
-from tenax.algorithms._ctm_tensor_convergence import *  # noqa: F401,F403
-from tenax.algorithms._ctm_tensor_energy import *  # noqa: F401,F403
-from tenax.algorithms._ctm_tensor_init import *  # noqa: F401,F403
-from tenax.algorithms._ctm_tensor_moves import *  # noqa: F401,F403
+from tenax.algorithms._ctm_tensor_convergence import (
+    _DIRECTION_MOVES as _DIRECTION_MOVES,
+)
+from tenax.algorithms._ctm_tensor_convergence import (  # noqa: F401
+    CHECKERBOARD_NEIGHBORS as CHECKERBOARD_NEIGHBORS,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    SINGLE_SITE_NEIGHBORS as SINGLE_SITE_NEIGHBORS,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    Coord as Coord,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    _ctm_sv_diff as _ctm_sv_diff,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    _ctm_tensor_multisite as _ctm_tensor_multisite,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    _ctm_tensor_sweep as _ctm_tensor_sweep,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    _ctm_tensor_sweep_multisite as _ctm_tensor_sweep_multisite,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    _ctm_tensor_sweep_paired as _ctm_tensor_sweep_paired,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    _normalize_tensor as _normalize_tensor,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    _renormalize_tensor_env as _renormalize_tensor_env,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    ctm_multisite as ctm_multisite,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    ctm_tensor as ctm_tensor,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    ctm_tensor_2site as ctm_tensor_2site,
+)
+from tenax.algorithms._ctm_tensor_energy import (  # noqa: F401
+    _rdm1x2_tensor as _rdm1x2_tensor,
+)
+from tenax.algorithms._ctm_tensor_energy import (
+    _rdm1x2_tensor_2site as _rdm1x2_tensor_2site,
+)
+from tenax.algorithms._ctm_tensor_energy import (
+    _rdm2x1_tensor as _rdm2x1_tensor,
+)
+from tenax.algorithms._ctm_tensor_energy import (
+    _rdm2x1_tensor_2site as _rdm2x1_tensor_2site,
+)
+from tenax.algorithms._ctm_tensor_energy import (
+    compute_energy_ctm_tensor as compute_energy_ctm_tensor,
+)
+from tenax.algorithms._ctm_tensor_energy import (
+    compute_energy_ctm_tensor_2site as compute_energy_ctm_tensor_2site,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    _STD_EDGE_SPECS as _STD_EDGE_SPECS,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    IN as IN,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    OUT as OUT,
+)
+from tenax.algorithms._ctm_tensor_init import (  # noqa: F401
+    CTMTensorEnv as CTMTensorEnv,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    _build_double_layer_open_tensor as _build_double_layer_open_tensor,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    _build_double_layer_tensor as _build_double_layer_tensor,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    _fuse_pair_by_label as _fuse_pair_by_label,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    _init_symmetric_standard_corner as _init_symmetric_standard_corner,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    _init_symmetric_standard_edge as _init_symmetric_standard_edge,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    _make_dense_standard_edge as _make_dense_standard_edge,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    initialize_ctm_tensor_env as initialize_ctm_tensor_env,
+)
+from tenax.algorithms._ctm_tensor_moves import (  # noqa: F401
+    _apply_projector_tensor as _apply_projector_tensor,
+)
+from tenax.algorithms._ctm_tensor_moves import (
+    _ctm_tensor_move_bottom as _ctm_tensor_move_bottom,
+)
+from tenax.algorithms._ctm_tensor_moves import (
+    _ctm_tensor_move_left as _ctm_tensor_move_left,
+)
+from tenax.algorithms._ctm_tensor_moves import (
+    _ctm_tensor_move_right as _ctm_tensor_move_right,
+)
+from tenax.algorithms._ctm_tensor_moves import (
+    _ctm_tensor_move_top as _ctm_tensor_move_top,
+)

--- a/src/tenax/algorithms/_split_ctm_tensor_energy.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_energy.py
@@ -9,7 +9,8 @@ __all__ = [
 
 import jax
 
-from tenax.algorithms._ctm_tensor import CTMTensorEnv, compute_energy_ctm_tensor
+from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
+from tenax.algorithms._ctm_tensor_init import CTMTensorEnv
 from tenax.algorithms._split_ctm_tensor_init import SplitCTMTensorEnv
 from tenax.algorithms._tensor_utils import fuse_indices
 from tenax.contraction.contractor import contract

--- a/src/tenax/algorithms/ad_utils.py
+++ b/src/tenax/algorithms/ad_utils.py
@@ -19,14 +19,16 @@ import jax.numpy as jnp
 import numpy as np
 from jax.scipy.sparse.linalg import gmres as jax_gmres
 
-from tenax.algorithms._ctm_tensor import (
+from tenax.algorithms._ctm_tensor_convergence import (
+    _ctm_sv_diff as _ctm_sv_diff_tensor,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    _ctm_tensor_sweep_multisite,
+)
+from tenax.algorithms._ctm_tensor_init import (
     CTMTensorEnv,
     _build_double_layer_tensor,
-    _ctm_tensor_sweep_multisite,
     initialize_ctm_tensor_env,
-)
-from tenax.algorithms._ctm_tensor import (
-    _ctm_sv_diff as _ctm_sv_diff_tensor,
 )
 from tenax.algorithms._split_ctm_tensor import (
     _split_ctm_tensor_sweep,

--- a/src/tenax/algorithms/fermionic_ipeps.py
+++ b/src/tenax/algorithms/fermionic_ipeps.py
@@ -445,7 +445,7 @@ def fermionic_ctm(A, config):
         Converged ``CTMTensorEnv`` (if Tensor input) or ``CTMEnvironment``.
     """
     if isinstance(A, Tensor):
-        from tenax.algorithms._ctm_tensor import ctm_tensor
+        from tenax.algorithms._ctm_tensor_convergence import ctm_tensor
 
         return ctm_tensor(
             A,
@@ -455,7 +455,7 @@ def fermionic_ctm(A, config):
         )
 
     from tenax.algorithms.ipeps_config import CTMConfig
-    from tenax.algorithms.ipeps_ctm import ctm
+    from tenax.algorithms.ipeps_ctm_convergence import ctm
 
     ctm_cfg = CTMConfig(
         chi=config.ctm_chi,
@@ -479,7 +479,8 @@ def compute_energy_fermionic_ctm(A, env, hamiltonian_gate):
     Returns:
         Energy per site (float).
     """
-    from tenax.algorithms._ctm_tensor import CTMTensorEnv, compute_energy_ctm_tensor
+    from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
+    from tenax.algorithms._ctm_tensor_init import CTMTensorEnv
 
     if isinstance(env, CTMTensorEnv):
         # If env tensors are DenseTensor (fermionic fallback), densify A and gate

--- a/src/tenax/algorithms/ipeps.py
+++ b/src/tenax/algorithms/ipeps.py
@@ -25,7 +25,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from tenax.algorithms.ipeps_config import CTMEnvironment, iPEPSConfig
-from tenax.algorithms.ipeps_ctm import ctm_2site
+from tenax.algorithms.ipeps_ctm_convergence import ctm_2site
 from tenax.algorithms.ipeps_rdm import compute_energy_ctm_2site
 from tenax.algorithms.ipeps_simple_update import (
     _make_trotter_gate_tensor,

--- a/src/tenax/algorithms/ipeps_ctm.py
+++ b/src/tenax/algorithms/ipeps_ctm.py
@@ -1,5 +1,89 @@
-"""CTM algorithm functions for iPEPS — re-export shim."""
+"""CTM algorithm functions for iPEPS — public re-export shim.
 
-from tenax.algorithms.ipeps_ctm_convergence import *  # noqa: F401,F403
-from tenax.algorithms.ipeps_ctm_init import *  # noqa: F401,F403
-from tenax.algorithms.ipeps_ctm_moves import *  # noqa: F401,F403
+Internal code should import directly from the concrete modules:
+  - ``ipeps_ctm_convergence`` (ctm, ctm_2site, ctm_split, sweeps, ...)
+  - ``ipeps_ctm_init``        (_build_double_layer, _initialize_ctm_env, ...)
+  - ``ipeps_ctm_moves``       (directional moves, projectors, ...)
+
+This module re-exports public names so that ``from tenax.algorithms.ipeps_ctm
+import X`` keeps working for downstream / notebook code.
+"""
+
+from tenax.algorithms.ipeps_ctm_convergence import (  # noqa: F401
+    _ctm_2site_sweep as _ctm_2site_sweep,
+)
+from tenax.algorithms.ipeps_ctm_convergence import (
+    _ctm_sv_diff as _ctm_sv_diff,
+)
+from tenax.algorithms.ipeps_ctm_convergence import (
+    _ctm_sweep as _ctm_sweep,
+)
+from tenax.algorithms.ipeps_ctm_convergence import (
+    _renormalize_env as _renormalize_env,
+)
+from tenax.algorithms.ipeps_ctm_convergence import (
+    _split_ctm_sweep as _split_ctm_sweep,
+)
+from tenax.algorithms.ipeps_ctm_convergence import (
+    _split_env_to_standard as _split_env_to_standard,
+)
+from tenax.algorithms.ipeps_ctm_convergence import (
+    ctm as ctm,
+)
+from tenax.algorithms.ipeps_ctm_convergence import (
+    ctm_2site as ctm_2site,
+)
+from tenax.algorithms.ipeps_ctm_convergence import (
+    ctm_split as ctm_split,
+)
+from tenax.algorithms.ipeps_ctm_init import (  # noqa: F401
+    _build_double_layer as _build_double_layer,
+)
+from tenax.algorithms.ipeps_ctm_init import (
+    _initialize_ctm_env as _initialize_ctm_env,
+)
+from tenax.algorithms.ipeps_ctm_init import (
+    _initialize_split_ctm_env as _initialize_split_ctm_env,
+)
+from tenax.algorithms.ipeps_ctm_moves import (  # noqa: F401
+    _ctm_bottom_move as _ctm_bottom_move,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _ctm_bottom_move_2site as _ctm_bottom_move_2site,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _ctm_left_move as _ctm_left_move,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _ctm_left_move_2site as _ctm_left_move_2site,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _ctm_move as _ctm_move,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _ctm_move_eigh as _ctm_move_eigh,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _ctm_move_qr as _ctm_move_qr,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _ctm_right_move as _ctm_right_move,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _ctm_right_move_2site as _ctm_right_move_2site,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _ctm_top_move as _ctm_top_move,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _ctm_top_move_2site as _ctm_top_move_2site,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _split_ctm_move as _split_ctm_move,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _split_ctm_projector as _split_ctm_projector,
+)
+from tenax.algorithms.ipeps_ctm_moves import (
+    _svd_split_edge as _svd_split_edge,
+)

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -335,11 +335,9 @@ def _optimize_gs_ad_tensor(
     """
     import optax
 
-    from tenax.algorithms._ctm_tensor import (
-        compute_energy_ctm_tensor,
-        initialize_ctm_tensor_env,
-    )
     from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
+    from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
+    from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env
     from tenax.algorithms.ad_utils import _config_to_tuple, ctm_tensor_converge
 
     gate = (
@@ -799,11 +797,9 @@ def _optimize_gs_ad_tensor_2site(
     """
     import optax
 
-    from tenax.algorithms._ctm_tensor import (
-        compute_energy_ctm_tensor_2site,
-        initialize_ctm_tensor_env,
-    )
     from tenax.algorithms._ctm_tensor_convergence import CHECKERBOARD_NEIGHBORS
+    from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor_2site
+    from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env
     from tenax.algorithms.ad_utils import (
         _config_from_tuple,
         _config_to_tuple,

--- a/src/tenax/algorithms/ipeps_rdm.py
+++ b/src/tenax/algorithms/ipeps_rdm.py
@@ -13,7 +13,7 @@ from tenax.algorithms.ipeps_config import (
     CTMEnvironment,
     SplitCTMEnvironment,
 )
-from tenax.algorithms.ipeps_ctm import (
+from tenax.algorithms.ipeps_ctm_convergence import (
     _split_env_to_standard,
 )
 


### PR DESCRIPTION
## Summary

- All internal `src/` modules now import CTM symbols directly from concrete implementation modules (`_ctm_tensor_init`, `_ctm_tensor_convergence`, `_ctm_tensor_energy`, `_ctm_tensor_c4v`, `ipeps_ctm_convergence`) instead of going through the `_ctm_tensor.py` and `ipeps_ctm.py` wildcard re-export shims.
- The shim modules (`_ctm_tensor.py`, `ipeps_ctm.py`) are retained with explicit (non-wildcard) re-exports for backward compatibility with downstream/notebook code and tests.
- No function implementations changed; only import paths were updated.

Closes #281

## Test plan

- [x] `uv run pytest -m core -x -q` passes (688 tests)
- [ ] CI required checks (Python 3.11, 3.12, macOS 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)