### PR TITLE
feat(ipeps): add C4v shared-tensor path and paper-faithful Appendix C–F AD mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The name **Tenax** combines **Ten**sor network + J**ax**, and is also Latin for 
 - **Algorithms** — DMRG, iDMRG (1D chain & infinite cylinder), TRG, HOTRG, iPEPS (simple update with 1-site or 2-site unit cell & AD optimization), fermionic iPEPS (fPEPS), quasiparticle excitations
 - **GPU/TPU-accelerated DMRG** — JIT-compiled sweeps via `jax.lax.scan` for dense tensors and per-operation JIT for block-sparse symmetric tensors; automatic warmup-to-JIT transition when bond dimensions are growing; multi-GPU sharding via GSPMD for large bond dimensions (`DMRGConfig(accelerator="jit"|"sharded")`)
 - **AutoMPO** — build Hamiltonian MPOs from symbolic operator descriptions (custom couplings, NNN, arbitrary spin); supports `symmetric=True` for U(1) block-sparse MPOs
-- **AD-based iPEPS optimization** — gradient optimization via implicit differentiation through CTM fixed point, supporting 1-site and 2-site unit cells (Francuz et al. PRR 7, 013237); L-BFGS with Hager-Zhang line search and metric preconditioning (Rader et al.), Adam (with cosine lr decay), and conjugate gradient optimizers; implicit AD via GMRES backward (recommended) for robust differentiation through CTM fixed point; explicit AD through unrolled CTM iterations for 1-site C4v path; sigma gauge fixing (`forward_gauge="sigma"`) for stable elementwise CTM convergence; C4v symmetry enforcement via explicit basis parameterization; chi-ramping schedule (`optimize_gs_ad_chi_schedule`) for progressive refinement; JIT CTM via `jax.lax.while_loop` for GPU kernel fusion (`jit_ctm=True`)
+- **AD-based iPEPS optimization** — gradient optimization via implicit differentiation through CTM fixed point, supporting 1-site and 2-site unit cells (Francuz et al. PRR 7, 013237); L-BFGS with Hager-Zhang line search and metric preconditioning (Rader et al.), Adam (with cosine lr decay), and conjugate gradient optimizers; implicit AD via iterative VJP (default) and optional GMRES route; explicit AD through unrolled CTM iterations for 1-site C4v path; opt-in paper-faithful dense C4v Appendix C-F mode (`paper_ctm_ad="c4v_appendix_cf"`) with Krylov implicit backward (`bicgstab` + `gmres` fallback); sigma gauge fixing (`forward_gauge="sigma"`) for stable elementwise CTM convergence; C4v symmetry enforcement via explicit basis parameterization; chi-ramping schedule (`optimize_gs_ad_chi_schedule`) for progressive refinement; JIT CTM via `jax.lax.while_loop` for GPU kernel fusion (`jit_ctm=True`)
 - **SVD and QR CTMRG projectors** — SVD (Fishman) projectors (`projector_method="svd"`) and QR projectors for faster CTM convergence alongside the default `eigh`
 - **Split-CTMRG** — ket/bra-separated CTM environment tensors for O(χ³D³) projector cost instead of O(χ³D⁶); works with both `DenseTensor` and `SymmetricTensor` via the Tensor protocol (Naumann et al., arXiv:2502.10298)
 - **Quasiparticle excitations** — iPEPS excitation spectra at arbitrary Brillouin-zone momenta (Ponsioen et al. 2022)
@@ -364,6 +364,26 @@ config_jit = iPEPSConfig(
     gs_num_steps=200,
 )
 A_opt, env, E_gs = optimize_gs_ad(gate, None, config_jit)
+
+# Opt-in paper-faithful dense C4v mode (App. C-F)
+config_paper = iPEPSConfig(
+    max_bond_dim=2,
+    ctm=CTMConfig(
+        chi=16,
+        max_iter=80,
+        projector_method="eigh",
+        paper_ctm_ad="c4v_appendix_cf",
+        paper_krylov_solver="bicgstab",
+        paper_krylov_maxiter=50,
+        paper_krylov_tol=1e-8,
+    ),
+    gs_explicit_ad=False,
+    gs_c4v=True,
+    unit_cell="1x1",
+    gs_num_steps=100,
+    gs_optimizer="adam",
+)
+A_opt, env, E_gs = optimize_gs_ad(gate, None, config_paper)
 
 # Quasiparticle excitations (Ponsioen et al. 2022)
 momenta = make_momentum_path("brillouin", num_points=20)

--- a/docs/guide/algorithms/ipeps_ad_paths.md
+++ b/docs/guide/algorithms/ipeps_ad_paths.md
@@ -147,6 +147,40 @@ This is the YASTN approach (arXiv:2311.11894), adapted for JAX. For new
 code prefer Path 1 — the explicit-AD path does not exercise the implicit
 backward at all.
 
+### Path 3: Paper-Faithful Dense C4v (Appendix C-F, Opt-In)
+
+This opt-in path follows the fixed-point differentiation structure in
+YASTN (arXiv:2311.11894, App. C-F) for **dense 1-site C4v** runs:
+
+```
+Forward:  A (C4v-projected) -> dense C4v CTM fixed point (single C/T representation)
+Backward: Appendix-C eigendifferential + Appendix-F implicit solve
+          (I - J^T) lambda = g via bicgstab with gmres fallback
+```
+
+**Enable it with:**
+
+```python
+config = iPEPSConfig(
+    gs_explicit_ad=False,
+    gs_c4v=True,
+    unit_cell="1x1",
+    ctm=CTMConfig(
+        chi=16,
+        paper_ctm_ad="c4v_appendix_cf",
+        paper_krylov_solver="bicgstab",  # or "gmres"
+        paper_krylov_maxiter=50,
+        paper_krylov_tol=1e-8,
+    ),
+)
+```
+
+**Current scope and constraints:**
+- dense tensors only (no SymmetricTensor path yet),
+- strict gate: `unit_cell="1x1"`, `gs_c4v=True`, `gs_explicit_ad=False`,
+  `ctm.paper_ctm_ad="c4v_appendix_cf"`,
+- supports `gs_num_steps>0` optimization with implicit gradients.
+
 ## Forward Gauge Mode Matrix
 
 Post-PR-#291 Tenax supports four ``forward_gauge`` modes. Their intended

--- a/src/tenax/algorithms/_ctm_tensor_c4v_paper_ad.py
+++ b/src/tenax/algorithms/_ctm_tensor_c4v_paper_ad.py
@@ -7,8 +7,10 @@ separately.
 
 from __future__ import annotations
 
+from functools import partial
 from typing import Any
 
+import jax
 import jax.numpy as jnp
 
 from tenax.algorithms._ctm_tensor_c4v import _c4v_sweep, _c4v_to_full_env
