### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tenax-tn"
-version = "0.4.2"
+version = "0.5.0"
 description = "JAX-based tensor network library with symmetry-aware block-sparse tensors"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/tenax/__init__.py
+++ b/src/tenax/__init__.py
@@ -80,7 +80,7 @@ from tenax.linalg import eigh, qr, rsvd, svd
 from tenax.network.netfile import NetworkBlueprint, from_netfile
 from tenax.network.network import TensorNetwork, build_mps, build_peps
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"
 
 # ---------------------------------------------------------------------------
 # Lazy imports: algorithm modules are loaded on first access


### PR DESCRIPTION
## Summary
Minor bump to 0.5.0 after 35 commits since v0.4.2. Resolves #270.

**Breaking change**: \`paper_*\`/\`appendix_*\` config fields renamed to \`ctm_ad_mode\`/\`adjoint_*\`/\`regularized\` in #306.

**New features**:
- 2-site shared-tensor C4v AD path (#304)
- Paper-faithful reference-mode C4v CTM AD with Appendix C–F backward (#304)
- Stable AD: sigma gauge, Fishman SVD projectors, regularized eigh, JIT CTM

## Test plan
- [ ] CI green (Python 3.11, 3.12, macOS)
- [ ] After merge: tag \`v0.5.0\` and verify publish.yml produces sdist + 2 linux + 2 macOS wheels
- [ ] Verify TestPyPI publish
- [ ] Verify PyPI publish
- [ ] \`pip install tenax-tn==0.5.0\` smoke test in a fresh env