### PR TITLE
docs: update guides, skills, and CHANGELOG for post-PR-#341 AD policy

### DIFF
--- a/.claude/skills/tenax-ipeps-workflow/SKILL.md
+++ b/.claude/skills/tenax-ipeps-workflow/SKILL.md
@@ -160,14 +160,18 @@ differentiation (AD) to variationally optimize the iPEPS tensors directly.
 Tenax supports two AD paths:
 
 1. **Implicit AD** (default, recommended): differentiates through the CTM
-   fixed point via VJP iteration (Francuz et al., PRR 7, 013237). Uses
-   sigma gauge (auto-promoted from QR at runtime). Memory-efficient and
-   variational.
-2. **Explicit AD**: backpropagates through unrolled CTM steps. Uses QR
-   projectors with phase gauge. Faster per step but uses more memory.
-   Set `gs_implicit_ad=False` to enable.
+   fixed point via VJP iteration (Francuz et al., PRR 7, 013237).  Uses
+   the AD-correct ``forward_gauge="phase"`` default.  Memory-efficient
+   and variational.
+2. **Explicit AD**: backpropagates through unrolled CTM steps.  Uses QR
+   projectors with the same ``"phase"`` gauge.  Faster per step but
+   uses more memory.  Set `gs_implicit_ad=False` to enable.
 