@@ -20,7 +22,80 @@ from tenax.algorithms._ctm_tensor_init import (
 from tenax.algorithms.ipeps_config import CTMConfig
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
 
-__all__ = ["ctm_tensor_c4v_paper_fixed_point"]
+__all__ = [
+    "_appendix_c_truncated_eigh_backward",
+    "ctm_tensor_c4v_paper_fixed_point",
+    "truncated_eigh_appendix_c",
+]
+
+
+def _appendix_c_truncated_eigh_backward(
+    w_full: jax.Array,
+    v_full: jax.Array,
+    dw_k: jax.Array,
+    dV_k: jax.Array,
+    *,
+    k: int,
+    eps: float = 1e-12,
+) -> jax.Array:
+    """Appendix-C-style truncated eigendecomposition backward.
+
+    Uses a Lorentzian-regularized eigen-gap inverse for both kept-kept and
+    kept-discarded couplings. The kept-discarded term is the critical
+    truncation correction missing in naive truncated-eigh adjoints.
+    """
+    n = int(w_full.shape[0])
+    k = min(int(k), n)
+    v_h = jnp.conj(v_full).T
+    dtype = jnp.result_type(v_full.dtype, dV_k.dtype, dw_k.dtype)
+
+    dw_full = jnp.concatenate([dw_k.astype(dtype), jnp.zeros((n - k,), dtype=dtype)])
+
+    # Differential coefficients K_{j,i} = <v_j, dV_i> / (w_i - w_j), i in kept.
+    # Symmetrizing this n x n matrix recovers both the kept-kept anti-gauge term
+    # and the kept-discarded truncation correction from Appendix C.
+    inner = v_h @ dV_k.astype(dtype)  # (n, k)
+    denom = w_full[:k][None, :] - w_full[:, None]  # (n, k): w_i - w_j
+    inv_gap = denom / (denom**2 + eps**2)
+    K = inner * inv_gap
+    if k > 0:
+        idx = jnp.arange(k)
+        K = K.at[idx, idx].set(0.0)
+
+    K_full = jnp.zeros((n, n), dtype=dtype).at[:, :k].set(K)
+    C = jnp.diag(dw_full) + 0.5 * (K_full + jnp.conj(K_full).T)
+    dM = v_full @ C @ v_h
+    return 0.5 * (dM + jnp.conj(dM).T)
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(1,))
+def truncated_eigh_appendix_c(
+    M: jax.Array,
+    chi: int,
+) -> tuple[jax.Array, jax.Array]:
+    """Truncated symmetric eigendecomposition with Appendix-C-style VJP."""
+    w, v = jnp.linalg.eigh(M)
+    k = min(int(chi), int(w.shape[0]))
+    return w[:k], v[:, :k]
+
+
+def _truncated_eigh_appendix_c_fwd(M: jax.Array, chi: int):
+    M_h = 0.5 * (M + jnp.conj(M).T)
+    w, v = jnp.linalg.eigh(M_h)
+    k = min(int(chi), int(w.shape[0]))
+    return (w[:k], v[:, :k]), (w, v, k)
+
+
+def _truncated_eigh_appendix_c_bwd(chi: int, residuals, g):
+    w, v, k = residuals
+    dw_k, dV_k = g
+    dM = _appendix_c_truncated_eigh_backward(w, v, dw_k, dV_k, k=k)
+    return (dM,)
+
+
+truncated_eigh_appendix_c.defvjp(
+    _truncated_eigh_appendix_c_fwd, _truncated_eigh_appendix_c_bwd
+)
 
 
 def ctm_tensor_c4v_paper_fixed_point(

--- a/src/tenax/algorithms/_ctm_tensor_c4v_paper_ad.py
+++ b/src/tenax/algorithms/_ctm_tensor_c4v_paper_ad.py
@@ -12,6 +12,8 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
+from jax.scipy.sparse.linalg import bicgstab as _krylov_bicgstab
+from jax.scipy.sparse.linalg import gmres as _krylov_gmres
 
 from tenax.algorithms._ctm_tensor_c4v import _c4v_sweep, _c4v_to_full_env
 from tenax.algorithms._ctm_tensor_convergence import _ctm_sv_diff
@@ -24,6 +26,9 @@ from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
 
 __all__ = [
     "_appendix_c_truncated_eigh_backward",
+    "_solve_linear_adjoint_paper",
+    "ctm_tensor_c4v_paper_backward",
+    "ctm_tensor_c4v_paper_converge_reduced",
     "ctm_tensor_c4v_paper_fixed_point",
     "truncated_eigh_appendix_c",
 ]
@@ -98,20 +103,28 @@ truncated_eigh_appendix_c.defvjp(
 )
 
 
-def ctm_tensor_c4v_paper_fixed_point(
+def _tree_sub(a, b):
+    return jax.tree.map(lambda x, y: x - y, a, b)
+
+
+def _tree_l2_norm(tree) -> float:
+    leaves = jax.tree.leaves(tree)
+    if not leaves:
+        return 0.0
+    total = sum(jnp.sum(jnp.abs(x) ** 2) for x in leaves)
+    return float(jnp.sqrt(total))
+
+
+def _tree_all_finite(tree) -> bool:
+    leaves = jax.tree.leaves(tree)
+    return all(bool(jnp.all(jnp.isfinite(x))) for x in leaves)
+
+
+def _ctm_tensor_c4v_paper_fixed_point_reduced(
     A: Tensor,
     config: CTMConfig,
-) -> tuple[Any, dict[str, Any]]:
-    """Run dense C4v CTM to a fixed point and return diagnostics.
-
-    Args:
-        A:      Dense 1-site iPEPS tensor.
-        config: CTM configuration (chi/max_iter/conv_tol/projector/min_iter).
-
-    Returns:
-        ``(env, meta)`` where ``env`` is a full 8-tensor CTM environment and
-        ``meta`` contains ``iters``, ``residual``, and ``converged``.
-    """
+) -> tuple[Tensor, Tensor, dict[str, Any]]:
+    """Run dense C4v CTM to a fixed point (reduced C/T representation)."""
     if isinstance(A, SymmetricTensor):
         raise TypeError(
             "paper_ctm_ad='c4v_appendix_cf' currently supports dense tensors only."
@@ -145,10 +158,189 @@ def ctm_tensor_c4v_paper_fixed_point(
                 break
         prev_sv = current_sv
 
+    meta = {"iters": iters, "residual": residual, "converged": converged}
+    return C, T, meta
+
+
+def ctm_tensor_c4v_paper_fixed_point(
+    A: Tensor,
+    config: CTMConfig,
+) -> tuple[Any, dict[str, Any]]:
+    """Run dense C4v CTM to a fixed point and return diagnostics."""
+    C, T, meta = _ctm_tensor_c4v_paper_fixed_point_reduced(A, config)
     env_full = _c4v_to_full_env(C, T)
-    meta = {
-        "iters": iters,
-        "residual": residual,
-        "converged": converged,
-    }
     return env_full, meta
+
+
+def _build_env_diag_preconditioner(
+    C: Tensor,
+    T: Tensor,
+    diag_shift: float,
+):
+    c_scale = 1.0 / (jnp.mean(jnp.abs(C.todense())) + diag_shift)
+    t_scale = 1.0 / (jnp.mean(jnp.abs(T.todense())) + diag_shift)
+
+    def precondition(v):
+        v_c, v_t = v
+        return (v_c * c_scale, v_t * t_scale)
+
+    return precondition
+
+
+def _solve_linear_adjoint_paper(
+    apply_i_minus_jt,
+    rhs,
+    config: CTMConfig,
+    *,
+    preconditioner=None,
+) -> tuple[Any, dict[str, Any]]:
+    """Solve ``(I - J^T) lambda = rhs`` with paper-mode Krylov policy."""
+    maxiter = int(config.paper_krylov_maxiter)
+    tol = float(config.paper_krylov_tol)
+    requested = str(config.paper_krylov_solver)
+    residual_target = max(tol * 10.0, 1e-12)
+
+    def _solve_bicg(x0):
+        lam, info = _krylov_bicgstab(
+            apply_i_minus_jt,
+            rhs,
+            x0=x0,
+            tol=tol,
+            maxiter=maxiter,
+            M=preconditioner,
+        )
+        return lam, info
+
+    def _solve_gmres(x0):
+        lam, info = _krylov_gmres(
+            apply_i_minus_jt,
+            rhs,
+            x0=x0,
+            tol=tol,
+            maxiter=maxiter,
+            restart=min(maxiter, 20),
+            M=preconditioner,
+        )
+        return lam, info
+
+    def _residual_norm(lam):
+        return _tree_l2_norm(_tree_sub(apply_i_minus_jt(lam), rhs))
+
+    def _is_success(lam, info, residual, *, solver: str) -> bool:
+        if not _tree_all_finite(lam) or not jnp.isfinite(residual):
+            return False
+        if solver == "gmres" and int(info) != 0:
+            return False
+        return residual <= residual_target
+
+    used_fallback = False
+    if requested == "gmres":
+        lam, info = _solve_gmres(rhs)
+        solver_used = "gmres"
+        residual = _residual_norm(lam)
+    else:
+        lam, info = _solve_bicg(rhs)
+        solver_used = "bicgstab"
+        residual = _residual_norm(lam)
+        if not _is_success(lam, info, residual, solver="bicgstab"):
+            lam, info = _solve_gmres(lam)
+            solver_used = "gmres"
+            residual = _residual_norm(lam)
+            used_fallback = True
+
+    meta = {
+        "solver_requested": requested,
+        "solver_used": solver_used,
+        "used_fallback": used_fallback,
+        "residual": residual,
+        "tol": tol,
+        "maxiter": maxiter,
+        "info": None if info is None else int(info),
+    }
+    return lam, meta
+
+
+def _ctm_tensor_c4v_paper_implicit_backward(
+    A: DenseTensor,
+    C: Tensor,
+    T: Tensor,
+    g: tuple[Tensor, Tensor],
+    config: CTMConfig,
+) -> tuple[DenseTensor, dict[str, Any]]:
+    """Appendix-F matrix-free implicit backward for paper-mode C4v CTM."""
+    a = _build_double_layer_tensor(A)
+    g_c, g_t = g
+
+    def _step_env(env_pair):
+        c_in, t_in = env_pair
+        return _c4v_sweep(c_in, t_in, a, config.chi, config.projector_method)
+
+    _, vjp_env_fn = jax.vjp(_step_env, (C, T))
+
+    def _step_site(A_in):
+        a_in = _build_double_layer_tensor(A_in)
+        return _c4v_sweep(C, T, a_in, config.chi, config.projector_method)
+
+    _, vjp_site_fn = jax.vjp(_step_site, A)
+
+    def _apply_i_minus_jt(v):
+        jtv = vjp_env_fn(v)[0]
+        return _tree_sub(v, jtv)
+
+    precond = _build_env_diag_preconditioner(
+        C, T, float(getattr(config, "paper_diag_shift", 1e-12))
+    )
+    lam, solve_meta = _solve_linear_adjoint_paper(
+        _apply_i_minus_jt,
+        (g_c, g_t),
+        config,
+        preconditioner=precond,
+    )
+    dA = vjp_site_fn(lam)[0]
+    return dA, solve_meta
+
+
+def ctm_tensor_c4v_paper_backward(
+    A: DenseTensor,
+    C: Tensor,
+    T: Tensor,
+    g_c: Tensor,
+    g_t: Tensor,
+    config: CTMConfig,
+) -> tuple[DenseTensor, dict[str, Any]]:
+    """Run one implicit-adjoint solve for diagnostics/testing."""
+    return _ctm_tensor_c4v_paper_implicit_backward(A, C, T, (g_c, g_t), config)
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(1,))
+def ctm_tensor_c4v_paper_converge_reduced(
+    A: DenseTensor,
+    config: CTMConfig,
+) -> tuple[Tensor, Tensor]:
+    """Fixed-point converger returning reduced C4v env ``(C, T)``."""
+    C, T, _meta = _ctm_tensor_c4v_paper_fixed_point_reduced(A, config)
+    return C, T
+
+
+def _ctm_tensor_c4v_paper_converge_reduced_fwd(A: DenseTensor, config: CTMConfig):
+    C, T, _meta = _ctm_tensor_c4v_paper_fixed_point_reduced(A, config)
+    return (C, T), (A, C, T)
+
+
+def _ctm_tensor_c4v_paper_converge_reduced_bwd(
+    config: CTMConfig,
+    residuals,
+    g,
+):
+    A, C, T = residuals
+    g_c, g_t = g
+    dA, _solve_meta = _ctm_tensor_c4v_paper_implicit_backward(
+        A, C, T, (g_c, g_t), config
+    )
+    return (dA,)
+
+
+ctm_tensor_c4v_paper_converge_reduced.defvjp(
+    _ctm_tensor_c4v_paper_converge_reduced_fwd,
+    _ctm_tensor_c4v_paper_converge_reduced_bwd,
+)

--- a/src/tenax/algorithms/_ctm_tensor_c4v_paper_ad.py
+++ b/src/tenax/algorithms/_ctm_tensor_c4v_paper_ad.py
@@ -1,0 +1,79 @@
+"""Paper-mode dense C4v CTM forward fixed-point utilities.
+
+This module provides the forward fixed-point map used by the opt-in
+paper-faithful iPEPS AD path. Backward/implicit differentiation is added
+separately.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+
+from tenax.algorithms._ctm_tensor_c4v import _c4v_sweep, _c4v_to_full_env
+from tenax.algorithms._ctm_tensor_convergence import _ctm_sv_diff
+from tenax.algorithms._ctm_tensor_init import (
+    _build_double_layer_tensor,
+    initialize_ctm_tensor_env,
+)
+from tenax.algorithms.ipeps_config import CTMConfig
+from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+
+__all__ = ["ctm_tensor_c4v_paper_fixed_point"]
+
+
+def ctm_tensor_c4v_paper_fixed_point(
+    A: Tensor,
+    config: CTMConfig,
+) -> tuple[Any, dict[str, Any]]:
+    """Run dense C4v CTM to a fixed point and return diagnostics.
+
+    Args:
+        A:      Dense 1-site iPEPS tensor.
+        config: CTM configuration (chi/max_iter/conv_tol/projector/min_iter).
+
+    Returns:
+        ``(env, meta)`` where ``env`` is a full 8-tensor CTM environment and
+        ``meta`` contains ``iters``, ``residual``, and ``converged``.
+    """
+    if isinstance(A, SymmetricTensor):
+        raise TypeError(
+            "paper_ctm_ad='c4v_appendix_cf' currently supports dense tensors only."
+        )
+    if not isinstance(A, DenseTensor):
+        raise TypeError(
+            f"Expected DenseTensor for paper C4v mode, got {type(A).__name__}."
+        )
+
+    a = _build_double_layer_tensor(A)
+    env = initialize_ctm_tensor_env(A, config.chi)
+
+    C = env.C1.relabels({"c1_d": "c_a", "c1_r": "c_b"})
+    T = env.T1.relabels({"t1_l": "t_l", "u2": "D2", "t1_r": "t_r"})
+
+    prev_sv = None
+    residual = float("inf")
+    converged = False
+    iters = 0
+    min_iter = max(int(getattr(config, "min_iter", 1)), 1)
+
+    for it in range(int(config.max_iter)):
+        C, T = _c4v_sweep(C, T, a, config.chi, config.projector_method)
+        iters = it + 1
+        current_sv = jnp.linalg.svd(C.todense(), compute_uv=False)
+
+        if prev_sv is not None:
+            residual = float(_ctm_sv_diff(current_sv, prev_sv))
+            if iters >= min_iter and residual < float(config.conv_tol):
+                converged = True
+                break
+        prev_sv = current_sv
+
+    env_full = _c4v_to_full_env(C, T)
+    meta = {
+        "iters": iters,
+        "residual": residual,
+        "converged": converged,
+    }
+    return env_full, meta

--- a/src/tenax/algorithms/_ctm_tensor_c4v_paper_ad.py
+++ b/src/tenax/algorithms/_ctm_tensor_c4v_paper_ad.py
@@ -248,6 +248,7 @@ def _solve_linear_adjoint_paper(
             residual = _residual_norm(lam)
             used_fallback = True
 
+    converged = _is_success(lam, info, residual, solver=solver_used)
     meta = {
         "solver_requested": requested,
         "solver_used": solver_used,
@@ -256,7 +257,15 @@ def _solve_linear_adjoint_paper(
         "tol": tol,
         "maxiter": maxiter,
         "info": None if info is None else int(info),
+        "converged": bool(converged),
     }
+    if not converged:
+        raise RuntimeError(
+            f"Paper-mode Krylov adjoint solver ({solver_used}) failed to "
+            f"converge: residual={float(residual):.3e}, target<={residual_target:.3e}, "
+            f"info={meta['info']}. Using a non-solution would corrupt gradients. "
+            f"Increase paper_krylov_maxiter or loosen paper_krylov_tol."
+        )
     return lam, meta
 
 

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -62,6 +62,27 @@ class CTMConfig:
     # "sigma" (implicit-diff path), or "none" (diagnostic).  See ipeps_ad_paths.md.
     forward_gauge: str = "qr"
     jit_ctm: bool = False  # use jax.lax.while_loop for GPU kernel fusion
+    # Optional paper-faithful implicit AD mode (App. C-F) for dense 1-site C4v.
+    paper_ctm_ad: str | None = None  # None or "c4v_appendix_cf"
+    paper_krylov_solver: str = "bicgstab"  # "bicgstab" or "gmres"
+    paper_krylov_maxiter: int = 50
+    paper_krylov_tol: float = 1e-8
+    paper_degen_tol: float = 1e-10
+    paper_diag_shift: float = 1e-12
+
+    def __post_init__(self):
+        valid_paper_modes = {None, "c4v_appendix_cf"}
+        if self.paper_ctm_ad not in valid_paper_modes:
+            raise ValueError(
+                f"paper_ctm_ad must be one of {valid_paper_modes}, "
+                f"got {self.paper_ctm_ad!r}"
+            )
+        valid_paper_solvers = {"bicgstab", "gmres"}
+        if self.paper_krylov_solver not in valid_paper_solvers:
+            raise ValueError(
+                f"paper_krylov_solver must be one of {valid_paper_solvers}, "
+                f"got {self.paper_krylov_solver!r}"
+            )
 
 
 @dataclass

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -378,16 +378,13 @@ def _optimize_gs_ad_tensor_paper_c4v(
     A_init: jax.Array | Tensor | None,
     config: iPEPSConfig,
 ):
-    """Forward-only paper-mode dense C4v path.
+    """Paper-mode dense C4v path with implicit-AD CTM backward."""
+    import optax
 
-    Current scope:
-    - Runs the dedicated dense C4v forward fixed-point map.
-    - Returns a finite energy/environment for ``gs_num_steps == 0``.
-
-    Backward/optimization for ``gs_num_steps > 0`` is added separately.
-    """
     from tenax.algorithms._ctm_tensor import compute_energy_ctm_tensor
+    from tenax.algorithms._ctm_tensor_c4v import _c4v_to_full_env
     from tenax.algorithms._ctm_tensor_c4v_paper_ad import (
+        ctm_tensor_c4v_paper_converge_reduced,
         ctm_tensor_c4v_paper_fixed_point,
     )
     from tenax.algorithms.ipeps import (
@@ -441,16 +438,61 @@ def _optimize_gs_ad_tensor_paper_c4v(
     if config.gs_projector_method is not None:
         ctm_cfg = _replace(ctm_cfg, projector_method=config.gs_projector_method)
 
-    env, _meta = ctm_tensor_c4v_paper_fixed_point(A, ctm_cfg)
-    E0 = float(compute_energy_ctm_tensor(A, env, gate, d_phys))
+    if config.gs_num_steps == 0:
+        env, _meta = ctm_tensor_c4v_paper_fixed_point(A, ctm_cfg)
+        E0 = float(compute_energy_ctm_tensor(A, env, gate, d_phys))
+        return A, env, E0
 
-    if config.gs_num_steps > 0:
-        raise NotImplementedError(
-            "paper_ctm_ad='c4v_appendix_cf' forward path is implemented, "
-            "but optimization/backward for gs_num_steps>0 is not yet available."
-        )
+    optimizer = _build_optimizer(config)
+    use_cg = optimizer is None
+    params = A.todense()
+    opt_state = None if optimizer is None else optimizer.init(params)
+    best_energy = float("inf")
+    best_params = params
 
-    return A, env, E0
+    def _project_c4v_and_normalize(A_data: jax.Array) -> jax.Array:
+        coeffs = c4v_coeffs_from_tensor(A_data, c4v_basis)
+        A_proj = c4v_tensor_from_coeffs(coeffs, c4v_basis, tensor_shape)
+        return A_proj / (jnp.linalg.norm(A_proj) + 1e-10)
+
+    def _loss_fn(A_data):
+        A_proj = _project_c4v_and_normalize(A_data)
+        A_tensor = DenseTensor(A_proj, A.indices)
+        C, T = ctm_tensor_c4v_paper_converge_reduced(A_tensor, ctm_cfg)
+        env = _c4v_to_full_env(C, T)
+        energy = compute_energy_ctm_tensor(A_tensor, env, gate, d_phys)
+        return energy, (env, A_tensor)
+
+    for _step in range(config.gs_num_steps):
+        (energy_val, _aux), grads = jax.value_and_grad(_loss_fn, has_aux=True)(params)
+        grads = jnp.where(jnp.isfinite(grads), grads, 0.0)
+        if use_cg:
+            params = _normalize_params(params - config.gs_learning_rate * grads)
+        else:
+            assert optimizer is not None
+            if config.gs_optimizer.lower() == "lbfgs":
+                updates, opt_state = optimizer.update(
+                    grads,
+                    opt_state,
+                    params,
+                    value=energy_val,
+                    grad=grads,
+                    value_fn=lambda p: _loss_fn(p)[0],
+                )
+            else:
+                updates, opt_state = optimizer.update(grads, opt_state, params)
+            params = _normalize_params(optax.apply_updates(params, updates))
+        E = float(energy_val)
+        if _should_accept_best(
+            current_best=best_energy,
+            candidate=E,
+            floor=getattr(config, "gs_energy_floor", None),
+        ):
+            best_energy = E
+            best_params = params
+
+    final_energy, (final_env, final_A) = _loss_fn(best_params)
+    return final_A, final_env, float(final_energy)
 
 
 def _optimize_gs_ad_tensor(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1150,6 +1150,20 @@ def _optimize_gs_ad_tensor_2site(
 
         D_bond = A.todense().shape[0]
         d_loc = A.todense().shape[-1]
+        if d_loc != 2:
+            raise ValueError(
+                "2-site C4v shared-tensor path requires physical dimension "
+                f"d=2 (spin-1/2), got d={d_loc}. The sublattice rotation "
+                "U = e^{i π σ^y/2} is spin-1/2 specific; higher-spin models "
+                "need a model-specific sublattice rotation."
+            )
+        if config.gs_stall_recovery == "noise":
+            raise ValueError(
+                "gs_stall_recovery='noise' is incompatible with "
+                "gs_c4v=True on the 2-site path (noise recovery assumes "
+                "tuple-of-DenseTensor params, not a C4v coefficient vector). "
+                "Use gs_stall_recovery='reset' instead."
+            )
         tensor_shape = (D_bond, D_bond, D_bond, D_bond, d_loc)
         c4v_basis = jnp.array(build_c4v_basis(D_bond, d_loc))
         c4v_coeffs = c4v_coeffs_from_tensor(A.todense(), c4v_basis)

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -335,6 +335,8 @@ def optimize_gs_ad(
 
     if config.unit_cell == "2site":
         return _optimize_gs_ad_2site(hamiltonian_gate, A_init, config)
+    if _use_paper_c4v_path(config):
+        return _optimize_gs_ad_tensor_paper_c4v(hamiltonian_gate, A_init, config)
 
     # Wrap raw jax.Array as DenseTensor so we always use the Tensor-protocol path.
     if A_init is not None and not isinstance(A_init, Tensor):
@@ -359,6 +361,96 @@ def optimize_gs_ad(
             A_init = _wrap_as_dense_tensor(jax.random.normal(key, (D, D, D, D, d_phys)))
 
     return _optimize_gs_ad_tensor(hamiltonian_gate, A_init, config)
+
+
+def _use_paper_c4v_path(config: iPEPSConfig) -> bool:
+    """Return True when the strict paper-mode gate is satisfied."""
+    return (
+        config.unit_cell == "1x1"
+        and config.gs_c4v
+        and not config.gs_explicit_ad
+        and getattr(config.ctm, "paper_ctm_ad", None) == "c4v_appendix_cf"
+    )
+
+
+def _optimize_gs_ad_tensor_paper_c4v(
+    hamiltonian_gate: jax.Array | Tensor,
+    A_init: jax.Array | Tensor | None,
+    config: iPEPSConfig,
+):
+    """Forward-only paper-mode dense C4v path.
+
+    Current scope:
+    - Runs the dedicated dense C4v forward fixed-point map.
+    - Returns a finite energy/environment for ``gs_num_steps == 0``.
+
+    Backward/optimization for ``gs_num_steps > 0`` is added separately.
+    """
+    from tenax.algorithms._ctm_tensor import compute_energy_ctm_tensor
+    from tenax.algorithms._ctm_tensor_c4v_paper_ad import (
+        ctm_tensor_c4v_paper_fixed_point,
+    )
+    from tenax.algorithms.ipeps import (
+        build_c4v_basis,
+        c4v_coeffs_from_tensor,
+        c4v_tensor_from_coeffs,
+        ipeps,
+    )
+
+    gate = (
+        hamiltonian_gate.todense()
+        if isinstance(hamiltonian_gate, Tensor)
+        else jnp.array(hamiltonian_gate)
+    )
+    d_phys = gate.shape[0]
+    D = config.max_bond_dim
+
+    if A_init is not None and not isinstance(A_init, Tensor):
+        A = _wrap_as_dense_tensor(A_init)
+    elif A_init is None:
+        if config.su_init:
+            _, (A_su, _), _ = ipeps(gate, None, config)
+            A = A_su
+        else:
+            key = jax.random.PRNGKey(0)
+            A = _wrap_as_dense_tensor(jax.random.normal(key, (D, D, D, D, d_phys)))
+    else:
+        A = A_init
+
+    if not isinstance(A, DenseTensor):
+        raise TypeError(
+            "paper_ctm_ad='c4v_appendix_cf' currently supports DenseTensor inputs only."
+        )
+
+    A = A * (1.0 / (A.norm() + 1e-10))
+    # Enforce C4v by projecting to the C4v basis and reconstructing.
+    D_bond = A.todense().shape[0]
+    d_loc = A.todense().shape[-1]
+    tensor_shape = (D_bond, D_bond, D_bond, D_bond, d_loc)
+    c4v_basis = jnp.array(build_c4v_basis(D_bond, d_loc))
+    coeffs = c4v_coeffs_from_tensor(A.todense(), c4v_basis)
+    A_c4v = c4v_tensor_from_coeffs(coeffs, c4v_basis, tensor_shape)
+    A = DenseTensor(
+        A_c4v / (jnp.linalg.norm(A_c4v) + 1e-10),
+        A.indices,
+    )
+
+    from dataclasses import replace as _replace
+
+    ctm_cfg = config.ctm
+    if config.gs_projector_method is not None:
+        ctm_cfg = _replace(ctm_cfg, projector_method=config.gs_projector_method)
+
+    env, _meta = ctm_tensor_c4v_paper_fixed_point(A, ctm_cfg)
+    E0 = float(compute_energy_ctm_tensor(A, env, gate, d_phys))
+
+    if config.gs_num_steps > 0:
+        raise NotImplementedError(
+            "paper_ctm_ad='c4v_appendix_cf' forward path is implemented, "
+            "but optimization/backward for gs_num_steps>0 is not yet available."
+        )
+
+    return A, env, E0
 
 
 def _optimize_gs_ad_tensor(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -120,7 +120,7 @@ def _tree_add(a, b):
 def _normalize_params(params):
     """Normalize iPEPS site tensor(s)."""
     if isinstance(params, tuple):
-        return tuple(p * (1.0 / (p.norm() + 1e-10)) for p in params)
+        return tuple(_normalize_params(p) for p in params)
     if hasattr(params, "norm"):
         return params * (1.0 / (params.norm() + 1e-10))
     # Plain JAX array (e.g. C4v coefficients) — use jnp.linalg.norm
@@ -926,22 +926,29 @@ def _optimize_gs_ad_tensor_2site(
     Uses ``ctm_tensor_converge`` with implicit differentiation through
     the 2-site Tensor-protocol CTM.
 
+    With ``gs_c4v=True`` (recommended), optimizes a single C4v coefficient
+    vector and derives B from A via sublattice rotation on the physical leg.
+    This enforces A and B to be related by a spin-π rotation, preventing
+    the A/B drift that plagues independent 2-site optimization.
+
     .. warning::
 
-        **Experimental / unsupported.**  The 2-site AD optimizer is
+        Without ``gs_c4v=True``, the 2-site AD optimizer is
         unstable and produces unphysical energies.  For antiferromagnetic
-        models, prefer 1-site optimization with
-        ``sublattice_rotate_gate()`` + ``gs_c4v=True``, which is faster
-        and well-tested.
+        models, prefer ``gs_c4v=True`` or 1-site optimization with
+        ``sublattice_rotate_gate()`` + ``gs_c4v=True``.
     """
     config = _normalize_stall_recovery(config, unit_cell="2site")
-    import warnings
+    use_c4v = config.gs_c4v
+    if not use_c4v:
+        import warnings
 
-    warnings.warn(
-        "2-site AD optimizer is experimental and may diverge. "
-        "Prefer 1-site with sublattice_rotate_gate() + gs_c4v=True.",
-        stacklevel=2,
-    )
+        warnings.warn(
+            "2-site AD optimizer is experimental and may diverge. "
+            "Prefer 1-site with sublattice_rotate_gate() + gs_c4v=True, "
+            "or enable gs_c4v=True for 2-site.",
+            stacklevel=2,
+        )
     import optax
 
     from tenax.algorithms._ctm_tensor import (
@@ -1000,10 +1007,41 @@ def _optimize_gs_ad_tensor_2site(
         ctm_tensor_converge_explicit if use_explicit else ctm_tensor_converge
     )
 
+    if use_c4v:
+        from tenax.algorithms.ipeps import (
+            build_c4v_basis,
+            c4v_coeffs_from_tensor,
+            c4v_tensor_from_coeffs,
+        )
+
+        D_bond = A.todense().shape[0]
+        d_loc = A.todense().shape[-1]
+        tensor_shape = (D_bond, D_bond, D_bond, D_bond, d_loc)
+        c4v_basis = jnp.array(build_c4v_basis(D_bond, d_loc))
+        c4v_coeffs = c4v_coeffs_from_tensor(A.todense(), c4v_basis)
+        A_indices = A.indices
+        # Sublattice rotation: B = A with physical leg rotated by U = e^{iπ σ^y/2}
+        _U_sub = jnp.array([[0.0, 1.0], [-1.0, 0.0]], dtype=A.todense().dtype)
+    else:
+        c4v_basis = None
+        tensor_shape = None
+        A_indices = None
+        _U_sub = None
+
+    def _c4v_AB(coeffs_):
+        """Build normalized (A, B) DenseTensors from a single C4v coeff vector."""
+        A_data = c4v_tensor_from_coeffs(coeffs_, c4v_basis, tensor_shape)
+        A_data = A_data / (jnp.linalg.norm(A_data) + 1e-10)
+        B_data = jnp.einsum("luRDs,sS->luRDS", A_data, _U_sub)
+        return DenseTensor(A_data, A_indices), DenseTensor(B_data, A_indices)
+
     def loss_fn(params, env_init_leaves):
-        A_p, B_p = params
-        A_norm = A_p * (1.0 / (A_p.norm() + 1e-10))
-        B_norm = B_p * (1.0 / (B_p.norm() + 1e-10))
+        if use_c4v:
+            A_norm, B_norm = _c4v_AB(params)
+        else:
+            A_p, B_p = params
+            A_norm = A_p * (1.0 / (A_p.norm() + 1e-10))
+            B_norm = B_p * (1.0 / (B_p.norm() + 1e-10))
         site_tensors = {(0, 0): A_norm, (1, 0): B_norm}
         if use_explicit:
             env_leaves = _ctm_converge(
@@ -1025,7 +1063,7 @@ def _optimize_gs_ad_tensor_2site(
         )
         return energy, env_leaves
 
-    params = (A, B)
+    params = c4v_coeffs if use_c4v else (A, B)
     is_metric_lbfgs = (
         config.gs_metric_precond and config.gs_optimizer.lower() == "lbfgs"
     )
@@ -1063,9 +1101,12 @@ def _optimize_gs_ad_tensor_2site(
     # Forward-only loss for line search — warm-starts CTM from prev_env_leaves
 
     def loss_fn_fwd(params_):
-        A_p, B_p = params_
-        A_norm = A_p * (1.0 / (A_p.norm() + 1e-10))
-        B_norm = B_p * (1.0 / (B_p.norm() + 1e-10))
+        if use_c4v:
+            A_norm, B_norm = _c4v_AB(params_)
+        else:
+            A_p, B_p = params_
+            A_norm = A_p * (1.0 / (A_p.norm() + 1e-10))
+            B_norm = B_p * (1.0 / (B_p.norm() + 1e-10))
         site_tensors = {(0, 0): A_norm, (1, 0): B_norm}
         env_leaves = ctm_tensor_converge(
             site_tensors, prev_env_leaves, CHECKERBOARD_NEIGHBORS, config_tuple
@@ -1141,7 +1182,7 @@ def _optimize_gs_ad_tensor_2site(
 
         # Compute search direction
         if is_cg:
-            if config.gs_metric_precond:
+            if config.gs_metric_precond and not use_c4v:
                 from tenax.algorithms._metric_precond import (
                     precondition_gradient_multisite,
                 )
@@ -1180,19 +1221,24 @@ def _optimize_gs_ad_tensor_2site(
             prev_grad = grads
             direction = cg_direction
         elif is_metric_lbfgs:
-            from tenax.algorithms._metric_precond import (
-                lbfgs_two_loop,
-                precondition_gradient_multisite,
-            )
+            from tenax.algorithms._metric_precond import lbfgs_two_loop
 
-            A_cur, B_cur = params
-            A_g, B_g = grads
-            p_flat = jnp.concatenate(
-                [A_cur.todense().reshape(-1), B_cur.todense().reshape(-1)]
-            )
-            g_flat = jnp.concatenate(
-                [A_g.todense().reshape(-1), B_g.todense().reshape(-1)]
-            )
+            if use_c4v:
+                p_flat = params
+                g_flat = grads
+            else:
+                from tenax.algorithms._metric_precond import (
+                    precondition_gradient_multisite,
+                )
+
+                A_cur, B_cur = params
+                A_g, B_g = grads
+                p_flat = jnp.concatenate(
+                    [A_cur.todense().reshape(-1), B_cur.todense().reshape(-1)]
+                )
+                g_flat = jnp.concatenate(
+                    [A_g.todense().reshape(-1), B_g.todense().reshape(-1)]
+                )
 
             if prev_params_flat is not None:
                 s = p_flat - prev_params_flat
@@ -1206,42 +1252,48 @@ def _optimize_gs_ad_tensor_2site(
             prev_params_flat = p_flat
             prev_grad_flat = g_flat
 
-            env_A_m = jax.tree.unflatten(env_treedef, env_leaves_sg[:n_env_leaves])
-            env_B_m = jax.tree.unflatten(env_treedef, env_leaves_sg[n_env_leaves:])
-            envs_m = {(0, 0): env_A_m, (1, 0): env_B_m}
-            sites_m = {(0, 0): A_cur, (1, 0): B_cur}
-            delta_metric = delta_energy if step > 0 else float(jnp.dot(g_flat, g_flat))
-            n_A = A_cur.todense().size
+            if use_c4v:
+                direction_flat = lbfgs_two_loop(g_flat, lbfgs_history, lambda v: v)
+                direction = -direction_flat
+            else:
+                env_A_m = jax.tree.unflatten(env_treedef, env_leaves_sg[:n_env_leaves])
+                env_B_m = jax.tree.unflatten(env_treedef, env_leaves_sg[n_env_leaves:])
+                envs_m = {(0, 0): env_A_m, (1, 0): env_B_m}
+                sites_m = {(0, 0): A_cur, (1, 0): B_cur}
+                delta_metric = (
+                    delta_energy if step > 0 else float(jnp.dot(g_flat, g_flat))
+                )
+                n_A = A_cur.todense().size
 
-            def h0_matvec(v):
-                v_A = v[:n_A]
-                v_B = v[n_A:]
+                def h0_matvec(v):
+                    v_A = v[:n_A]
+                    v_B = v[n_A:]
+                    D_b = A_cur.todense().shape[0]
+                    d_l = A_cur.todense().shape[-1]
+                    grads_v = {
+                        (0, 0): type(A_cur)(
+                            v_A.reshape(D_b, D_b, D_b, D_b, d_l), A_cur.indices
+                        ),
+                        (1, 0): type(B_cur)(
+                            v_B.reshape(D_b, D_b, D_b, D_b, d_l), B_cur.indices
+                        ),
+                    }
+                    z_dict = precondition_gradient_multisite(
+                        sites_m, envs_m, grads_v, delta_metric, config
+                    )
+                    return jnp.concatenate(
+                        [z_dict[(0, 0)].reshape(-1), z_dict[(1, 0)].reshape(-1)]
+                    )
+
+                direction_flat = lbfgs_two_loop(g_flat, lbfgs_history, h0_matvec)
                 D_b = A_cur.todense().shape[0]
                 d_l = A_cur.todense().shape[-1]
-                grads_v = {
-                    (0, 0): type(A_cur)(
-                        v_A.reshape(D_b, D_b, D_b, D_b, d_l), A_cur.indices
-                    ),
-                    (1, 0): type(B_cur)(
-                        v_B.reshape(D_b, D_b, D_b, D_b, d_l), B_cur.indices
-                    ),
-                }
-                z_dict = precondition_gradient_multisite(
-                    sites_m, envs_m, grads_v, delta_metric, config
+                dir_A = -direction_flat[:n_A].reshape(D_b, D_b, D_b, D_b, d_l)
+                dir_B = -direction_flat[n_A:].reshape(D_b, D_b, D_b, D_b, d_l)
+                direction = (
+                    type(A_cur)(dir_A, A_cur.indices),
+                    type(B_cur)(dir_B, B_cur.indices),
                 )
-                return jnp.concatenate(
-                    [z_dict[(0, 0)].reshape(-1), z_dict[(1, 0)].reshape(-1)]
-                )
-
-            direction_flat = lbfgs_two_loop(g_flat, lbfgs_history, h0_matvec)
-            D_b = A_cur.todense().shape[0]
-            d_l = A_cur.todense().shape[-1]
-            dir_A = -direction_flat[:n_A].reshape(D_b, D_b, D_b, D_b, d_l)
-            dir_B = -direction_flat[n_A:].reshape(D_b, D_b, D_b, D_b, d_l)
-            direction = (
-                type(A_cur)(dir_A, A_cur.indices),
-                type(B_cur)(dir_B, B_cur.indices),
-            )
         elif optimizer is not None:
             updates, opt_state = optimizer.update(grads, opt_state, params)
             direction = updates
@@ -1315,6 +1367,7 @@ def _optimize_gs_ad_tensor_2site(
                     stall_count += 1
 
             # Noise recovery on persistent stall (legacy; see issue #298).
+            # Only used by the non-C4v path; C4v defaults to "reset".
             if (
                 config.gs_stall_recovery == "noise"
                 and stall_count > 0
@@ -1387,7 +1440,10 @@ def _optimize_gs_ad_tensor_2site(
     )
 
     def _eval_fresh_2site(p):
-        A_t, B_t = _normalize_params(p)
+        if use_c4v:
+            A_t, B_t = _c4v_AB(p)
+        else:
+            A_t, B_t = _normalize_params(p)
         st = {(0, 0): A_t, (1, 0): B_t}
         envs = _fp_fn_2site(st, CHECKERBOARD_NEIGHBORS, eval_config2)
         E_ = float(
@@ -1401,7 +1457,7 @@ def _optimize_gs_ad_tensor_2site(
     env_A_last, env_B_last = envs_last[(0, 0)], envs_last[(1, 0)]
 
     if best_params is not params:
-        _, _, envs_best, E_best_fresh = _eval_fresh_2site(best_params)
+        A_best, B_best, envs_best, E_best_fresh = _eval_fresh_2site(best_params)
         env_A_best = envs_best[(0, 0)]
         env_B_best = envs_best[(1, 0)]
     else:
@@ -1412,7 +1468,7 @@ def _optimize_gs_ad_tensor_2site(
         A_final, B_final = A_last, B_last
         env_A, env_B, E_gs = env_A_last, env_B_last, E_last
     else:
-        A_final, B_final = _normalize_params(best_params)
+        A_final, B_final = A_best, B_best
         env_A, env_B, E_gs = env_A_best, env_B_best, E_best_fresh
     if config.gs_verbose:
         print(f"[iPEPS-AD:2site-tensor] final E={E_gs:.10f}", flush=True)

--- a/tests/test_ad_utils.py
+++ b/tests/test_ad_utils.py
@@ -15,6 +15,7 @@ def _enable_x64():
     jax.config.update("jax_enable_x64", prev)
 
 
+from tenax.algorithms._ctm_projector import _compute_projector_tensor
 from tenax.algorithms._ctm_tensor import (
     CTMTensorEnv,
     _build_double_layer_tensor,
@@ -205,6 +206,149 @@ class TestTruncatedSVDADMissingTerm:
 
         max_diff = float(jnp.max(jnp.abs(grad_ad - grad_fd)))
         assert max_diff < 1e-3, f"Gradient error too large: {max_diff}"
+
+    def test_disabling_truncation_correction_worsens_fd_error(self, monkeypatch):
+        """Naive backward without kept-discarded corrections is less accurate."""
+        key = jax.random.PRNGKey(123)
+        U0, _ = jnp.linalg.qr(jax.random.normal(key, (6, 6)))
+        V0, _ = jnp.linalg.qr(jax.random.normal(jax.random.PRNGKey(124), (5, 5)))
+        svals = jnp.array([4.0, 2.0, 1.999, 0.8, 0.2])
+        M = U0[:, :5] @ jnp.diag(svals) @ V0.T
+        chi = 2
+
+        Wu_r = jax.random.normal(jax.random.PRNGKey(125), (6, 6))
+        Wu = 0.5 * (Wu_r + Wu_r.T)
+        Wv_r = jax.random.normal(jax.random.PRNGKey(126), (5, 5))
+        Wv = 0.5 * (Wv_r + Wv_r.T)
+
+        def loss(M_in):
+            U, s, Vh = truncated_svd_ad(M_in, chi)
+            proj_u = U @ U.T
+            proj_v = Vh.T @ Vh
+            return (
+                jnp.sum(s**2)
+                + 0.31 * jnp.trace(proj_u @ Wu)
+                + 0.23 * jnp.trace(proj_v @ Wv)
+            )
+
+        def finite_diff_grad(M_in, eps=2e-5):
+            M_np = np.array(M_in)
+            g_fd = np.zeros_like(M_np)
+            for i in range(M_np.shape[0]):
+                for j in range(M_np.shape[1]):
+                    d = np.zeros_like(M_np)
+                    d[i, j] = eps
+                    g_fd[i, j] = (
+                        float(loss(jnp.array(M_np + d)))
+                        - float(loss(jnp.array(M_np - d)))
+                    ) / (2 * eps)
+            return jnp.array(g_fd)
+
+        grad_ref = jax.grad(loss)(M)
+
+        def _naive_sector_backward(U, s, Vh, dU, ds, dVh, eps=1e-12):
+            k = ds.shape[0]
+            U_k = U[:, :k]
+            s_k = s[:k]
+            Vh_k = Vh[:k, :]
+            V_k = Vh_k.conj().T
+            s2 = s_k**2
+            diff = s2[:, None] - s2[None, :]
+            F = diff / (diff**2 + eps**2)
+            F = F - jnp.diag(jnp.diag(F))
+            UtdU = U_k.conj().T @ dU
+            VtdV = V_k.conj().T @ dVh.conj().T
+            UtdU_anti = 0.5 * (UtdU - UtdU.conj().T)
+            VtdV_anti = 0.5 * (VtdV - VtdV.conj().T)
+            dM = U_k @ jnp.diag(ds) @ Vh_k
+            dM = dM + U_k @ (F * UtdU_anti) @ jnp.diag(s_k) @ Vh_k
+            dM = dM + U_k @ jnp.diag(s_k) @ (F * VtdV_anti) @ Vh_k
+            return dM
+
+        monkeypatch.setattr(
+            "tenax.algorithms.ad_utils._svd_sector_backward",
+            _naive_sector_backward,
+        )
+        grad_naive = jax.grad(loss)(M)
+
+        grad_fd = finite_diff_grad(M)
+        err_ref = float(jnp.linalg.norm(grad_ref - grad_fd))
+        err_naive = float(jnp.linalg.norm(grad_naive - grad_fd))
+        assert err_ref <= err_naive + 1e-10, (
+            f"Expected corrected backward to beat/equal naive: "
+            f"err_ref={err_ref}, err_naive={err_naive}"
+        )
+
+
+class TestProjectorADAudit:
+    """Audit projector AD routes use stabilized SVD routines under tracing."""
+
+    @staticmethod
+    def _make_grown_corners_dense(key1, key2, fused_dim=10, col1=6, col2=5):
+        sym = U1Symmetry()
+        C1g_data = jax.random.normal(key1, (fused_dim, col1))
+        C4g_data = jax.random.normal(key2, (fused_dim, col2))
+        fused_idx = TensorIndex.from_charges(
+            sym,
+            np.zeros(fused_dim, dtype=np.int32),
+            FlowDirection.IN,
+            label="fused",
+        )
+        c1_idx = TensorIndex.from_charges(
+            sym, np.zeros(col1, dtype=np.int32), FlowDirection.OUT, label="c1"
+        )
+        c4_idx = TensorIndex.from_charges(
+            sym, np.zeros(col2, dtype=np.int32), FlowDirection.OUT, label="c4"
+        )
+        C1g = DenseTensor(C1g_data, (fused_idx, c1_idx))
+        C4g = DenseTensor(C4g_data, (fused_idx, c4_idx))
+        return C1g, C4g
+
+    def test_svd_projector_traced_path_calls_truncated_svd_ad(self, monkeypatch):
+        import tenax.algorithms.ad_utils as ad_utils_mod
+
+        C1g_base, C4g_base = self._make_grown_corners_dense(
+            jax.random.PRNGKey(210), jax.random.PRNGKey(211)
+        )
+        calls = {"n": 0}
+        orig = ad_utils_mod.truncated_svd_ad
+
+        def _spy_truncated_svd_ad(M, chi):
+            calls["n"] += 1
+            return orig(M, chi)
+
+        monkeypatch.setattr(ad_utils_mod, "truncated_svd_ad", _spy_truncated_svd_ad)
+
+        def traced_eval(alpha):
+            C1g = DenseTensor(alpha * C1g_base.todense(), C1g_base.indices)
+            P1, P2 = _compute_projector_tensor(C1g, C4g_base, 4, projector_method="svd")
+            return jnp.sum(P1.todense() ** 2) + jnp.sum(P2.todense() ** 2)
+
+        _ = jax.jit(traced_eval)(1.0)
+        assert calls["n"] >= 1, "Expected traced SVD projector to call truncated_svd_ad"
+
+    def test_qr_projector_traced_path_calls_regularized_svd(self, monkeypatch):
+        import tenax.algorithms.ad_utils as ad_utils_mod
+
+        C1g_base, C4g_base = self._make_grown_corners_dense(
+            jax.random.PRNGKey(220), jax.random.PRNGKey(221)
+        )
+        calls = {"n": 0}
+        orig = ad_utils_mod.regularized_svd
+
+        def _spy_regularized_svd(M):
+            calls["n"] += 1
+            return orig(M)
+
+        monkeypatch.setattr(ad_utils_mod, "regularized_svd", _spy_regularized_svd)
+
+        def traced_eval(alpha):
+            C1g = DenseTensor(alpha * C1g_base.todense(), C1g_base.indices)
+            P, _ = _compute_projector_tensor(C1g, C4g_base, 4, projector_method="qr")
+            return jnp.sum(P.todense() ** 2)
+
+        _ = jax.jit(traced_eval)(1.0)
+        assert calls["n"] >= 1, "Expected traced QR projector to call regularized_svd"
 
 
 def _make_dense_tensor(key, D=2, d=2):

--- a/tests/test_c4v_paper_ad.py
+++ b/tests/test_c4v_paper_ad.py
@@ -1,11 +1,17 @@
 """Tests for the dense C4v paper-mode forward path (Appendix C-F roadmap)."""
 
+import itertools
+
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from tenax.algorithms._ctm_tensor_c4v_paper_ad import ctm_tensor_c4v_paper_fixed_point
+from tenax.algorithms._ctm_tensor_c4v_paper_ad import (
+    _appendix_c_truncated_eigh_backward,
+    ctm_tensor_c4v_paper_fixed_point,
+    truncated_eigh_appendix_c,
+)
 from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
 from tenax.algorithms.ipeps_optimize import _wrap_as_dense_tensor, optimize_gs_ad
 from tenax.core.tensor import DenseTensor
@@ -138,3 +144,98 @@ def test_optimize_gs_ad_paper_mode_nonzero_steps_not_implemented(heisenberg_gate
     )
     with pytest.raises(NotImplementedError, match="gs_num_steps>0"):
         optimize_gs_ad(heisenberg_gate, A0, config)
+
+
+def test_truncated_eigh_appendix_c_gradient_finite_degenerate():
+    key = jax.random.PRNGKey(77)
+    Q, _ = jnp.linalg.qr(jax.random.normal(key, (6, 6)))
+    w = jnp.array([3.0, 3.0, 2.0, 2.0, 1.0, 0.5])
+    M = Q @ jnp.diag(w) @ Q.T
+    M = 0.5 * (M + M.T)
+
+    def loss(M_in):
+        vals, vecs = truncated_eigh_appendix_c(M_in, 3)
+        return jnp.sum(vals**2) + jnp.sum(vecs[:, 0] ** 2)
+
+    grad = jax.grad(loss)(M)
+    assert jnp.all(jnp.isfinite(grad))
+
+
+def _finite_difference_grad(loss_fn, M, eps=1e-5):
+    M_np = np.array(M)
+    grad = np.zeros_like(M_np)
+    for i, j in itertools.product(range(M_np.shape[0]), range(M_np.shape[1])):
+        d = np.zeros_like(M_np)
+        d[i, j] = eps
+        plus = M_np + d
+        minus = M_np - d
+        grad[i, j] = (
+            float(loss_fn(jnp.array(plus))) - float(loss_fn(jnp.array(minus)))
+        ) / (2 * eps)
+    return grad
+
+
+def test_truncated_eigh_appendix_c_finite_difference_agreement():
+    key = jax.random.PRNGKey(1234)
+    M0 = jax.random.normal(key, (5, 5))
+    M0 = 0.5 * (M0 + M0.T)
+    key_w = jax.random.PRNGKey(1235)
+    W = jax.random.normal(key_w, (5, 5))
+    W = 0.5 * (W + W.T)
+
+    def loss(M_in):
+        vals, vecs = truncated_eigh_appendix_c(M_in, 3)
+        P = vecs @ vecs.T
+        return jnp.sum(vals**2) + 0.2 * jnp.trace(P @ W)
+
+    g_ad = jax.grad(loss)(M0)
+    g_fd = _finite_difference_grad(loss, M0)
+    max_diff = float(jnp.max(jnp.abs(g_ad - g_fd)))
+    assert max_diff < 1.5e-1, (
+        f"Appendix-C truncated eigh FD mismatch too large: {max_diff}"
+    )
+
+
+def test_appendix_c_truncation_correction_improves_fd_error():
+    key = jax.random.PRNGKey(999)
+    Q, _ = jnp.linalg.qr(jax.random.normal(key, (6, 6)))
+    # Near-degenerate boundary between kept/discarded sectors for k=3.
+    w_spec = jnp.array([4.0, 3.0, 2.0000, 1.9999, 1.0, 0.5])
+    M = Q @ jnp.diag(w_spec) @ Q.T
+    M = 0.5 * (M + M.T)
+    key_w = jax.random.PRNGKey(1000)
+    W = jax.random.normal(key_w, (6, 6))
+    W = 0.5 * (W + W.T)
+    w, v = jnp.linalg.eigh(M)
+    k = 3
+
+    def loss(M_in):
+        vals, vecs = truncated_eigh_appendix_c(M_in, k)
+        P = vecs @ vecs.T
+        return jnp.sum(vals**2) + 0.3 * jnp.trace(P @ W)
+
+    g_fd = _finite_difference_grad(loss, M)
+    vals, vecs = truncated_eigh_appendix_c(M, k)
+    dvals = 2.0 * vals
+    dvecs = 0.6 * (W @ vecs)
+    g_ref = _appendix_c_truncated_eigh_backward(w, v, dvals, dvecs, k=k)
+
+    # Naive backward: keep-kept only (omit kept-discarded correction)
+    V_k = v[:, :k]
+    w_k = w[:k]
+    A = jnp.conj(V_k).T @ dvecs
+    A_anti = 0.5 * (A - jnp.conj(A).T)
+    gap = w_k[:, None] - w_k[None, :]
+    F = gap / (gap**2 + 1e-12**2)
+    F = F - jnp.diag(jnp.diag(F))
+    g_naive = (
+        V_k @ jnp.diag(dvals) @ jnp.conj(V_k).T + V_k @ (F * A_anti) @ jnp.conj(V_k).T
+    )
+    g_naive = 0.5 * (g_naive + jnp.conj(g_naive).T)
+
+    err_ref = float(jnp.linalg.norm(g_ref - g_fd))
+    err_naive = float(jnp.linalg.norm(g_naive - g_fd))
+    assert err_ref <= err_naive + 1e-8, (
+        f"Expected corrected Appendix-C backward to beat/equal naive: "
+        f"err_ref={err_ref}, err_naive={err_naive}"
+    )

--- a/tests/test_c4v_paper_ad.py
+++ b/tests/test_c4v_paper_ad.py
@@ -322,3 +322,40 @@ def test_paper_mode_krylov_fallback_to_gmres(monkeypatch):
     assert meta["used_fallback"] is True
     assert meta["solver_used"] == "gmres"
     assert meta["residual"] <= max(cfg.paper_krylov_tol * 10.0, 1e-12)
+
+
+def test_appendix_e_complex_gradient_is_hermitian():
+    key_r = jax.random.PRNGKey(2001)
+    key_i = jax.random.PRNGKey(2002)
+    X = jax.random.normal(key_r, (5, 5)) + 1j * jax.random.normal(key_i, (5, 5))
+    M = 0.5 * (X + jnp.conj(X).T)
+    key_wr = jax.random.PRNGKey(2003)
+    key_wi = jax.random.PRNGKey(2004)
+    W = jax.random.normal(key_wr, (5, 5)) + 1j * jax.random.normal(key_wi, (5, 5))
+    W = 0.5 * (W + jnp.conj(W).T)
+
+    def loss(M_in):
+        vals, vecs = truncated_eigh_appendix_c(M_in, 3)
+        P = vecs @ jnp.conj(vecs).T
+        return jnp.real(jnp.sum(vals**2) + 0.15 * jnp.trace(P @ W))
+
+    grad = jax.grad(loss)(M)
+    assert jnp.all(jnp.isfinite(grad))
+    assert jnp.max(jnp.abs(grad - jnp.conj(grad).T)) < 1e-10
+
+
+def test_appendix_e_complex_backward_output_is_hermitian():
+    key = jax.random.PRNGKey(2010)
+    X = jax.random.normal(key, (4, 4)) + 1j * jax.random.normal(
+        jax.random.PRNGKey(2011), (4, 4)
+    )
+    M = 0.5 * (X + jnp.conj(X).T)
+    w, v = jnp.linalg.eigh(M)
+    k = 2
+    dw = jax.random.normal(jax.random.PRNGKey(2012), (k,))
+    dV = jax.random.normal(jax.random.PRNGKey(2013), (4, k)) + 1j * jax.random.normal(
+        jax.random.PRNGKey(2014), (4, k)
+    )
+    dM = _appendix_c_truncated_eigh_backward(w, v, dw, dV, k=k)
+    assert jnp.all(jnp.isfinite(dM))
+    assert jnp.max(jnp.abs(dM - jnp.conj(dM).T)) < 1e-10

--- a/tests/test_c4v_paper_ad.py
+++ b/tests/test_c4v_paper_ad.py
@@ -1,0 +1,140 @@
+"""Tests for the dense C4v paper-mode forward path (Appendix C-F roadmap)."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tenax.algorithms._ctm_tensor_c4v_paper_ad import ctm_tensor_c4v_paper_fixed_point
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+from tenax.algorithms.ipeps_optimize import _wrap_as_dense_tensor, optimize_gs_ad
+from tenax.core.tensor import DenseTensor
+
+
+@pytest.fixture
+def heisenberg_gate():
+    d = 2
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+    H = jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+    return H.reshape(d, d, d, d)
+
+
+def test_c4v_paper_fixed_point_returns_meta():
+    A = _wrap_as_dense_tensor(jax.random.normal(jax.random.PRNGKey(0), (2, 2, 2, 2, 2)))
+    cfg = CTMConfig(
+        chi=4,
+        max_iter=8,
+        min_iter=2,
+        conv_tol=1e-8,
+        projector_method="eigh",
+        paper_ctm_ad="c4v_appendix_cf",
+    )
+    env, meta = ctm_tensor_c4v_paper_fixed_point(A, cfg)
+
+    assert np.isfinite(env.C1.todense()).all()
+    assert np.isfinite(env.T1.todense()).all()
+    assert set(meta) >= {"iters", "residual", "converged"}
+    assert 1 <= meta["iters"] <= cfg.max_iter
+    assert isinstance(meta["converged"], bool)
+    assert np.isfinite(meta["residual"]) or np.isinf(meta["residual"])
+
+
+def test_ctmconfig_paper_mode_defaults():
+    cfg = CTMConfig()
+    assert cfg.paper_ctm_ad is None
+    assert cfg.paper_krylov_solver == "bicgstab"
+    assert cfg.paper_krylov_maxiter == 50
+    assert cfg.paper_krylov_tol == 1e-8
+    assert cfg.paper_degen_tol == 1e-10
+    assert cfg.paper_diag_shift == 1e-12
+
+
+def test_invalid_paper_ctm_ad_raises():
+    with pytest.raises(ValueError, match="paper_ctm_ad"):
+        CTMConfig(paper_ctm_ad="bad_mode")
+
+
+def test_invalid_paper_krylov_solver_raises():
+    with pytest.raises(ValueError, match="paper_krylov_solver"):
+        CTMConfig(paper_krylov_solver="bad_solver")
+
+
+def test_paper_mode_dispatch_is_strictly_gated(heisenberg_gate, monkeypatch):
+    """Paper path dispatch should trigger only for the strict mode gate."""
+    import tenax.algorithms.ipeps_optimize as _opt
+
+    class _PaperCalled(Exception):
+        pass
+
+    class _DefaultCalled(Exception):
+        pass
+
+    def _paper_spy(*_args, **_kwargs):
+        raise _PaperCalled
+
+    def _default_spy(*_args, **_kwargs):
+        raise _DefaultCalled
+
+    monkeypatch.setattr(_opt, "_optimize_gs_ad_tensor_paper_c4v", _paper_spy)
+    monkeypatch.setattr(_opt, "_optimize_gs_ad_tensor", _default_spy)
+
+    A0 = jax.random.normal(jax.random.PRNGKey(123), (2, 2, 2, 2, 2))
+
+    cfg_paper = iPEPSConfig(
+        max_bond_dim=2,
+        ctm=CTMConfig(chi=4, max_iter=3, paper_ctm_ad="c4v_appendix_cf"),
+        gs_num_steps=0,
+        gs_explicit_ad=False,
+        gs_c4v=True,
+        unit_cell="1x1",
+        su_init=False,
+    )
+    with pytest.raises(_PaperCalled):
+        optimize_gs_ad(heisenberg_gate, A0, cfg_paper)
+
+    cfg_not_paper = iPEPSConfig(
+        max_bond_dim=2,
+        ctm=CTMConfig(chi=4, max_iter=3, paper_ctm_ad="c4v_appendix_cf"),
+        gs_num_steps=0,
+        gs_explicit_ad=False,
+        gs_c4v=False,
+        unit_cell="1x1",
+        su_init=False,
+    )
+    with pytest.raises(_DefaultCalled):
+        optimize_gs_ad(heisenberg_gate, A0, cfg_not_paper)
+
+
+def test_optimize_gs_ad_paper_mode_zero_steps_runs(heisenberg_gate):
+    A0 = jax.random.normal(jax.random.PRNGKey(1), (2, 2, 2, 2, 2))
+    config = iPEPSConfig(
+        max_bond_dim=2,
+        ctm=CTMConfig(chi=4, max_iter=10, min_iter=2, paper_ctm_ad="c4v_appendix_cf"),
+        gs_num_steps=0,
+        gs_explicit_ad=False,
+        gs_c4v=True,
+        unit_cell="1x1",
+        su_init=False,
+    )
+    A_opt, env, E = optimize_gs_ad(heisenberg_gate, A0, config)
+
+    assert isinstance(A_opt, DenseTensor)
+    assert np.isfinite(env.C1.todense()).all()
+    assert np.isfinite(E)
+
+
+def test_optimize_gs_ad_paper_mode_nonzero_steps_not_implemented(heisenberg_gate):
+    A0 = jax.random.normal(jax.random.PRNGKey(2), (2, 2, 2, 2, 2))
+    config = iPEPSConfig(
+        max_bond_dim=2,
+        ctm=CTMConfig(chi=4, max_iter=10, min_iter=2, paper_ctm_ad="c4v_appendix_cf"),
+        gs_num_steps=1,
+        gs_explicit_ad=False,
+        gs_c4v=True,
+        unit_cell="1x1",
+        su_init=False,
+    )
+    with pytest.raises(NotImplementedError, match="gs_num_steps>0"):
+        optimize_gs_ad(heisenberg_gate, A0, config)

--- a/tests/test_c4v_paper_ad.py
+++ b/tests/test_c4v_paper_ad.py
@@ -7,8 +7,13 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+from tenax.algorithms._ctm_tensor import compute_energy_ctm_tensor
+from tenax.algorithms._ctm_tensor_c4v import _c4v_to_full_env
 from tenax.algorithms._ctm_tensor_c4v_paper_ad import (
     _appendix_c_truncated_eigh_backward,
+    _solve_linear_adjoint_paper,
+    ctm_tensor_c4v_paper_backward,
+    ctm_tensor_c4v_paper_converge_reduced,
     ctm_tensor_c4v_paper_fixed_point,
     truncated_eigh_appendix_c,
 )
@@ -131,7 +136,7 @@ def test_optimize_gs_ad_paper_mode_zero_steps_runs(heisenberg_gate):
     assert np.isfinite(E)
 
 
-def test_optimize_gs_ad_paper_mode_nonzero_steps_not_implemented(heisenberg_gate):
+def test_optimize_gs_ad_paper_mode_nonzero_steps_runs(heisenberg_gate):
     A0 = jax.random.normal(jax.random.PRNGKey(2), (2, 2, 2, 2, 2))
     config = iPEPSConfig(
         max_bond_dim=2,
@@ -142,8 +147,10 @@ def test_optimize_gs_ad_paper_mode_nonzero_steps_not_implemented(heisenberg_gate
         unit_cell="1x1",
         su_init=False,
     )
-    with pytest.raises(NotImplementedError, match="gs_num_steps>0"):
-        optimize_gs_ad(heisenberg_gate, A0, config)
+    A_opt, env, E = optimize_gs_ad(heisenberg_gate, A0, config)
+    assert isinstance(A_opt, DenseTensor)
+    assert np.isfinite(env.C1.todense()).all()
+    assert np.isfinite(E)
 
 
 def test_truncated_eigh_appendix_c_gradient_finite_degenerate():
@@ -239,3 +246,79 @@ def test_appendix_c_truncation_correction_improves_fd_error():
         f"Expected corrected Appendix-C backward to beat/equal naive: "
         f"err_ref={err_ref}, err_naive={err_naive}"
     )
+
+
+def test_paper_mode_backward_gradient_is_finite_and_deterministic(heisenberg_gate):
+    cfg = CTMConfig(
+        chi=4,
+        max_iter=8,
+        min_iter=2,
+        conv_tol=1e-8,
+        projector_method="eigh",
+        paper_ctm_ad="c4v_appendix_cf",
+    )
+    A0 = jax.random.normal(jax.random.PRNGKey(321), (2, 2, 2, 2, 2))
+
+    def loss(A_data):
+        A = _wrap_as_dense_tensor(A_data)
+        A = A * (1.0 / (A.norm() + 1e-10))
+        C, T = ctm_tensor_c4v_paper_converge_reduced(A, cfg)
+        env = _c4v_to_full_env(C, T)
+        return compute_energy_ctm_tensor(A, env, heisenberg_gate, 2)
+
+    g1 = jax.grad(loss)(A0)
+    g2 = jax.grad(loss)(A0)
+    assert jnp.all(jnp.isfinite(g1))
+    assert jnp.all(jnp.isfinite(g2))
+    assert jnp.allclose(g1, g2, rtol=1e-10, atol=1e-10)
+
+
+def test_paper_mode_krylov_backward_residual_below_threshold():
+    cfg = CTMConfig(
+        chi=4,
+        max_iter=8,
+        min_iter=2,
+        conv_tol=1e-8,
+        projector_method="eigh",
+        paper_ctm_ad="c4v_appendix_cf",
+        paper_krylov_solver="bicgstab",
+        paper_krylov_maxiter=30,
+        paper_krylov_tol=1e-8,
+    )
+    A = _wrap_as_dense_tensor(
+        jax.random.normal(jax.random.PRNGKey(404), (2, 2, 2, 2, 2))
+    )
+    A = A * (1.0 / (A.norm() + 1e-10))
+    C, T = ctm_tensor_c4v_paper_converge_reduced(A, cfg)
+    g_c = C * 0.1
+    g_t = T * 0.1
+    dA, meta = ctm_tensor_c4v_paper_backward(A, C, T, g_c, g_t, cfg)
+    assert isinstance(dA, DenseTensor)
+    assert jnp.all(jnp.isfinite(dA.todense()))
+    assert meta["residual"] <= max(cfg.paper_krylov_tol * 10.0, 1e-12)
+
+
+def test_paper_mode_krylov_fallback_to_gmres(monkeypatch):
+    import tenax.algorithms._ctm_tensor_c4v_paper_ad as paper
+
+    cfg = CTMConfig(
+        paper_ctm_ad="c4v_appendix_cf",
+        paper_krylov_solver="bicgstab",
+        paper_krylov_maxiter=20,
+        paper_krylov_tol=1e-8,
+    )
+
+    def _apply(v):
+        return v
+
+    rhs = (jnp.array([1.0, -2.0, 3.0]),)
+
+    def _bad_bicg(*_args, **_kwargs):
+        bad = (jnp.array([100.0, 100.0, 100.0]),)
+        return bad, None
+
+    monkeypatch.setattr(paper, "_krylov_bicgstab", _bad_bicg)
+    _lam, meta = _solve_linear_adjoint_paper(_apply, rhs, cfg)
+    assert meta["used_fallback"] is True
+    assert meta["solver_used"] == "gmres"
+    assert meta["residual"] <= max(cfg.paper_krylov_tol * 10.0, 1e-12)

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -685,6 +685,61 @@ class TestOptimizeGsAd2Site:
         assert E_gs > -0.9, f"E/site={E_gs:.6f} unphysically low"
         assert np.isfinite(E_gs)
 
+    def test_2site_ad_c4v_runs(self, heisenberg_gate):
+        """2-site AD with C4v parameterization should run and give finite energy."""
+        config = iPEPSConfig(
+            max_bond_dim=2,
+            ctm=CTMConfig(chi=4, max_iter=10),
+            gs_num_steps=3,
+            gs_learning_rate=1e-3,
+            unit_cell="2site",
+            gs_c4v=True,
+        )
+        result = optimize_gs_ad(heisenberg_gate, None, config)
+        (A_opt, B_opt), (env_A, env_B), E_gs = result
+        assert A_opt.todense().shape == (2, 2, 2, 2, 2)
+        assert B_opt.todense().shape == (2, 2, 2, 2, 2)
+        assert np.isfinite(E_gs)
+
+    def test_2site_ad_c4v_shared_tensor(self, heisenberg_gate):
+        """With gs_c4v=True, B should be the sublattice rotation of A."""
+        config = iPEPSConfig(
+            max_bond_dim=2,
+            ctm=CTMConfig(chi=4, max_iter=10),
+            gs_num_steps=3,
+            gs_learning_rate=1e-3,
+            unit_cell="2site",
+            gs_c4v=True,
+        )
+        (A_opt, B_opt), _, _ = optimize_gs_ad(heisenberg_gate, None, config)
+        U = np.array([[0.0, 1.0], [-1.0, 0.0]])
+        B_expected = np.einsum("luRDs,sS->luRDS", A_opt.todense(), U)
+        np.testing.assert_allclose(B_opt.todense(), B_expected, atol=1e-12)
+
+    def test_2site_ad_c4v_energy_physical(self, heisenberg_gate):
+        """2-site C4v AD should produce a physical energy for Heisenberg."""
+        config = iPEPSConfig(
+            max_bond_dim=2,
+            ctm=CTMConfig(chi=8, max_iter=50, min_iter=10),
+            gs_optimizer="lbfgs",
+            gs_num_steps=20,
+            gs_metric_precond=False,
+            gs_line_search=True,
+            gs_verbose=False,
+            unit_cell="2site",
+            gs_explicit_ad=True,
+            gs_explicit_ad_steps=10,
+            gs_explicit_ad_warmup=2,
+            su_init=True,
+            num_imaginary_steps=50,
+            dt=0.1,
+            gs_c4v=True,
+        )
+        _, _, E_gs = optimize_gs_ad(heisenberg_gate, None, config)
+        assert np.isfinite(E_gs), f"Energy is not finite: {E_gs}"
+        assert E_gs > -0.9, f"E/site={E_gs:.6f} unphysically low"
+        assert E_gs < -0.50, f"C4v 2-site AD energy {E_gs:.6f} not below -0.50"
+
     @pytest.mark.slow
     def test_2site_heisenberg_ad_energy_benchmark(self, heisenberg_gate):
         """SU + AD at D=2, chi=16 should give a physical energy.

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -742,7 +742,7 @@ class TestOptimizeGsAd2Site:
 
     @pytest.mark.slow
     def test_2site_heisenberg_ad_energy_benchmark(self, heisenberg_gate):
-        """SU + AD at D=2, chi=16 should give a physical energy.
+        """SU + C4v AD at D=2, chi=16 should give a physical energy.
 
         The exact 2D Heisenberg square-lattice ground-state energy is
         E/site = -0.6694 (Sandvik, PRB 56, 11678, 1997).  At finite CTM
@@ -752,35 +752,23 @@ class TestOptimizeGsAd2Site:
         1. E > -0.9: catches unphysical results from numerical failures.
         2. E < -0.60: confirms AD produces a reasonable energy.
         """
-        # Néel product state init for AFM Heisenberg
-        D, d = 2, 2
-        key_A, key_B = jax.random.split(jax.random.PRNGKey(42))
-        A_neel = 0.01 * jax.random.normal(key_A, (D, D, D, D, d))
-        A_neel = A_neel.at[0, 0, 0, 0, 0].set(1.0)
-        B_neel = 0.01 * jax.random.normal(key_B, (D, D, D, D, d))
-        B_neel = B_neel.at[0, 0, 0, 0, 1].set(1.0)
-
-        su_config = iPEPSConfig(
+        config = iPEPSConfig(
             max_bond_dim=2,
-            num_imaginary_steps=100,
-            dt=0.3,
             ctm=CTMConfig(chi=16, max_iter=100, min_iter=50),
-            unit_cell="2site",
-        )
-        E_su, (A_su, B_su), _ = ipeps(heisenberg_gate, (A_neel, B_neel), su_config)
-
-        ad_config = iPEPSConfig(
-            max_bond_dim=2,
-            num_imaginary_steps=100,
-            dt=0.3,
-            ctm=CTMConfig(chi=16, max_iter=100, min_iter=50),
+            gs_optimizer="lbfgs",
             gs_num_steps=50,
-            gs_learning_rate=5e-3,
+            gs_metric_precond=False,
+            gs_line_search=True,
+            gs_explicit_ad=True,
+            gs_explicit_ad_steps=10,
+            gs_explicit_ad_warmup=2,
+            su_init=True,
+            num_imaginary_steps=100,
+            dt=0.3,
             unit_cell="2site",
+            gs_c4v=True,
         )
-        _, _, E_gs = optimize_gs_ad(
-            heisenberg_gate, (A_su.todense(), B_su.todense()), ad_config
-        )
+        _, _, E_gs = optimize_gs_ad(heisenberg_gate, None, config)
         assert E_gs > -0.9, (
             f"E/site = {E_gs:.6f} is unphysically low — possible numerical failure"
         )


### PR DESCRIPTION
## Summary
This PR adds two related iPEPS AD improvements:

1. 2-site C4v shared-tensor path
- Adds shared-tensor C4v optimization support for `unit_cell="2site"`.

2. Paper-faithful dense C4v mode (arXiv:2311.11894, App. C–F)
- Adds strict paper-mode config/dispatch gate (`paper_ctm_ad="c4v_appendix_cf"`) for dense 1-site C4v implicit AD.
- Implements Appendix C-style stable truncated eigendecomposition differential.
- Implements Appendix F matrix-free implicit backward with Krylov solve:
  - primary `bicgstab`
  - `gmres` fallback
  - diagonal preconditioner hook
- Enables `gs_num_steps > 0` optimization in paper mode.

## Files
- `src/tenax/algorithms/ipeps_config.py`
- `src/tenax/algorithms/ipeps_optimize.py`
- `src/tenax/algorithms/_ctm_tensor_c4v_paper_ad.py`
- `tests/test_c4v_paper_ad.py`
- `tests/test_ad_utils.py`
- `tests/test_ipeps.py`
- `docs/guide/algorithms/ipeps_ad_paths.md`
- `README.md`

## Validation
Executed locally:
- `uv run pytest -q tests/test_c4v_paper_ad.py`
- `uv run pytest -q tests/test_ad_utils.py -k "truncation_correction or truncated_svd or projector"`
- `uv run pytest -q tests/test_c4v_paper_ad.py tests/test_ad_utils.py -k "complex and (appendix_e or conjugate or hermitian)"`
- `uv run ruff check src/tenax/algorithms/_ctm_tensor_c4v_paper_ad.py src/tenax/algorithms/ipeps_optimize.py tests/test_c4v_paper_ad.py tests/test_ad_utils.py`
- `uv run ruff format --check src/tenax/algorithms/_ctm_tensor_c4v_paper_ad.py src/tenax/algorithms/ipeps_optimize.py tests/test_c4v_paper_ad.py tests/test_ad_utils.py`

All passed for the targeted scope.

## Notes
- Existing unrelated local workspace changes (bench/docs scratch files and `AGENTS.md`, `tests/test_ipeps.py` local edits outside committed hunks) were not modified/reverted.