### PR TITLE
fix(ad): adaptive Lorentzian broadening in regularized_eigh backward

### DIFF
--- a/src/tenax/algorithms/ad_utils.py
+++ b/src/tenax/algorithms/ad_utils.py
@@ -344,6 +344,9 @@ regularized_svd.defvjp(_regularized_svd_fwd, _regularized_svd_bwd)
 # ---------------------------------------------------------------------------
 
 _EIGH_LORENTZ_EPS = 1e-12
+_EIGH_LORENTZ_REL = (
+    1e-7  # relative broadening: eps = max(_EIGH_LORENTZ_EPS, _REL * max|w|)
+)
 
 
 @partial(jax.custom_vjp)
@@ -374,7 +377,13 @@ def _regularized_eigh_bwd(residuals, g):
     """
     w, v = residuals
     dw, dv = g
-    eps = _EIGH_LORENTZ_EPS
+    # Adaptive Lorentzian broadening: scale with largest |w| to cap F at ~1/eps.
+    # Hardcoded eps=1e-12 broadcast gradient spikes to O(1e12) when two
+    # eigenvalues of the projector density matrix were numerically degenerate;
+    # scaling eps with max|w| caps F at O(_EIGH_LORENTZ_REL^-1) and preserves
+    # directional information for non-degenerate modes (issue #299).
+    w_scale = jnp.maximum(jnp.max(jnp.abs(w)), _EIGH_LORENTZ_EPS)
+    eps = jnp.maximum(_EIGH_LORENTZ_EPS, _EIGH_LORENTZ_REL * w_scale)
 
     # Lorentzian-regularized F-matrix
     diff = w[:, None] - w[None, :]


### PR DESCRIPTION
## Summary

- Scale `_regularized_eigh_bwd` Lorentzian broadening parameter adaptively: `eps = max(1e-12, 1e-7 * max|λ|)` instead of a hardcoded `1e-12`.
- Eliminates O(1e12) F-matrix gradient spikes that occurred when two eigenvalues of the CTM projector density matrix were nearly degenerate, poisoning L-BFGS curvature estimates.

## Investigation findings (issue #299)

The 2-site iPEPS AD L-BFGS path stalling at E≈−0.558 (issue #299) turned out to have **two stacked layers**:

1. **Numerical throttle (this PR fixes).** `eps=1e-12` produces `F ≈ diff / (diff² + eps²)` spikes of O(1e12) at near-degenerate eigenvalues. These poison L-BFGS inverse-Hessian estimates → Hager-Zhang accepts α≈0 → optimizer freezes near SU-init baseline.

2. **Non-variational CTM landscape (not fixable by this PR).** Once the throttle is removed, L-BFGS+HZ+metric descends *through* the physical minimum into a fake CTM minimum:

   | Config | E/site |
   |---|---|
   | Baseline (ε=1e-12 fixed) | −0.558 (throttled) |
   | Adaptive ε, χ=8, no floor | −1.400 (non-variational) |
   | Adaptive ε, χ=16, no floor | −0.811 (non-variational) |
   | Adaptive ε, χ=8, floor=−0.70 | −0.576 (variational) |
   | Adaptive ε, χ=16, floor=−0.70 | −0.569 (variational) |
   | Literature D=2 χ=8 2-site | −0.655 (target) |

   The 0.08 gap to literature on the variational-floor path is **not a numerical issue** — the 2-site Néel-init L-BFGS+HZ+metric path simply does not have a variational CTM stationary point at −0.6548. The `UserWarning: 2-site AD optimizer is experimental` remains appropriate.

## Also found (separate issues)

- **Duplicated sigma-gauge warmup block** in `_ctm_tensor_multisite_fixed_point_jit` (ad_utils.py lines 1426–1454): identical QR-warmup block pasted twice, decrementing `max_iter`/`min_iter` twice when `forward_gauge="sigma"` + `jit_ctm=True`. Copy-paste bug from PR #290. Filed separately.

## Test plan

- [x] 692/692 core tests pass (`pytest -m core`)
- [x] Verified adaptive ε unblocks the optimizer (E drops from −0.558 to −1.400 without floor)
- [x] Verified `gs_energy_floor` keeps result variational (−0.576 at χ=8)
- [x] No new test needed — this is a gradient-quality fix; existing iPEPS AD tests cover the forward path

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)