### PR TITLE
refactor(ipeps): rename paper/appendix APIs to descriptive names

### DIFF
--- a/.claude/skills/tenax-ipeps-workflow/SKILL.md
+++ b/.claude/skills/tenax-ipeps-workflow/SKILL.md
@@ -122,6 +122,15 @@ energy, peps, (env_A, env_B) = ipeps(gate, None, config)
 print(f"Energy per site: {energy:.6f}")  # ≈ -0.65 for Heisenberg
 ```
 
+**AD stage: prefer the shared-tensor C4v path for spin-1/2 AFMs.**
+Under AD (Stage 3), the unconstrained 2-site optimizer is known to drift
+and produce unphysical energies. For Heisenberg-like models, add
+`gs_c4v=True` to the 2-site config: Tenax optimizes a single
+C4v-parameterized tensor `A` and derives `B` from `A` by sublattice
+rotation (`B = e^{i π σ^y/2}` on the physical leg). This is stable across
+χ=8–24 at D=2 Heisenberg and is the recommended 2-site path. It requires
+physical dimension d=2.
+
 ### Key parameters
 
 | Parameter | Role | Guidance |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The name **Tenax** combines **Ten**sor network + J**ax**, and is also Latin for 
 - **Algorithms** — DMRG, iDMRG (1D chain & infinite cylinder), TRG, HOTRG, iPEPS (simple update with 1-site or 2-site unit cell & AD optimization), fermionic iPEPS (fPEPS), quasiparticle excitations
 - **GPU/TPU-accelerated DMRG** — JIT-compiled sweeps via `jax.lax.scan` for dense tensors and per-operation JIT for block-sparse symmetric tensors; automatic warmup-to-JIT transition when bond dimensions are growing; multi-GPU sharding via GSPMD for large bond dimensions (`DMRGConfig(accelerator="jit"|"sharded")`)
 - **AutoMPO** — build Hamiltonian MPOs from symbolic operator descriptions (custom couplings, NNN, arbitrary spin); supports `symmetric=True` for U(1) block-sparse MPOs
-- **AD-based iPEPS optimization** — gradient optimization via implicit differentiation through CTM fixed point, supporting 1-site and 2-site unit cells (Francuz et al. PRR 7, 013237); L-BFGS with Hager-Zhang line search and metric preconditioning (Rader et al.), Adam (with cosine lr decay), and conjugate gradient optimizers; implicit AD via iterative VJP (default) and optional GMRES route; explicit AD through unrolled CTM iterations for 1-site C4v path; opt-in paper-faithful dense C4v Appendix C-F mode (`paper_ctm_ad="c4v_appendix_cf"`) with Krylov implicit backward (`bicgstab` + `gmres` fallback); sigma gauge fixing (`forward_gauge="sigma"`) for stable elementwise CTM convergence; C4v symmetry enforcement via explicit basis parameterization; chi-ramping schedule (`optimize_gs_ad_chi_schedule`) for progressive refinement; JIT CTM via `jax.lax.while_loop` for GPU kernel fusion (`jit_ctm=True`)
+- **AD-based iPEPS optimization** — gradient optimization via implicit differentiation through CTM fixed point, supporting 1-site and 2-site unit cells (Francuz et al. PRR 7, 013237); L-BFGS with Hager-Zhang line search and metric preconditioning (Rader et al.), Adam (with cosine lr decay), and conjugate gradient optimizers; implicit AD via iterative VJP (default) and optional GMRES route; explicit AD through unrolled CTM iterations for 1-site C4v path; **2-site shared-tensor C4v path** (`unit_cell="2site"` + `gs_c4v=True`) where a single C4v tensor is optimized and the second sublattice is derived by spin-π rotation, stable across χ=8–24 for spin-1/2 AFMs; opt-in reference-mode dense C4v Appendix C-F mode (`ctm_ad_mode="c4v_reference"`) with Krylov implicit backward (`bicgstab` + `gmres` fallback); sigma gauge fixing (`forward_gauge="sigma"`) for stable elementwise CTM convergence; C4v symmetry enforcement via explicit basis parameterization; chi-ramping schedule (`optimize_gs_ad_chi_schedule`) for progressive refinement; JIT CTM via `jax.lax.while_loop` for GPU kernel fusion (`jit_ctm=True`)
 - **SVD and QR CTMRG projectors** — SVD (Fishman) projectors (`projector_method="svd"`) and QR projectors for faster CTM convergence alongside the default `eigh`
 - **Split-CTMRG** — ket/bra-separated CTM environment tensors for O(χ³D³) projector cost instead of O(χ³D⁶); works with both `DenseTensor` and `SymmetricTensor` via the Tensor protocol (Naumann et al., arXiv:2502.10298)
 - **Quasiparticle excitations** — iPEPS excitation spectra at arbitrary Brillouin-zone momenta (Ponsioen et al. 2022)
@@ -73,8 +73,12 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from tenax import (
-    U1Symmetry, TensorIndex, FlowDirection,
-    SymmetricTensor, TensorNetwork, contract
+    U1Symmetry,
+    TensorIndex,
+    FlowDirection,
+    SymmetricTensor,
+    TensorNetwork,
+    contract,
 )
 
 # Define U(1) symmetric tensor indices with named legs
@@ -85,16 +89,16 @@ key = jax.random.PRNGKey(0)
 
 A = SymmetricTensor.random_normal(
     indices=(
-        TensorIndex(u1, phys_charges, FlowDirection.IN,  label="p0"),
-        TensorIndex(u1, bond_charges, FlowDirection.IN,  label="left"),
+        TensorIndex(u1, phys_charges, FlowDirection.IN, label="p0"),
+        TensorIndex(u1, bond_charges, FlowDirection.IN, label="left"),
         TensorIndex(u1, bond_charges, FlowDirection.OUT, label="bond"),
     ),
     key=key,
 )
 B = SymmetricTensor.random_normal(
     indices=(
-        TensorIndex(u1, phys_charges, FlowDirection.IN,  label="p1"),
-        TensorIndex(u1, bond_charges, FlowDirection.IN,  label="bond"),  # shared label
+        TensorIndex(u1, phys_charges, FlowDirection.IN, label="p1"),
+        TensorIndex(u1, bond_charges, FlowDirection.IN, label="bond"),  # shared label
         TensorIndex(u1, bond_charges, FlowDirection.OUT, label="right"),
     ),
     key=jax.random.PRNGKey(1),
@@ -167,9 +171,9 @@ for x in range(Lx):
     for y in range(Ly):
         # Within-ring bond (periodic y)
         i, j = x * Ly + y, x * Ly + (y + 1) % Ly
-        auto += (1.0, "Sz", min(i,j), "Sz", max(i,j))
-        auto += (0.5, "Sp", min(i,j), "Sm", max(i,j))
-        auto += (0.5, "Sm", min(i,j), "Sp", max(i,j))
+        auto += (1.0, "Sz", min(i, j), "Sz", max(i, j))
+        auto += (0.5, "Sp", min(i, j), "Sm", max(i, j))
+        auto += (0.5, "Sm", min(i, j), "Sp", max(i, j))
         # Between-ring bond (open x)
         if x < Lx - 1:
             i, j = x * Ly + y, (x + 1) * Ly + y
@@ -251,6 +255,7 @@ mpo = auto.to_mpo()
 
 # Or use the functional interface with custom operators
 import numpy as np
+
 custom_ops = {
     "X": np.array([[0.0, 1.0], [1.0, 0.0]]),
     "Z": np.array([[1.0, 0.0], [0.0, -1.0]]),
@@ -274,9 +279,9 @@ from tenax import iPEPSConfig, CTMConfig, ipeps
 Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
 Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
 Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
-gate = jnp.einsum("ij,kl->ikjl", Sz, Sz) \
-     + 0.5 * (jnp.einsum("ij,kl->ikjl", Sp, Sm)
-             + jnp.einsum("ij,kl->ikjl", Sm, Sp))
+gate = jnp.einsum("ij,kl->ikjl", Sz, Sz) + 0.5 * (
+    jnp.einsum("ij,kl->ikjl", Sp, Sm) + jnp.einsum("ij,kl->ikjl", Sm, Sp)
+)
 
 # 2-site checkerboard iPEPS — captures Neel order
 config = iPEPSConfig(
@@ -297,17 +302,22 @@ See `examples/heisenberg_ipeps_su.py` for 1-site and 2-site unit cell examples.
 ```python
 import jax.numpy as jnp
 from tenax import (
-    iPEPSConfig, CTMConfig, optimize_gs_ad, optimize_gs_ad_chi_schedule,
-    ExcitationConfig, compute_excitations, make_momentum_path,
+    iPEPSConfig,
+    CTMConfig,
+    optimize_gs_ad,
+    optimize_gs_ad_chi_schedule,
+    ExcitationConfig,
+    compute_excitations,
+    make_momentum_path,
 )
 
 # Build a 2-site Heisenberg gate
 Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
 Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
 Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
