### PR TITLE
ci: skip core tests in test-full to avoid OOM flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,15 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
-      - name: Run all tests
+      - name: Run non-core tests (algorithm + slow + integration)
+        # Skip ``-m core`` since the required ``test`` job already covers it.
+        # Running everything-not-core here avoids duplicating the core suite
+        # (which was contributing to OOM / runner-lost-communication flakes
+        # when the full suite ran end-to-end).
         env:
           JAX_PLATFORMS: cpu
         run: |
-          uv run pytest tests/ \
+          uv run pytest tests/ -m "not core" \
             --cov=tenax \
             --cov-report=xml \
             --cov-report=term-missing \


### PR DESCRIPTION
## Summary

The ``test-full`` matrix was running the entire test suite (1718 tests), duplicating the 731 core tests already covered by the required ``test``, ``test-no-cython``, and ``test-macos`` jobs.  This contributed to OOM / "runner lost communication" flakes (exit 137 / SIGKILL) on the post-merge push-to-main runs (visible after PR #342, #343 merges).

Switch to ``-m \"not core\"`` so test-full runs only the algorithm, slow, and unmarked integration tests (987 tests) that are NOT already covered by required CI.  Preserves end-to-end coverage while cutting the matrix-job runtime / memory footprint by ~42%.

## Test counts (locally)

| Marker | Count |
|--------|-------|
| ``-m core`` (required jobs) | 731 |
| ``-m \"not core\"`` (new test-full) | 987 |
| Total | 1718 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)