### PR TITLE
fix(test): use gs_c4v=True in test_ad_d2_energy (#325)

### DIFF
--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -849,6 +849,12 @@ class TestHeisenbergBenchmark:
             gs_num_steps=50,
             gs_learning_rate=5e-3,
             unit_cell="2site",
+            # gs_c4v=True is required for 2-site stability — without the
+            # shared-tensor C4v constraint the optimizer drifts into non-
+            # variational CTM regions and energy walks below the QMC
+            # ground state.  See issue #325 and the warning in
+            # ``_optimize_gs_ad_tensor_2site``.
+            gs_c4v=True,
         )
         _, _, E_gs = optimize_gs_ad(
             heisenberg_gate, (A_su.todense(), B_su.todense()), ad_config


### PR DESCRIPTION
## Summary

Switch ``test_ad_d2_energy`` to ``gs_c4v=True`` so the 2-site AD optimizer exercises the production-stable shared-tensor C4v path instead of the unstable independent-A/B path.

Closes #325.

## Why

The previous test ran 2-site AD with ``gs_c4v=False`` (default). Without the shared-tensor C4v constraint, the optimizer drifts into non-variational CTM regions and produces energies below QMC. The test was tripping its own ``E_gs > -0.80`` sanity floor with ``E_gs ≈ -0.88``.

Empirical verification today (2026-04-15, GPU): ``gs_c4v=False`` at chi=8, 15 L-BFGS steps, reaches in-loop ``E_best=-0.7516`` and final re-eval ``-0.9464`` — both below the QMC ground state of ``-0.6694``. The pathology is documented in ``project_multisite_ad_instability.md`` and ``project_2site_c4v_benchmark.md``.

The 2-site AD warning in ``_optimize_gs_ad_tensor_2site`` already says:

> "2-site AD optimizer is experimental and may diverge. Prefer 1-site with sublattice_rotate_gate() + gs_c4v=True, or enable gs_c4v=True for 2-site."

So this just brings the test in line with the docstring's recommendation.

## Test plan

- [x] Local: ``JAX_PLATFORMS=cpu uv run pytest tests/test_ipeps.py::TestHeisenbergBenchmark::test_ad_d2_energy --no-cov`` — 1 passed in 6:28 (was failing on main with E_gs=-0.88)
- [ ] Full ``-m core`` CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)