### PR TITLE
ci: drop --auto from sync-skills merge

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -41,6 +41,6 @@ jobs:
             --title "chore: sync skills from tenax" \
             --body "Auto-synced from [tenax main](https://github.com/tenax-lab/tenax)." \
             --repo tenax-lab/tenax-toolkit)
-          gh pr merge "$PR_URL" --squash --auto --delete-branch
+          gh pr merge "$PR_URL" --squash --delete-branch
         env:
           GH_TOKEN: ${{ secrets.PLUGIN_REPO_TOKEN }}


### PR DESCRIPTION
## Summary
- Drop \`--auto\` from the sync-skills workflow's \`gh pr merge\` call
- tenax-toolkit main has no branch protection, so auto-merge errors with "Protected branch rules not configured"
- Stale sync PRs #4/#5/#6 on tenax-toolkit will be merged manually after this lands

## Test plan
- [ ] Next skills change on main triggers sync-skills and the PR merges cleanly