-gate = jnp.einsum("ij,kl->ikjl", Sz, Sz) \
-     + 0.5 * (jnp.einsum("ij,kl->ikjl", Sp, Sm)
-             + jnp.einsum("ij,kl->ikjl", Sm, Sp))
+gate = jnp.einsum("ij,kl->ikjl", Sz, Sz) + 0.5 * (
+    jnp.einsum("ij,kl->ikjl", Sp, Sm) + jnp.einsum("ij,kl->ikjl", Sm, Sp)
+)
 
 # Recommended AD configuration: L-BFGS + explicit AD + QR projectors.
 # The optimizer auto-promotes forward_gauge="qr" to "phase" for the
@@ -318,14 +328,14 @@ config = iPEPSConfig(
     ctm=CTMConfig(
         chi=16,
         max_iter=80,
-        projector_method="qr",        # recommended projector for explicit AD
+        projector_method="qr",  # recommended projector for explicit AD
     ),
-    gs_explicit_ad=True,              # default; unrolled + checkpointed CTM
+    gs_explicit_ad=True,  # default; unrolled + checkpointed CTM
     gs_projector_method="qr",
-    gs_optimizer="lbfgs",             # L-BFGS with Hager-Zhang line search
+    gs_optimizer="lbfgs",  # L-BFGS with Hager-Zhang line search
     gs_line_search_method="hager_zhang",
-    gs_metric_precond=True,           # metric preconditioning (Rader et al.)
-    gs_c4v=True,                      # C4v basis parameterization
+    gs_metric_precond=True,  # metric preconditioning (Rader et al.)
+    gs_c4v=True,  # C4v basis parameterization
     su_init=True,
 )
 A_opt, env, E_gs = optimize_gs_ad(gate, None, config)
@@ -335,14 +345,25 @@ print(f"Ground-state energy: {E_gs:.6f}")
 chi_schedule = [4, 8, 16]
 A_opt, env, E_gs = optimize_gs_ad_chi_schedule(gate, None, config, chi_schedule)
 
-# 2-site AD optimization for antiferromagnets (Neel order)
+# 2-site shared-tensor C4v AD for antiferromagnets (Neel order)
+# A single C4v-parameterized tensor is optimized; B is derived from A via
+# sublattice rotation B = e^{i pi sigma^y/2} on the physical leg.  This
+# ties the two sublattices together and avoids the A/B drift that makes
+# the unconstrained 2-site AD path unstable.  Spin-1/2 (d=2) only.
 config_2site = iPEPSConfig(
     max_bond_dim=2,
-    ctm=CTMConfig(chi=16, max_iter=50, projector_method="qr"),
+    ctm=CTMConfig(chi=16, max_iter=100, min_iter=50),
+    gs_optimizer="lbfgs",
     gs_explicit_ad=True,
-    gs_num_steps=200,
+    gs_explicit_ad_steps=10,
+    gs_explicit_ad_warmup=2,
+    gs_num_steps=50,
+    gs_line_search=True,
     unit_cell="2site",
+    gs_c4v=True,
     su_init=True,
+    num_imaginary_steps=100,
+    dt=0.3,
 )
 (A_opt, B_opt), (env_A, env_B), E_gs = optimize_gs_ad(gate, None, config_2site)
 
@@ -365,17 +386,17 @@ config_jit = iPEPSConfig(
 )
 A_opt, env, E_gs = optimize_gs_ad(gate, None, config_jit)
 
