### PR TITLE
feat(tuning): machine-readable parameter registry + tuning guide

### DIFF
--- a/docs/guide/tuning.md
+++ b/docs/guide/tuning.md
@@ -1,0 +1,273 @@
+# Tuning guide
+
+This page is a cross-cutting reference for the most-tuned parameters in
+Tenax, grouped by *what you are trying to do* rather than by which
+dataclass a field lives on.
+
+A **machine-readable registry** of these parameters lives at
+`src/tenax/tuning/registry.py`. Future autotuning / hyperparameter-search
+tooling should consume `tenax.tuning.all_params()` rather than re-parsing
+this page.
+
+```python
+from tenax.tuning import all_params, params_by_category, TuningCategory
+
+for p in params_by_category(TuningCategory.ACCURACY):
+    print(p.fully_qualified_name(), p.default, p.hint.range)
+```
+
+> **Authoritative defaults** live in the dataclasses
+> (`tenax.algorithms.ipeps_config.CTMConfig`,
+> `tenax.algorithms.ipeps_config.iPEPSConfig`, etc.). This page and the
+> registry mirror them — if you see a mismatch, the dataclass wins.
+
+---
+
+## Quick-reference: what to tune first
+
+| Goal | First knob | Then | Last resort |
+|---|---|---|---|
+| Energy not converging | `CTMConfig.chi` ↑ | `iPEPSConfig.gs_num_steps` ↑ | `gs_optimizer` → `lbfgs` |
+| AD forward is slow | `CTMConfig.jit_ctm=True` | loosen `conv_tol` | reduce `chi` |
+| AD backward `Krylov failed to converge` | `adjoint_tikhonov` → `1e-4` | `adjoint_maxiter` ↑ | loosen `adjoint_tol` |
+| L-BFGS stalls at a plateau | `gs_stall_recovery="reset"` | `su_init=False` | `gs_metric_precond=False` |
+| NaN during optimization | `ad_regularize_svd=True` (default) | `forward_gauge="phase"` | check for degenerate singular values |
+| Benchmark for paper | `gs_num_steps ≥ 2000` | `adjoint_tikhonov=0` | tighten `conv_tol` to `1e-10` |
+
+---
+
+## Accuracy knobs
+
+The two knobs that dominate everything else are `CTMConfig.chi` and
+`iPEPSConfig.gs_num_steps`. Tune them first; everything else is
+secondary.
+
+### `CTMConfig.chi` — CTM environment bond dimension
+
+- **Default:** `20`
+- **Scale:** log₂ (typical values 4, 8, 16, 32, 64)
+- **Cost:** `O(chi⁶)` runtime per CTM sweep, `O(chi⁴)` memory
+- **When to raise:** the ground-state energy still changes as you
+  increase `chi`. For D≤3 square iPEPS, `chi ∈ [16, 32]` is usually
+  enough. Kagome or D>3 typically need `chi ≥ 64`.
+- **When *not* to raise:** doubling `chi` is roughly 64× slower. Pin
+  `chi` and tune optimizer knobs first.
+
+### `CTMConfig.max_iter` + `CTMConfig.conv_tol`
+
+Convergence budget for a single CTM sweep-loop.
+
+- **Defaults:** `max_iter=100`, `conv_tol=1e-8`
+- Raise `max_iter` to 200–500 when `conv_tol` is tight (1e-10) near
+  criticality.
+- **Schedule trick:** use `iPEPSConfig.gs_ctm_conv_tol_schedule` to
+  ramp `conv_tol` from loose → tight during AD optimization:
+  ```python
+  iPEPSConfig(
+      gs_ctm_conv_tol_schedule=[(0.0, 1e-5), (0.5, 1e-7), (0.8, 1e-9)],
+      ...,
+  )
+  ```
+  Saves 10–30% runtime on long runs with no accuracy loss.
+
+---
+
+## Stability knobs (AD paths)
+
+The iPEPS AD paths are sensitive to gauge choices and to near-singular
+linear systems in the backward pass. These knobs don't affect forward
+accuracy but *do* determine whether the backward pass produces finite,
+well-conditioned gradients.
+
+See `docs/guide/algorithms/ipeps_ad_paths.md` for the full matrix of
+which AD path pairs with which gauge.
+
+### `CTMConfig.forward_gauge`
+
+Values: `"qr"` (default), `"phase"`, `"sigma"`, `"none"`
+
+- `"qr"`: forward-only CTM, notebooks, diagnostics. `optimize_gs_ad`
+  auto-promotes this to `"phase"` when `gs_explicit_ad=True`.
+- `"phase"`: explicit-AD default after promotion. Numerically stable
+  for unrolled backprop.
+- `"sigma"`: required for the implicit-diff path at D ≥ 2. Aligns each
+  sweep's output to the previous sweep's input, stabilizing the VJP.
+- `"none"`: diagnostic only. Expect instabilities.
+
+### `CTMConfig.ad_regularize_svd` (default `True`)
+
+Use the Lorentzian-regularized SVD backward pass. Prevents NaN from
+degenerate / near-degenerate singular values in the projector
+computation. **Do not turn off** unless you're deliberately debugging
+a numerical issue.
+
+Reference: Francuz et al., arXiv:2311.11894.
+
+### `CTMConfig.adjoint_tikhonov` (default `1e-6`)
+
+Tikhonov damping on the linear adjoint system
+
+```
+((I - J^T) + τ·I) λ = g
+```
+
+solved during implicit-diff CTM. Near a fixed point, `J` has
+eigenvalues approaching 1 along the slowest modes, so `(I - J^T)` is
+near-singular and the Krylov solver stalls. Adding `τ·I` bounds the
+condition number at the cost of a small O(τ) gradient bias.
+
+| τ | Use case |
+|---|---|
+| `0.0` | strictly exact gradient; use for publication runs *if* the solver converges |
+| `1e-6` (default) | robustness floor — smaller than `adjoint_tol`, so it can't bias beyond already-accepted tolerance |
+| `1e-4` | first fallback when you hit `"Krylov adjoint failed to converge"` |
+| `1e-3` | benchmark / smoke-run setting; noticeable bias (~0.1%) but reliably stable |
+| `≥ 1e-2` | too aggressive — gradient direction is wrong |
+
+Applies only when `CTMConfig.ctm_ad_mode="c4v_reference"`.
+
+References: Liao et al. (arXiv:1903.09650), Francuz et al.
+(arXiv:2311.11894), variPEPS (arXiv:2308.12358).
+
+### `CTMConfig.adjoint_tol`, `adjoint_maxiter`, `adjoint_solver`
+
+Krylov solver knobs for the implicit-diff adjoint. The effective
+residual target is `max(10 × adjoint_tol, 1e-12)`. The solver order is
+BiCGStab → GMRES (automatic fallback).
+
+- Loosen `adjoint_tol` to `1e-5` when the outer optimizer is near the
+  ground state; tighten to `1e-10` for publication-quality gradients.
+- `adjoint_maxiter=50` is tight. Raise to `200+` for tight `adjoint_tol`
+  or ill-conditioned systems.
+
+---
+
+## Optimizer knobs
+
+### `iPEPSConfig.gs_optimizer`
+
+Values: `"cg"` (default), `"lbfgs"`, `"adam"`
+
+- **CG** — preconditioned conjugate gradient. Best with
+  `gs_metric_precond=True`. Fast, stable, recommended default.
+- **L-BFGS** — often reaches slightly lower energies than CG but can
+  stall in bad basins. Pair with `gs_stall_recovery="reset"` for
+  robustness.
+- **Adam** — robust to noisy gradients (useful for large-chi with
+  loose CTM `conv_tol`) but slower to converge. Needs `gs_learning_rate`
+  in `1e-3..1e-2`.
+
+### `iPEPSConfig.gs_num_steps`
+
+| Purpose | Typical |
+|---|---|
+| Smoke test / CI | 10–50 |
+| Benchmark | 100–500 |
+| Publication (variPEPS-style) | 2000+ |
+
+### `iPEPSConfig.gs_metric_precond` (default `True`)
+
+Metric preconditioning (natural gradient) via the local tangent-space
+metric `N_ij = <∂ᵢψ | ∂ⱼψ>`. Applied through GMRES. Roughly 1.5–3×
+slower per step but dramatically faster outer-loop convergence.
+
+Reference: Rader et al., arXiv:2511.09546.
+
+### `iPEPSConfig.gs_line_search_method`
+
+Values: `"armijo"` (default), `"hager_zhang"`
+
+Armijo is cheap and usually enough. Hager-Zhang is stronger and matches
+variPEPS — try it when Armijo is rejecting too many steps or when you
+want publication-quality step selection.
+
+Reference: Hager & Zhang, SIAM J. Optim. 16(1):170–192 (2005).
+
+### `iPEPSConfig.gs_stall_recovery`
+
+Values: `None` (auto), `"noise"`, `"reset"`
+
+- **`"noise"`** — inject a `gs_noise_amplitude` Frobenius perturbation
+  when the line search stalls. Required for 1-site C4v to break out of
+  SU-init plateaus.
+- **`"reset"`** — clear L-BFGS `(s, y)` history, roll back to
+  `best_params`, force steepest descent on the next step. This is what
+  variPEPS does; best for 2-site runs.
+- **`None`** (default) — auto-select: `"noise"` for 1-site, `"reset"`
+  for 2-site.
+
+---
+
+## Initialization
+
+### `iPEPSConfig.su_init` (default `True`)
+
+Initialize via simple update before AD. Usually a good idea — SU gives
+you a state already close to the ground state manifold.
+
+**Exception:** for the sublattice-rotated Heisenberg Hamiltonian, SU
+converges to the classical `|↑↑⟩` product state, which is a
+gradient-zero extremum at `E = -0.5/site`. L-BFGS cannot escape it. Use
+`su_init=False` (random init) for this model, at the cost of a less
+informative start.
+
+---
+
+## Method selection
+
+### `iPEPSConfig.gs_explicit_ad` (default `True`)
+
+- **`True`** (explicit) — differentiate through unrolled CTM sweeps via
+  `jax.checkpoint`. Recommended path post PR #291. Memory scales with
+  `gs_explicit_ad_steps`.
+- **`False`** (implicit) — solve the fixed-point adjoint equation.
+  Required by the `ctm_ad_mode="c4v_reference"` path (Francuz et al.
+  App. C–F). Lower memory but needs `adjoint_tikhonov > 0` near the GS.
+
+### `iPEPSConfig.gs_c4v` (default `False`)
+
+Enforce C4v symmetry on the site tensor during AD by parameterizing in
+a C4v basis. For D=2, reduces the parameter count from 16 → ~4 and is
+**the only stable 1-site iPEPS AD path in Tenax today** for
+C4v-symmetric models (square Heisenberg after sublattice rotation,
+XXZ, TFIM).
+
+### `CTMConfig.projector_method`
+
+Values: `"eigh"` (default), `"qr"`, `"svd"` (Fishman)
+
+- `"eigh"`: default for forward CTM.
+- `"qr"`: cheaper at large `chi` (> 32); use for forward-only runs.
+- `"svd"`: Fishman projector; the only fully AD-stable choice post
+  PR #291. If you're differentiating through CTM and not already
+  using it, switch.
+
+Reference: Fishman et al., arXiv:1711.01288.
+
+---
+
+## Performance-only knobs
+
+These don't change numerics (within tolerance) but speed things up.
+
+### `CTMConfig.jit_ctm` (default `False`)
+
+Fuse the entire CTM convergence loop into a single `jax.lax.while_loop`
+kernel. 5–30× speedup on GPU for `chi ≥ 16`. Falls back to the Python
+loop for `SymmetricTensor` inputs (block-sparse ops aren't
+JIT-traceable).
+
+### `CTMConfig.gmres_precondition` (experimental, default `False`)
+
+Diagonal scaling preconditioner for the GMRES implicit-diff backward.
+Currently experimental — do not turn on for production.
+
+---
+
+## See also
+
+- `docs/guide/algorithms/ipeps_ad_paths.md` — AD mode matrix
+- `docs/ipeps-code-paths.md` — which function goes with which config
+- `src/tenax/tuning/registry.py` — machine-readable parameter metadata
+- `src/tenax/algorithms/ipeps_config.py` — authoritative dataclass
+  defaults (always the source of truth)