-### Recommended AD configuration (implicit, sigma gauge)
+No silent gauge promotion in either path — the user's
+``ctm.forward_gauge`` choice (``"phase"``, ``"qr"``, ``"sigma"``,
+``"none"``) is preserved as-is.
+
+### Recommended AD configuration
 
 ```python
 from tenax import iPEPSConfig, CTMConfig, optimize_gs_ad
@@ -177,9 +181,10 @@ config = iPEPSConfig(
     ctm=CTMConfig(
         chi=16,
         max_iter=60,
+        # forward_gauge="phase" is the default — AD-correct for both
+        # implicit and explicit, 1-site and 2-site.
     ),
     # gs_implicit_ad=True is the default (implicit diff + VJP backward)
-    # forward_gauge="qr" is auto-promoted to "sigma" for implicit AD
     gs_optimizer="lbfgs",
     gs_line_search_method="hager_zhang",
     gs_metric_precond=True,
@@ -248,13 +253,15 @@ config = iPEPSConfig(
 
 ### Key AD tips
 
-- **Implicit AD with sigma gauge is the default and recommended path.**
-  The optimizer auto-promotes `forward_gauge="qr"` to `"sigma"` at
-  runtime. Sigma gauge aligns CTM environments via power iteration,
-  making the fixed-point smooth for implicit differentiation.
-- **Explicit AD (`gs_implicit_ad=False`) uses phase gauge.** When set,
-  the optimizer auto-promotes to `"phase"` instead. Use
-  `projector_method="qr"` for best performance with explicit AD.
+- **Default `forward_gauge="phase"` works for both implicit and explicit
+  AD.** variPEPS-style Frobenius normalization + phase fix.  Stable
+  for 1-site and 2-site at chi up to 32+.  No silent promotion: the
+  user's explicit choice is preserved.
+- **Sigma gauge (`forward_gauge="sigma"`)** is required for strict
+  element-wise convergence at large chi (1-site path).  Aligns CTM
+  environments via power iteration of the transfer matrix.
+- **Explicit AD (`gs_implicit_ad=False`)** uses the same `"phase"` gauge.
+  Use `projector_method="qr"` for best performance with explicit AD.
 - **Start with SU init (`su_init=True`).** The simple update provides a good
   starting tensor that avoids bad local minima. Without it, random
   initialization often converges to excited states.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- **Python-loop CTM AD with JIT-fused GMRES backward** — explicit and
+  implicit AD share a Python-loop CTM forward; backward solves
+  `(I − J^T)λ = ∂E/∂env` via JIT-fused GMRES (#340, #341)
+- **Block-sparse CTM/AD** for `SymmetricTensor` iPEPS — `SymmetricTensor`
+  passes through `jax.custom_vjp` as a pytree leaf without `todense()`
+  round-trip; block-sparse Fishman SVD projector (`_svd_projector_symmetric`);
+  sigma gauge fixing and convergence checks preserve `SymmetricTensor`
+  type (#341)
+- **`CTMConfig.gmres_maxiter`** — separate knob for the outer GMRES
+  iteration budget (was wired to `gmres_restart`, capping the adjoint
+  solve at the restart size) (#343)
+
+### Behavior Changes
+
+- **`CTMConfig.forward_gauge` default changed from `"qr"` to `"phase"`** —
+  the AD-correct choice for both implicit and explicit AD (1-site and
+  2-site).  No silent gauge promotion in `optimize_gs_ad`: an explicit
+  user choice is preserved (was previously promoted `"qr"` → `"phase"`
+  for AD paths) (#343)
+- **`build_ad_ctm_config`** no longer promotes `forward_gauge="qr"` to
+  `"phase"`.  Direct `CTMConfig()` users now see the same gauge the
+  optimizer uses (#343)
+
+### Bug Fixes
+
+- Fix `_phase_fix_normalize_tensor` returning `DenseTensor` regardless of
+  input type — `SymmetricTensor` environments are now preserved across
+  CTM sweeps (#341)
+
+### Tests
+
+- Unblock 2 xfail tests now passing: `test_vjp_gradient_finite_with_elementwise`,
+  `test_optimize_gs_ad_symmetric_energy_decreases` (#344)
+- Migrate baseline gauge-policy tests to spy on `ctm_energy_implicit`
+  (the legacy `ctm_tensor_converge_explicit` is no longer routed
+  through by the optimizer) (#344)
+
+### CI
+
+- `test-full` matrix now runs only `-m "not core"` to avoid duplicating
+  the 731 core tests already covered by required jobs.  Eliminates OOM
+  / "runner lost communication" flakes on push to main (#345)
+
 ## v0.4.2 (2026-04-05)
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -319,9 +319,9 @@ gate = jnp.einsum("ij,kl->ikjl", Sz, Sz) + 0.5 * (
 )
 
 # Recommended AD configuration: L-BFGS + explicit AD + QR projectors.
-# The optimizer auto-promotes forward_gauge="qr" to "phase" for the
-# unrolled CTM sweeps (variPEPS-style Frobenius + phase fix). Reaches
-# E=-0.6628 at D=2, chi=16 (literature: -0.6548 at D=2).
+# forward_gauge defaults to "phase" (variPEPS-style Frobenius + phase
+# fix), correct for both implicit and explicit AD. Reaches E=-0.6628
+# at D=2, chi=16 (literature: -0.6548 at D=2).
 config = iPEPSConfig(
     max_bond_dim=2,
     ctm=CTMConfig(

--- a/docs/guide/algorithms/ad_excitations.md
+++ b/docs/guide/algorithms/ad_excitations.md
@@ -95,7 +95,14 @@ ill-defined.
 Tenax provides two gauge-fixing strategies, selected via
 ``CTMConfig.forward_gauge``:
 
-#### QR gauge (``forward_gauge="qr"``, default)
+#### Phase gauge (``forward_gauge="phase"``, default)
+
+Applies **Frobenius normalization + global phase fix** (variPEPS-style)
+to each corner and edge after every CTM step.  Cheapest gauge fix that
+still stabilizes unrolled AD; works for both implicit and explicit AD,
+1-site and 2-site.  See ``docs/guide/algorithms/ctm.md`` for details.
+
+#### QR gauge (``forward_gauge="qr"``)
 
 Applies **QR decomposition** (via ``tenax.linalg.qr``, block-sparse
 for ``SymmetricTensor``) to each corner after every CTM step:

--- a/docs/guide/algorithms/ctm.md
+++ b/docs/guide/algorithms/ctm.md
@@ -52,7 +52,7 @@ ctm_cfg = CTMConfig(
     chi=32,                      # environment bond dimension
     max_iter=100,                # maximum CTM iterations
     conv_tol=1e-10,              # convergence tolerance on corner singular values
-    forward_gauge="qr",         # "qr" (default), "sigma", "phase", or "none"
+    forward_gauge="phase",      # "phase" (default), "qr", "sigma", or "none"
     projector_method="eigh",    # "eigh" (default), "qr", or "svd" (Fishman)
     ad_backward_method="vjp",   # "vjp" (default) or "gmres" (experimental)
 )
@@ -83,17 +83,21 @@ after each CTM sweep. Four modes are supported:
 
 | Value | Description |
 |-------|-------------|
-| ``"qr"`` (default) | QR decomposition on corners with sign-fixed diagonal. Fast and stable for simple update and forward-only CTM. |
-| ``"phase"`` | variPEPS-style Frobenius normalization + phase fixing. Cheapest gauge fix that still stabilizes unrolled AD. **Recommended for explicit AD** and auto-enabled by ``optimize_gs_ad`` when ``gs_implicit_ad=False`` and the user leaves ``forward_gauge="qr"``. |
-| ``"sigma"`` | Transfer-matrix eigenvector alignment via power iteration. Required for the implicit-diff / GMRES backward path where element-wise CTM convergence is needed. |
+| ``"phase"`` (default) | variPEPS-style Frobenius normalization + phase fixing. Cheapest gauge fix that still stabilizes unrolled AD. **Recommended for both implicit and explicit AD** (1-site and 2-site). |
+| ``"qr"`` | Legacy QR decomposition on corners with sign-fixed diagonal. Fast and stable for simple update and forward-only CTM. |
+| ``"sigma"`` | Transfer-matrix eigenvector alignment via power iteration. Required for element-wise CTM convergence at large chi (1-site path). |
 | ``"none"`` | No gauge fix. Diagnostic / benchmark mode only — isolates the cost of gauge fixing from the rest of the sweep. Not recommended for production runs. |
 
 Without a gauge fix, the ``eigh`` projector CTM converges spectrally (corner
 singular values stabilize) but is chaotic element-wise — the individual
 tensor entries keep fluctuating between iterations, which makes implicit
 differentiation ill-conditioned. ``forward_gauge="phase"`` fixes this with
-negligible overhead for explicit AD, while ``forward_gauge="sigma"`` is the
-historical choice that remains appropriate for the implicit-diff path.
+negligible overhead, while ``forward_gauge="sigma"`` is appropriate when
+strict element-wise convergence is needed at large chi.
+
+**No silent gauge promotion.** ``optimize_gs_ad`` passes the configured
+``forward_gauge`` through unchanged.  Set it explicitly to override the
+``"phase"`` default.
 
 ### AD backward method
 

--- a/docs/guide/algorithms/ipeps.md
+++ b/docs/guide/algorithms/ipeps.md
@@ -48,7 +48,7 @@ ctm_config = CTMConfig(
     max_iter=100,        # maximum CTM iterations
     conv_tol=1e-8,       # convergence tolerance on corner singular values
     renormalize=True,
-    forward_gauge="qr",  # "qr" (default), "sigma", "phase", or "none"
+    forward_gauge="phase",  # "phase" (default), "qr", "sigma", or "none"
 )
 
 config = iPEPSConfig(
@@ -67,9 +67,9 @@ fixed after each CTM sweep during the forward pass. Four modes are supported:
 
 | Value | Description |
 |-------|-------------|
-| ``"qr"`` (default) | QR decomposition on each corner with sign-fixed diagonal. Fast and stable for simple update and forward-only CTM. |
-| ``"phase"`` | variPEPS-style Frobenius normalization + phase fixing. Cheapest gauge fix that still stabilizes unrolled AD. **Recommended for explicit AD**. |
-| ``"sigma"`` | Transfer-matrix eigenvector alignment via power iteration. Historical choice — kept for the implicit-diff / GMRES backward path where element-wise convergence is needed. |
+| ``"phase"`` (default) | variPEPS-style Frobenius normalization + phase fixing. Cheapest gauge fix that still stabilizes unrolled AD. **Recommended for both implicit and explicit AD** (1-site and 2-site). |
+| ``"qr"`` | Legacy QR decomposition on each corner with sign-fixed diagonal. Fast and stable for simple update and forward-only CTM. |
+| ``"sigma"`` | Transfer-matrix eigenvector alignment via power iteration. Required for element-wise convergence at large chi (1-site path). |
 | ``"none"`` | No gauge fix. Diagnostic / benchmark mode only. |
 
 **Auto-promotion for explicit AD**: when you call ``optimize_gs_ad`` with

--- a/docs/guide/algorithms/ipeps_ad_paths.md
+++ b/docs/guide/algorithms/ipeps_ad_paths.md
@@ -27,7 +27,7 @@ config = iPEPSConfig(
         max_iter=80,
         conv_tol=1e-8,
         projector_method="qr",  # fastest, best energy, scales to chi=64+
-        # forward_gauge auto-set to "phase" for explicit AD
+        # forward_gauge defaults to "phase" (AD-correct for 1-site and 2-site)
     ),
     gs_implicit_ad=False,
     gs_explicit_ad_steps=30,
@@ -97,10 +97,10 @@ gauge for equal or better energy.
 **Configuration**:
 - `gs_implicit_ad=False` — backprop through unrolled steps (explicit AD, default).
 - `gs_projector_method="qr"` — QR projectors (recommended for explicit AD).
-- `forward_gauge="qr"` (config default) — `optimize_gs_ad` auto-promotes to
-  `"phase"` at runtime when `gs_implicit_ad=False`. Users can override with
-  `forward_gauge="sigma"` (historical path) or `forward_gauge="none"`
-  (diagnostic); see the mode table below.
+- `forward_gauge="phase"` (config default, AD-correct).  Users can
+  override with `forward_gauge="sigma"` (historical path), `"qr"`
+  (legacy), or `"none"` (diagnostic); see the mode table below.  No
+  silent promotion — explicit user choice is preserved.
 - `projector_backward="auto"` (config default) — when `projector_method="eigh"`
   and `gs_implicit_ad=False`, `optimize_gs_ad` auto-promotes to `"lorentzian"`,
   routing the projector VJP through the Francuz–Schuch–Vanhecke
@@ -261,21 +261,22 @@ config = iPEPSConfig(
 
 ## Forward Gauge Mode Matrix
 
-Post-PR-#291 Tenax supports four ``forward_gauge`` modes. Their intended
-use is summarized below:
+Tenax supports four ``forward_gauge`` modes. Their intended use is
+summarized below:
 
 | Mode | Explicit AD (Path 1) | Implicit AD (Path 2, VJP) | Notes |
 |------|----------------------|----------------------------|-------|
-| ``"qr"`` (static default) | Auto-promoted to ``"phase"`` when ``gs_implicit_ad=False`` | Works for simple cases but not preferred | Conservative default for callers that construct ``CTMConfig`` directly. |
-| ``"phase"`` | **Recommended** | Not validated | Cheapest gauge fix; Frobenius + differentiable phase fix. |
-| ``"sigma"`` | Historical — still correct but ~6–9× slower than phase | **Required** for stable element-wise convergence | Power iteration (30 steps) per sweep. |
+| ``"phase"`` (default) | **Recommended** | **Recommended** | Cheapest gauge fix; Frobenius + differentiable phase fix. Works for 1-site and 2-site. |
+| ``"qr"`` | Legacy QR gauge | Works for simple cases but not preferred | Forward-only CTM, notebooks, diagnostics. |
+| ``"sigma"`` | Historical — still correct but ~6–9× slower than phase | Required for element-wise convergence at large chi (1-site only) | Power iteration (30 steps) per sweep. |
 | ``"none"`` | Benchmark / diagnostic only | Unstable | Isolates gauge-fix cost from projector cost. |
 
-The auto-promotion rule lives in ``optimize_gs_ad``: when
-``gs_implicit_ad=False`` and ``ctm.forward_gauge == "qr"`` (the static default),
-the optimizer replaces the forward gauge with ``"phase"`` for the run. If the
-user explicitly sets ``forward_gauge`` to any other value (``"sigma"``,
-``"phase"``, or ``"none"``), that choice is respected without modification.
+**No silent gauge promotion**: ``optimize_gs_ad`` passes
+``ctm.forward_gauge`` through unchanged.  An explicit user choice
+(``"qr"``, ``"sigma"``, ``"phase"``, or ``"none"``) is always
+respected.  This was previously achieved through an auto-promotion of
+``"qr"`` → ``"phase"``; the promotion was removed in PR #343 in favor
+of a sensible static default.
 
 The GMRES backward (``ad_backward_method="gmres"``) is tracked as an open
 gap — see issue #292 and the ``xfail``-marked regression test in

--- a/docs/guide/tuning.md
+++ b/docs/guide/tuning.md
@@ -84,15 +84,19 @@ which AD path pairs with which gauge.
 
 ### `CTMConfig.forward_gauge`
 
-Values: `"qr"` (default), `"phase"`, `"sigma"`, `"none"`
+Values: `"phase"` (default), `"qr"`, `"sigma"`, `"none"`
 
-- `"qr"`: forward-only CTM, notebooks, diagnostics. `optimize_gs_ad`
-  auto-promotes this to `"phase"` when `gs_implicit_ad=False`.
-- `"phase"`: explicit-AD default after promotion. Numerically stable
-  for unrolled backprop.
-- `"sigma"`: required for the implicit-diff path at D ≥ 2. Aligns each
-  sweep's output to the previous sweep's input, stabilizing the VJP.
-- `"none"`: diagnostic only. Expect instabilities.
+- `"phase"`: AD-correct default. variPEPS-style Frobenius normalization
+  + phase fix per absorption.  Stable for both implicit and explicit
+  AD (1-site and 2-site).
+- `"qr"`: legacy QR gauge.  Forward-only CTM, notebooks, diagnostics.
+  Explicit user choice is preserved — no silent promotion.
+- `"sigma"`: transfer-matrix eigenvector alignment, required for
+  element-wise CTM convergence at large chi.  1-site path only.
+- `"none"`: diagnostic only.  Expect instabilities.
+
+**No silent gauge promotion** in AD paths: if you pass `"qr"` you get
+`"qr"`.  Set `forward_gauge` explicitly to override the default.
 
 ### `CTMConfig.ad_regularize_svd` (default `True`)
 
@@ -254,6 +258,22 @@ These don't change numerics (within tolerance) but speed things up.
 
 Diagonal scaling preconditioner for the GMRES implicit-diff backward.
 Currently experimental — do not turn on for production.
+
+### `CTMConfig.gmres_maxiter` (default `200`)
+
+Maximum total GMRES iterations for the implicit-AD backward solve.
+The Krylov restart size is set by `gmres_restart` (default 20); the
+outer iteration budget is `gmres_maxiter`.  Increase when difficult
+CTM fixed points (large chi, near-critical) need more iterations to
+satisfy `gmres_tol`; decrease to bound runtime when accepting a
+looser solve.
+
+### `CTMConfig.gmres_restart` (default `20`)
+
+Krylov dimension between restarts in GMRES.  Larger restart values
+give better convergence per outer iteration but use more memory
+(quadratic in `gmres_restart`).  Default 20 balances memory and
+convergence for typical iPEPS adjoint systems.
 
 ### `CTMConfig.chi_ramp` (default `None`)
 

--- a/docs/ipeps-code-paths.md
+++ b/docs/ipeps-code-paths.md
@@ -72,9 +72,9 @@ Paths marked **BROKEN** are known non-functional. Paths marked
  │ warmup (stop_gradient)       │                           │
  │ ──── W steps ────            │                ┌──────────┴─────────┐
  │                              │                │                    │
- │ auto-phase gauge promotion:  │                ▼                    ▼
- │  qr → phase when user left   │         ctm_ad_mode=None      ctm_ad_mode=
- │  forward_gauge="qr"          │         (custom_vjp           "c4v_reference"
+ │ forward_gauge: passed         │                ▼                    ▼
+ │   through unchanged           │         ctm_ad_mode=None      ctm_ad_mode=
+ │   (no silent promotion)       │         (custom_vjp           "c4v_reference"
  │                              │          ctm_tensor_converge) (Francuz et al.,
  │ backprop (jax.checkpoint)    │                               dense 1-site
  │ ──── B steps ────            │          ┌───────┼───────┐    C4v, opt-in)
@@ -142,12 +142,12 @@ Legend:
 
 ## Recommended Path (post-PR-#291)
 
-For AFM models on the square lattice, the post-PR-#291 recommended path is
-sublattice rotation + C4v + explicit AD + QR projectors. The optimizer
-transparently promotes the conservative default ``forward_gauge="qr"`` to
-``"phase"`` (variPEPS-style Frobenius + phase fix) for the unrolled CTM
-sweeps, which is 6–9× faster than the historical sigma gauge with equal or
-better energy.
+For AFM models on the square lattice, the recommended path is
+sublattice rotation + C4v + explicit AD + QR projectors.  The default
+``forward_gauge="phase"`` (variPEPS-style Frobenius + phase fix) is
+used for the unrolled CTM sweeps, which is 6–9× faster than the
+historical sigma gauge with equal or better energy.  Explicit user
+choices for ``forward_gauge`` are preserved without silent promotion.
 
 ```python
 from tenax import (
@@ -317,18 +317,18 @@ for the full benchmark table and the projector × gauge comparison matrix.
 | Backward              | ``ad_backward_method``      | ``"vjp"``        | ``"gmres"`` (BROKEN — issue #292)    |
 | Projector             | ``projector_method``        | ``"eigh"``       | ``"qr"`` (recommended) / ``"svd"``   |
 | Projector backward    | ``projector_backward``      | ``"auto"``       | ``"standard"`` / ``"lorentzian"`` (auto-promoted to lorentzian when ``gs_implicit_ad=False`` and ``projector_method="eigh"``) |
-| Forward gauge         | ``forward_gauge``           | ``"qr"``         | ``"phase"`` / ``"sigma"`` / ``"none"`` |
+| Forward gauge         | ``forward_gauge``           | ``"phase"``      | ``"qr"`` / ``"sigma"`` / ``"none"`` (no silent promotion) |
 | Conv tol schedule     | ``gs_ctm_conv_tol_schedule``| ``None``         | ``[(frac, tol), ...]``               |
 | Metric precond        | ``gs_metric_precond``       | ``True``         | ``False`` = standard grad            |
 | Stall recovery        | ``gs_stall_recovery``       | ``None``         | ``"noise"`` / ``"reset"`` (auto)     |
 | Energy floor          | ``gs_energy_floor``         | ``None``         | ``float`` = reject below as non-variational |
 | CTM variant           | (function choice)           | standard         | split, C4v                           |
 
-The static default ``forward_gauge="qr"`` is kept conservative so that
-callers who construct a ``CTMConfig`` directly (forward-only CTM,
-notebooks, diagnostics) see predictable behavior.  ``optimize_gs_ad``
-auto-promotes to ``"phase"`` at runtime when ``gs_implicit_ad=False`` and
-the user has not opted into a different gauge.
+The static default ``forward_gauge="phase"`` is the AD-correct choice
+for both implicit and explicit AD (1-site and 2-site).  ``optimize_gs_ad``
+passes the user's configured gauge through unchanged — no silent
+promotion of any value.  Direct ``CTMConfig()`` users get the same
+behavior the optimizer uses.
 
 ## Key Files
 


### PR DESCRIPTION
## Summary

Reflects the changes from PRs #340/#341/#343/#344 in user-facing documentation:

- ``forward_gauge`` static default is now ``\"phase\"`` (was ``\"qr\"``); no silent gauge promotion in AD paths.
- ``CTMConfig.gmres_maxiter`` field documented in tuning.md.
- AD config table in docs/ipeps-code-paths.md updated to reflect new default + no-promotion policy; flow diagram comment fixed.
- iPEPS AD paths guide rewritten so the gauge mode matrix shows ``\"phase\"`` as the default and removes the auto-promotion narrative.
- CTM guide reorders gauge mode table with ``\"phase\"`` first.
- ad_excitations.md gains a new "Phase gauge" subsection.
- README.md feature comment updated.
- tenax-ipeps-workflow skill now describes the no-promotion policy.
- CHANGELOG.md gets an Unreleased entry covering #340/#341/#343/#344/#345.

## Test plan

- [x] ``uv run --extra docs sphinx-build -W -b html docs/ docs/_build/html`` passes with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)