### PR TITLE
fix(ipeps): address P1/P2/P3 review comments from PRs #311, #314, #318, #320

### DIFF
--- a/docs/dmrg-code-paths.md
+++ b/docs/dmrg-code-paths.md
@@ -114,18 +114,18 @@ require them to be uniform, and route to `_dense_ops()` or
 | Controlled Bond Expansion (CBE)        | **Working**      | McCulloch–Osborne, arXiv:2403.00562; dense + symmetric.            |
 | iDMRG 2-site (dense)                   | **Working**      | Default; 2-site unit cell only.                                    |
 | iDMRG 2-site (symmetric)               | **Working**      | Block-sparse fixed-point solve.                                    |
-| iDMRG 1-site (dense)                   | **Working**      | DMRG3S not wired in iDMRG path.                                    |
+| iDMRG 1-site (dense)                   | **Working**      | DMRG3S wired via `_idmrg_1site_sweep` + `expand_and_truncate_dense`.|
 | iDMRG 1-site (symmetric)               | **BROKEN**       | Raises `NotImplementedError`.                                      |
 | iDMRG `unit_cell_size > 2`             | **BROKEN**       | Raises `NotImplementedError`; 2-site cell hard-coded.              |
-| TDVP 1-site                            | **Working**      | Real + imaginary time via `krylov_expm`; not in `__all__` yet.     |
+| TDVP 1-site                            | **Working**      | Real + imaginary time via `krylov_expm`; exported in `__all__`.    |
 | TDVP 2-site                            | **Working**      | Allows bond growth via SVD truncation.                             |
 | JIT sweeps (dense, GPU/TPU)            | **Working**      | `accelerator="jit"`; PR #209.                                      |
 | Sharded DMRG (multi-device)            | **Working**      | `accelerator="sharded"`; dense 2-site only.                        |
-| Cython fused Lanczos (CPU)             | **Working**      | Opt-in; disable via `TENAX_DISABLE_CYTHON_BLAS=1`; PR #226.        |
-| Fermionic DMRG                         | **ABSENT**       | No dedicated path; build fermionic MPO on `SymmetricTensor` by hand.|
+| Cython fused Lanczos (CPU)             | **Working**      | On by default when extension imports; opt-out via `TENAX_DISABLE_CYTHON_BLAS=1`; PR #226. |
+| Fermionic DMRG                         | **Working**      | `AutoMPO(..., fermionic_ops=...)` + `fermion_site_ops`; see `tests/test_fermionic.py`. |
 | TEBD                                   | **ABSENT**       | Not implemented; use TDVP or iPEPS simple update.                  |
-| Multi-state targeting (`num_states>1`) | **ABSENT**       | Raises `NotImplementedError`.                                      |
-| Perturbative noise (`noise != 0`)      | **ABSENT**       | Raises `NotImplementedError`; use DMRG3S or CBE instead.           |
+| Multi-state targeting (`num_states>1`) | **BROKEN**       | `dmrg()` raises `NotImplementedError` at entry.                    |
+| Perturbative noise (`noise != 0`)      | **BROKEN**       | `dmrg()` raises `NotImplementedError` at entry; use DMRG3S or CBE. |
 
 ## Config Cheat Sheet
 