--- a/src/tenax/tuning/__init__.py
+++ b/src/tenax/tuning/__init__.py
@@ -1,0 +1,42 @@
+"""Machine-readable tuning registry for Tenax algorithm parameters.
+
+This subpackage declares a structured catalog of tunable parameters
+across Tenax's config dataclasses. It is consumed by:
+
+  - ``docs/guide/tuning.md`` (human-facing reference, hand-written)
+  - future autotuning / hyperparameter-search tooling that needs
+    machine-readable metadata (ranges, scales, dependencies, costs)
+
+The registry does *not* replace the dataclass defaults — those remain
+authoritative. The registry adds semantic metadata that pure Python
+dataclasses can't carry (tuning range, cost model, dependencies,
+categorical groupings).
+"""
+
+from tenax.tuning.registry import (
+    CostModel,
+    Dependency,
+    ParamSpec,
+    Scale,
+    Sensitivity,
+    TuningCategory,
+    TuningHint,
+    all_params,
+    get_param,
+    params_by_category,
+    params_by_dataclass,
+)
+
+__all__ = [
+    "CostModel",
+    "Dependency",
+    "ParamSpec",
+    "Scale",
+    "Sensitivity",
+    "TuningCategory",
+    "TuningHint",
+    "all_params",
+    "get_param",
+    "params_by_category",
+    "params_by_dataclass",
+]

