### PR TITLE
fix(ipeps): honor gmres_maxiter and drop silent gauge promotion

### DIFF
--- a/src/tenax/algorithms/ipeps_ad_policy.py
+++ b/src/tenax/algorithms/ipeps_ad_policy.py
@@ -41,10 +41,11 @@ def build_ad_ctm_config(config: iPEPSConfig) -> CTMConfig:
     """Return the effective CTMConfig used by iPEPS AD optimizers.
 
     Applies AD-only policy overrides while leaving ``config.ctm`` unchanged.
+    No silent gauge promotion: explicit user choices are preserved.  The
+    defaults (``projector_method="svd"``, ``forward_gauge="phase"``) are
+    already correct for AD paths.
     """
     ctm_cfg = config.ctm
     if config.gs_projector_method is not None:
         ctm_cfg = replace(ctm_cfg, projector_method=config.gs_projector_method)
-    if ctm_cfg.forward_gauge == "qr":
-        ctm_cfg = replace(ctm_cfg, forward_gauge="phase")
     return ctm_cfg

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -61,12 +61,13 @@ class CTMConfig:
     ad_backward_method: str = "vjp"  # "vjp" (iterative VJP) or "gmres" (xfail — #292)
     gmres_tol: float = 1e-6  # tolerance for GMRES backward solve
     gmres_restart: int = 20  # Krylov dimension for GMRES (no outer restarts)
+    gmres_maxiter: int = 200  # max total GMRES iterations (outer budget)
     ctm_conv_method: str = "elementwise"  # "elementwise" or "sv" (singular value)
     # forward_gauge: "phase" (default — Frobenius-norm phase fix per CTM
     # absorption; works for both implicit and explicit AD, 1-site and
     # 2-site).  "sigma" (transfer-matrix eigenvector alignment, 1-site