--- a/src/tenax/algorithms/_ctm_projector.py
+++ b/src/tenax/algorithms/_ctm_projector.py
@@ -703,10 +703,15 @@ def _compute_projector_tensor(
         # of (Q, R), so applying this fix has no effect on the forward
         # output but makes the autodiff gradient consistent across
         # arbitrarily small perturbations of M.
+        # For complex matrices, `diag_R >= 0` is undefined; rotate by the
+        # phase of diag(R) so diag(R) becomes real and non-negative. This
+        # reduces to the ±1 sign convention in the real case.
         diag_R = jnp.diag(R)
-        signs = jnp.where(diag_R >= 0, 1.0, -1.0).astype(R.dtype)
-        Q = Q * signs[None, :]
-        R = R * signs[:, None]
+        abs_diag = jnp.abs(diag_R)
+        safe_abs = jnp.where(abs_diag > 0, abs_diag, 1.0)
+        phase = (diag_R / safe_abs).astype(R.dtype)
+        Q = Q * phase[None, :]
+        R = R * jnp.conj(phase)[:, None]
         if _has_tracers:
             from tenax.algorithms.ad_utils import regularized_svd
 

--- a/src/tenax/algorithms/_ctm_projector.py
+++ b/src/tenax/algorithms/_ctm_projector.py
@@ -705,11 +705,16 @@ def _compute_projector_tensor(
         # arbitrarily small perturbations of M.
         # For complex matrices, `diag_R >= 0` is undefined; rotate by the
         # phase of diag(R) so diag(R) becomes real and non-negative. This
-        # reduces to the ±1 sign convention in the real case.
+        # reduces to the ±1 sign convention in the real case. When a
+        # diagonal entry is exactly zero the gauge is unconstrained, so
+        # use phase=1 (leave the column/row untouched) rather than
+        # phase=0 which would zero out that column of Q and row of R.
         diag_R = jnp.diag(R)
         abs_diag = jnp.abs(diag_R)
-        safe_abs = jnp.where(abs_diag > 0, abs_diag, 1.0)
-        phase = (diag_R / safe_abs).astype(R.dtype)
+        unit = jnp.ones_like(diag_R)
+        phase = jnp.where(
+            abs_diag > 0, diag_R / jnp.where(abs_diag > 0, abs_diag, 1.0), unit
+        ).astype(R.dtype)
         Q = Q * phase[None, :]
         R = R * jnp.conj(phase)[:, None]
         if _has_tracers:

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -48,19 +48,6 @@ class CTMConfig:
     conv_tol: float = 1e-8
     renormalize: bool = True
     projector_method: str = "eigh"  # "eigh", "qr", or "svd" (Fishman)
-    # Backward pass used for the eigh projector inside AD.
-    #   "auto"       -> default; ``optimize_gs_ad`` promotes to "lorentzian"
-    #                   when ``gs_explicit_ad=True`` and ``projector_method``
-    #                   is "eigh", otherwise the effective value is "standard".
-    #                   Mirrors the ``forward_gauge`` auto-promotion pattern.
-    #   "standard"   -> force the existing ``regularized_eigh`` backward.
-    #                   Never auto-promoted away from this value.
-    #   "lorentzian" -> force the truncated-eigh Lorentzian backward from
-    #                   ``_lorentzian_eigh.py`` (plan PR #315, Task 2).
-    #                   Honored even when ``projector_method != "eigh"``, in
-    #                   which case the forward doesn't use eigh at all and
-    #                   the flag is a no-op.
-    projector_backward: Literal["auto", "standard", "lorentzian"] = "auto"
     min_iter: int = 10  # minimum CTM sweeps before checking convergence
     qr_warmup_steps: int = 3  # eigh warm-up iterations before QR kicks in
     chi_I: int | None = None  # interlayer bond dim for split-CTMRG; None => chi_I = chi
@@ -107,6 +94,21 @@ class CTMConfig:
     #     tensor network library for variational ground state simulations in
     #     two spatial dimensions", SciPost Phys. Codebases (arXiv:2308.12358).
     adjoint_tikhonov: float = 1e-6
+    # Backward pass used for the eigh projector inside AD.
+    #   "auto"       -> default; ``optimize_gs_ad`` promotes to "lorentzian"
+    #                   when ``gs_explicit_ad=True`` and the effective
+    #                   projector is "eigh", otherwise the effective value is
+    #                   "standard".  Mirrors the ``forward_gauge`` pattern.
+    #   "standard"   -> force the existing ``regularized_eigh`` backward.
+    #                   Never auto-promoted away from this value.
+    #   "lorentzian" -> force the truncated-eigh Lorentzian backward from
+    #                   ``_lorentzian_eigh.py`` (plan PR #315, Task 2).
+    #                   Honored even when ``projector_method != "eigh"``, in
+    #                   which case the forward doesn't use eigh at all and
+    #                   the flag is a no-op.
+    # Kept at the end of the dataclass to preserve positional-argument
+    # compatibility for callers that construct CTMConfig positionally.
+    projector_backward: Literal["auto", "standard", "lorentzian"] = "auto"
 
     def __post_init__(self):
         valid_modes = {None, "c4v_reference"}

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -50,7 +50,13 @@ def _resolve_projector_backward(config: iPEPSConfig) -> iPEPSConfig:
     if not config.gs_explicit_ad:
         return config
     ctm_cfg = config.ctm
-    if ctm_cfg.projector_method != "eigh":
+    # Match against the *effective* projector: ``gs_projector_method``
+    # overrides ``ctm.projector_method`` in the optimizer body, so inspect
+    # the override first. Without this the AD path ends up on ``eigh``
+    # while ``projector_backward`` stays on the legacy regularized_eigh
+    # branch (#318 review).
+    effective_projector = config.gs_projector_method or ctm_cfg.projector_method
+    if effective_projector != "eigh":
         return config
     if ctm_cfg.projector_backward != "auto":
         return config

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -770,6 +770,12 @@ def _optimize_gs_ad_tensor(
             )
             logged = True
 
+        # Refresh warm-start state before the early-exit check so the
+        # post-loop fresh re-eval sees the current converged env, not the
+        # previous iterate (#320 review).
+        prev_energy = energy_float
+        prev_env_leaves = env_leaves_sg
+
         if delta_energy < config.gs_conv_tol:
             if config.gs_verbose:
                 if not logged:
@@ -785,8 +791,6 @@ def _optimize_gs_ad_tensor(
                     "1site-tensor", step, delta_energy, config.gs_conv_tol
                 )
             break
-        prev_energy = energy_float
-        prev_env_leaves = env_leaves_sg
 
         # Compute search direction
         if is_cg:
@@ -1421,6 +1425,12 @@ def _optimize_gs_ad_tensor_2site(
             )
             logged = True
 
+        # Refresh warm-start state before the early-exit check so the
+        # post-loop fresh re-eval sees the current converged env, not the
+        # previous iterate (#320 review).
+        prev_energy = energy_float
+        prev_env_leaves = env_leaves_sg
+
         if delta_energy < config.gs_conv_tol:
             if config.gs_verbose:
                 if not logged:
@@ -1436,8 +1446,6 @@ def _optimize_gs_ad_tensor_2site(
                     "2site-tensor", step, delta_energy, config.gs_conv_tol
                 )
             break
-        prev_energy = energy_float
-        prev_env_leaves = env_leaves_sg
 
         # Compute search direction
         if is_cg:

--- a/src/tenax/tuning/registry.py
+++ b/src/tenax/tuning/registry.py
@@ -439,7 +439,9 @@ _register(
         hint=TuningHint(
             scale=Scale.LOG10,
             sensitivity=Sensitivity.MEDIUM,
-            range=(0.0, 1e-2),
+            # Strictly positive lower bound so LOG10 sampling is well-defined;
+            # pass 0.0 explicitly for a strictly exact adjoint outside tuning.
+            range=(1e-10, 1e-2),
             applies_when={"CTMConfig.ctm_ad_mode": "c4v_reference"},
             cost=CostModel(
                 runtime="neutral (improves convergence = fewer iters)",


### PR DESCRIPTION
## Summary

Sweep of review comments from the codex-connector bot across PRs #311, #314, #318, #320.

**P1:**
- **#320** (`ipeps_optimize.py`): refresh `prev_env_leaves` before the `gs_conv_tol` early-exit check on both 1-site and 2-site paths so the post-loop fresh CTM re-eval warm-starts from the current converged env.
- **#311** (`_ctm_projector.py`): replace `diag_R >= 0` with a phase rotation in the QR sign-fix to handle complex matrices (ordering on complex raises in JAX).

**P2:**
- **#318** (`ipeps_config.py`): move `CTMConfig.projector_backward` to the end of the dataclass to preserve positional-arg compatibility.
- **#318** (`ipeps_optimize.py`): auto-promotion now inspects the *effective* projector (`gs_projector_method` override takes precedence).
- **#311** (`tuning/registry.py`): tighten `adjoint_tikhonov` LOG10 range to `(1e-10, 1e-2)` so log-scale sampling is well-defined.
- **#314** (`docs/dmrg-code-paths.md`): correct iDMRG DMRG3S wiring, TDVP `__all__`, Cython Lanczos opt-out, and Fermionic DMRG availability notes.

**P3:**
- **#314** (`docs/dmrg-code-paths.md`): reclassify `num_states>1` and `noise` as **BROKEN** (they raise at entry) rather than **ABSENT**.

## Notes

- **P1.2** from PR #313 (`CTMConfig.adjoint_tikhonov` allegedly missing) was a false positive — the field exists at `ipeps_config.py:109` and all 91 registry/tuning tests pass. Not addressed.
- Three tests in `tests/test_ad_utils.py` (`test_explicit_ad_matches_finite_difference[eigh]`, `test_explicit_ad_qr_known_non_smoothness`, `test_gradient_is_a_descent_direction`) already fail on `main` and are unrelated to this change.

## Test plan

- [x] `tests/test_c4v_reference_ad.py` + `tests/test_ipeps_config.py` + `tests/test_projector_backward_dispatch.py` pass (40 passed)
- [x] Registry + tuning selection passes (91 passed)
- [ ] Full `-m core` CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
