### PR TITLE
fix(ctm): remove duplicated sigma-gauge warmup block in JIT CTM

### DIFF
--- a/src/tenax/algorithms/ad_utils.py
+++ b/src/tenax/algorithms/ad_utils.py
@@ -1447,23 +1447,6 @@ def _ctm_tensor_multisite_fixed_point_jit(
 
     env_leaves = tuple(_flatten_envs(envs))
 
-    # Match Python loop: first sweep uses QR gauge to establish a clean
-    # starting point before sigma gauge takes over.
-    if use_sigma:
-        envs = _ctm_tensor_sweep_multisite(
-            envs,
-            double_layers_cached,
-            neighbors,
-            chi,
-            config.renormalize,
-            config.projector_method,
-        )
-        envs = {c: _gauge_fix_ctm_tensor(e) for c, e in envs.items()}
-        max_iter = max(max_iter - 1, 1)
-        min_iter = max(min_iter - 1, 0)
-
-    env_leaves = tuple(_flatten_envs(envs))
-
     def _one_sweep(e_leaves, sigma_ref=None):
         return tuple(
             _ctm_tensor_step_multisite(


### PR DESCRIPTION
## Summary

- Remove verbatim-duplicated QR-gauge warmup block in `_ctm_tensor_multisite_fixed_point_jit` (ad_utils.py lines 1450–1465).
- When `forward_gauge="sigma"` + `jit_ctm=True`, the JIT path was running **two** QR warmup sweeps and decrementing `max_iter`/`min_iter` twice before entering the sigma `while_loop`. Only one warmup sweep is intended.
- Copy-paste artifact likely from PR #290.

Found during the #299 investigation.

## Test plan

- [x] 692/692 core tests pass (`pytest -m core`)
- No existing test exercises `forward_gauge="sigma"` + `jit_ctm=True` on multisite — the bug was silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)