-    # only), "qr" (legacy, auto-promoted to "phase"), or "none"
-    # (diagnostic).  See ipeps_ad_paths.md.
+    # only), "qr" (legacy), or "none" (diagnostic).  No silent promotion
+    # — explicit user choice is preserved.  See ipeps_ad_paths.md.
     forward_gauge: str = "phase"
     # Optional reference-mode implicit AD mode (App. C-F) for dense 1-site C4v.
     ctm_ad_mode: str | None = None  # None or "c4v_reference"

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -416,9 +416,9 @@ def optimize_gs_ad(
     if config.gs_num_steps < 0:
         raise ValueError(f"gs_num_steps must be >= 0, got {config.gs_num_steps}")
 
-    # Auto-promote projector_backward before dispatch so every downstream
-    # helper (1-site, 2-site, reference-C4v) sees the same CTM config.
-    # Mirrors the forward_gauge "qr" -> "phase" promotion further below.
+    # Resolve projector_backward policy before dispatch so every downstream
+    # helper (1-site, 2-site, reference-C4v) sees the same CTM config.  No
+    # silent gauge promotion — explicit user choices are preserved.
     # See docs/plans/2026-04-13-multisite-c4v-reference-ad-plan.md Task 8.
     config = _resolve_projector_backward(config)
 
@@ -703,7 +703,7 @@ def _optimize_gs_ad_tensor(
                 conv_method=ctm_cfg.ctm_conv_method,
                 min_iter=ctm_cfg.min_iter,
                 gmres_tol=ctm_cfg.gmres_tol,
-                gmres_maxiter=ctm_cfg.gmres_restart,
+                gmres_maxiter=ctm_cfg.gmres_maxiter,
                 gmres_restart=ctm_cfg.gmres_restart,
                 arnoldi_precheck=False,
             )
@@ -1439,7 +1439,7 @@ def _optimize_gs_ad_tensor_2site(
                 conv_method=ctm_cfg_2s.ctm_conv_method,
                 min_iter=ctm_cfg_2s.min_iter,
                 gmres_tol=ctm_cfg_2s.gmres_tol,
-                gmres_maxiter=ctm_cfg_2s.gmres_restart,
+                gmres_maxiter=ctm_cfg_2s.gmres_maxiter,
                 gmres_restart=ctm_cfg_2s.gmres_restart,
                 energy_fn=_energy_fn_2site,
                 arnoldi_precheck=False,
@@ -2107,7 +2107,7 @@ def _optimize_gs_ad_multisite(
                 conv_method=ctm_cfg.ctm_conv_method,
                 min_iter=ctm_cfg.min_iter,
                 gmres_tol=ctm_cfg.gmres_tol,
-                gmres_maxiter=ctm_cfg.gmres_restart,
+                gmres_maxiter=ctm_cfg.gmres_maxiter,
                 gmres_restart=ctm_cfg.gmres_restart,
                 energy_fn=_energy_fn,
                 arnoldi_precheck=False,

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -1773,16 +1773,16 @@ class TestNoiseRecovery:
 
 
 class TestPostPR291ADBaseline:
-    """Regression tests locking down the post-PR-#291 iPEPS AD baseline
-    (issue #292).
+    """Regression tests locking down the post-PR-#341 iPEPS AD baseline.
 
-    After PR #291 the explicit-AD path supports an expanded set of
-    ``forward_gauge`` modes (``qr``, ``sigma``, ``phase``, ``none``) and
-    ``iPEPSConfig`` exposes a new ``gs_ctm_conv_tol_schedule`` knob. The
-    optimizer auto-promotes the conservative default ``forward_gauge="qr"``
-    to ``"phase"`` when ``gs_implicit_ad=False`` and the user has not
-    explicitly opted into a different gauge. These tests pin that behavior
-    so future refactors cannot silently drift off the documented baseline.
+    ``CTMConfig.forward_gauge`` accepts four modes (``qr``, ``sigma``,
+    ``phase``, ``none``) and defaults to ``"phase"`` — the value that is
+    correct for both implicit and explicit AD (1-site and 2-site).  No
+    silent promotion: explicit user choice is preserved by the AD config
+    builder (see ``tests/test_ipeps_ad_policy.py``).  ``iPEPSConfig``
+    exposes a ``gs_ctm_conv_tol_schedule`` knob.  These tests pin that
+    behavior so future refactors cannot silently drift off the documented
+    baseline.
     """
 
     @pytest.fixture
@@ -1800,14 +1800,14 @@ class TestPostPR291ADBaseline:
             cfg = CTMConfig(forward_gauge=mode)
             assert cfg.forward_gauge == mode
 
-    def test_forward_gauge_default_is_conservative_qr(self):
-        """Config default stays ``qr``; auto-phase promotion is runtime-only.
+    def test_forward_gauge_default_is_phase(self):
+        """Config default is ``phase`` — the AD-correct choice.
 
-        Keeping the static default conservative avoids silently changing
-        behavior for callers that construct a ``CTMConfig`` directly (e.g.
-        implicit-diff paths, diagnostics, or notebooks).
+        ``"phase"`` is the correct default for both implicit and explicit
+        AD (1-site and 2-site).  No silent promotion: direct ``CTMConfig()``
+        users get the same behavior the AD optimizer uses.
         """
-        assert CTMConfig().forward_gauge == "qr"
+        assert CTMConfig().forward_gauge == "phase"
 
     def test_gs_ctm_conv_tol_schedule_is_configurable(self):
         """New iPEPSConfig knob from PR #291 is exposed and round-trips."""
@@ -1879,12 +1879,12 @@ class TestPostPR291ADBaseline:
         captured["_real"] = real
         return captured
 
-    def test_explicit_ad_auto_promotes_qr_gauge_to_phase(
+    def test_explicit_ad_preserves_explicit_qr_gauge(
         self, monkeypatch, heisenberg_gate
     ):
-        """``optimize_gs_ad`` auto-switches ``forward_gauge='qr'`` to
-        ``'phase'`` when ``gs_implicit_ad=False`` and the user has not
-        explicitly opted into a non-qr gauge (post-PR-#291 runtime behavior)."""
+        """``optimize_gs_ad`` preserves explicit ``forward_gauge='qr'`` — no
+        silent promotion.  The default is now ``"phase"``; a user who opts
+        into ``"qr"`` explicitly gets ``"qr"``."""
         captured = self._capture_explicit_ad_gauge(monkeypatch)
         config = iPEPSConfig(
             max_bond_dim=2,
@@ -1898,7 +1898,7 @@ class TestPostPR291ADBaseline:
         )
         with pytest.raises(captured["_sentinel"]):
             optimize_gs_ad(heisenberg_gate, None, config)
-        assert captured["forward_gauge"] == "phase"
+        assert captured["forward_gauge"] == "qr"
 
     def test_explicit_ad_respects_explicit_sigma_gauge(
         self, monkeypatch, heisenberg_gate

--- a/tests/test_ipeps_ad_policy.py
+++ b/tests/test_ipeps_ad_policy.py
@@ -22,14 +22,15 @@ def test_build_ad_ctm_config_applies_projector_override_without_mutation():
     assert config.ctm.projector_method == "svd"
 
 
-def test_build_ad_ctm_config_promotes_qr_to_phase():
+def test_build_ad_ctm_config_preserves_explicit_qr_no_silent_promotion():
+    """Explicit user choice of ``forward_gauge="qr"`` is preserved — no silent override."""
     config = iPEPSConfig(
         ctm=CTMConfig(chi=8, forward_gauge="qr"),
     )
 
     updated = build_ad_ctm_config(config)
 
-    assert updated.forward_gauge == "phase"
+    assert updated.forward_gauge == "qr"
     assert config.ctm.forward_gauge == "qr"
 
 


### PR DESCRIPTION
## Summary

Follow-up to PR #341 addressing two P1 review findings:

1. **Adjoint GMRES capped to restart size** — All three AD call sites wired `gmres_maxiter=ctm_cfg.gmres_restart` (default 20), so users requesting a larger iteration budget were silently ignored. Add a `gmres_maxiter: int = 200` field to `CTMConfig` and thread it through at lines 706 (1-site), 1442 (2-site), 2110 (multisite).

2. **Inconsistent gauge promotion policy** — The projector promotion was disabled (`resolve_projector_backward` is now a no-op), but `build_ad_ctm_config` still silently promoted `forward_gauge="qr"` → `"phase"`. Apply the same "no silent overrides" policy:
   - Keep `forward_gauge="phase"` as the static default (AD-correct, matches projector policy).
   - Remove the `"qr" → "phase"` promotion.
   - Update stale tests: baseline default is now `"phase"`; policy test now asserts "preserves `qr`" instead of "promotes `qr`".

## Review comments addressed

- https://github.com/tenax-lab/tenax/pull/341#discussion_r3123232038 (P1 gmres_maxiter 1-site)
- https://github.com/tenax-lab/tenax/pull/341#discussion_r3133676342 (P1 gmres_maxiter multisite)
- https://github.com/tenax-lab/tenax/pull/341#discussion_r3136414938 (P1 forward_gauge default regression)

## Note on unrelated test failures

Five tests in `TestPostPR291ADBaseline` (`test_explicit_ad_*_gauge`, `test_implicit_ad_does_not_auto_promote_gauge`, `test_gs_ctm_conv_tol_schedule_is_applied_across_steps`) use a spy on `ctm_tensor_converge_explicit`, which PR #341 stopped routing through. They are pre-existing failures on main, unrelated to this change. They need a separate update to spy on `ctm_energy_explicit` instead.

## Test plan

- [x] 731 core tests pass
- [x] `test_ipeps_ad_policy.py`: 5 passed (including new `test_build_ad_ctm_config_preserves_explicit_qr_no_silent_promotion`)
- [x] `test_forward_gauge_default_is_phase`: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)