### PR TITLE
fix(ipeps): implicit-diff backward honors forward_gauge='sigma'

### DIFF
--- a/src/tenax/algorithms/ad_utils.py
+++ b/src/tenax/algorithms/ad_utils.py
@@ -1137,7 +1137,7 @@ def _ctm_tensor_converge_bwd(neighbors, config_tuple, residuals, g):
         site_leaves = site_leaves + tuple(jax.tree.leaves(site_tensors[c]))
     env_leaves = _flatten_envs(envs)
 
-    use_sigma = getattr(config, "ctm_conv_method", "sv") == "elementwise"
+    use_sigma = getattr(config, "forward_gauge", "qr") == "sigma"
 
     if use_sigma:
         # --- YASTN-style backward: sigma-gauged step function ---


### PR DESCRIPTION
## Summary

One-line fix in `ad_utils.py:1140`: the implicit-diff `ctm_tensor_converge` backward was gating its sigma-gauged step function on `ctm_conv_method == "elementwise"`, a convergence-check setting unrelated to the gauge at the fixed point. It should read `forward_gauge == "sigma"` like the rest of the file.

## Impact

When a caller set `forward_gauge="sigma"` + `gs_explicit_ad=False` (the implicit-diff path), the forward CTM loop applied sigma gauge (lines 1309-1334) but the custom_vjp backward fell into the gauge-free branch, never calling `_precompute_sigma_matrices` / `_apply_sigma_to_env_leaves`. The backward ran `_ctm_tensor_step_multisite(..., skip_gauge=True)`, so the effective VJP was ungauged. For large χ this is exactly the pathology sigma gauge is designed to prevent.

## Empirical validation

2-site C4v Heisenberg, D=2:

| config | χ | in-loop E_best | final E | verdict |
|---|---|---|---|---|
| explicit + phase gauge | 16 | -1.3201 | -0.6370 | unphysical in-loop (projector discontinuity) |
| implicit + sigma gauge, **before** fix | 16 | same pathology | — | backward was ungauged |
| implicit + sigma gauge, **after** fix | 16 | **-0.6388** | **-0.6363** | bounded, physical |

Still slow (as `project_implicit_diff_gmres.md` documents) but the unphysical explosion at χ≥16 is gone.

## Test plan

- [x] No test regressions in `test_c4v_reference_ad.py` / `test_ipeps_config.py` / `test_projector_backward_dispatch.py` (32 passed)
- [ ] Full `-m core` CI
- [ ] Follow-up: wire regression test that runs `forward_gauge="sigma"` + implicit diff at χ=16 and asserts E stays above -1.0

## Related memory

- `project_implicit_diff_gmres.md` — noted "implicit + sigma slow" but didn't catch that the backward was silently ungauged
- `project_2site_sigma_gauge_dead_end.md` — explicit-AD dead end for sigma gauge; this fix only affects the implicit path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
