### PR TITLE
fix(ipeps): polymorphic optimizer shell for SymmetricTensor AD (#297)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -15,7 +15,7 @@ import numpy as np
 from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.symmetry import U1Symmetry
-from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+from tenax.core.tensor import DenseTensor, Tensor
 
 _logger = logging.getLogger(__name__)
 
@@ -586,21 +586,6 @@ def _optimize_gs_ad_tensor(
     A = A_init
     A = A * (1.0 / (A.norm() + 1e-10))
 
-    # The 1-site optimizer operates on a dense view of ``A`` throughout:
-    # ``loss_fn`` dense-wraps ``A`` via ``A.todense()`` for the CTM forward
-    # pass, the env template's pytree structure must match that dense view,
-    # the metric-preconditioned CG / L-BFGS direction is rebuilt as
-    # ``type(A)(dense_array, A.indices)`` (which only works for
-    # ``DenseTensor``), and the final ``_eval_fresh`` already returns a
-    # ``DenseTensor``.  Dense-wrap ``A`` once here so the optimizer state
-    # is internally consistent for both ``DenseTensor`` and
-    # ``SymmetricTensor`` inputs — otherwise the symmetric path hits a
-    # mismatched pytree structure in ``_unflatten_envs_init`` (see
-    # issue #294) or a ``SymmetricTensor(dense_array, ...)`` constructor
-    # failure in the metric-precond branch.
-    if not isinstance(A, DenseTensor):
-        A = DenseTensor(A.todense(), A.indices)
-
     # Override CTM config fields for AD optimization
     ctm_cfg = config.ctm
     from dataclasses import replace as _replace
@@ -649,10 +634,10 @@ def _optimize_gs_ad_tensor(
     def loss_fn(params, env_init_leaves):
         if use_c4v:
             A_data = c4v_tensor_from_coeffs(params, c4v_basis, tensor_shape)
+            A_norm_data = A_data / (jnp.linalg.norm(A_data) + 1e-10)
+            A_norm = DenseTensor(A_norm_data, A.indices)
         else:
-            A_data = params.todense()
-        A_norm_data = A_data / (jnp.linalg.norm(A_data) + 1e-10)
-        A_norm = DenseTensor(A_norm_data, A.indices)
+            A_norm = params * (1.0 / (params.norm() + 1e-10))
         site_tensors = {(0, 0): A_norm}
         if use_explicit:
             env_leaves = _ctm_converge(
@@ -698,6 +683,7 @@ def _optimize_gs_ad_tensor(
         _config_from_tuple,
         _ctm_tensor_multisite_fixed_point,
         _ctm_tensor_multisite_fixed_point_jit,
+        _wrap_tensor,
     )
 
     _fp_fn = (
@@ -710,10 +696,10 @@ def _optimize_gs_ad_tensor(
         """Forward-only loss for line search — warm-starts CTM from prev_env_leaves."""
         if use_c4v:
             A_data = c4v_tensor_from_coeffs(p, c4v_basis, tensor_shape)
+            A_norm_data = A_data / (jnp.linalg.norm(A_data) + 1e-10)
+            A_norm = DenseTensor(A_norm_data, A.indices)
         else:
-            A_data = p.todense()
-        A_norm_data = A_data / (jnp.linalg.norm(A_data) + 1e-10)
-        A_norm = DenseTensor(A_norm_data, A.indices)
+            A_norm = p * (1.0 / (p.norm() + 1e-10))
         site_tensors = {(0, 0): A_norm}
         env_leaves = ctm_tensor_converge(
             site_tensors, prev_env_leaves, SINGLE_SITE_NEIGHBORS, config_tuple
@@ -808,7 +794,7 @@ def _optimize_gs_ad_tensor(
                 z_dense = precondition_gradient(
                     A, env_for_metric, grads, delta_metric, config
                 )
-                z = type(grads)(z_dense, grads.indices)
+                z = _wrap_tensor(z_dense, grads)
                 neg_z = jax.tree.map(lambda g: -g, z)
                 if prev_precond_grad is not None and cg_direction is not None:
                     z_diff = jax.tree.map(lambda a, b: a - b, z, prev_precond_grad)
@@ -866,8 +852,8 @@ def _optimize_gs_ad_tensor(
                 d_loc = A.todense().shape[-1]
 
                 def h0_matvec(v):
-                    v_tensor = type(A)(
-                        v.reshape(D_bond, D_bond, D_bond, D_bond, d_loc), A.indices
+                    v_tensor = _wrap_tensor(
+                        v.reshape(D_bond, D_bond, D_bond, D_bond, d_loc), A
                     )
                     result = precondition_gradient(
                         A, env_for_metric, v_tensor, delta_metric, config
@@ -878,7 +864,7 @@ def _optimize_gs_ad_tensor(
                 direction_dense = -direction_flat.reshape(
                     D_bond, D_bond, D_bond, D_bond, d_loc
                 )
-                direction = type(A)(direction_dense, A.indices)
+                direction = _wrap_tensor(direction_dense, A)
         elif optimizer is not None:
             updates, opt_state = optimizer.update(grads, opt_state, params)
             direction = updates
@@ -970,9 +956,8 @@ def _optimize_gs_ad_tensor(
                         noise_key, data.shape
                     )
                     noisy = data + noise * jnp.linalg.norm(data)
-                    params = type(params)(
-                        noisy / (jnp.linalg.norm(noisy) + 1e-10), params.indices
-                    )
+                    noisy = noisy / (jnp.linalg.norm(noisy) + 1e-10)
+                    params = _wrap_tensor(noisy, params)
                 if config.gs_verbose:
                     print(f"[iPEPS-AD] stall #{stall_count}, adding noise", flush=True)
                 # Reset optimizer state
@@ -1051,10 +1036,10 @@ def _optimize_gs_ad_tensor(
         """
         if use_c4v:
             A_data = c4v_tensor_from_coeffs(p, c4v_basis, tensor_shape)
+            A_data = A_data / (jnp.linalg.norm(A_data) + 1e-10)
+            A_t = DenseTensor(A_data, A.indices)
         else:
-            A_data = p.todense()
-        A_data = A_data / (jnp.linalg.norm(A_data) + 1e-10)
-        A_t = DenseTensor(A_data, A.indices)
+            A_t = p * (1.0 / (p.norm() + 1e-10))
         envs_init = (
             _unflatten_env_single(envs_init_leaves)
             if envs_init_leaves is not None
@@ -1200,6 +1185,7 @@ def _optimize_gs_ad_tensor_2site(
         _config_to_tuple,
         _ctm_tensor_multisite_fixed_point,
         _ctm_tensor_multisite_fixed_point_jit,
+        _wrap_tensor,
         ctm_tensor_converge,
         ctm_tensor_converge_explicit,
     )
@@ -1220,20 +1206,6 @@ def _optimize_gs_ad_tensor_2site(
     A, B = AB_init
     A = A * (1.0 / (A.norm() + 1e-10))
     B = B * (1.0 / (B.norm() + 1e-10))
-
-    # Same rationale as ``_optimize_gs_ad_tensor``: the 2-site metric
-    # preconditioning branch rebuilds ``type(A_g)(dense_array, indices)``
-    # from the preconditioner output, which only works for ``DenseTensor``.
-    # Dense-wrap upfront so the rest of the optimizer is internally
-    # consistent.  The 2-site AD optimizer is already labeled experimental
-    # (see ``UserWarning`` in ``_optimize_gs_ad_2site``), so losing the
-    # block-sparse forward pass on SymmetricTensor inputs is acceptable
-    # here until the metric-precond path is made symmetry-aware (tracked
-    # by issue #294 follow-ups).
-    if not isinstance(A, DenseTensor):
-        A = DenseTensor(A.todense(), A.indices)
-    if not isinstance(B, DenseTensor):
-        B = DenseTensor(B.todense(), B.indices)
 
     from dataclasses import replace as _replace
 
@@ -1471,8 +1443,8 @@ def _optimize_gs_ad_tensor_2site(
                     sites_m, envs_m, grads_m, delta_metric, config
                 )
                 z = (
-                    type(A_g)(z_dict[(0, 0)], A_g.indices),
-                    type(B_g)(z_dict[(1, 0)], B_g.indices),
+                    _wrap_tensor(z_dict[(0, 0)], A_g),
+                    _wrap_tensor(z_dict[(1, 0)], B_g),
                 )
                 neg_z = jax.tree.map(lambda g: -g, z)
                 if prev_precond_grad is not None and cg_direction is not None:
@@ -1550,11 +1522,11 @@ def _optimize_gs_ad_tensor_2site(
                     D_b = A_cur.todense().shape[0]
                     d_l = A_cur.todense().shape[-1]
                     grads_v = {
-                        (0, 0): type(A_cur)(
-                            v_A.reshape(D_b, D_b, D_b, D_b, d_l), A_cur.indices
+                        (0, 0): _wrap_tensor(
+                            v_A.reshape(D_b, D_b, D_b, D_b, d_l), A_cur
                         ),
-                        (1, 0): type(B_cur)(
-                            v_B.reshape(D_b, D_b, D_b, D_b, d_l), B_cur.indices
+                        (1, 0): _wrap_tensor(
+                            v_B.reshape(D_b, D_b, D_b, D_b, d_l), B_cur
                         ),
                     }
                     z_dict = precondition_gradient_multisite(
@@ -1573,8 +1545,8 @@ def _optimize_gs_ad_tensor_2site(
                 dir_A = -direction_flat[:n_A].reshape(D_b, D_b, D_b, D_b, d_l)
                 dir_B = -direction_flat[n_A:].reshape(D_b, D_b, D_b, D_b, d_l)
                 direction = (
-                    type(A_cur)(dir_A, A_cur.indices),
-                    type(B_cur)(dir_B, B_cur.indices),
+                    _wrap_tensor(dir_A, A_cur),
+                    _wrap_tensor(dir_B, B_cur),
                 )
         elif optimizer is not None:
             updates, opt_state = optimizer.update(grads, opt_state, params)
@@ -1662,9 +1634,8 @@ def _optimize_gs_ad_tensor_2site(
                     data = p.todense()
                     noise = config.gs_noise_amplitude * jax.random.normal(k, data.shape)
                     noisy = data + noise * jnp.linalg.norm(data)
-                    noisy_params.append(
-                        type(p)(noisy / (jnp.linalg.norm(noisy) + 1e-10), p.indices)
-                    )
+                    noisy = noisy / (jnp.linalg.norm(noisy) + 1e-10)
+                    noisy_params.append(_wrap_tensor(noisy, p))
                 params = tuple(noisy_params)
                 if config.gs_verbose:
                     print(f"[iPEPS-AD] stall #{stall_count}, adding noise", flush=True)
@@ -1797,13 +1768,10 @@ def optimize_fpeps_ad(
     to compute exact gradients of the energy with respect to the
     fermionic site tensor, then optimizes with optax.
 
-    The AD backward pass (GMRES implicit differentiation) currently
-    requires ``DenseTensor`` leaves for stable gradients, so input
-    ``SymmetricTensor`` tensors are automatically wrapped as
-    ``DenseTensor`` (preserving the index structure including
-    ``FermionParity`` symmetry charges and flow directions).  The
-    returned ``A_opt`` is a ``DenseTensor`` with the same index
-    metadata.
+    Accepts either ``DenseTensor`` or ``SymmetricTensor`` (e.g.
+    ``FermionParity`` symmetry) inputs — the optimizer shell is
+    polymorphic over the Tensor protocol (#297) and returns a tensor
+    of the same type as the input, preserving charges and flows.
 
     Args:
         hamiltonian_gate: 2-site Hamiltonian as a ``Tensor`` (typically
@@ -1820,9 +1788,9 @@ def optimize_fpeps_ad(
             physical dimension d=2, FermionParity charges).
 
     Returns:
-        ``(A_opt, env, E_gs)`` where ``A_opt`` is the optimized
-        ``DenseTensor``, ``env`` is a ``CTMTensorEnv``, and ``E_gs``
-        is the ground-state energy per site.
+        ``(A_opt, env, E_gs)`` where ``A_opt`` is the optimized site
+        tensor (same type as ``A_init``), ``env`` is a ``CTMTensorEnv``,
+        and ``E_gs`` is the ground-state energy per site.
     """
     if A_init is None:
         if fpeps_config is None:
@@ -1833,11 +1801,5 @@ def optimize_fpeps_ad(
         from tenax.algorithms.fermionic_ipeps import _build_initial_fpeps_tensor
 
         A_init = _build_initial_fpeps_tensor(fpeps_config)
-
-    # Wrap SymmetricTensor as DenseTensor for stable AD backward pass.
-    # The DenseTensor retains the original index metadata (symmetry,
-    # charges, flows) so the CTM pipeline uses the correct labels.
-    if isinstance(A_init, SymmetricTensor):
-        A_init = DenseTensor(A_init.todense(), A_init.indices)
 
     return _optimize_gs_ad_tensor(hamiltonian_gate, A_init, config)

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -1221,6 +1221,46 @@ class TestADSymmetric:
         assert np.isfinite(E_sym)
         assert np.isfinite(E_dense)
 
+    def test_optimize_gs_ad_nontrivial_u1_preserves_symmetric_type(self):
+        """Regression for #297: optimizer shell must accept a SymmetricTensor
+        with *non-trivial* U(1) charges and return a SymmetricTensor (not
+        silently downgrade to DenseTensor via a .todense() band-aid)."""
+        from tenax.core.index import FlowDirection, TensorIndex
+        from tenax.core.symmetry import U1Symmetry
+        from tenax.core.tensor import SymmetricTensor
+
+        sym = U1Symmetry()
+        # Non-trivial U(1) charges [0, 1] on every leg.  Flow directions
+        # sum to zero (per-charge) so at least the all-zero block exists
+        # and the CTM pipeline can proceed.
+        virt = np.array([0, 1], dtype=np.int32)
+        phys = np.array([0, 1], dtype=np.int32)
+        indices = (
+            TensorIndex.from_charges(sym, virt.copy(), FlowDirection.OUT, label="u"),
+            TensorIndex.from_charges(sym, virt.copy(), FlowDirection.IN, label="d"),
+            TensorIndex.from_charges(sym, virt.copy(), FlowDirection.OUT, label="l"),
+            TensorIndex.from_charges(sym, virt.copy(), FlowDirection.IN, label="r"),
+            TensorIndex.from_charges(sym, phys.copy(), FlowDirection.IN, label="phys"),
+        )
+        A_sym = SymmetricTensor.random_normal(indices, jax.random.PRNGKey(0))
+
+        gate = self._heisenberg_gate()
+        config = iPEPSConfig(
+            max_bond_dim=2,
+            ctm=CTMConfig(chi=4, max_iter=10),
+            gs_num_steps=1,
+            gs_learning_rate=0.01,
+        )
+        A_opt, _env, E_gs = optimize_gs_ad(gate, A_sym, config)
+
+        # Core assertion: the optimizer shell did not silently downgrade
+        # the SymmetricTensor input to a DenseTensor.  Prior to #297 this
+        # would fail because the shell dense-wrapped A upfront.
+        assert isinstance(A_opt, SymmetricTensor), (
+            f"expected SymmetricTensor, got {type(A_opt).__name__}"
+        )
+        assert np.isfinite(E_gs)
+
 
 class TestTensor2SiteSimpleUpdate:
     """Tests for the 2-site Tensor-protocol simple update."""


### PR DESCRIPTION
## Summary

Closes #297.

Makes `_optimize_gs_ad_tensor` and `_optimize_gs_ad_tensor_2site` in `src/tenax/algorithms/ipeps_optimize.py` polymorphic over `DenseTensor` and `SymmetricTensor` by:

1. **Replacing** all `type(X)(dense_array, X.indices)` rebuilds with the existing `ad_utils._wrap_tensor(dense, original)` helper — this dispatches to `SymmetricTensor.from_dense(..., tol=inf)` for `SymmetricTensor` inputs and `DenseTensor(...)` for dense.
2. **Normalizing polymorphically**: `A_norm = params * (1.0 / (params.norm() + 1e-10))` instead of `.todense()` + `jnp.linalg.norm()` + `DenseTensor(...)` re-wrap.
3. **Removing the PR #296 dense-wrap band-aid** at the top of both 1-site and 2-site shells (lines ~601 and ~1233 previously force-downgraded `SymmetricTensor` inputs to `DenseTensor`).
4. **Removing `optimize_fpeps_ad`'s `isinstance(A_init, SymmetricTensor)` force-dense wrap**; updating its docstring.

## Sites fixed

1-site (`_optimize_gs_ad_tensor`):
- `loss_fn` / `loss_fn_fwd` / `_eval_fresh` — polymorphic normalization on non-C4v path
- CG metric-precond `z = _wrap_tensor(z_dense, grads)`
- L-BFGS metric-precond `h0_matvec` and `direction` wraps
- Noise-recovery rewrap

2-site (`_optimize_gs_ad_tensor_2site`):
- Removed band-aid
- CG metric-precond `z` tuple wraps
- L-BFGS `h0_matvec` `grads_v` dict and `direction` tuple wraps
- Noise-recovery rewrap

## Tests

- New: `TestADSymmetric::test_optimize_gs_ad_nontrivial_u1_preserves_symmetric_type` — runs `optimize_gs_ad` on a `SymmetricTensor` with U(1) charges `[0, 1]` on every leg and asserts the returned `A_opt` is still a `SymmetricTensor`. Prior to this PR, the upfront dense-wrap silently downgraded it.
- Existing `TestADSymmetric::test_optimize_gs_ad_symmetric_energy_decreases` (xfail, strict=False) now **xpasses** — with the true block-sparse path (not the dense-wrap workaround), `E_init` and `E_gs` land on compatible fixed points, so the comparison is meaningful again.

## Out of scope

- `precondition_gradient` / `precondition_gradient_multisite` in `_metric_precond.py` still internally `.todense()` the gradient and return a dense array. The output is wrapped back via `_wrap_tensor` → `SymmetricTensor.from_dense(tol=inf)`, so charge structure is preserved but the solve itself loses block sparsity. Making the metric-precond math block-sparse is a separate optimization — tracked as follow-up.
- Multi-site unit cells >2: the shell polymorphism is a precondition for those; feature is still a separate request.
- The fermionic `fermionic_ipeps.py:compute_energy` dense-fallback on `env.C1 is DenseTensor` is a different type-matching concern (energy-eval boundary, not the AD shell) and is left alone.

## Test plan

- [x] `TestADSymmetric` + `TestOptimizeGsAdDenseOnly` all pass (5 passed, 1 xpassed, ~4min)
- [x] New `test_optimize_gs_ad_nontrivial_u1_preserves_symmetric_type` passes (~3min)
- [ ] Full CI (core Python 3.11, 3.12, macOS 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)