--- a/src/tenax/tuning/registry.py
+++ b/src/tenax/tuning/registry.py
@@ -1,0 +1,752 @@
+"""Tuning parameter registry.
+
+Defines the schema and catalog of tunable parameters across Tenax's
+algorithm config dataclasses. Future autotuners can import this module,
+enumerate ``ParamSpec`` entries, and use the metadata to drive search.
+
+Schema design notes
+-------------------
+* **Authoritative defaults live in the dataclasses**, not here. The
+  registry stores semantic metadata (tuning range, cost model,
+  dependencies) that dataclasses can't carry.
+* Entries are declarative — no runtime logic, no imports of algorithm
+  internals. This keeps the registry cheap to import and safe to use
+  from tooling / CI checks.
+* The ``all_params()`` function returns a copy so callers can mutate
+  without polluting the module-level catalog.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class Scale(Enum):
+    """Parameter search scale — hint for autotuners."""
+
+    LINEAR = "linear"
+    LOG10 = "log10"
+    LOG2 = "log2"
+    CATEGORICAL = "categorical"
+    BOOLEAN = "boolean"
+
+
+class Sensitivity(Enum):
+    """How strongly tuning this parameter affects results.
+
+    ``HIGH`` = primary accuracy / convergence knob; small changes matter.
+    ``MEDIUM`` = visible effect, often method-dependent.
+    ``LOW`` = safe default usually fine; touch only in edge cases.
+    """
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class TuningCategory(Enum):
+    """What kind of knob is this?
+
+    Used by docs generation and by autotuners that want to search only
+    a subset of the parameter space (e.g. "tune accuracy only, leave
+    method selection fixed").
+    """
+
+    # Primary accuracy / convergence knobs (chi, max_iter, tolerances).
+    ACCURACY = "accuracy"
+    # Performance-oriented (jit, preconditioning, warmup steps).
+    PERFORMANCE = "performance"
+    # Numerical stability / regularization (Tikhonov, SVD broadening).
+    STABILITY = "stability"
+    # Selects *which* algorithm/variant is used (projector_method, solver).
+    METHOD_SELECTION = "method_selection"
+    # Optimizer behavior for ground-state search (lr, num_steps, line search).
+    OPTIMIZER = "optimizer"
+    # Initialization strategy (su_init, random seed handling).
+    INITIALIZATION = "initialization"
+    # Diagnostic / logging only — no effect on numerics.
+    DIAGNOSTIC = "diagnostic"
+
+
+@dataclass(frozen=True)
+class CostModel:
+    """How tuning this parameter changes resource usage.
+
+    All fields are strings because the cost axes are often symbolic
+    (``"O(chi^6)"``) or qualitative (``"monotone_improving"``). A future
+    autotuner can parse these if it wants to, but the primary consumer
+    is the human reference page.
+    """
+
+    runtime: str | None = None  # e.g. "O(chi^6)" or "neutral"
+    memory: str | None = None  # e.g. "O(chi^4)" or "none"
+    accuracy: str | None = None  # e.g. "monotone_improving" or "biases_O(tau)"
+
+
+@dataclass(frozen=True)
+class Dependency:
+    """Cross-parameter relationship (for validators / coupled search)."""
+
+    name: str  # dotted name of the related parameter
+    relation: str  # human-readable description of the coupling
+
+
+@dataclass(frozen=True)
+class TuningHint:
+    """Metadata for automated or manual tuning of a parameter."""
+
+    scale: Scale
+    sensitivity: Sensitivity
+    # For numeric params: inclusive search range as (lo, hi). None if N/A.
+    range: tuple[float, float] | None = None
+    # For categorical / enum params: allowed values. None if N/A.
+    values: tuple[Any, ...] | None = None
+    # Cost model for this knob.
+    cost: CostModel = field(default_factory=CostModel)
+    # When is this parameter even *applicable*? E.g. a CTM-AD knob is
+    # only meaningful when ``ctm_ad_mode="c4v_reference"``. Expressed as
+    # ``{other_param_name: required_value_or_values}``. Empty = always.
+    applies_when: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ParamSpec:
+    """A single tunable parameter."""
+
+    name: str  # field name on the dataclass
+    dataclass_name: str  # e.g. "CTMConfig" or "iPEPSConfig"
+    type_str: str  # e.g. "int", "float", "str", "bool"
+    default: Any  # current dataclass default (mirrored — keep in sync!)
+    category: TuningCategory
+    description: str
+    hint: TuningHint
+    dependencies: tuple[Dependency, ...] = ()
+    when_to_tune: str = ""  # "Increase when energy doesn't converge"
+    when_not_to_tune: str = ""  # "Usually the default is fine"
+    references: tuple[str, ...] = ()  # paper DOIs / arXiv IDs
+
+    def fully_qualified_name(self) -> str:
+        return f"{self.dataclass_name}.{self.name}"
+
+
+# ---------------------------------------------------------------------------
+# Parameter catalog
+# ---------------------------------------------------------------------------
+
+_PARAMETERS: list[ParamSpec] = []
+
+
+def _register(spec: ParamSpec) -> None:
+    _PARAMETERS.append(spec)
+
+
+# --- CTMConfig: primary accuracy knobs --------------------------------------
+
+_register(
+    ParamSpec(
+        name="chi",
+        dataclass_name="CTMConfig",
+        type_str="int",
+        default=20,
+        category=TuningCategory.ACCURACY,
+        description=(
+            "Bond dimension of the CTM environment tensors. The primary "
+            "accuracy knob: higher chi = more environment fidelity."
+        ),
+        hint=TuningHint(
+            scale=Scale.LOG2,
+            sensitivity=Sensitivity.HIGH,
+            range=(4, 128),
+            cost=CostModel(
+                runtime="O(chi^6) per sweep for full CTM",
+                memory="O(chi^4)",
+                accuracy="monotone_improving",
+            ),
+        ),
+        when_to_tune=(
+            "Increase when the ground-state energy has not converged as "
+            "a function of chi. For D<=3 square iPEPS, chi in [16, 32] is "
+            "usually enough; kagome / D>3 may need chi>=64."
+        ),
+        when_not_to_tune=(
+            "Doubling chi typically costs ~64x more runtime. Pin chi and "
+            "tune optimizer first."
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="max_iter",
+        dataclass_name="CTMConfig",
+        type_str="int",
+        default=100,
+        category=TuningCategory.ACCURACY,
+        description="Maximum CTM sweeps before declaring convergence.",
+        hint=TuningHint(
+            scale=Scale.LINEAR,
+            sensitivity=Sensitivity.MEDIUM,
+            range=(20, 500),
+            cost=CostModel(runtime="linear", memory="none"),
+        ),
+        when_to_tune=(
+            "Raise if CTM hits the iteration cap before reaching conv_tol. "
+            "For tight conv_tol (1e-10) near criticality, 200–500 is common."
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="conv_tol",
+        dataclass_name="CTMConfig",
+        type_str="float",
+        default=1e-8,
+        category=TuningCategory.ACCURACY,
+        description=(
+            "CTM convergence tolerance on the singular-value difference "
+            "between successive sweeps."
+        ),
+        hint=TuningHint(
+            scale=Scale.LOG10,
+            sensitivity=Sensitivity.HIGH,
+            range=(1e-10, 1e-4),
+            cost=CostModel(
+                runtime="inversely coupled to max_iter",
+                memory="none",
+                accuracy="tighter = better observables",
+            ),
+        ),
+        dependencies=(
+            Dependency(
+                name="CTMConfig.max_iter",
+                relation="tol<<1 requires max_iter high enough to reach it",
+            ),
+        ),
+        when_to_tune=(
+            "Loosen to 1e-5 for rapid prototyping or early-training schedule; "
+            "tighten to 1e-10 for final observables."
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="projector_method",
+        dataclass_name="CTMConfig",
+        type_str="str",
+        default="eigh",
+        category=TuningCategory.METHOD_SELECTION,
+        description=(
+            "Algorithm used to compute CTM projectors: 'eigh' (symmetric "
+            "eigendecomposition), 'qr' (QR gauge), or 'svd' (Fishman SVD)."
+        ),
+        hint=TuningHint(
+            scale=Scale.CATEGORICAL,
+            sensitivity=Sensitivity.MEDIUM,
+            values=("eigh", "qr", "svd"),
+            cost=CostModel(
+                runtime="eigh ~= svd < qr for small chi; qr wins at large chi",
+                memory="neutral",
+                accuracy="'svd' is the only fully AD-stable choice post PR #291",
+            ),
+        ),
+        when_to_tune=(
+            "Use 'svd' when differentiating through the CTM sweep "
+            "(Fishman projector); try 'qr' for forward-only runs with "
+            "chi > 32 where eigh becomes a bottleneck."
+        ),
+        references=("arXiv:1711.01288",),  # Fishman projectors
+    )
+)
+
+_register(
+    ParamSpec(
+        name="forward_gauge",
+        dataclass_name="CTMConfig",
+        type_str="str",
+        default="qr",
+        category=TuningCategory.STABILITY,
+        description=(
+            "Gauge fix applied to the environment tensors after each CTM "
+            "sweep. Determines AD stability for implicit- and explicit-diff "
+            "paths."
+        ),
+        hint=TuningHint(
+            scale=Scale.CATEGORICAL,
+            sensitivity=Sensitivity.HIGH,
+            values=("qr", "phase", "sigma", "none"),
+            cost=CostModel(runtime="neutral", memory="none"),
+        ),
+        when_to_tune=(
+            "'phase' is the default for explicit-AD (auto-promoted from "
+            "'qr'); 'sigma' is required for implicit-diff stability at "
+            "D>=2. 'none' is diagnostic only."
+        ),
+        references=("arXiv:2311.11894",),  # Francuz et al.
+    )
+)
+
+_register(
+    ParamSpec(
+        name="jit_ctm",
+        dataclass_name="CTMConfig",
+        type_str="bool",
+        default=False,
+        category=TuningCategory.PERFORMANCE,
+        description=(
+            "Use jax.lax.while_loop to fuse the entire CTM convergence "
+            "loop into a single compiled kernel (matches variPEPS)."
+        ),
+        hint=TuningHint(
+            scale=Scale.BOOLEAN,
+            sensitivity=Sensitivity.MEDIUM,
+            cost=CostModel(
+                runtime="5–30x speedup on GPU for large chi",
+                memory="slightly higher (traced residuals)",
+            ),
+        ),
+        when_to_tune="Turn on for GPU forward-only runs with chi>=16.",
+        when_not_to_tune=(
+            "Falls back to Python loop for SymmetricTensor (block-sparse "
+            "not JIT-traceable)."
+        ),
+    )
+)
+
+# --- CTMConfig: implicit-diff adjoint knobs ---------------------------------
+
+_register(
+    ParamSpec(
+        name="ctm_ad_mode",
+        dataclass_name="CTMConfig",
+        type_str="str | None",
+        default=None,
+        category=TuningCategory.METHOD_SELECTION,
+        description=(
+            "Opt-in reference-mode implicit AD path for dense 1-site C4v "
+            "(Francuz et al. App. C–F). None disables; 'c4v_reference' "
+            "enables the dense C4v fixed-point backward."
+        ),
+        hint=TuningHint(
+            scale=Scale.CATEGORICAL,
+            sensitivity=Sensitivity.HIGH,
+            values=(None, "c4v_reference"),
+        ),
+        dependencies=(
+            Dependency(
+                name="iPEPSConfig.gs_explicit_ad",
+                relation="'c4v_reference' requires gs_explicit_ad=False",
+            ),
+            Dependency(
+                name="iPEPSConfig.gs_c4v",
+                relation="'c4v_reference' requires gs_c4v=True",
+            ),
+            Dependency(
+                name="iPEPSConfig.unit_cell",
+                relation="'c4v_reference' requires unit_cell='1x1'",
+            ),
+        ),
+        references=("arXiv:2311.11894",),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="adjoint_solver",
+        dataclass_name="CTMConfig",
+        type_str="str",
+        default="bicgstab",
+        category=TuningCategory.METHOD_SELECTION,
+        description=(
+            "Krylov solver used for the linear adjoint system "
+            "(I - J^T) lambda = g in reference-mode implicit AD."
+        ),
+        hint=TuningHint(
+            scale=Scale.CATEGORICAL,
+            sensitivity=Sensitivity.LOW,
+            values=("bicgstab", "gmres"),
+            applies_when={"CTMConfig.ctm_ad_mode": "c4v_reference"},
+        ),
+        when_to_tune=(
+            "BiCGStab is cheaper per iteration; GMRES is the automatic "
+            "fallback when BiCGStab stalls."
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="adjoint_tol",
+        dataclass_name="CTMConfig",
+        type_str="float",
+        default=1e-8,
+        category=TuningCategory.ACCURACY,
+        description=(
+            "Target residual tolerance for the Krylov adjoint solve. The "
+            "effective residual target is max(10*tol, 1e-12)."
+        ),
+        hint=TuningHint(
+            scale=Scale.LOG10,
+            sensitivity=Sensitivity.MEDIUM,
+            range=(1e-10, 1e-4),
+            applies_when={"CTMConfig.ctm_ad_mode": "c4v_reference"},
+            cost=CostModel(runtime="linear in solver iterations"),
+        ),
+        when_to_tune=(
+            "Loosen to 1e-5 when the outer optimizer is near the GS and "
+            "the adjoint solver fails to converge; tighten to 1e-10 for "
+            "publication-quality gradients."
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="adjoint_maxiter",
+        dataclass_name="CTMConfig",
+        type_str="int",
+        default=50,
+        category=TuningCategory.ACCURACY,
+        description="Maximum Krylov iterations in the adjoint solve.",
+        hint=TuningHint(
+            scale=Scale.LINEAR,
+            sensitivity=Sensitivity.LOW,
+            range=(20, 500),
+            applies_when={"CTMConfig.ctm_ad_mode": "c4v_reference"},
+        ),
+        when_to_tune=(
+            "Raise to 200+ when adjoint_tol is tight or the system is "
+            "ill-conditioned near the fixed point."
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="adjoint_tikhonov",
+        dataclass_name="CTMConfig",
+        type_str="float",
+        default=1e-6,
+        category=TuningCategory.STABILITY,
+        description=(
+            "Tikhonov damping on the linear adjoint system: solve "
+            "((I - J^T) + tau I) lambda = g instead of (I - J^T) lambda = g. "
+            "Stabilizes the Krylov solve when (I - J^T) becomes near-singular."
+        ),
+        hint=TuningHint(
+            scale=Scale.LOG10,
+            sensitivity=Sensitivity.MEDIUM,
+            range=(0.0, 1e-2),
+            applies_when={"CTMConfig.ctm_ad_mode": "c4v_reference"},
+            cost=CostModel(
+                runtime="neutral (improves convergence = fewer iters)",
+                memory="none",
+                accuracy="biases gradient by O(tau) along slow modes",
+            ),
+        ),
+        dependencies=(
+            Dependency(
+                name="CTMConfig.adjoint_tol",
+                relation="tau <= 10*adjoint_tol has no visible effect",
+            ),
+        ),
+        when_to_tune=(
+            "Raise to 1e-4..1e-3 if the Krylov solver throws "
+            "'failed to converge'. Set to 0 for strictly exact gradients."
+        ),
+        references=(
+            "arXiv:1903.09650",  # Liao et al.
+            "arXiv:2311.11894",  # Francuz et al.
+            "arXiv:2308.12358",  # variPEPS
+        ),
+    )
+)
+
+# --- iPEPSConfig: optimizer selection & step budget -------------------------
+
+_register(
+    ParamSpec(
+        name="gs_optimizer",
+        dataclass_name="iPEPSConfig",
+        type_str="str",
+        default="cg",
+        category=TuningCategory.METHOD_SELECTION,
+        description="Outer-loop optimizer for ground-state AD.",
+        hint=TuningHint(
+            scale=Scale.CATEGORICAL,
+            sensitivity=Sensitivity.HIGH,
+            values=("cg", "adam", "lbfgs"),
+        ),
+        when_to_tune=(
+            "CG is the default and works best with metric preconditioning. "
+            "L-BFGS often reaches lower energies but can stall in bad "
+            "basins. Adam is more robust to noisy gradients but slower to "
+            "converge."
+        ),
+        dependencies=(
+            Dependency(
+                name="iPEPSConfig.gs_metric_precond",
+                relation="preconditioning especially helps CG and L-BFGS",
+            ),
+            Dependency(
+                name="iPEPSConfig.gs_line_search",
+                relation="CG/L-BFGS default to line search on",
+            ),
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="gs_num_steps",
+        dataclass_name="iPEPSConfig",
+        type_str="int",
+        default=200,
+        category=TuningCategory.OPTIMIZER,
+        description="Number of AD ground-state optimization steps.",
+        hint=TuningHint(
+            scale=Scale.LINEAR,
+            sensitivity=Sensitivity.HIGH,
+            range=(10, 5000),
+            cost=CostModel(runtime="linear", memory="none"),
+        ),
+        when_to_tune=(
+            "variPEPS typically uses 2000+ steps for publication runs. "
+            "Smoke tests: 10–50. Benchmarks: 100–500."
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="gs_learning_rate",
+        dataclass_name="iPEPSConfig",
+        type_str="float",
+        default=1e-3,
+        category=TuningCategory.OPTIMIZER,
+        description="Base learning rate / trust-region scale for the optimizer.",
+        hint=TuningHint(
+            scale=Scale.LOG10,
+            sensitivity=Sensitivity.HIGH,
+            range=(1e-5, 1e-1),
+        ),
+        when_to_tune=(
+            "Adam wants 1e-3..1e-2; CG/L-BFGS typically ignore this in "
+            "favor of line search."
+        ),
+        dependencies=(
+            Dependency(
+                name="iPEPSConfig.gs_optimizer",
+                relation="Effect depends on optimizer; line-search paths "
+                "use it only for initial step size",
+            ),
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="gs_line_search_method",
+        dataclass_name="iPEPSConfig",
+        type_str="str",
+        default="armijo",
+        category=TuningCategory.METHOD_SELECTION,
+        description="Line-search algorithm used by CG/L-BFGS.",
+        hint=TuningHint(
+            scale=Scale.CATEGORICAL,
+            sensitivity=Sensitivity.MEDIUM,
+            values=("armijo", "hager_zhang"),
+        ),
+        when_to_tune=(
+            "Hager-Zhang is stronger and matches variPEPS; Armijo is "
+            "cheaper per step and the current default."
+        ),
+        references=("doi:10.1137/030601880",),  # Hager-Zhang 2005
+    )
+)
+
+_register(
+    ParamSpec(
+        name="gs_stall_recovery",
+        dataclass_name="iPEPSConfig",
+        type_str="str | None",
+        default=None,
+        category=TuningCategory.OPTIMIZER,
+        description=(
+            "Strategy when the line search stalls: 'noise' injects a "
+            "Frobenius perturbation (legacy 1-site C4v); 'reset' clears "
+            "L-BFGS (s,y) history and rolls back to best_params "
+            "(variPEPS). None = auto-per-dispatcher."
+        ),
+        hint=TuningHint(
+            scale=Scale.CATEGORICAL,
+            sensitivity=Sensitivity.MEDIUM,
+            values=(None, "noise", "reset"),
+        ),
+        when_to_tune=(
+            "Set to 'reset' for 2-site runs that get stuck; 'noise' is "
+            "required for 1-site C4v to break out of SU-init plateaus."
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="gs_metric_precond",
+        dataclass_name="iPEPSConfig",
+        type_str="bool",
+        default=True,
+        category=TuningCategory.PERFORMANCE,
+        description=(
+            "Metric preconditioning (natural gradient) using the local "
+            "tangent-space metric N_ij = <d_i psi | d_j psi>."
+        ),
+        hint=TuningHint(
+            scale=Scale.BOOLEAN,
+            sensitivity=Sensitivity.HIGH,
+            cost=CostModel(
+                runtime="~1.5–3x per step (GMRES solves)",
+                accuracy="dramatically faster outer-loop convergence",
+            ),
+        ),
+        references=("arXiv:2511.09546",),  # Rader et al.
+    )
+)
+
+_register(
+    ParamSpec(
+        name="gs_explicit_ad",
+        dataclass_name="iPEPSConfig",
+        type_str="bool",
+        default=True,
+        category=TuningCategory.METHOD_SELECTION,
+        description=(
+            "Differentiate through unrolled CTM sweeps (True) instead of "
+            "using implicit differentiation (False). Explicit is the "
+            "recommended path post PR #291."
+        ),
+        hint=TuningHint(
+            scale=Scale.BOOLEAN,
+            sensitivity=Sensitivity.HIGH,
+            cost=CostModel(
+                runtime="explicit = ~gs_explicit_ad_steps x forward cost",
+                memory="explicit = higher (retained activations)",
+            ),
+        ),
+        dependencies=(
+            Dependency(
+                name="CTMConfig.forward_gauge",
+                relation="auto-promotes qr -> phase when explicit=True",
+            ),
+            Dependency(
+                name="CTMConfig.ctm_ad_mode",
+                relation="implicit c4v_reference path requires explicit=False",
+            ),
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="su_init",
+        dataclass_name="iPEPSConfig",
+        type_str="bool",
+        default=True,
+        category=TuningCategory.INITIALIZATION,
+        description=(
+            "Initialize the site tensor via simple update before AD "
+            "(True) or from a random tensor (False)."
+        ),
+        hint=TuningHint(
+            scale=Scale.BOOLEAN,
+            sensitivity=Sensitivity.HIGH,
+        ),
+        when_to_tune=(
+            "SU init usually helps. EXCEPTION: for the sublattice-rotated "
+            "Heisenberg Hamiltonian, SU converges to the classical product "
+            "state, which is a gradient-zero extremum at E=-0.5/site — "
+            "L-BFGS cannot escape. Use su_init=False there."
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="gs_c4v",
+        dataclass_name="iPEPSConfig",
+        type_str="bool",
+        default=False,
+        category=TuningCategory.METHOD_SELECTION,
+        description=(
+            "Enforce C4v symmetry on the site tensor during AD by "
+            "parameterizing in a C4v basis."
+        ),
+        hint=TuningHint(
+            scale=Scale.BOOLEAN,
+            sensitivity=Sensitivity.HIGH,
+        ),
+        when_to_tune=(
+            "Turn on for C4v-symmetric models (sublattice-rotated square "
+            "Heisenberg, XXZ, TFIM). For D=2, this reduces the parameter "
+            "count from 16 to ~4 and is the only stable path for 1-site "
+            "iPEPS AD in Tenax today."
+        ),
+    )
+)
+
+_register(
+    ParamSpec(
+        name="gs_ctm_conv_tol_schedule",
+        dataclass_name="iPEPSConfig",
+        type_str="list[tuple[float, float]] | None",
+        default=None,
+        category=TuningCategory.PERFORMANCE,
+        description=(
+            "Ramp CTM conv_tol during optimization: list of (step_fraction, "
+            "conv_tol) pairs. Early steps can use a looser CTM tolerance "
+            "to save time, tightening as the optimizer converges."
+        ),
+        hint=TuningHint(
+            scale=Scale.CATEGORICAL,  # arbitrary schedule structure
+            sensitivity=Sensitivity.MEDIUM,
+            cost=CostModel(
+                runtime="10–30% speedup for long runs",
+                accuracy="neutral if schedule ends tight",
+            ),
+        ),
+        when_to_tune=(
+            "Large chi + many steps: e.g. [(0.0, 1e-5), (0.5, 1e-7), (0.8, 1e-9)]."
+        ),
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Query API
+# ---------------------------------------------------------------------------
+
+
+def all_params() -> list[ParamSpec]:
+    """Return all registered parameters as a fresh list."""
+    return list(_PARAMETERS)
+
+
+def get_param(fully_qualified_name: str) -> ParamSpec | None:
+    """Look up a parameter by its ``Dataclass.field`` name."""
+    for p in _PARAMETERS:
+        if p.fully_qualified_name() == fully_qualified_name:
+            return p
+    return None
+
+
+def params_by_category(category: TuningCategory) -> list[ParamSpec]:
+    """Return all parameters in a given semantic category."""
+    return [p for p in _PARAMETERS if p.category == category]
+
+
+def params_by_dataclass(dataclass_name: str) -> list[ParamSpec]:
+    """Return all parameters declared on a given dataclass."""
+    return [p for p in _PARAMETERS if p.dataclass_name == dataclass_name]

--- a/tests/test_tuning_registry.py
+++ b/tests/test_tuning_registry.py
@@ -1,0 +1,117 @@
+"""Sanity checks for the tuning registry.
+
+Ensures the registry entries don't drift out of sync with the
+authoritative dataclass defaults over time, and that the schema
+is internally consistent.
+"""
+
+from dataclasses import fields
+
+import pytest
+
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+from tenax.tuning import (
+    ParamSpec,
+    Sensitivity,
+    TuningCategory,
+    all_params,
+    get_param,
+    params_by_category,
+    params_by_dataclass,
+)
+
+_DATACLASSES = {
+    "CTMConfig": CTMConfig,
+    "iPEPSConfig": iPEPSConfig,
+}
+
+
+def _dataclass_default(cls, field_name):
+    for f in fields(cls):
+        if f.name == field_name:
+            if f.default_factory is not None and callable(f.default_factory):  # type: ignore[misc]
+                return f.default_factory()
+            return f.default
+    raise LookupError(field_name)
+
+
+class TestRegistrySchema:
+    def test_all_specs_are_param_spec(self):
+        for p in all_params():
+            assert isinstance(p, ParamSpec)
+
+    def test_fully_qualified_names_unique(self):
+        names = [p.fully_qualified_name() for p in all_params()]
+        assert len(names) == len(set(names)), f"Duplicate names: {names}"
+
+    def test_dataclass_names_are_known(self):
+        unknown = {
+            p.dataclass_name
+            for p in all_params()
+            if p.dataclass_name not in _DATACLASSES
+        }
+        assert not unknown, f"Unknown dataclass(es) referenced: {unknown}"
+
+
+class TestRegistryDefaultsMatchDataclasses:
+    @pytest.mark.parametrize(
+        "spec", all_params(), ids=lambda p: p.fully_qualified_name()
+    )
+    def test_default_matches_dataclass(self, spec):
+        cls = _DATACLASSES[spec.dataclass_name]
+        actual = _dataclass_default(cls, spec.name)
+        assert spec.default == actual, (
+            f"{spec.fully_qualified_name()}: registry says {spec.default!r}, "
+            f"dataclass says {actual!r}"
+        )
+
+
+class TestRegistryQueryAPI:
+    def test_get_param_round_trip(self):
+        for p in all_params():
+            assert get_param(p.fully_qualified_name()) is p
+
+    def test_get_param_missing_returns_none(self):
+        assert get_param("CTMConfig.definitely_does_not_exist") is None
+
+    def test_params_by_category_partition(self):
+        covered = set()
+        for cat in TuningCategory:
+            for p in params_by_category(cat):
+                covered.add(p.fully_qualified_name())
+        all_names = {p.fully_qualified_name() for p in all_params()}
+        assert covered == all_names
+
+    def test_params_by_dataclass(self):
+        for cls_name in _DATACLASSES:
+            ps = params_by_dataclass(cls_name)
+            for p in ps:
+                assert p.dataclass_name == cls_name
+
+
+class TestRegistryHintSanity:
+    @pytest.mark.parametrize(
+        "spec", all_params(), ids=lambda p: p.fully_qualified_name()
+    )
+    def test_hint_sensitivity_is_enum(self, spec):
+        assert isinstance(spec.hint.sensitivity, Sensitivity)
+
+    @pytest.mark.parametrize(
+        "spec", all_params(), ids=lambda p: p.fully_qualified_name()
+    )
+    def test_categorical_has_values(self, spec):
+        from tenax.tuning import Scale
+
+        if spec.hint.scale == Scale.CATEGORICAL:
+            # Categorical scale should list allowed values — unless the
+            # param is a free-form schedule-like structure.
+            if spec.hint.values is not None:
+                assert len(spec.hint.values) >= 2
+
+    @pytest.mark.parametrize(
+        "spec", all_params(), ids=lambda p: p.fully_qualified_name()
+    )
+    def test_numeric_range_sane(self, spec):
+        if spec.hint.range is not None:
+            lo, hi = spec.hint.range
+            assert lo <= hi


### PR DESCRIPTION
## Summary

Adds \`tenax.tuning\`, a structured catalog of the most-tuned parameters across Tenax's algorithm config dataclasses. Today this is consumed by the human-facing tuning guide; the eventual consumer is hyperparameter search / autotuning tooling that needs typed, queryable metadata (ranges, scales, dependencies, costs) — not a pile of inline comments.

### What's included

\`src/tenax/tuning/registry.py\` — schema dataclasses (\`ParamSpec\`, \`TuningHint\`, \`CostModel\`, \`Dependency\`), enums (\`Scale\`, \`Sensitivity\`, \`TuningCategory\`), and a **21-parameter catalog** spanning \`CTMConfig\` and \`iPEPSConfig\`:

- **Accuracy:** chi, max_iter, conv_tol, adjoint_tol, gs_num_steps
- **Stability:** forward_gauge, adjoint_tikhonov
- **Method selection:** projector_method, ctm_ad_mode, adjoint_solver, gs_optimizer, gs_explicit_ad, gs_c4v, gs_line_search_method
- **Performance:** jit_ctm, gs_metric_precond, gs_ctm_conv_tol_schedule
- **Optimizer:** gs_num_steps, gs_learning_rate, gs_stall_recovery
- **Initialization:** su_init

Query API: \`all_params()\`, \`get_param(name)\`, \`params_by_category(cat)\`, \`params_by_dataclass(name)\`.

\`tests/test_tuning_registry.py\` — **91 drift-check tests:**
- Schema sanity (every entry is a \`ParamSpec\`, no duplicate FQ names, all dataclass references are known)
- **Each registry entry's default matches the actual dataclass default** (parametrized so any drift surfaces in exactly one row)
- Query API round-trip / category partitioning
- Hint sanity (numeric ranges sorted, categorical params have values)

Runs in **~0.1s**.

\`docs/guide/tuning.md\` — ~270-line human reference page organized **by goal** rather than by dataclass:
- Quick-reference "what to tune first" table
- Accuracy knobs, stability knobs, optimizer knobs, initialization, method selection, performance-only
- Cross-links to the registry for machine-readable access

### Why it's worth having

1. **Future autotuning** — a hyperparameter search needs to know each knob's type, range, scale (linear / log10 / categorical), sensitivity, and cost model. The registry encodes all of that in importable Python.
2. **Drift prevention** — the test suite fails fast if anyone changes a dataclass default without updating the registry, or vice versa. Today the inline comments in the dataclasses are the only documentation, and they silently rot.
3. **Goal-oriented docs** — users currently have to read several config dataclasses to figure out which knob to touch. The new guide answers \"AD backward fails\" → \`adjoint_tikhonov\` → \`1e-4\` directly.

### Why it's safe

- **No production code touched.** \`src/tenax/tuning/\` is a brand-new package.
- **Authoritative defaults still live in the dataclasses.** The registry mirrors them; the tests guarantee they cannot drift.
- The registry has no runtime imports of algorithm internals — cheap to import and safe to use from CI / tooling.

## Test plan

- [ ] CI: required checks green
- [x] Local: \`uv run pytest tests/test_tuning_registry.py\` → 91 passed in 0.09s
- [x] Local: \`uv run python -c \"from tenax.tuning import all_params; print(len(all_params()))\"\` → 21

🤖 Generated with [Claude Code](https://claude.com/claude-code)