### PR TITLE
fix(ipeps): tangent-project 2-site AD direction to close #328

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -178,6 +178,36 @@ def _normalize_params(params):
     return params / (jnp.linalg.norm(params) + 1e-10)
 
 
+def _tangent_project_unit(direction, params):
+    """Project ``direction`` onto the tangent space of the unit-norm
+    constraint ``||p|| = 1`` at ``params``.
+
+    For a constraint ``||p|| = 1``, the tangent space at ``p`` is
+    ``{v : <p, v> = 0}`` and the orthogonal projection of ``v`` is
+    ``v - (<p, v> / <p, p>) p``.  Applied element-wise for tuple
+    parameter trees.
+
+    Used by the 2-site iPEPS AD optimizer to kill the radial component
+    of the search direction before the line search (issue #328).
+    Without this, the Euclidean L-BFGS direction can have a large
+    component along ``A`` (or ``B``) that takes the line search on a
+    long chord into a non-variational CTM region before
+    ``_normalize_params`` retracts the iterate back.  Stale curvature
+    pairs computed on that chord then corrupt subsequent L-BFGS steps.
+    """
+    if isinstance(params, tuple):
+        return tuple(_tangent_project_unit(d, p) for d, p in zip(direction, params))
+    if hasattr(params, "todense"):
+        p_flat = params.todense().reshape(-1)
+        d_flat = direction.todense().reshape(-1)
+        p_norm_sq = jnp.dot(p_flat, p_flat) + 1e-30
+        coef = jnp.dot(p_flat, d_flat) / p_norm_sq
+        return direction - params * coef
+    p_norm_sq = jnp.dot(params, params) + 1e-30
+    coef = jnp.dot(params, direction) / p_norm_sq
+    return direction - coef * params
+
+
 def _backtracking_line_search(
     params,
     direction,
@@ -1582,6 +1612,18 @@ def _optimize_gs_ad_tensor_2site(
         else:
             direction = jax.tree.map(lambda g: -g, grads)
 
+        # Issue #328: kill the radial component of the search direction
+        # so the line-search chord stays on-manifold to first order.
+        # ``_normalize_params`` projects the final iterate back to unit
+        # norm, but the intermediate chord ``params + alpha * direction``
+        # drifts off the sphere proportional to ``alpha * <params, dir>``
+        # — for a Euclidean L-BFGS direction this can be large and push
+        # the line search into non-variational CTM regions before
+        # retraction.  Stale curvature pairs accumulated on that chord
+        # then corrupt subsequent L-BFGS steps.
+        if not use_c4v:
+            direction = _tangent_project_unit(direction, params)
+
         if use_ls:
             if config.gs_line_search_method == "hager_zhang":
                 from tenax.algorithms._line_search import hager_zhang_line_search
@@ -1589,7 +1631,9 @@ def _optimize_gs_ad_tensor_2site(
                 slope = _tree_dot(grads, direction)
                 if slope >= 0:
                     direction = jax.tree.map(lambda g: -g, grads)
-                    slope = -_tree_dot(grads, grads)
+                    if not use_c4v:
+                        direction = _tangent_project_unit(direction, params)
+                    slope = _tree_dot(grads, direction)
                     if is_metric_lbfgs:
                         lbfgs_history.clear()
 
@@ -1633,6 +1677,8 @@ def _optimize_gs_ad_tensor_2site(
                 slope_bt = _tree_dot(grads, direction)
                 if slope_bt >= 0:
                     direction = jax.tree.map(lambda g: -g, grads)
+                    if not use_c4v:
+                        direction = _tangent_project_unit(direction, params)
                     if is_metric_lbfgs:
                         lbfgs_history.clear()
                 params, new_energy, step_size = _backtracking_line_search(

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -740,6 +740,55 @@ class TestOptimizeGsAd2Site:
         assert E_gs > -0.9, f"E/site={E_gs:.6f} unphysically low"
         assert E_gs < -0.50, f"C4v 2-site AD energy {E_gs:.6f} not below -0.50"
 
+    def test_2site_noc4v_ad_stays_variational_issue_328(self, heisenberg_gate):
+        """Regression for #328: 2-site AD with gs_c4v=False must not drift
+        into non-variational CTM territory.
+
+        The issue observed E_best = -33.85 (!!) for gs_c4v=False implicit AD
+        on the same Heisenberg gate at chi=16.  The tangent-space projection
+        of the L-BFGS/CG direction (Option A in the issue) kills the
+        off-manifold chord that pushed the line search into a CTM fixed
+        point where the finite-chi energy is unphysically low.
+
+        This test only asserts E_gs > -2.0 (very loose) — even with the fix
+        there's no finite-chi variational guarantee; what the fix prevents
+        is order-of-magnitude drift.
+        """
+        config = iPEPSConfig(
+            max_bond_dim=2,
+            ctm=CTMConfig(chi=4, max_iter=10),
+            gs_num_steps=5,
+            gs_learning_rate=1e-2,
+            unit_cell="2site",
+            gs_c4v=False,
+        )
+        _, _, E_gs = optimize_gs_ad(heisenberg_gate, None, config)
+        assert np.isfinite(E_gs), f"non-finite E_gs = {E_gs}"
+        assert E_gs > -2.0, (
+            f"E/site = {E_gs:.6f} is wildly unphysical — tangent projection "
+            f"likely broken (#328 regression)"
+        )
+
+    def test_2site_noc4v_ad_norms_stay_unit(self, heisenberg_gate):
+        """Regression for #328: ||A|| and ||B|| must stay ~1 throughout
+        gs_c4v=False 2-site AD.  _normalize_params retracts to unit norm
+        at each step and tangent projection keeps the chord on-manifold,
+        so the returned A_opt / B_opt should have unit norm to high
+        precision."""
+        config = iPEPSConfig(
+            max_bond_dim=2,
+            ctm=CTMConfig(chi=4, max_iter=10),
+            gs_num_steps=5,
+            gs_learning_rate=1e-2,
+            unit_cell="2site",
+            gs_c4v=False,
+        )
+        (A_opt, B_opt), _, _ = optimize_gs_ad(heisenberg_gate, None, config)
+        A_norm = float(jnp.linalg.norm(A_opt.todense().reshape(-1)))
+        B_norm = float(jnp.linalg.norm(B_opt.todense().reshape(-1)))
+        assert abs(A_norm - 1.0) < 1e-4, f"||A_opt|| = {A_norm}, expected ~1.0"
+        assert abs(B_norm - 1.0) < 1e-4, f"||B_opt|| = {B_norm}, expected ~1.0"
+
     @pytest.mark.slow
     def test_2site_heisenberg_ad_energy_benchmark(self, heisenberg_gate):
         """SU + C4v AD at D=2, chi=16 should give a physical energy.


### PR DESCRIPTION
## Summary

Closes #328 with Option A+ (tangent projection, principled variant of the issue's recommended minimal Option A).

Adds ``_tangent_project_unit(direction, params)`` that subtracts the radial component of a search direction from the unit-norm manifold, and applies it in ``_optimize_gs_ad_tensor_2site`` just before the line search whenever ``gs_c4v=False``.

## Rationale

The issue observed ``E_best = -33.85`` for gs_c4v=False 2-site implicit AD on Heisenberg — well below the physical ground state. Its Option A recommendation was *explicit unit-norm retraction of the iterate*. On closer reading, ``_normalize_params`` was already doing that at every accepted step, so literal Option A is essentially a no-op.

What **wasn't** happening: the line-search chord ``params + alpha * direction`` was evaluated **off-manifold**, drifting from the sphere by ``alpha * <p, direction>``. For a Euclidean L-BFGS direction this radial component is large, and the chord takes the line search into a CTM fixed point that is non-variational at finite χ — which is how the -33.85 landed.

This PR kills the radial component of the direction itself, so the chord stays on the sphere to first order:

$$P_T(v) = v - \\frac{\\langle p, v \\rangle}{\\langle p, p \\rangle} p$$

``_normalize_params`` then handles the second-order correction (dividing by ``sqrt(1 + alpha^2 \\|v_T\\|^2)``) at retraction. L-BFGS curvature pairs stored in the Euclidean flat space remain consistent because ``s_k`` and ``y_k`` are now differences of iterates that never leave a ~1e-4 neighborhood of the unit sphere.

## Scope

Strictly 2-site (``_optimize_gs_ad_tensor_2site``), ``gs_c4v=False``. The 1-site and C4v paths are untouched — they're already in production and are not the target of #328.

Sites where projection is applied:
- After direction computation, before line search (L-BFGS / CG / optax / steepest)
- In the Hager-Zhang positive-slope fallback (``direction = -grads``)
- In the backtracking positive-slope fallback

## Tests

- ``test_2site_noc4v_ad_stays_variational_issue_328``: asserts ``E > -2.0`` for gs_c4v=False Heisenberg at D=2 χ=4. Catches order-of-magnitude drift — pre-fix the same optimizer at higher χ hit -33.85.
- ``test_2site_noc4v_ad_norms_stay_unit``: asserts ``|||A_opt|| - 1| < 1e-4`` and same for B, confirming retraction is effective after projection.

Existing 2-site AD tests (``test_2site_ad_runs``, ``test_2site_ad_c4v_runs``, ``test_2site_ad_energy_decreases``) still pass.

## Out of scope

- **Option B** (joint 2×2-block multi-site metric via ``norm_environment_matvec_joint``): larger, requires a new CTM contraction, tracked as follow-up if the remaining instability at larger χ requires it.
- **Option C** (full Riemannian L-BFGS with parallel transport of the curvature history): strictly best but significantly more code; strongly depends on whether Option A+ is already enough.
- 1-site path: has the same Euclidean-vs-sphere coordinate mismatch in principle but is known to work in production with sigma/QR gauge — not in #328's scope.

## Test plan

- [x] New ``test_2site_noc4v_ad_stays_variational_issue_328`` passes
- [x] New ``test_2site_noc4v_ad_norms_stay_unit`` passes (|||A_opt||-1| < 1e-4)
- [x] Existing ``TestOptimizeGsAd2Site::test_2site_ad_runs``, ``test_2site_ad_c4v_runs``, ``test_2site_ad_energy_decreases`` still pass
- [ ] Full CI (core Python 3.11, 3.12, macOS 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)