-# Opt-in paper-faithful dense C4v mode (App. C-F)
-config_paper = iPEPSConfig(
+# Opt-in reference-mode dense C4v mode (Francuz et al., App. C-F)
+config_reference = iPEPSConfig(
     max_bond_dim=2,
     ctm=CTMConfig(
         chi=16,
         max_iter=80,
         projector_method="eigh",
-        paper_ctm_ad="c4v_appendix_cf",
-        paper_krylov_solver="bicgstab",
-        paper_krylov_maxiter=50,
-        paper_krylov_tol=1e-8,
+        ctm_ad_mode="c4v_reference",
+        adjoint_solver="bicgstab",
+        adjoint_maxiter=50,
+        adjoint_tol=1e-8,
     ),
     gs_explicit_ad=False,
     gs_c4v=True,
@@ -383,7 +404,7 @@ config_paper = iPEPSConfig(
     gs_num_steps=100,
     gs_optimizer="adam",
 )
-A_opt, env, E_gs = optimize_gs_ad(gate, None, config_paper)
+A_opt, env, E_gs = optimize_gs_ad(gate, None, config_reference)
 
 # Quasiparticle excitations (Ponsioen et al. 2022)
 momenta = make_momentum_path("brillouin", num_points=20)
@@ -439,12 +460,13 @@ import numpy as np
 u1 = U1Symmetry()
 charges = np.array([-1, 0, 1], dtype=np.int32)
 print(u1.fuse(charges, charges))  # [-2, 0, 2]
-print(u1.dual(charges))           # [1, 0, -1]
+print(u1.dual(charges))  # [1, 0, -1]
 
 # Z_3: charges mod 3
 z3 = ZnSymmetry(3)
-print(z3.fuse(np.array([1, 2], dtype=np.int32),
-              np.array([2, 2], dtype=np.int32)))  # [0, 1]
+print(
+    z3.fuse(np.array([1, 2], dtype=np.int32), np.array([2, 2], dtype=np.int32))
+)  # [0, 1]
 
 # Product symmetry: combine two symmetries (e.g., charge × S_z)
 sym = ProductSymmetry(U1Symmetry(), U1Symmetry())
@@ -471,6 +493,7 @@ enable x64 manually:
 
 ```python
 import jax
+
 jax.config.update("jax_enable_x64", True)
 
 import tenax

--- a/docs/guide/algorithms/ipeps_ad_paths.md
+++ b/docs/guide/algorithms/ipeps_ad_paths.md
@@ -8,8 +8,11 @@ against the AFM Heisenberg model on the square lattice.
 
 ```python
 from tenax import (
-    CTMConfig, iPEPSConfig, heisenberg_gate,
-    optimize_gs_ad, optimize_gs_ad_chi_schedule,
+    CTMConfig,
+    iPEPSConfig,
+    heisenberg_gate,
+    optimize_gs_ad,
+    optimize_gs_ad_chi_schedule,
     sublattice_rotate_gate,
 )
 
@@ -23,7 +26,7 @@ config = iPEPSConfig(
         chi=16,
         max_iter=80,
         conv_tol=1e-8,
-        projector_method="qr",        # fastest, best energy, scales to chi=64+
+        projector_method="qr",  # fastest, best energy, scales to chi=64+
         # forward_gauge auto-set to "phase" for explicit AD
     ),
     gs_explicit_ad=True,
@@ -147,7 +150,59 @@ This is the YASTN approach (arXiv:2311.11894), adapted for JAX. For new
 code prefer Path 1 — the explicit-AD path does not exercise the implicit
 backward at all.
 
-### Path 3: Paper-Faithful Dense C4v (Appendix C-F, Opt-In)
+### Path 3: 2-site Shared-Tensor C4v (Checkerboard AFM)
+
+For antiferromagnetic models on the square lattice where the Néel order is
+explicit in the unit cell, the 2-site shared-tensor C4v path optimizes a
+**single** C4v-parameterized tensor ``A`` and derives ``B`` from ``A`` via
+sublattice rotation on the physical leg:
+
+```
+B = einsum("luRDs,sS->luRDS", A, U_sub)     U_sub = e^{i π σ^y / 2}
+```
+
+This ties the two sublattices together, eliminating the A/B drift that
+causes the unconstrained 2-site AD path to collapse into non-variational
+CTM artifacts. The rotation is spin-1/2 specific — the path raises
+``ValueError`` for physical dimension ``d ≠ 2``.
+
+**Enable it with:**
+
+```python
+config = iPEPSConfig(
+    max_bond_dim=2,
+    ctm=CTMConfig(chi=16, max_iter=100, min_iter=50),
+    gs_optimizer="lbfgs",
+    gs_num_steps=50,
+    gs_line_search=True,
+    gs_explicit_ad=True,
+    gs_explicit_ad_steps=10,
+    gs_explicit_ad_warmup=2,
+    su_init=True,
+    num_imaginary_steps=100,
+    dt=0.3,
+    unit_cell="2site",
+    gs_c4v=True,
+)
+_, _, E_gs = optimize_gs_ad(heisenberg_gate, None, config)
+```
+
+**Constraints:**
+
+- spin-1/2 only (``d=2``) — the physical-leg rotation is hard-coded
+  to ``e^{i π σ^y/2}``,
+- ``gs_stall_recovery="noise"`` is rejected with a clear error (the noise
+  branch requires ``(A, B)`` tuple params; use the ``"reset"`` default or
+  the ``"reset"`` auto-default for 2-site),
+- metric preconditioning is skipped on this path because ``params`` is
+  a flat coefficient vector rather than a ``(A, B)`` DenseTensor pair.
+
+Compared to the legacy independent 2-site path (each sublattice parameterized
+separately), the shared-tensor approach is stable across chi=8/16/20/24 at
+D=2 Heisenberg, while the independent path diverges to unphysical
+energies at chi>16.
+
+### Path 4: Paper-Faithful Dense C4v (Appendix C-F, Opt-In)
 
 This opt-in path follows the fixed-point differentiation structure in
 YASTN (arXiv:2311.11894, App. C-F) for **dense 1-site C4v** runs:
@@ -167,10 +222,10 @@ config = iPEPSConfig(
     unit_cell="1x1",
     ctm=CTMConfig(
         chi=16,
-        paper_ctm_ad="c4v_appendix_cf",
-        paper_krylov_solver="bicgstab",  # or "gmres"
-        paper_krylov_maxiter=50,
-        paper_krylov_tol=1e-8,
+        ctm_ad_mode="c4v_reference",
+        adjoint_solver="bicgstab",  # or "gmres"
+        adjoint_maxiter=50,
+        adjoint_tol=1e-8,
     ),
 )
 ```
@@ -178,7 +233,7 @@ config = iPEPSConfig(
 **Current scope and constraints:**
 - dense tensors only (no SymmetricTensor path yet),
 - strict gate: `unit_cell="1x1"`, `gs_c4v=True`, `gs_explicit_ad=False`,
-  `ctm.paper_ctm_ad="c4v_appendix_cf"`,
+  `ctm.ctm_ad_mode="c4v_reference"`,
 - supports `gs_num_steps>0` optimization with implicit gradients.
 
 ## Forward Gauge Mode Matrix
@@ -301,9 +356,11 @@ optimization stability and speed.
    diagnostic mode.
 
 3. **2-site explicit AD**: The 2-site optimizer supports the same
-   auto-phase promotion as the 1-site C4v path, but its convergence has
-   not been benchmarked as thoroughly as the 1-site C4v workflow. Treat
-   the 2-site explicit-AD path as experimental for now.
+   auto-phase promotion as the 1-site C4v path. For antiferromagnetic
+   models, prefer the 2-site **shared-tensor C4v path** (Path 3) over
+   the unconstrained 2-site optimizer, which is known to drift apart
+   and produce unphysical energies. The unconstrained path emits an
+   ``experimental`` warning on entry.
 
 4. **SymmetricTensor**: Block-sparse tensors fall back to the Python loop
    (not JIT-traceable). Both phase and sigma gauge work on this path, but

--- a/src/tenax/algorithms/_ctm_tensor_c4v_reference_ad.py
+++ b/src/tenax/algorithms/_ctm_tensor_c4v_reference_ad.py
@@ -1,7 +1,7 @@
-"""Paper-mode dense C4v CTM forward fixed-point utilities.
+"""Reference-mode dense C4v CTM forward fixed-point utilities.
 
 This module provides the forward fixed-point map used by the opt-in
-paper-faithful iPEPS AD path. Backward/implicit differentiation is added
+reference-mode iPEPS AD path. Backward/implicit differentiation is added
 separately.
 """
 
@@ -25,16 +25,16 @@ from tenax.algorithms.ipeps_config import CTMConfig
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
 
 __all__ = [
-    "_appendix_c_truncated_eigh_backward",
-    "_solve_linear_adjoint_paper",
-    "ctm_tensor_c4v_paper_backward",
-    "ctm_tensor_c4v_paper_converge_reduced",
-    "ctm_tensor_c4v_paper_fixed_point",
-    "truncated_eigh_appendix_c",
+    "_truncated_eigh_lorentzian_backward",
+    "_solve_linear_adjoint",
+    "ctm_tensor_c4v_reference_backward",
+    "ctm_tensor_c4v_reference_converge_reduced",
+    "ctm_tensor_c4v_reference_fixed_point",
+    "truncated_eigh_regularized",
 ]
 
 
-def _appendix_c_truncated_eigh_backward(
+def _truncated_eigh_lorentzian_backward(
     w_full: jax.Array,
     v_full: jax.Array,
     dw_k: jax.Array,
@@ -43,7 +43,7 @@ def _appendix_c_truncated_eigh_backward(
     k: int,
     eps: float = 1e-12,
 ) -> jax.Array:
-    """Appendix-C-style truncated eigendecomposition backward.
+    """Regularized truncated eigendecomposition backward.
 
     Uses a Lorentzian-regularized eigen-gap inverse for both kept-kept and
     kept-discarded couplings. The kept-discarded term is the critical
@@ -58,7 +58,8 @@ def _appendix_c_truncated_eigh_backward(
 
     # Differential coefficients K_{j,i} = <v_j, dV_i> / (w_i - w_j), i in kept.
     # Symmetrizing this n x n matrix recovers both the kept-kept anti-gauge term
-    # and the kept-discarded truncation correction from Appendix C.
+    # and the kept-discarded truncation correction from the Francuz et al.
+    # regularized differential.
     inner = v_h @ dV_k.astype(dtype)  # (n, k)
     denom = w_full[:k][None, :] - w_full[:, None]  # (n, k): w_i - w_j
     inv_gap = denom / (denom**2 + eps**2)
@@ -74,32 +75,32 @@ def _appendix_c_truncated_eigh_backward(
 
 
 @partial(jax.custom_vjp, nondiff_argnums=(1,))
-def truncated_eigh_appendix_c(
+def truncated_eigh_regularized(
     M: jax.Array,
     chi: int,
 ) -> tuple[jax.Array, jax.Array]:
-    """Truncated symmetric eigendecomposition with Appendix-C-style VJP."""
+    """Truncated symmetric eigendecomposition with a regularized VJP."""
     w, v = jnp.linalg.eigh(M)
     k = min(int(chi), int(w.shape[0]))
     return w[:k], v[:, :k]
 
 
-def _truncated_eigh_appendix_c_fwd(M: jax.Array, chi: int):
+def _truncated_eigh_regularized_fwd(M: jax.Array, chi: int):
     M_h = 0.5 * (M + jnp.conj(M).T)
     w, v = jnp.linalg.eigh(M_h)
     k = min(int(chi), int(w.shape[0]))
     return (w[:k], v[:, :k]), (w, v, k)
 
 
-def _truncated_eigh_appendix_c_bwd(chi: int, residuals, g):
+def _truncated_eigh_regularized_bwd(chi: int, residuals, g):
     w, v, k = residuals
     dw_k, dV_k = g
-    dM = _appendix_c_truncated_eigh_backward(w, v, dw_k, dV_k, k=k)
+    dM = _truncated_eigh_lorentzian_backward(w, v, dw_k, dV_k, k=k)
     return (dM,)
 
 
-truncated_eigh_appendix_c.defvjp(
-    _truncated_eigh_appendix_c_fwd, _truncated_eigh_appendix_c_bwd
+truncated_eigh_regularized.defvjp(
+    _truncated_eigh_regularized_fwd, _truncated_eigh_regularized_bwd
 )
 
 
@@ -120,18 +121,18 @@ def _tree_all_finite(tree) -> bool:
     return all(bool(jnp.all(jnp.isfinite(x))) for x in leaves)
 
 
-def _ctm_tensor_c4v_paper_fixed_point_reduced(
+def _ctm_tensor_c4v_reference_fixed_point_reduced(
     A: Tensor,
     config: CTMConfig,
 ) -> tuple[Tensor, Tensor, dict[str, Any]]:
     """Run dense C4v CTM to a fixed point (reduced C/T representation)."""
     if isinstance(A, SymmetricTensor):
         raise TypeError(
-            "paper_ctm_ad='c4v_appendix_cf' currently supports dense tensors only."
+            "ctm_ad_mode='c4v_reference' currently supports dense tensors only."
         )
     if not isinstance(A, DenseTensor):
         raise TypeError(
-            f"Expected DenseTensor for paper C4v mode, got {type(A).__name__}."
+            f"Expected DenseTensor for reference C4v mode, got {type(A).__name__}."
         )
 
     a = _build_double_layer_tensor(A)
@@ -162,12 +163,12 @@ def _ctm_tensor_c4v_paper_fixed_point_reduced(
     return C, T, meta
 
 
-def ctm_tensor_c4v_paper_fixed_point(
+def ctm_tensor_c4v_reference_fixed_point(
     A: Tensor,
     config: CTMConfig,
 ) -> tuple[Any, dict[str, Any]]:
     """Run dense C4v CTM to a fixed point and return diagnostics."""
-    C, T, meta = _ctm_tensor_c4v_paper_fixed_point_reduced(A, config)
+    C, T, meta = _ctm_tensor_c4v_reference_fixed_point_reduced(A, config)
     env_full = _c4v_to_full_env(C, T)
     return env_full, meta
 
@@ -187,17 +188,17 @@ def _build_env_diag_preconditioner(
     return precondition
 
 
-def _solve_linear_adjoint_paper(
+def _solve_linear_adjoint(
     apply_i_minus_jt,
     rhs,
     config: CTMConfig,
     *,
     preconditioner=None,
 ) -> tuple[Any, dict[str, Any]]:
-    """Solve ``(I - J^T) lambda = rhs`` with paper-mode Krylov policy."""
-    maxiter = int(config.paper_krylov_maxiter)
-    tol = float(config.paper_krylov_tol)
-    requested = str(config.paper_krylov_solver)
+    """Solve ``(I - J^T) lambda = rhs`` with reference-mode Krylov policy."""
+    maxiter = int(config.adjoint_maxiter)
+    tol = float(config.adjoint_tol)
+    requested = str(config.adjoint_solver)
     residual_target = max(tol * 10.0, 1e-12)
 
     def _solve_bicg(x0):
@@ -261,22 +262,22 @@ def _solve_linear_adjoint_paper(
     }
     if not converged:
         raise RuntimeError(
-            f"Paper-mode Krylov adjoint solver ({solver_used}) failed to "
+            f"Reference-mode Krylov adjoint solver ({solver_used}) failed to "
             f"converge: residual={float(residual):.3e}, target<={residual_target:.3e}, "
             f"info={meta['info']}. Using a non-solution would corrupt gradients. "
-            f"Increase paper_krylov_maxiter or loosen paper_krylov_tol."
+            f"Increase adjoint_maxiter or loosen adjoint_tol."
         )
     return lam, meta
 
 
-def _ctm_tensor_c4v_paper_implicit_backward(
+def _ctm_tensor_c4v_reference_implicit_backward(
     A: DenseTensor,
     C: Tensor,
     T: Tensor,
     g: tuple[Tensor, Tensor],
     config: CTMConfig,
 ) -> tuple[DenseTensor, dict[str, Any]]:
-    """Appendix-F matrix-free implicit backward for paper-mode C4v CTM."""
+    """Matrix-free implicit backward for reference-mode C4v CTM."""
     a = _build_double_layer_tensor(A)
     g_c, g_t = g
 
@@ -297,9 +298,9 @@ def _ctm_tensor_c4v_paper_implicit_backward(
         return _tree_sub(v, jtv)
 
     precond = _build_env_diag_preconditioner(
-        C, T, float(getattr(config, "paper_diag_shift", 1e-12))
+        C, T, float(getattr(config, "adjoint_diag_shift", 1e-12))
     )
-    lam, solve_meta = _solve_linear_adjoint_paper(
+    lam, solve_meta = _solve_linear_adjoint(
         _apply_i_minus_jt,
         (g_c, g_t),
         config,
@@ -309,7 +310,7 @@ def _ctm_tensor_c4v_paper_implicit_backward(
     return dA, solve_meta
 
 
-def ctm_tensor_c4v_paper_backward(
+def ctm_tensor_c4v_reference_backward(
     A: DenseTensor,
     C: Tensor,
     T: Tensor,
@@ -318,38 +319,38 @@ def ctm_tensor_c4v_paper_backward(
     config: CTMConfig,
 ) -> tuple[DenseTensor, dict[str, Any]]:
     """Run one implicit-adjoint solve for diagnostics/testing."""
-    return _ctm_tensor_c4v_paper_implicit_backward(A, C, T, (g_c, g_t), config)
+    return _ctm_tensor_c4v_reference_implicit_backward(A, C, T, (g_c, g_t), config)
 
 
 @partial(jax.custom_vjp, nondiff_argnums=(1,))
-def ctm_tensor_c4v_paper_converge_reduced(
+def ctm_tensor_c4v_reference_converge_reduced(
     A: DenseTensor,
     config: CTMConfig,
 ) -> tuple[Tensor, Tensor]:
     """Fixed-point converger returning reduced C4v env ``(C, T)``."""
-    C, T, _meta = _ctm_tensor_c4v_paper_fixed_point_reduced(A, config)
+    C, T, _meta = _ctm_tensor_c4v_reference_fixed_point_reduced(A, config)
     return C, T
 
 
-def _ctm_tensor_c4v_paper_converge_reduced_fwd(A: DenseTensor, config: CTMConfig):
-    C, T, _meta = _ctm_tensor_c4v_paper_fixed_point_reduced(A, config)
+def _ctm_tensor_c4v_reference_converge_reduced_fwd(A: DenseTensor, config: CTMConfig):
+    C, T, _meta = _ctm_tensor_c4v_reference_fixed_point_reduced(A, config)
     return (C, T), (A, C, T)
 
 
-def _ctm_tensor_c4v_paper_converge_reduced_bwd(
+def _ctm_tensor_c4v_reference_converge_reduced_bwd(
     config: CTMConfig,
     residuals,
     g,
 ):
     A, C, T = residuals
     g_c, g_t = g
-    dA, _solve_meta = _ctm_tensor_c4v_paper_implicit_backward(
+    dA, _solve_meta = _ctm_tensor_c4v_reference_implicit_backward(
         A, C, T, (g_c, g_t), config
     )
     return (dA,)
 
 
-ctm_tensor_c4v_paper_converge_reduced.defvjp(
-    _ctm_tensor_c4v_paper_converge_reduced_fwd,
-    _ctm_tensor_c4v_paper_converge_reduced_bwd,
+ctm_tensor_c4v_reference_converge_reduced.defvjp(
+    _ctm_tensor_c4v_reference_converge_reduced_fwd,
+    _ctm_tensor_c4v_reference_converge_reduced_bwd,
 )

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -62,26 +62,25 @@ class CTMConfig:
     # "sigma" (implicit-diff path), or "none" (diagnostic).  See ipeps_ad_paths.md.
     forward_gauge: str = "qr"
     jit_ctm: bool = False  # use jax.lax.while_loop for GPU kernel fusion
-    # Optional paper-faithful implicit AD mode (App. C-F) for dense 1-site C4v.
-    paper_ctm_ad: str | None = None  # None or "c4v_appendix_cf"
-    paper_krylov_solver: str = "bicgstab"  # "bicgstab" or "gmres"
-    paper_krylov_maxiter: int = 50
-    paper_krylov_tol: float = 1e-8
-    paper_degen_tol: float = 1e-10
-    paper_diag_shift: float = 1e-12
+    # Optional reference-mode implicit AD mode (App. C-F) for dense 1-site C4v.
+    ctm_ad_mode: str | None = None  # None or "c4v_reference"
+    adjoint_solver: str = "bicgstab"  # "bicgstab" or "gmres"
+    adjoint_maxiter: int = 50
+    adjoint_tol: float = 1e-8
+    adjoint_degen_tol: float = 1e-10
+    adjoint_diag_shift: float = 1e-12
 
     def __post_init__(self):
-        valid_paper_modes = {None, "c4v_appendix_cf"}
-        if self.paper_ctm_ad not in valid_paper_modes:
+        valid_modes = {None, "c4v_reference"}
+        if self.ctm_ad_mode not in valid_modes:
             raise ValueError(
-                f"paper_ctm_ad must be one of {valid_paper_modes}, "
-                f"got {self.paper_ctm_ad!r}"
+                f"ctm_ad_mode must be one of {valid_modes}, got {self.ctm_ad_mode!r}"
             )
-        valid_paper_solvers = {"bicgstab", "gmres"}
-        if self.paper_krylov_solver not in valid_paper_solvers:
+        valid_solvers = {"bicgstab", "gmres"}
+        if self.adjoint_solver not in valid_solvers:
             raise ValueError(
-                f"paper_krylov_solver must be one of {valid_paper_solvers}, "
-                f"got {self.paper_krylov_solver!r}"
+                f"adjoint_solver must be one of {valid_solvers}, "
+                f"got {self.adjoint_solver!r}"
             )
 
 

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -335,8 +335,8 @@ def optimize_gs_ad(
 
     if config.unit_cell == "2site":
         return _optimize_gs_ad_2site(hamiltonian_gate, A_init, config)
-    if _use_paper_c4v_path(config):
-        return _optimize_gs_ad_tensor_paper_c4v(hamiltonian_gate, A_init, config)
+    if _use_reference_c4v_path(config):
+        return _optimize_gs_ad_tensor_reference_c4v(hamiltonian_gate, A_init, config)
 
     # Wrap raw jax.Array as DenseTensor so we always use the Tensor-protocol path.
     if A_init is not None and not isinstance(A_init, Tensor):
@@ -363,29 +363,29 @@ def optimize_gs_ad(
     return _optimize_gs_ad_tensor(hamiltonian_gate, A_init, config)
 
 
-def _use_paper_c4v_path(config: iPEPSConfig) -> bool:
-    """Return True when the strict paper-mode gate is satisfied."""
+def _use_reference_c4v_path(config: iPEPSConfig) -> bool:
+    """Return True when the strict reference-mode gate is satisfied."""
     return (
         config.unit_cell == "1x1"
         and config.gs_c4v
         and not config.gs_explicit_ad
-        and getattr(config.ctm, "paper_ctm_ad", None) == "c4v_appendix_cf"
+        and getattr(config.ctm, "ctm_ad_mode", None) == "c4v_reference"
     )
 
 
-def _optimize_gs_ad_tensor_paper_c4v(
+def _optimize_gs_ad_tensor_reference_c4v(
     hamiltonian_gate: jax.Array | Tensor,
     A_init: jax.Array | Tensor | None,
     config: iPEPSConfig,
 ):
-    """Paper-mode dense C4v path with implicit-AD CTM backward."""
+    """Reference-mode dense C4v path with implicit-AD CTM backward."""
     import optax
 
     from tenax.algorithms._ctm_tensor import compute_energy_ctm_tensor
     from tenax.algorithms._ctm_tensor_c4v import _c4v_to_full_env
-    from tenax.algorithms._ctm_tensor_c4v_paper_ad import (
-        ctm_tensor_c4v_paper_converge_reduced,
-        ctm_tensor_c4v_paper_fixed_point,
+    from tenax.algorithms._ctm_tensor_c4v_reference_ad import (
+        ctm_tensor_c4v_reference_converge_reduced,
+        ctm_tensor_c4v_reference_fixed_point,
     )
     from tenax.algorithms.ipeps import (
         build_c4v_basis,
@@ -416,7 +416,7 @@ def _optimize_gs_ad_tensor_paper_c4v(
 
     if not isinstance(A, DenseTensor):
         raise TypeError(
-            "paper_ctm_ad='c4v_appendix_cf' currently supports DenseTensor inputs only."
+            "ctm_ad_mode='c4v_reference' currently supports DenseTensor inputs only."
         )
 
     A = A * (1.0 / (A.norm() + 1e-10))
@@ -439,7 +439,7 @@ def _optimize_gs_ad_tensor_paper_c4v(
         ctm_cfg = _replace(ctm_cfg, projector_method=config.gs_projector_method)
 
     if config.gs_num_steps == 0:
-        env, _meta = ctm_tensor_c4v_paper_fixed_point(A, ctm_cfg)
+        env, _meta = ctm_tensor_c4v_reference_fixed_point(A, ctm_cfg)
         E0 = float(compute_energy_ctm_tensor(A, env, gate, d_phys))
         return A, env, E0
 
@@ -458,7 +458,7 @@ def _optimize_gs_ad_tensor_paper_c4v(
     def _loss_fn(A_data):
         A_proj = _project_c4v_and_normalize(A_data)
         A_tensor = DenseTensor(A_proj, A.indices)
-        C, T = ctm_tensor_c4v_paper_converge_reduced(A_tensor, ctm_cfg)
+        C, T = ctm_tensor_c4v_reference_converge_reduced(A_tensor, ctm_cfg)
         env = _c4v_to_full_env(C, T)
         energy = compute_energy_ctm_tensor(A_tensor, env, gate, d_phys)
         return energy, (env, A_tensor)
@@ -1411,10 +1411,16 @@ def _optimize_gs_ad_tensor_2site(
                 A_cur, B_cur = params
                 A_g, B_g = grads
                 p_flat = jnp.concatenate(
-                    [A_cur.todense().reshape(-1), B_cur.todense().reshape(-1)]
+                    [
+                        A_cur.todense().reshape(-1),
+                        B_cur.todense().reshape(-1),
+                    ]
                 )
                 g_flat = jnp.concatenate(
-                    [A_g.todense().reshape(-1), B_g.todense().reshape(-1)]
+                    [
+                        A_g.todense().reshape(-1),
+                        B_g.todense().reshape(-1),
+                    ]
                 )
 
             if prev_params_flat is not None:
@@ -1459,7 +1465,10 @@ def _optimize_gs_ad_tensor_2site(
                         sites_m, envs_m, grads_v, delta_metric, config
                     )
                     return jnp.concatenate(
-                        [z_dict[(0, 0)].reshape(-1), z_dict[(1, 0)].reshape(-1)]
+                        [
+                            z_dict[(0, 0)].reshape(-1),
+                            z_dict[(1, 0)].reshape(-1),
+                        ]
                     )
 
                 direction_flat = lbfgs_two_loop(g_flat, lbfgs_history, h0_matvec)

--- a/tests/test_c4v_reference_ad.py
+++ b/tests/test_c4v_reference_ad.py
@@ -1,4 +1,4 @@
-"""Tests for the dense C4v paper-mode forward path (Appendix C-F roadmap)."""
+"""Tests for the dense C4v reference-mode path."""
 
 import itertools
 
@@ -9,13 +9,13 @@ import pytest
 
 from tenax.algorithms._ctm_tensor import compute_energy_ctm_tensor
 from tenax.algorithms._ctm_tensor_c4v import _c4v_to_full_env
-from tenax.algorithms._ctm_tensor_c4v_paper_ad import (
-    _appendix_c_truncated_eigh_backward,
-    _solve_linear_adjoint_paper,
-    ctm_tensor_c4v_paper_backward,
-    ctm_tensor_c4v_paper_converge_reduced,
-    ctm_tensor_c4v_paper_fixed_point,
-    truncated_eigh_appendix_c,
+from tenax.algorithms._ctm_tensor_c4v_reference_ad import (
+    _solve_linear_adjoint,
+    _truncated_eigh_lorentzian_backward,
+    ctm_tensor_c4v_reference_backward,
+    ctm_tensor_c4v_reference_converge_reduced,
+    ctm_tensor_c4v_reference_fixed_point,
+    truncated_eigh_regularized,
 )
 from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
 from tenax.algorithms.ipeps_optimize import _wrap_as_dense_tensor, optimize_gs_ad
@@ -32,7 +32,7 @@ def heisenberg_gate():
     return H.reshape(d, d, d, d)
 
 
-def test_c4v_paper_fixed_point_returns_meta():
+def test_c4v_reference_fixed_point_returns_meta():
     A = _wrap_as_dense_tensor(jax.random.normal(jax.random.PRNGKey(0), (2, 2, 2, 2, 2)))
     cfg = CTMConfig(
         chi=4,
@@ -40,9 +40,9 @@ def test_c4v_paper_fixed_point_returns_meta():
         min_iter=2,
         conv_tol=1e-8,
         projector_method="eigh",
-        paper_ctm_ad="c4v_appendix_cf",
+        ctm_ad_mode="c4v_reference",
     )
-    env, meta = ctm_tensor_c4v_paper_fixed_point(A, cfg)
+    env, meta = ctm_tensor_c4v_reference_fixed_point(A, cfg)
 
     assert np.isfinite(env.C1.todense()).all()
     assert np.isfinite(env.T1.todense()).all()
@@ -52,62 +52,62 @@ def test_c4v_paper_fixed_point_returns_meta():
     assert np.isfinite(meta["residual"]) or np.isinf(meta["residual"])
 
 
-def test_ctmconfig_paper_mode_defaults():
+def test_ctmconfig_reference_mode_defaults():
     cfg = CTMConfig()
-    assert cfg.paper_ctm_ad is None
-    assert cfg.paper_krylov_solver == "bicgstab"
-    assert cfg.paper_krylov_maxiter == 50
-    assert cfg.paper_krylov_tol == 1e-8
-    assert cfg.paper_degen_tol == 1e-10
-    assert cfg.paper_diag_shift == 1e-12
+    assert cfg.ctm_ad_mode is None
+    assert cfg.adjoint_solver == "bicgstab"
+    assert cfg.adjoint_maxiter == 50
+    assert cfg.adjoint_tol == 1e-8
+    assert cfg.adjoint_degen_tol == 1e-10
+    assert cfg.adjoint_diag_shift == 1e-12
 
 
-def test_invalid_paper_ctm_ad_raises():
-    with pytest.raises(ValueError, match="paper_ctm_ad"):
-        CTMConfig(paper_ctm_ad="bad_mode")
+def test_invalid_ctm_ad_mode_raises():
+    with pytest.raises(ValueError, match="ctm_ad_mode"):
+        CTMConfig(ctm_ad_mode="bad_mode")
 
 
-def test_invalid_paper_krylov_solver_raises():
-    with pytest.raises(ValueError, match="paper_krylov_solver"):
-        CTMConfig(paper_krylov_solver="bad_solver")
+def test_invalid_adjoint_solver_raises():
+    with pytest.raises(ValueError, match="adjoint_solver"):
+        CTMConfig(adjoint_solver="bad_solver")
 
 
-def test_paper_mode_dispatch_is_strictly_gated(heisenberg_gate, monkeypatch):
-    """Paper path dispatch should trigger only for the strict mode gate."""
+def test_reference_mode_dispatch_is_strictly_gated(heisenberg_gate, monkeypatch):
+    """Reference path dispatch should trigger only for the strict mode gate."""
     import tenax.algorithms.ipeps_optimize as _opt
 
-    class _PaperCalled(Exception):
+    class _ReferenceCalled(Exception):
         pass
 
     class _DefaultCalled(Exception):
         pass
 
-    def _paper_spy(*_args, **_kwargs):
-        raise _PaperCalled
+    def _reference_spy(*_args, **_kwargs):
+        raise _ReferenceCalled
 
     def _default_spy(*_args, **_kwargs):
         raise _DefaultCalled
 
-    monkeypatch.setattr(_opt, "_optimize_gs_ad_tensor_paper_c4v", _paper_spy)
+    monkeypatch.setattr(_opt, "_optimize_gs_ad_tensor_reference_c4v", _reference_spy)
     monkeypatch.setattr(_opt, "_optimize_gs_ad_tensor", _default_spy)
 
     A0 = jax.random.normal(jax.random.PRNGKey(123), (2, 2, 2, 2, 2))
 
-    cfg_paper = iPEPSConfig(
+    cfg_reference = iPEPSConfig(
         max_bond_dim=2,
-        ctm=CTMConfig(chi=4, max_iter=3, paper_ctm_ad="c4v_appendix_cf"),
+        ctm=CTMConfig(chi=4, max_iter=3, ctm_ad_mode="c4v_reference"),
         gs_num_steps=0,
         gs_explicit_ad=False,
         gs_c4v=True,
         unit_cell="1x1",
         su_init=False,
     )
-    with pytest.raises(_PaperCalled):
-        optimize_gs_ad(heisenberg_gate, A0, cfg_paper)
+    with pytest.raises(_ReferenceCalled):
+        optimize_gs_ad(heisenberg_gate, A0, cfg_reference)
 
-    cfg_not_paper = iPEPSConfig(
+    cfg_not_reference = iPEPSConfig(
         max_bond_dim=2,
-        ctm=CTMConfig(chi=4, max_iter=3, paper_ctm_ad="c4v_appendix_cf"),
+        ctm=CTMConfig(chi=4, max_iter=3, ctm_ad_mode="c4v_reference"),
         gs_num_steps=0,
         gs_explicit_ad=False,
         gs_c4v=False,
@@ -115,14 +115,14 @@ def test_paper_mode_dispatch_is_strictly_gated(heisenberg_gate, monkeypatch):
         su_init=False,
     )
     with pytest.raises(_DefaultCalled):
-        optimize_gs_ad(heisenberg_gate, A0, cfg_not_paper)
+        optimize_gs_ad(heisenberg_gate, A0, cfg_not_reference)
 
 
-def test_optimize_gs_ad_paper_mode_zero_steps_runs(heisenberg_gate):
+def test_optimize_gs_ad_reference_mode_zero_steps_runs(heisenberg_gate):
     A0 = jax.random.normal(jax.random.PRNGKey(1), (2, 2, 2, 2, 2))
     config = iPEPSConfig(
         max_bond_dim=2,
-        ctm=CTMConfig(chi=4, max_iter=10, min_iter=2, paper_ctm_ad="c4v_appendix_cf"),
+        ctm=CTMConfig(chi=4, max_iter=10, min_iter=2, ctm_ad_mode="c4v_reference"),
         gs_num_steps=0,
         gs_explicit_ad=False,
         gs_c4v=True,
@@ -136,11 +136,11 @@ def test_optimize_gs_ad_paper_mode_zero_steps_runs(heisenberg_gate):
     assert np.isfinite(E)
 
 
-def test_optimize_gs_ad_paper_mode_nonzero_steps_runs(heisenberg_gate):
+def test_optimize_gs_ad_reference_mode_nonzero_steps_runs(heisenberg_gate):
     A0 = jax.random.normal(jax.random.PRNGKey(2), (2, 2, 2, 2, 2))
     config = iPEPSConfig(
         max_bond_dim=2,
-        ctm=CTMConfig(chi=4, max_iter=10, min_iter=2, paper_ctm_ad="c4v_appendix_cf"),
+        ctm=CTMConfig(chi=4, max_iter=10, min_iter=2, ctm_ad_mode="c4v_reference"),
         gs_num_steps=1,
         gs_explicit_ad=False,
         gs_c4v=True,
@@ -153,7 +153,7 @@ def test_optimize_gs_ad_paper_mode_nonzero_steps_runs(heisenberg_gate):
     assert np.isfinite(E)
 
 
-def test_truncated_eigh_appendix_c_gradient_finite_degenerate():
+def test_truncated_eigh_regularized_gradient_finite_degenerate():
     key = jax.random.PRNGKey(77)
     Q, _ = jnp.linalg.qr(jax.random.normal(key, (6, 6)))
     w = jnp.array([3.0, 3.0, 2.0, 2.0, 1.0, 0.5])
@@ -161,7 +161,7 @@ def test_truncated_eigh_appendix_c_gradient_finite_degenerate():
     M = 0.5 * (M + M.T)
 
     def loss(M_in):
-        vals, vecs = truncated_eigh_appendix_c(M_in, 3)
+        vals, vecs = truncated_eigh_regularized(M_in, 3)
         return jnp.sum(vals**2) + jnp.sum(vecs[:, 0] ** 2)
 
     grad = jax.grad(loss)(M)
@@ -182,7 +182,7 @@ def _finite_difference_grad(loss_fn, M, eps=1e-5):
     return grad
 
 
-def test_truncated_eigh_appendix_c_finite_difference_agreement():
+def test_truncated_eigh_regularized_finite_difference_agreement():
     key = jax.random.PRNGKey(1234)
     M0 = jax.random.normal(key, (5, 5))
     M0 = 0.5 * (M0 + M0.T)
@@ -191,7 +191,7 @@ def test_truncated_eigh_appendix_c_finite_difference_agreement():
     W = 0.5 * (W + W.T)
 
     def loss(M_in):
-        vals, vecs = truncated_eigh_appendix_c(M_in, 3)
+        vals, vecs = truncated_eigh_regularized(M_in, 3)
         P = vecs @ vecs.T
         return jnp.sum(vals**2) + 0.2 * jnp.trace(P @ W)
 
@@ -199,11 +199,11 @@ def test_truncated_eigh_appendix_c_finite_difference_agreement():
     g_fd = _finite_difference_grad(loss, M0)
     max_diff = float(jnp.max(jnp.abs(g_ad - g_fd)))
     assert max_diff < 1.5e-1, (
-        f"Appendix-C truncated eigh FD mismatch too large: {max_diff}"
+        f"Regularized truncated eigh FD mismatch too large: {max_diff}"
     )
 
 
-def test_appendix_c_truncation_correction_improves_fd_error():
+def test_regularized_truncation_correction_improves_fd_error():
     key = jax.random.PRNGKey(999)
     Q, _ = jnp.linalg.qr(jax.random.normal(key, (6, 6)))
     # Near-degenerate boundary between kept/discarded sectors for k=3.
@@ -217,15 +217,15 @@ def test_appendix_c_truncation_correction_improves_fd_error():
     k = 3
 
     def loss(M_in):
-        vals, vecs = truncated_eigh_appendix_c(M_in, k)
+        vals, vecs = truncated_eigh_regularized(M_in, k)
         P = vecs @ vecs.T
         return jnp.sum(vals**2) + 0.3 * jnp.trace(P @ W)
 
     g_fd = _finite_difference_grad(loss, M)
-    vals, vecs = truncated_eigh_appendix_c(M, k)
+    vals, vecs = truncated_eigh_regularized(M, k)
     dvals = 2.0 * vals
     dvecs = 0.6 * (W @ vecs)
-    g_ref = _appendix_c_truncated_eigh_backward(w, v, dvals, dvecs, k=k)
+    g_ref = _truncated_eigh_lorentzian_backward(w, v, dvals, dvecs, k=k)
 
     # Naive backward: keep-kept only (omit kept-discarded correction)
     V_k = v[:, :k]
@@ -243,26 +243,26 @@ def test_appendix_c_truncation_correction_improves_fd_error():
     err_ref = float(jnp.linalg.norm(g_ref - g_fd))
     err_naive = float(jnp.linalg.norm(g_naive - g_fd))
     assert err_ref <= err_naive + 1e-8, (
-        f"Expected corrected Appendix-C backward to beat/equal naive: "
+        f"Expected corrected regularized backward to beat/equal naive: "
         f"err_ref={err_ref}, err_naive={err_naive}"
     )
 
 
-def test_paper_mode_backward_gradient_is_finite_and_deterministic(heisenberg_gate):
+def test_reference_mode_backward_gradient_is_finite_and_deterministic(heisenberg_gate):
     cfg = CTMConfig(
         chi=4,
         max_iter=8,
         min_iter=2,
         conv_tol=1e-8,
         projector_method="eigh",
-        paper_ctm_ad="c4v_appendix_cf",
+        ctm_ad_mode="c4v_reference",
     )
     A0 = jax.random.normal(jax.random.PRNGKey(321), (2, 2, 2, 2, 2))
 
     def loss(A_data):
         A = _wrap_as_dense_tensor(A_data)
         A = A * (1.0 / (A.norm() + 1e-10))
-        C, T = ctm_tensor_c4v_paper_converge_reduced(A, cfg)
+        C, T = ctm_tensor_c4v_reference_converge_reduced(A, cfg)
         env = _c4v_to_full_env(C, T)
         return compute_energy_ctm_tensor(A, env, heisenberg_gate, 2)
 
@@ -273,39 +273,39 @@ def test_paper_mode_backward_gradient_is_finite_and_deterministic(heisenberg_gat
     assert jnp.allclose(g1, g2, rtol=1e-10, atol=1e-10)
 
 
-def test_paper_mode_krylov_backward_residual_below_threshold():
+def test_reference_mode_krylov_backward_residual_below_threshold():
     cfg = CTMConfig(
         chi=4,
         max_iter=8,
         min_iter=2,
         conv_tol=1e-8,
         projector_method="eigh",
-        paper_ctm_ad="c4v_appendix_cf",
-        paper_krylov_solver="bicgstab",
-        paper_krylov_maxiter=30,
-        paper_krylov_tol=1e-8,
+        ctm_ad_mode="c4v_reference",
+        adjoint_solver="bicgstab",
+        adjoint_maxiter=30,
+        adjoint_tol=1e-8,
     )
     A = _wrap_as_dense_tensor(
         jax.random.normal(jax.random.PRNGKey(404), (2, 2, 2, 2, 2))
     )
     A = A * (1.0 / (A.norm() + 1e-10))
-    C, T = ctm_tensor_c4v_paper_converge_reduced(A, cfg)
+    C, T = ctm_tensor_c4v_reference_converge_reduced(A, cfg)
     g_c = C * 0.1
     g_t = T * 0.1
-    dA, meta = ctm_tensor_c4v_paper_backward(A, C, T, g_c, g_t, cfg)
+    dA, meta = ctm_tensor_c4v_reference_backward(A, C, T, g_c, g_t, cfg)
     assert isinstance(dA, DenseTensor)
     assert jnp.all(jnp.isfinite(dA.todense()))
-    assert meta["residual"] <= max(cfg.paper_krylov_tol * 10.0, 1e-12)
+    assert meta["residual"] <= max(cfg.adjoint_tol * 10.0, 1e-12)
 
 
-def test_paper_mode_krylov_fallback_to_gmres(monkeypatch):
-    import tenax.algorithms._ctm_tensor_c4v_paper_ad as paper
+def test_reference_mode_krylov_fallback_to_gmres(monkeypatch):
+    import tenax.algorithms._ctm_tensor_c4v_reference_ad as reference_mod
 
     cfg = CTMConfig(
-        paper_ctm_ad="c4v_appendix_cf",
-        paper_krylov_solver="bicgstab",
-        paper_krylov_maxiter=20,
-        paper_krylov_tol=1e-8,
+        ctm_ad_mode="c4v_reference",
+        adjoint_solver="bicgstab",
+        adjoint_maxiter=20,
+        adjoint_tol=1e-8,
     )
 
     def _apply(v):
@@ -317,14 +317,14 @@ def test_paper_mode_krylov_fallback_to_gmres(monkeypatch):
         bad = (jnp.array([100.0, 100.0, 100.0]),)
         return bad, None
 
-    monkeypatch.setattr(paper, "_krylov_bicgstab", _bad_bicg)
-    _lam, meta = _solve_linear_adjoint_paper(_apply, rhs, cfg)
+    monkeypatch.setattr(reference_mod, "_krylov_bicgstab", _bad_bicg)
+    _lam, meta = _solve_linear_adjoint(_apply, rhs, cfg)
     assert meta["used_fallback"] is True
     assert meta["solver_used"] == "gmres"
-    assert meta["residual"] <= max(cfg.paper_krylov_tol * 10.0, 1e-12)
+    assert meta["residual"] <= max(cfg.adjoint_tol * 10.0, 1e-12)
 
 
-def test_appendix_e_complex_gradient_is_hermitian():
+def test_complex_adjoint_gradient_is_hermitian():
     key_r = jax.random.PRNGKey(2001)
     key_i = jax.random.PRNGKey(2002)
     X = jax.random.normal(key_r, (5, 5)) + 1j * jax.random.normal(key_i, (5, 5))
@@ -335,7 +335,7 @@ def test_appendix_e_complex_gradient_is_hermitian():
     W = 0.5 * (W + jnp.conj(W).T)
 
     def loss(M_in):
-        vals, vecs = truncated_eigh_appendix_c(M_in, 3)
+        vals, vecs = truncated_eigh_regularized(M_in, 3)
         P = vecs @ jnp.conj(vecs).T
         return jnp.real(jnp.sum(vals**2) + 0.15 * jnp.trace(P @ W))
 
@@ -344,7 +344,7 @@ def test_appendix_e_complex_gradient_is_hermitian():
     assert jnp.max(jnp.abs(grad - jnp.conj(grad).T)) < 1e-10
 
 
-def test_appendix_e_complex_backward_output_is_hermitian():
+def test_complex_adjoint_backward_output_is_hermitian():
     key = jax.random.PRNGKey(2010)
     X = jax.random.normal(key, (4, 4)) + 1j * jax.random.normal(
         jax.random.PRNGKey(2011), (4, 4)
@@ -356,6 +356,6 @@ def test_appendix_e_complex_backward_output_is_hermitian():
     dV = jax.random.normal(jax.random.PRNGKey(2013), (4, k)) + 1j * jax.random.normal(
         jax.random.PRNGKey(2014), (4, k)
     )
-    dM = _appendix_c_truncated_eigh_backward(w, v, dw, dV, k=k)
+    dM = _truncated_eigh_lorentzian_backward(w, v, dw, dV, k=k)
     assert jnp.all(jnp.isfinite(dM))
     assert jnp.max(jnp.abs(dM - jnp.conj(dM).T)) < 1e-10


### PR DESCRIPTION
## Summary
- rename `paper_*` and `appendix_*` iPEPS AD APIs/config to descriptive names
- rename C4v reference AD implementation/test files accordingly
- update docs and README examples to use the new names

## Validation
- `uv run ruff check README.md docs/guide/algorithms/ipeps_ad_paths.md src/tenax/algorithms/_ctm_tensor_c4v_reference_ad.py src/tenax/algorithms/ipeps_config.py src/tenax/algorithms/ipeps_optimize.py tests/test_c4v_reference_ad.py`
- `uv run ruff format --check --preview README.md docs/guide/algorithms/ipeps_ad_paths.md src/tenax/algorithms/_ctm_tensor_c4v_reference_ad.py src/tenax/algorithms/ipeps_config.py src/tenax/algorithms/ipeps_optimize.py tests/test_c4v_reference_ad.py`
- `uv run pytest -q tests/test_c4v_reference_ad.py`
- `uv run pytest -q tests/test_ad_utils.py -k "truncation_correction or truncated_svd or projector"`

Closes #305
