### PR TITLE
fix(ipeps): Hermitian inner product in _tangent_project_unit

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -200,11 +200,16 @@ def _tangent_project_unit(direction, params):
     if hasattr(params, "todense"):
         p_flat = params.todense().reshape(-1)
         d_flat = direction.todense().reshape(-1)
-        p_norm_sq = jnp.dot(p_flat, p_flat) + 1e-30
-        coef = jnp.dot(p_flat, d_flat) / p_norm_sq
+        # Use ``vdot`` (Hermitian inner product ``p^H v``) rather than
+        # ``dot`` (bilinear ``p^T v``) so the projection works correctly
+        # for complex-valued iPEPS site tensors — matches the optimizer's
+        # ``_tree_dot`` convention elsewhere.  For real tensors this is
+        # equivalent to ``jnp.dot``.
+        p_norm_sq = jnp.vdot(p_flat, p_flat).real + 1e-30
+        coef = jnp.vdot(p_flat, d_flat) / p_norm_sq
         return direction - params * coef
-    p_norm_sq = jnp.dot(params, params) + 1e-30
-    coef = jnp.dot(params, direction) / p_norm_sq
+    p_norm_sq = jnp.vdot(params, params).real + 1e-30
+    coef = jnp.vdot(params, direction) / p_norm_sq
     return direction - coef * params
 
 

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -789,6 +789,48 @@ class TestOptimizeGsAd2Site:
         assert abs(A_norm - 1.0) < 1e-4, f"||A_opt|| = {A_norm}, expected ~1.0"
         assert abs(B_norm - 1.0) < 1e-4, f"||B_opt|| = {B_norm}, expected ~1.0"
 
+    def test_tangent_project_unit_complex_is_hermitian(self):
+        """Regression for PR #330 review: _tangent_project_unit must use
+        the Hermitian inner product (vdot) so complex-valued tensors get
+        their true radial component removed.  With the bilinear jnp.dot
+        from the original PR, ``Re <p, v - coef*p>`` is non-zero for
+        complex inputs and the projection leaks radial drift."""
+        from tenax.algorithms.ipeps_optimize import _tangent_project_unit
+        from tenax.core import DenseTensor, FlowDirection, TensorIndex, U1Symmetry
+
+        sym = U1Symmetry()
+        D, d = 2, 2
+        charges = np.zeros(D, dtype=np.int32)
+        phys = np.zeros(d, dtype=np.int32)
+        indices = (
+            TensorIndex.from_charges(sym, charges.copy(), FlowDirection.OUT, label="u"),
+            TensorIndex.from_charges(sym, charges.copy(), FlowDirection.IN, label="d"),
+            TensorIndex.from_charges(sym, charges.copy(), FlowDirection.OUT, label="l"),
+            TensorIndex.from_charges(sym, charges.copy(), FlowDirection.IN, label="r"),
+            TensorIndex.from_charges(sym, phys.copy(), FlowDirection.IN, label="phys"),
+        )
+        key_p, key_v = jax.random.split(jax.random.PRNGKey(7))
+        # Complex params and complex direction with non-trivial imaginary parts
+        p_real = jax.random.normal(key_p, (D, D, D, D, d))
+        p_imag = jax.random.normal(jax.random.fold_in(key_p, 1), (D, D, D, D, d))
+        v_real = jax.random.normal(key_v, (D, D, D, D, d))
+        v_imag = jax.random.normal(jax.random.fold_in(key_v, 1), (D, D, D, D, d))
+        p_data = (p_real + 1j * p_imag).astype(jnp.complex128)
+        v_data = (v_real + 1j * v_imag).astype(jnp.complex128)
+        p = DenseTensor(p_data / (jnp.linalg.norm(p_data.reshape(-1)) + 1e-10), indices)
+        v = DenseTensor(v_data, indices)
+
+        v_proj = _tangent_project_unit(v, p)
+
+        # The projected direction must be Hermitian-orthogonal to p:
+        # Re(<p, v_proj>_H) ≈ 0 (and ideally also Im ≈ 0 for consistency).
+        p_flat = p.todense().reshape(-1)
+        vproj_flat = v_proj.todense().reshape(-1)
+        inner = jnp.vdot(p_flat, vproj_flat)
+        assert float(jnp.abs(inner.real)) < 1e-10, (
+            f"Re <p, P_T(v)>_H = {inner.real}, expected ~0"
+        )
+
     @pytest.mark.slow
     def test_2site_heisenberg_ad_energy_benchmark(self, heisenberg_gate):
         """SU + C4v AD at D=2, chi=16 should give a physical energy.


### PR DESCRIPTION
## Summary

Addresses P1 review feedback from [codex-connector on PR #330](https://github.com/tenax-lab/tenax/pull/330#discussion_r3084416286): replace ``jnp.dot`` (bilinear ``p^T v``) with ``jnp.vdot`` (Hermitian ``p^H v``) in ``_tangent_project_unit`` so the projection also works for complex-valued iPEPS tensors.

## The bug

In ``src/tenax/algorithms/ipeps_optimize.py::_tangent_project_unit`` the tangent-space coefficient was computed as:

```python
p_norm_sq = jnp.dot(p_flat, p_flat) + 1e-30
coef = jnp.dot(p_flat, d_flat) / p_norm_sq
```

For complex tensors ``jnp.dot`` is the bilinear form ``sum(p * v)``, not the Hermitian form ``sum(conj(p) * v)``.  Under the Hermitian metric (which the rest of the optimizer uses via ``_tree_dot``), the computed ``coef`` does **not** remove the true radial component of the direction, so the projection leaks radial drift — the exact drift #330 was meant to cancel.

## The fix

Use ``jnp.vdot``, which conjugates its first argument:

```python
p_norm_sq = jnp.vdot(p_flat, p_flat).real + 1e-30  # always real
coef = jnp.vdot(p_flat, d_flat) / p_norm_sq
```

For **real** tensors this reduces exactly to the old ``jnp.dot`` form, so existing real-only 2-site AD regression tests (``test_2site_noc4v_ad_stays_variational_issue_328``, ``test_2site_noc4v_ad_norms_stay_unit``) are unchanged and still pass.

For **complex** tensors (fermionic iPEPS, chiral / Kitaev models, complex-TI Heisenberg, ...), the projection is now Hermitian-orthogonal to ``p``.

## Test

New unit test ``TestOptimizeGsAd2Site::test_tangent_project_unit_complex_is_hermitian``:
- Builds a ``DenseTensor`` with complex128 data on a U(1)-trivial index tuple.
- Calls ``_tangent_project_unit(v, p)`` directly.
- Asserts ``|Re <p, P_T(v)>_H| < 1e-10`` — would fail with the old bilinear form whenever ``p`` has a non-trivial imaginary part.

## Test plan

- [x] ``test_tangent_project_unit_complex_is_hermitian`` passes
- [x] ``test_2site_noc4v_ad_stays_variational_issue_328`` still passes (real case unchanged)
- [x] ``test_2site_noc4v_ad_norms_stay_unit`` still passes
- [ ] Full CI (core Python 3.11, 3.12, macOS 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)