### PR TITLE
fix(ipeps): correct F-matrix sign in regularized_eigh backward (#316)

### DIFF
--- a/src/tenax/algorithms/ad_utils.py
+++ b/src/tenax/algorithms/ad_utils.py
@@ -385,8 +385,12 @@ def _regularized_eigh_bwd(residuals, g):
     w_scale = jnp.maximum(jnp.max(jnp.abs(w)), _EIGH_LORENTZ_EPS)
     eps = jnp.maximum(_EIGH_LORENTZ_EPS, _EIGH_LORENTZ_REL * w_scale)
 
-    # Lorentzian-regularized F-matrix
-    diff = w[:, None] - w[None, :]
+    # Lorentzian-regularized F-matrix.
+    # JAX reverse-mode convention for symmetric eigh wants
+    #   F_ij = 1 / (w_j - w_i)
+    # so ``diff[i, j] = w_j - w_i``.  The previous formulation used
+    # ``w_i - w_j`` which flipped the sign of the backward (issue #316).
+    diff = w[None, :] - w[:, None]
     F = diff / (diff**2 + eps**2)
     F = F - jnp.diag(jnp.diag(F))  # zero diagonal
 

--- a/tests/test_ad_utils.py
+++ b/tests/test_ad_utils.py
@@ -1277,6 +1277,47 @@ class TestRegularizedEigh:
         grad = jax.grad(loss)(M)
         assert jnp.all(jnp.isfinite(grad))
 
+    def test_structured_projector_loss_matches_fd(self):
+        """Regression for issue #316: sign of the F-matrix contraction.
+
+        ``sum(w**2)`` / ``sum(v[:, -1] ** 2)`` are insensitive to the sign
+        of the F-matrix term because they only touch the ``dw`` path or are
+        gauge-trivial (unit-norm eigenvector). A proper test must use a
+        gauge-invariant loss that is quadratic in the eigenvectors, such as
+        ``tr(P^T M P)`` with ``P`` the top-k projector. Finite differences
+        and AD must agree in sign and magnitude.
+        """
+        from tenax.algorithms.ad_utils import regularized_eigh
+
+        key = jax.random.PRNGKey(2024)
+        key_rho, key_obs, key_h = jax.random.split(key, 3)
+        C = jax.random.normal(key_rho, (6, 6))
+        rho = C @ C.T
+        rho = 0.5 * (rho + rho.T)
+        M_obs = jax.random.normal(key_obs, (6, 6))
+        M_obs = 0.5 * (M_obs + M_obs.T)
+
+        def loss(r):
+            _, v = regularized_eigh(r)
+            P = v[:, -3:][:, ::-1]
+            return jnp.trace(P.T @ M_obs @ P)
+
+        # Directional derivative along a symmetric perturbation h.
+        h = jax.random.normal(key_h, (6, 6))
+        h = 0.5 * (h + h.T)
+        eps = 1e-5
+        fd = float(loss(rho + eps * h) - loss(rho - eps * h)) / (2 * eps)
+        grad = jax.grad(loss)(rho)
+        ad = float(jnp.sum(grad * h))
+
+        assert jnp.isfinite(ad)
+        assert jnp.isfinite(fd)
+        assert abs(ad - fd) < 1e-4, (
+            f"regularized_eigh AD disagrees with FD on gauge-invariant "
+            f"projector loss: ad={ad:+.10f} fd={fd:+.10f} "
+            f"(sign bug in F contraction — issue #316)"
+        )
+
 
 class TestMultipletAwareTruncation:
     """SVD truncation should handle degenerate singular values at boundary."""


### PR DESCRIPTION
## Summary

One-line sign fix in \`_regularized_eigh_bwd\` (\`src/tenax/algorithms/ad_utils.py\`) plus a FD-AD regression test. The Lorentzian-regularized F-matrix was constructed with \`diff = w[:, None] - w[None, :]\` (i.e. \`F_ij = 1/(w_i - w_j)\`), but JAX's reverse-mode convention for symmetric eigh wants \`F_ij = 1/(w_j - w_i)\` — so \`diff[i, j]\` must be \`w_j - w_i\`. The previous formulation shipped the **negative** of the correct projector gradient for every downstream consumer.

Discovered during review of PR #318 / plan PR #315 Task 7.

Closes #316.

## Evidence (gauge-invariant structured loss, 6×6 PSD, f64)

Directional derivative of \`L1 = tr(Pᵀ M P)\` with top-3 projector, along a random symmetric direction:

| Path                                      | \`AD · h\`   |
|-------------------------------------------|-------------|
| FD (truth)                                | \`+1.56265686\` |
| \`jnp.linalg.eigh\` (native)              | \`+1.56265686\` ✓ |
| \`regularized_eigh\` (before)             | **\`-1.56265686\` ✗** |
| \`regularized_eigh\` (after this PR)      | \`+1.56265686\` ✓ |
| \`truncated_eigh_regularized\` (PR #318)  | \`+1.56265686\` ✓ |

Both gauge-invariant losses from issue #316's reproducer (\`L1 = tr(PᵀMP)\` and \`L2 = ‖Pᵀ t‖²\`) now agree with FD.

## Why nothing previously blew up

The existing \`TestRegularizedEigh\` tests used:
- \`sum(w**2)\` — flows through \`dw\`, not \`F ⊙ (VᵀdV)\`, so the sign of the F-contraction is invisible.
- \`sum(v[:, -1]**2)\` — **identically 1** because each eigenvector is unit-norm, giving zero gradient (vacuous).

Neither exercises the F-matrix term on a gauge-invariant structured loss, so the wrong sign slipped through. The new \`test_structured_projector_loss_matches_fd\` is the minimal structured-loss FD-AD regression that would have caught it.

## Impact on downstream consumers

Every iPEPS AD path that routes through \`regularized_eigh\` was affected:

- 1-site C4v explicit-AD recommended path (eigh projector + phase gauge)
- 2-site shared-tensor C4v explicit-AD path (before PR #318's Lorentzian route-around)
- Any non-c4v_reference path using \`projector_method="eigh"\` with tracers

These paths "worked" in benchmarks because gauge tricks, loose CTM tolerances, and L-BFGS history resets routed around the wrong gradient — but the underlying derivative was backwards. At χ=8 the cover broke down, producing issue #299's -0.558 plateau (the other half of which was the missing truncation-correction term — see PR #318).

## Relationship to PR #318

- **Orthogonal**: PR #318 adds a new \`projector_backward="lorentzian"\` path and routes around \`regularized_eigh\` entirely. This PR fixes the legacy path in place.
- **Both should land**: users who prefer to stay on the legacy backward (by setting \`projector_backward="standard"\`) now get a correct gradient; users on the auto-promoted Lorentzian path already do via PR #318.
- **Merge order**: either order works, but merging this PR **first** simplifies PR #318's diff history (PR #318's tests were pivoted specifically because of the sign bug; with this fix in place, PR #318's test surface is more obviously right).

## Test plan
- [x] \`uv run pytest tests/test_ad_utils.py tests/test_c4v_reference_ad.py tests/test_regularized_svd.py -q\` → **84 passed, 3 xfailed**, no regressions
- [x] New test \`test_structured_projector_loss_matches_fd\` passes with \`atol=1e-4\` (actual \`|AD-FD| ≈ 1e-8\`)
- [ ] CI: core tier
- [ ] Manual: re-run the 1-site C4v D=2 χ=16 benchmark to confirm no regression on the recommended path (expected: same or slightly faster convergence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)