### PR TITLE
feat(ipeps): coarse-grained iPEPS for honeycomb and kagome lattices

### DIFF
--- a/src/tenax/__init__.py
+++ b/src/tenax/__init__.py
@@ -125,6 +125,11 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     # _tensor_utils
     "fuse_indices": ("tenax.algorithms._tensor_utils", "fuse_indices"),
     "split_index": ("tenax.algorithms._tensor_utils", "split_index"),
+    # coarse_grain
+    "CGGates": ("tenax.algorithms.coarse_grain", "CGGates"),
+    "compute_energy_cg": ("tenax.algorithms.coarse_grain", "compute_energy_cg"),
+    "honeycomb_cg_gates": ("tenax.algorithms.coarse_grain", "honeycomb_cg_gates"),
+    "kagome_cg_gates": ("tenax.algorithms.coarse_grain", "kagome_cg_gates"),
     # auto_mpo
     "AutoMPO": ("tenax.algorithms.auto_mpo", "AutoMPO"),
     "HamiltonianTerm": ("tenax.algorithms.auto_mpo", "HamiltonianTerm"),
@@ -356,6 +361,11 @@ __all__ = [
     "compute_energy_split_ctm",
     "optimize_gs_ad",
     "optimize_gs_ad_chi_schedule",
+    # Coarse-grained iPEPS (honeycomb / kagome via 1-site square pipeline)
+    "CGGates",
+    "compute_energy_cg",
+    "honeycomb_cg_gates",
+    "kagome_cg_gates",
     # Standard CTM (Tensor protocol)
     "CTMTensorEnv",
     "ctm_tensor",

--- a/src/tenax/algorithms/_ctm_tensor_energy.py
+++ b/src/tenax/algorithms/_ctm_tensor_energy.py
@@ -7,6 +7,8 @@ __all__ = [
     "_rdm1x2_tensor_2site",
     "_rdm2x1_tensor",
     "_rdm2x1_tensor_2site",
+    "_rdm_1site_tensor",
+    "_rdm_diagonal_tensor",
     "compute_energy_ctm_tensor",
     "compute_energy_ctm_tensor_2site",
     "compute_energy_ctm_tensor_multisite",
@@ -18,10 +20,150 @@ import jax.numpy as jnp
 from tenax.algorithms._ctm_tensor_init import (
     CTMTensorEnv,
     _build_double_layer_open_tensor,
+    _build_double_layer_tensor,
 )
 from tenax.contraction.contractor import contract
 from tenax.core import EPS
 from tenax.core.tensor import Tensor
+
+
+def _rdm_1site_tensor(A: Tensor, env: CTMTensorEnv) -> jax.Array:
+    """Single-site RDM using label-based Tensor contractions.
+
+    Contracts the network::
+
+        C1 — T1 — C2
+        |      |      |
+        T4   ao     T2
+        |      |      |
+        C4 — T3 — C3
+
+    Where ``ao = _build_double_layer_open_tensor(A)`` has labels
+    ``(u2, d2, l2, r2, phys, phys_bra)``.
+
+    Returns dense RDM of shape ``(d, d)`` in ``(phys, phys_bra)`` convention,
+    symmetrised and trace-normalised.
+    """
+    ao = _build_double_layer_open_tensor(A)  # (u2, d2, l2, r2, phys, phys_bra)
+
+    # Step 1: top row = C1 · T1 · C2
+    C1 = env.C1.relabel("c1_r", "t1_l")
+    C2 = env.C2.relabel("c2_l", "t1_r")
+    C1_T1 = contract(C1, env.T1)  # (c1_d, u2, t1_r)
+    top_row = contract(C1_T1, C2)  # (c1_d, u2, c2_d)
+
+    # Step 2: bottom row = C4 · T3 · C3
+    C4 = env.C4.relabel("c4_u", "t3_r")
+    C3 = env.C3.relabel("c3_l", "t3_l")
+    C4_T3 = contract(C4, env.T3)  # (c4_r, d2, t3_l)
+    bot_row = contract(C4_T3, C3)  # (c4_r, d2, c3_u)
+
+    # Step 3: add T4 — connects c1_d ↔ t4_d, t4_u ↔ c4_r
+    T4 = env.T4.relabels({"t4_d": "c1_d", "t4_u": "c4_r"})
+    top_T4 = contract(top_row, T4)  # (u2, c2_d, l2, c4_r)
+
+    # Step 4: add T2 — connects c2_d ↔ t2_u, t2_d ↔ c3_u
+    T2 = env.T2.relabels({"t2_u": "c2_d", "t2_d": "c3_u"})
+    top_T4_T2 = contract(top_T4, T2)  # (u2, l2, c4_r, r2, c3_u)
+
+    # Step 5: contract with bottom row (shared: c4_r, c3_u; also d2)
+    env_full = contract(top_T4_T2, bot_row)  # (u2, l2, r2, d2)
+
+    # Step 6: contract full environment with ao (shared: u2, d2, l2, r2)
+    rdm_t = contract(
+        env_full,
+        ao,
+        output_labels=["phys", "phys_bra"],
+    )
+
+    rdm = rdm_t.todense()
+    rdm = 0.5 * (rdm + rdm.conj().T)
+    rdm = rdm / (jnp.trace(rdm) + EPS)
+    return rdm
+
+
+def _rdm_diagonal_tensor(A: Tensor, env: CTMTensorEnv) -> jax.Array:
+    r"""Diagonal (NNN) 2-site RDM from a 2×2 plaquette contraction.
+
+    Top-left (TL) and bottom-right (BR) sites have physical legs open;
+    top-right (TR) and bottom-left (BL) have physical legs traced (closed).
+
+    Returns dense RDM of shape ``(d, d, d, d)`` in
+    ``(s1_ket, s2_ket, s1_bra, s2_bra)`` convention (TL=s1, BR=s2),
+    symmetrised and trace-normalised.
+    """
+    ao = _build_double_layer_open_tensor(A)  # (u2, d2, l2, r2, phys, phys_bra)
+    ac = _build_double_layer_tensor(A)  # (u2, d2, l2, r2)
+
+    # Right-column copies (suffix R)
+    T1_R = env.T1.relabels({"t1_l": "t1_lR", "u2": "u2R", "t1_r": "t1_rR"})
+    T3_R = env.T3.relabels({"t3_r": "t3_rR", "d2": "d2R", "t3_l": "t3_lR"})
+
+    # Bottom-row copies (suffix B)
+    T4_B = env.T4.relabels({"t4_d": "t4_dB", "l2": "l2B", "t4_u": "t4_uB"})
+    T2_B = env.T2.relabels({"t2_u": "t2_uB", "r2": "r2B", "t2_d": "t2_dB"})
+
+    # Site tensors
+    ac_TR = ac.relabels({"u2": "u2R", "d2": "d2_TR", "l2": "l2_TR", "r2": "r2R"})
+    ac_BL = ac.relabels({"u2": "u2_BL", "d2": "d2B_BL", "l2": "l2B", "r2": "r2_BL"})
+    ao_BR = ao.relabels(
+        {
+            "u2": "u2_BR",
+            "d2": "d2R",
+            "l2": "l2_BR",
+            "r2": "r2B",
+            "phys": "phys_BR",
+            "phys_bra": "phys_bra_BR",
+        }
+    )
+
+    # Left half: C1 · T1_L · T4_T · ao_TL · T4_B · ac_BL · C4 · T3_L
+    C1 = env.C1.relabel("c1_r", "t1_l")
+    C1_T1L = contract(C1, env.T1)
+    T4_T = env.T4.relabels({"t4_d": "c1_d"})
+    left_top = contract(C1_T1L, T4_T)
+    left_top_ao = contract(left_top, ao)
+    T4_B = T4_B.relabel("t4_dB", "t4_u")
+    left_mid = contract(left_top_ao, T4_B)
+    ac_BL = ac_BL.relabel("u2_BL", "d2")
+    left_site = contract(left_mid, ac_BL)
+    C4 = env.C4.relabel("c4_u", "t3_r")
+    C4_T3L = contract(C4, env.T3)
+    C4_T3L = C4_T3L.relabels({"c4_r": "t4_uB", "d2": "d2B_BL"})
+    left_half = contract(left_site, C4_T3L)
+
+    # Right half: C2 · T1_R · T2_T · ac_TR · T2_B · ao_BR · C3 · T3_R
+    C2 = env.C2.relabel("c2_l", "t1_rR")
+    T1R_C2 = contract(T1_R, C2)
+    T2_T = env.T2.relabels({"t2_u": "c2_d"})
+    right_top = contract(T1R_C2, T2_T)
+    ac_TR = ac_TR.relabel("r2R", "r2")
+    right_top_ac = contract(right_top, ac_TR)
+    T2_B = T2_B.relabel("t2_uB", "t2_d")
+    right_mid = contract(right_top_ac, T2_B)
+    ao_BR = ao_BR.relabel("u2_BR", "d2_TR")
+    right_site = contract(right_mid, ao_BR)
+    C3 = env.C3.relabel("c3_l", "t3_lR")
+    T3R_C3 = contract(T3_R, C3)
+    T3R_C3 = T3R_C3.relabel("c3_u", "t2_dB")
+    right_half = contract(right_site, T3R_C3)
+
+    # Combine left and right halves
+    right_half = right_half.relabels(
+        {"t1_lR": "t1_r", "l2_TR": "r2", "l2_BR": "r2_BL", "t3_rR": "t3_l"}
+    )
+    rdm_t = contract(
+        left_half,
+        right_half,
+        output_labels=["phys", "phys_BR", "phys_bra", "phys_bra_BR"],
+    )
+
+    rdm = rdm_t.todense()
+    d = rdm.shape[0]
+    rdm_mat = rdm.reshape(d * d, d * d)
+    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
+    rdm_mat = rdm_mat / (jnp.trace(rdm_mat) + EPS)
+    return rdm_mat.reshape(d, d, d, d)
 
 
 def _rdm2x1_tensor(A: Tensor, env: CTMTensorEnv) -> jax.Array:

--- a/src/tenax/algorithms/coarse_grain.py
+++ b/src/tenax/algorithms/coarse_grain.py
@@ -1,0 +1,291 @@
+"""Coarse-grained iPEPS gate construction for non-square lattices.
+
+Maps non-square lattices (honeycomb, kagome, ...) onto the 1-site
+square-lattice iPEPS pipeline by grouping physical sites into a single
+coarse-grained tensor with effective physical dimension d_eff.
+"""
+
+from __future__ import annotations
+
+__all__ = ["CGGates", "honeycomb_cg_gates", "kagome_cg_gates", "compute_energy_cg"]
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+
+from tenax.algorithms._ctm_tensor_energy import (
+    _rdm1x2_tensor,
+    _rdm2x1_tensor,
+    _rdm_1site_tensor,
+)
+from tenax.algorithms._ctm_tensor_init import CTMTensorEnv
+from tenax.core.tensor import Tensor
+
+
+@dataclass(frozen=True)
+class CGGates:
+    """Coarse-grained Hamiltonian gates and parameterization.
+
+    Attributes:
+        h_intra:  Intra-cell interaction, shape ``(d_eff, d_eff)``
+                  where ``d_eff = d ** n_sites``.
+        h_inter:  Inter-cell interactions, a dict mapping direction labels
+                  (e.g. ``"h"``, ``"v"``) to rank-4 tensors of shape
+                  ``(d_eff, d_eff, d_eff, d_eff)``.
+        n_sites:  Number of physical sites per coarse-grained tensor.
+        map_fn:   Callable that contracts raw site tensors into a CG tensor.
+                  Signature: ``map_fn(*params) -> jnp.ndarray`` of shape
+                  ``(D, D, D, D, d_eff)``.  When ``None``, the optimizer
+                  treats the CG tensor itself as the variational parameter.
+        init_fn:  Callable that creates initial site tensors.
+                  Signature: ``init_fn(D, key) -> tuple[jnp.ndarray, ...]``.
+                  When ``None``, a random CG tensor is used directly.
+    """
+
+    h_intra: jnp.ndarray
+    h_inter: dict[str, jnp.ndarray]
+    n_sites: int
+    map_fn: Callable | None = None
+    init_fn: Callable | None = None
+
+
+def _ss_2site(dtype=jnp.float64) -> jnp.ndarray:
+    """Return the (4,4) Heisenberg S*S matrix for two spin-1/2 sites.
+
+    Uses the identity  S_1 . S_2 = Sz Sz + 0.5 (S+ S- + S- S+).
+    Basis ordering: |00>, |01>, |10>, |11>  (computational / product basis).
+    """
+    h = jnp.zeros((4, 4), dtype=dtype)
+    # Sz Sz: diagonal in product basis
+    # |00>: +1/4,  |01>: -1/4,  |10>: -1/4,  |11>: +1/4
+    h = h.at[0, 0].set(0.25)
+    h = h.at[1, 1].set(-0.25)
+    h = h.at[2, 2].set(-0.25)
+    h = h.at[3, 3].set(0.25)
+    # 0.5 * (S+ S- + S- S+): off-diagonal swap terms
+    # S+_1 S-_2: |10> -> |01>, so <01|S+S-|10> = 1  -> factor 0.5
+    # S-_1 S+_2: |01> -> |10>, so <10|S-S+|01> = 1  -> factor 0.5
+    h = h.at[1, 2].set(0.5)
+    h = h.at[2, 1].set(0.5)
+    return h
+
+
+def honeycomb_cg_gates(J: float = 1.0, dtype=jnp.float64) -> CGGates:
+    """Build coarse-grained Hamiltonian gates for the honeycomb lattice.
+
+    The honeycomb lattice has 2 sub-sites (a, b) per coarse-grained tensor,
+    connected by the x-link.  Physical index ordering: |phys_a, phys_b>.
+    d_eff = 4 (two spin-1/2 sites).
+
+    Inter-cell links:
+        - y-link (vertical, ``"v"``): connects phys_b of CG tensor 1 to
+          phys_a of CG tensor 2.  Operator: I_a1 x H_{b1,a2} x I_b2.
+        - z-link (horizontal, ``"h"``): connects phys_a of CG tensor 1 to
+          phys_b of CG tensor 2.  Operator acts on indices (0, 3).
+
+    Args:
+        J:      Coupling constant (default 1.0).
+        dtype:  Data type for the arrays.
+
+    Returns:
+        A :class:`CGGates` instance.
+    """
+    ss = _ss_2site(dtype)  # (4, 4) = (d_a d_b, d_a d_b)
+
+    # --- intra-cell: x-link, S_a . S_b on the product space ---
+    h_intra = J * ss
+
+    # --- inter-cell gates as rank-4 tensors (d_eff, d_eff, d_eff, d_eff) ---
+    # Each CG tensor has basis |a, b> with d=2 each, so d_eff=4.
+    # Gate legs: (site1_out, site2_out, site1_in, site2_in) where
+    # site_k = (a_k, b_k), then reshaped to d_eff.
+
+    d = 2  # single-site dimension
+    eye = jnp.eye(d, dtype=dtype)
+    ss_2x2 = ss.reshape(d, d, d, d)  # H[i,j,k,l] acting on two d=2 sites
+
+    # y-link ("v"): S_{b1} . S_{a2}  --  I_{a1} x H_{b1,a2} x I_{b2}
+    # 8-leg tensor: h_v[a1, b1, a2, b2, a1', b1', a2', b2']
+    #   = eye[a1,a1'] * ss_2x2[b1,a2,b1',a2'] * eye[b2,b2']
+    h_v_8leg = jnp.einsum("ae,bcfg,dh->abcdefgh", eye, ss_2x2, eye)
+    h_v_gate = J * h_v_8leg.reshape(4, 4, 4, 4)
+
+    # z-link ("h"): S_{a1} . S_{b2}  --  H_{a1,b2} x I_{b1} x I_{a2}
+    # 8-leg tensor: h_h[a1, b1, a2, b2, a1', b1', a2', b2']
+    #   = ss_2x2[a1,b2,a1',b2'] * eye[b1,b1'] * eye[a2,a2']
+    h_h_8leg = jnp.einsum("adeh,bf,cg->abcdefgh", ss_2x2, eye, eye)
+    h_h_gate = J * h_h_8leg.reshape(4, 4, 4, 4)
+
+    h_inter = {"v": h_v_gate, "h": h_h_gate}
+
+    def _honeycomb_map(t1: jnp.ndarray, t2: jnp.ndarray) -> jnp.ndarray:
+        """Contract two honeycomb site tensors into a CG square-lattice tensor.
+
+        t1: (D, D, d, D_x) — legs [left, down, phys_a, x_right]
+        t2: (D_x, d, D, D) — legs [x_left, phys_b, right, up]
+        Result: (D, D, d*d, D, D) reshaped to (left, down, d_eff, right, up)
+                then transposed to (up, down, left, right, d_eff).
+        """
+        # Contract over x-link: t1 axis 3 with t2 axis 0
+        cg = jnp.tensordot(t1, t2, ((3,), (0,)))
+        # cg shape: (D_l, D_d, d_a, d_b, D_r, D_u) = (l, d, sa, sb, r, u)
+        D_l, D_d, d_a, d_b, D_r, D_u = cg.shape
+        # Fuse physical dims, reorder to (u, d, l, r, phys)
+        cg = cg.reshape(D_l, D_d, d_a * d_b, D_r, D_u)
+        return cg.transpose(4, 1, 0, 3, 2)  # (u, d, l, r, phys)
+
+    def _honeycomb_init(D: int, key: jax.Array) -> tuple[jnp.ndarray, jnp.ndarray]:
+        """Random initialization for two honeycomb site tensors."""
+        k1, k2 = jax.random.split(key)
+        t1 = jax.random.normal(k1, (D, D, d, D))  # (l, d, phys_a, x)
+        t2 = jax.random.normal(k2, (D, d, D, D))  # (x, phys_b, r, u)
+        return (t1, t2)
+
+    return CGGates(
+        h_intra=h_intra,
+        h_inter=h_inter,
+        n_sites=2,
+        map_fn=_honeycomb_map,
+        init_fn=_honeycomb_init,
+    )
+
+
+def _embed_inter(site_1: int, site_2: int, d: int = 2, n_sites: int = 3):
+    """Embed S*S between sub-site *site_1* of CG tensor 1 and *site_2* of CG tensor 2.
+
+    Returns a rank-4 tensor of shape ``(d_eff, d_eff, d_eff, d_eff)`` where
+    ``d_eff = d ** n_sites``.  Legs are ``(cg1_out, cg2_out, cg1_in, cg2_in)``.
+    """
+    import numpy as np
+
+    d_eff = d**n_sites
+    Sz = np.array([[0.5, 0], [0, -0.5]])
+    Sp = np.array([[0, 1.0], [0, 0]])
+    Sm = np.array([[0, 0], [1.0, 0]])
+    eye = np.eye(d)
+    result = np.zeros((d_eff, d_eff, d_eff, d_eff))
+    for Sa, Sb in [(Sz, Sz), (0.5 * Sp, Sm), (0.5 * Sm, Sp)]:
+        # Build operator for CG tensor 1: identity on all sub-sites except site_1
+        op1 = [eye.copy() for _ in range(n_sites)]
+        op1[site_1] = Sa
+        kron1 = op1[0]
+        for o in op1[1:]:
+            kron1 = np.kron(kron1, o)
+        # Build operator for CG tensor 2: identity on all sub-sites except site_2
+        op2 = [eye.copy() for _ in range(n_sites)]
+        op2[site_2] = Sb
+        kron2 = op2[0]
+        for o in op2[1:]:
+            kron2 = np.kron(kron2, o)
+        # Outer product: result[i,j,k,l] += kron1[i,k] * kron2[j,l]
+        result += np.einsum("ik,jl->ijkl", kron1, kron2)
+    return result
+
+
+def kagome_cg_gates(J: float = 1.0, dtype=jnp.float64) -> CGGates:
+    """Build coarse-grained Hamiltonian gates for the kagome lattice.
+
+    Three kagome sub-sites (u, v, w) in an up-triangle fuse into one
+    coarse-grained tensor with ``d_eff = 2**3 = 8``.  Physical index
+    ordering: ``|phys_u, phys_v, phys_w>``.
+
+    Intra-cell interaction:
+        ``H_tri = S_u . S_v + S_u . S_w + S_v . S_w``
+
+    Inter-cell links (between neighbouring CG tensors):
+        - horizontal (``"h"``): w of left CG <-> v of right CG
+        - vertical (``"v"``): v of top CG <-> u of bottom CG
+        - diagonal (``"diag"``): w of top CG <-> u of bottom-right CG
+
+    Args:
+        J:      Coupling constant (default 1.0).
+        dtype:  Data type for the arrays.
+
+    Returns:
+        A :class:`CGGates` instance with ``n_sites=3``.
+    """
+    import numpy as np
+
+    d = 2
+    eye = np.eye(d)
+    ss = np.array(_ss_2site(dtype))  # (4, 4)
+    ss4 = ss.reshape(d, d, d, d)  # [s1_ket, s2_ket, s1_bra, s2_bra]
+
+    # --- intra-cell: 3 pair interactions on the up-triangle ---
+    # 6-index tensor layout: [u_ket, v_ket, w_ket, u_bra, v_bra, w_bra]
+
+    # H_uv: ss4 acts on (u, v), identity on w
+    # Result[u, v, w, u', v', w'] = ss4[u, v, u', v'] * eye[w, w']
+    h_uv = np.einsum("ijkl,mn->ijmkln", ss4, eye).reshape(8, 8)
+
+    # H_uw: ss4 acts on (u, w), identity on v
+    # Result[u, v, w, u', v', w'] = ss4[u, w, u', w'] * eye[v, v']
+    h_uw = np.einsum("ijkl,mn->imjknl", ss4, eye).reshape(8, 8)
+
+    # H_vw: ss4 acts on (v, w), identity on u
+    # Result[u, v, w, u', v', w'] = eye[u, u'] * ss4[v, w, v', w']
+    h_vw = np.einsum("mn,ijkl->mijnkl", eye, ss4).reshape(8, 8)
+
+    h_intra = jnp.array(J * (h_uv + h_uw + h_vw), dtype=dtype)
+
+    # --- inter-cell gates ---
+    h_inter = {
+        "h": jnp.array(J * _embed_inter(2, 1), dtype=dtype),  # w1 <-> v2
+        "v": jnp.array(J * _embed_inter(1, 0), dtype=dtype),  # v1 <-> u2
+        "diag": jnp.array(J * _embed_inter(2, 0), dtype=dtype),  # w1 <-> u2
+    }
+    return CGGates(h_intra=h_intra, h_inter=h_inter, n_sites=3)
+
+
+# Maps direction keys to the RDM function that produces the corresponding
+# 2-site reduced density matrix.
+_RDM_DISPATCH: dict[str, object] = {
+    "h": _rdm2x1_tensor,
+    "v": _rdm1x2_tensor,
+}
+
+
+def compute_energy_cg(
+    A: Tensor,
+    env: CTMTensorEnv,
+    gates: CGGates,
+    d_eff: int,
+) -> jax.Array:
+    """Energy per microscopic site for a coarse-grained 1-site iPEPS.
+
+    Combines the intra-cell (1-site RDM) and inter-cell (2-site RDM) energy
+    contributions and divides by the number of physical sites per
+    coarse-grained tensor.
+
+    Args:
+        A:      The coarse-grained iPEPS tensor (physical dim = *d_eff*).
+        env:    Converged CTM environment for *A*.
+        gates:  Coarse-grained Hamiltonian gates (:class:`CGGates`).
+        d_eff:  Effective physical dimension (``d ** n_sites``).
+
+    Returns:
+        Scalar real energy per microscopic site.
+    """
+    # --- intra-cell energy from 1-site RDM ---
+    rdm_1 = _rdm_1site_tensor(A, env)  # (d_eff, d_eff)
+    e_intra = jnp.einsum("ij,ij->", rdm_1, gates.h_intra)
+
+    # --- inter-cell energies from 2-site RDMs ---
+    e_inter = jnp.zeros((), dtype=rdm_1.dtype)
+    for direction, gate in gates.h_inter.items():
+        if direction in _RDM_DISPATCH:
+            rdm_fn = _RDM_DISPATCH[direction]
+        elif direction == "diag":
+            # Diagonal RDM will be implemented in Task 6; lazy import to
+            # avoid a hard dependency until then.
+            from tenax.algorithms._ctm_tensor_energy import _rdm_diagonal_tensor
+
+            rdm_fn = _rdm_diagonal_tensor
+        else:
+            raise ValueError(f"Unknown inter-cell direction: {direction!r}")
+        rdm = rdm_fn(A, env)  # (d_eff, d_eff, d_eff, d_eff)
+        e_inter = e_inter + jnp.einsum("ijkl,ijkl->", rdm, gate)
+
+    return ((e_intra + e_inter) / gates.n_sites).real

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -247,6 +247,9 @@ class iPEPSConfig:
     gs_metric_precond: bool = True  # metric preconditioning for CG/L-BFGS
     metric_gmres_maxiter: int = 30  # Krylov dimension for metric inversion
     metric_gmres_tol: float = 1e-2  # GMRES tolerance (loose is fine)
+    # Coarse-grained iPEPS: when set, optimize_gs_ad uses compute_energy_cg
+    # instead of compute_energy_ctm_tensor.  Only valid with unit_cell="1x1".
+    cg_gates: object | None = None
 
     def __post_init__(self):
         import warnings
@@ -270,6 +273,15 @@ class iPEPSConfig:
             raise ValueError(
                 f"unit_cell must be one of {valid_unit_cells} or a Lattice, "
                 f"got {self.unit_cell!r}"
+            )
+        if self.cg_gates is not None and self.unit_cell != "1x1":
+            raise ValueError(
+                f"cg_gates requires unit_cell='1x1', got {self.unit_cell!r}"
+            )
+        if self.cg_gates is not None and self.su_init:
+            raise ValueError(
+                "cg_gates is incompatible with su_init=True "
+                "(simple update uses the microscopic gate, not the CG gates)"
             )
         valid_stall_recovery = {None, "noise", "reset"}
         if self.gs_stall_recovery not in valid_stall_recovery:

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -67,7 +67,17 @@ def _normalize_stall_recovery(config, *, unit_cell: str):
 
     if config.gs_stall_recovery is not None:
         return config
-    default = "noise" if unit_cell == "1x1" else "reset"
+    # CG with map_fn optimizes a tuple of raw site tensors; the noise
+    # injection path assumes a single tensor (calls .todense()/jnp.linalg.norm
+    # on params), so default to "reset" for that case.
+    cg_with_map_fn = (
+        config.cg_gates is not None
+        and getattr(config.cg_gates, "map_fn", None) is not None
+    )
+    if cg_with_map_fn:
+        default = "reset"
+    else:
+        default = "noise" if unit_cell == "1x1" else "reset"
     return replace(config, gs_stall_recovery=default)
 
 
@@ -448,6 +458,11 @@ def optimize_gs_ad(
         if config.su_init:
             _, (A_su, _B_su), _ = ipeps(gate, None, config)
             A_init = A_su
+        elif config.cg_gates is not None and config.cg_gates.init_fn is not None:
+            key = jax.random.PRNGKey(0)
+            raw_params = config.cg_gates.init_fn(D, key)
+            cg_data = config.cg_gates.map_fn(*raw_params)
+            A_init = _wrap_as_dense_tensor(cg_data)
         else:
             key = jax.random.PRNGKey(0)
             k1, k2 = jax.random.split(key)
@@ -627,6 +642,20 @@ def _optimize_gs_ad_tensor(
     from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
     from tenax.algorithms.ad_utils import CTMRGGradientError
 
+    cg_gates = config.cg_gates
+    _use_cg = cg_gates is not None
+    if _use_cg:
+        from tenax.algorithms.coarse_grain import compute_energy_cg
+
+        _cg_d_eff = int(cg_gates.h_intra.shape[0])
+        _cg_map_fn = cg_gates.map_fn
+        _cg_init_fn = cg_gates.init_fn
+    else:
+        compute_energy_cg = None
+        _cg_d_eff = None
+        _cg_map_fn = None
+        _cg_init_fn = None
+
     gate = (
         hamiltonian_gate.todense()
         if isinstance(hamiltonian_gate, Tensor)
@@ -669,6 +698,29 @@ def _optimize_gs_ad_tensor(
     explicit_steps = config.gs_explicit_ad_steps
     explicit_warmup = config.gs_explicit_ad_warmup
 
+    def _params_to_A_norm(params):
+        """Convert raw optimizer params to a normalized DenseTensor."""
+        if _use_cg and _cg_map_fn is not None:
+            cg_data = _cg_map_fn(*params)
+            cg_data = cg_data / (jnp.linalg.norm(cg_data) + 1e-10)
+            return DenseTensor(cg_data, A.indices)
+        if use_c4v:
+            A_data = c4v_tensor_from_coeffs(params, c4v_basis, tensor_shape)
+            A_norm_data = A_data / (jnp.linalg.norm(A_data) + 1e-10)
+            return DenseTensor(A_norm_data, A.indices)
+        return params * (1.0 / (params.norm() + 1e-10))
+
+    if _use_cg:
+
+        def _cg_energy_callable(site_tensors, envs, _gate):
+            """energy_fn closure for ctm_energy_explicit/implicit (CG path)."""
+            A_norm = site_tensors[(0, 0)]
+            return compute_energy_cg(A_norm, envs[(0, 0)], cg_gates, _cg_d_eff)
+
+        _energy_fn_kw = _cg_energy_callable
+    else:
+        _energy_fn_kw = None
+
     def _ctm_energy_fn(site_tensors):
         """Dispatch to implicit or explicit CTM energy."""
         env_init = _env_cache.get("envs", None)
@@ -684,6 +736,7 @@ def _optimize_gs_ad_tensor(
                 renormalize=ctm_cfg.renormalize,
                 projector_backward=ctm_cfg.projector_backward,
                 env_init=env_init,
+                energy_fn=_energy_fn_kw,
             )
         else:
             return ctm_energy_implicit(
@@ -706,27 +759,18 @@ def _optimize_gs_ad_tensor(
                 gmres_maxiter=ctm_cfg.gmres_maxiter,
                 gmres_restart=ctm_cfg.gmres_restart,
                 arnoldi_precheck=False,
+                energy_fn=_energy_fn_kw,
             )
 
     def loss_fn(params):
-        if use_c4v:
-            A_data = c4v_tensor_from_coeffs(params, c4v_basis, tensor_shape)
-            A_norm_data = A_data / (jnp.linalg.norm(A_data) + 1e-10)
-            A_norm = DenseTensor(A_norm_data, A.indices)
-        else:
-            A_norm = params * (1.0 / (params.norm() + 1e-10))
+        A_norm = _params_to_A_norm(params)
         site_tensors = {(0, 0): A_norm}
         energy = _ctm_energy_fn(site_tensors)
         return energy
 
     def _update_env_cache(params):
         """Re-run forward CTM (no grad) to warm-start next step."""
-        if use_c4v:
-            A_data = c4v_tensor_from_coeffs(params, c4v_basis, tensor_shape)
-            A_data = A_data / (jnp.linalg.norm(A_data) + 1e-10)
-            A_norm = DenseTensor(A_data, A.indices)
-        else:
-            A_norm = params * (1.0 / (params.norm() + 1e-10))
+        A_norm = _params_to_A_norm(params)
         site_tensors = {(0, 0): A_norm}
         envs, _ = python_loop_ctm_converge(
             site_tensors,
@@ -746,7 +790,14 @@ def _optimize_gs_ad_tensor(
     is_metric_lbfgs = (
         config.gs_metric_precond and config.gs_optimizer.lower() == "lbfgs"
     )
-    params = c4v_coeffs if use_c4v else A
+    if _use_cg and _cg_init_fn is not None:
+        # CG with map_fn: optimize the raw site tensors, contract via map_fn
+        # in _params_to_A_norm at each loss evaluation.
+        params = _cg_init_fn(config.max_bond_dim, jax.random.PRNGKey(0))
+    elif use_c4v:
+        params = c4v_coeffs
+    else:
+        params = A
     optimizer = None if is_metric_lbfgs else _build_optimizer(config)
     opt_state = optimizer.init(params) if optimizer is not None else None
     use_ls = _use_line_search(config)
@@ -771,12 +822,7 @@ def _optimize_gs_ad_tensor(
 
     def loss_fn_fwd(p):
         """Forward-only loss for line search — warm-starts CTM from env cache."""
-        if use_c4v:
-            A_data = c4v_tensor_from_coeffs(p, c4v_basis, tensor_shape)
-            A_norm_data = A_data / (jnp.linalg.norm(A_data) + 1e-10)
-            A_norm = DenseTensor(A_norm_data, A.indices)
-        else:
-            A_norm = p * (1.0 / (p.norm() + 1e-10))
+        A_norm = _params_to_A_norm(p)
         site_tensors = {(0, 0): A_norm}
         envs, _ = python_loop_ctm_converge(
             site_tensors,
@@ -791,6 +837,8 @@ def _optimize_gs_ad_tensor(
             chi_ramp=ctm_cfg.chi_ramp,
             env_init=_env_cache.get("envs", None),
         )
+        if _use_cg:
+            return float(compute_energy_cg(A_norm, envs[(0, 0)], cg_gates, _cg_d_eff))
         return float(compute_energy_ctm_tensor(A_norm, envs[(0, 0)], gate, d_phys))
 
     stall_count = 0  # noise recovery: consecutive line search failures
@@ -1132,7 +1180,7 @@ def _optimize_gs_ad_tensor(
                     )
         else:
             params = optax.apply_updates(params, direction)
-            if not use_c4v:
+            if not use_c4v and not (_use_cg and _cg_map_fn is not None):
                 params = params * (1.0 / (params.norm() + 1e-10))
 
     # Re-evaluate both final A and best_A with fully converged fresh CTM.
@@ -1142,12 +1190,7 @@ def _optimize_gs_ad_tensor(
 
     def _eval_fresh(p, env_init=None):
         """Evaluate energy with fully converged fresh CTM."""
-        if use_c4v:
-            A_data = c4v_tensor_from_coeffs(p, c4v_basis, tensor_shape)
-            A_data = A_data / (jnp.linalg.norm(A_data) + 1e-10)
-            A_t = DenseTensor(A_data, A.indices)
-        else:
-            A_t = p * (1.0 / (p.norm() + 1e-10))
+        A_t = _params_to_A_norm(p)
         envs, _ = python_loop_ctm_converge(
             {(0, 0): A_t},
             SINGLE_SITE_NEIGHBORS,
@@ -1164,7 +1207,10 @@ def _optimize_gs_ad_tensor(
             env_init=env_init,
         )
         env_ = envs[(0, 0)]
-        E_ = float(compute_energy_ctm_tensor(A_t, env_, gate, d_phys))
+        if _use_cg:
+            E_ = float(compute_energy_cg(A_t, env_, cg_gates, _cg_d_eff))
+        else:
+            E_ = float(compute_energy_ctm_tensor(A_t, env_, gate, d_phys))
         return A_t, env_, E_
 
     A_final, env_final, E_final = _eval_fresh(params, _env_cache.get("envs", None))

--- a/tests/test_coarse_grain.py
+++ b/tests/test_coarse_grain.py
@@ -1,0 +1,346 @@
+"""Tests for coarse-grained iPEPS gate construction and 1-site RDM."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tenax.algorithms._ctm_tensor import initialize_ctm_tensor_env
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
+from tenax.algorithms._ctm_tensor_energy import _rdm_1site_tensor, _rdm_diagonal_tensor
+from tenax.algorithms.ad_utils import _config_to_tuple, ctm_tensor_converge
+from tenax.algorithms.coarse_grain import (
+    CGGates,
+    compute_energy_cg,
+    honeycomb_cg_gates,
+    kagome_cg_gates,
+)
+from tenax.algorithms.ipeps_config import CTMConfig
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import U1Symmetry
+from tenax.core.tensor import DenseTensor
+
+
+@pytest.fixture(autouse=True)
+def _enable_x64():
+    """Enable float64 for this test module and restore afterwards."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    yield
+    jax.config.update("jax_enable_x64", prev)
+
+
+def test_returns_cg_gates():
+    """honeycomb_cg_gates returns a CGGates with n_sites == 2."""
+    gates = honeycomb_cg_gates()
+    assert isinstance(gates, CGGates)
+    assert gates.n_sites == 2
+
+
+def test_h_intra_shape_and_hermiticity():
+    """h_intra is a (4,4) Hermitian matrix."""
+    gates = honeycomb_cg_gates()
+    assert gates.h_intra.shape == (4, 4)
+    np.testing.assert_allclose(gates.h_intra, gates.h_intra.conj().T, atol=1e-14)
+
+
+def test_h_intra_eigenvalues():
+    """S*S eigenvalues are [-3/4, +1/4, +1/4, +1/4] (singlet-triplet)."""
+    gates = honeycomb_cg_gates()
+    eigvals = np.sort(np.linalg.eigvalsh(np.asarray(gates.h_intra)))
+    expected = np.array([-3 / 4, 1 / 4, 1 / 4, 1 / 4])
+    np.testing.assert_allclose(eigvals, expected, atol=1e-14)
+
+
+def test_h_inter_keys_and_shapes():
+    """h_inter has keys {'h', 'v'}, each with shape (4,4,4,4)."""
+    gates = honeycomb_cg_gates()
+    assert set(gates.h_inter.keys()) == {"h", "v"}
+    for key in ("h", "v"):
+        assert gates.h_inter[key].shape == (4, 4, 4, 4)
+
+
+def test_h_inter_hermiticity():
+    """Each h_inter reshaped to (16,16) is Hermitian."""
+    gates = honeycomb_cg_gates()
+    for key in ("h", "v"):
+        mat = gates.h_inter[key].reshape(16, 16)
+        np.testing.assert_allclose(mat, mat.conj().T, atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# 1-site RDM tests
+# ---------------------------------------------------------------------------
+
+
+def _make_product_state_cg_tensor(state_a, state_b, D=1):
+    """Build a D=1 CG tensor |state_a>x|state_b> as a DenseTensor.
+
+    The effective physical dimension is len(state_a)*len(state_b).
+    Virtual indices are trivial (D=1, charge=0).
+    """
+    d_eff = len(state_a) * len(state_b)
+    phys = np.kron(state_a, state_b)
+    data = np.zeros((D, D, D, D, d_eff))
+    data[0, 0, 0, 0, :] = phys
+
+    sym = U1Symmetry()
+    charges_D = np.zeros(D, dtype=np.int32)
+    charges_phys = np.zeros(d_eff, dtype=np.int32)
+    indices = (
+        TensorIndex.from_charges(sym, charges_D.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, charges_D.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, charges_D.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, charges_D.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(
+            sym, charges_phys.copy(), FlowDirection.IN, label="phys"
+        ),
+    )
+    return DenseTensor(jnp.array(data), indices)
+
+
+def _converge_ctm_env(A, chi=4, max_iter=20):
+    """Run CTM to convergence and return (env_leaves, env_treedef)."""
+    env_init = initialize_ctm_tensor_env(A, chi)
+    env_leaves_init, env_treedef = jax.tree.flatten(env_init)
+    config = CTMConfig(chi=chi, max_iter=max_iter)
+    config_tuple = _config_to_tuple(config)
+    env_leaves = ctm_tensor_converge(
+        {(0, 0): A}, None, SINGLE_SITE_NEIGHBORS, config_tuple
+    )
+    env = jax.tree.unflatten(env_treedef, list(env_leaves))
+    return env
+
+
+class TestRDM1Site:
+    """Tests for the 1-site reduced density matrix."""
+
+    def test_product_state_trace(self):
+        """For |up,down> product state, rdm has Tr=1 and is a pure state."""
+        up = np.array([1.0, 0.0])
+        down = np.array([0.0, 1.0])
+        A = _make_product_state_cg_tensor(up, down)
+
+        env = _converge_ctm_env(A, chi=4, max_iter=20)
+        rdm = _rdm_1site_tensor(A, env)
+
+        # Trace should be 1 (normalised)
+        np.testing.assert_allclose(jnp.trace(rdm).real, 1.0, atol=1e-10)
+
+        # Pure state: rho^2 = rho
+        rdm2 = rdm @ rdm
+        np.testing.assert_allclose(rdm2, rdm, atol=1e-10)
+
+    def test_honeycomb_product_state_energy(self):
+        """Tr(rdm . h_intra) for |up,down> = -1/4 (Sz.Sz of antiparallel)."""
+        up = np.array([1.0, 0.0])
+        down = np.array([0.0, 1.0])
+        A = _make_product_state_cg_tensor(up, down)
+
+        env = _converge_ctm_env(A, chi=4, max_iter=20)
+        rdm = _rdm_1site_tensor(A, env)
+
+        gates = honeycomb_cg_gates()
+        h_intra = gates.h_intra  # (4, 4) Heisenberg S.S
+
+        energy = jnp.trace(rdm @ h_intra).real
+        # |up,down> -> Sz.Sz = (1/2)(-1/2) = -1/4, Sp.Sm + Sm.Sp = 0
+        np.testing.assert_allclose(energy, -0.25, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# compute_energy_cg tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeEnergyCG:
+    def test_honeycomb_neel_product_state(self):
+        """Honeycomb Neel |up,down>: E/site = -3/8.
+
+        3 bonds (x, y, z) per unit cell of 2 sites.
+        For Neel |up,down> state, every bond has S.S = -1/4.
+        E/site = 3 * (-1/4) / 2 = -3/8 = -0.375.
+        """
+        up = np.array([1.0, 0.0])
+        down = np.array([0.0, 1.0])
+        A = _make_product_state_cg_tensor(up, down)
+        env = _converge_ctm_env(A, chi=4, max_iter=20)
+        gates = honeycomb_cg_gates()
+        E = compute_energy_cg(A, env, gates, d_eff=4)
+        np.testing.assert_allclose(float(E), -0.375, atol=1e-4)
+
+    def test_honeycomb_ferro_product_state(self):
+        """Honeycomb ferro |up,up>: E/site = +3/8.
+
+        For |up,up> state, every bond has Sz.Sz = +1/4, S+S-=S-S+=0.
+        E/site = 3 * (1/4) / 2 = 3/8 = 0.375.
+        """
+        up = np.array([1.0, 0.0])
+        A = _make_product_state_cg_tensor(up, up)
+        env = _converge_ctm_env(A, chi=4, max_iter=20)
+        gates = honeycomb_cg_gates()
+        E = compute_energy_cg(A, env, gates, d_eff=4)
+        np.testing.assert_allclose(float(E), 0.375, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# AD optimization integration test
+# ---------------------------------------------------------------------------
+
+
+class TestHoneycombAD:
+    @pytest.mark.slow
+    def test_honeycomb_d2_energy_is_physical(self):
+        """Honeycomb D=2 AD optimization must produce finite negative E/site."""
+        from tenax.algorithms.coarse_grain import honeycomb_cg_gates
+        from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+        from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+        gates = honeycomb_cg_gates()
+        config = iPEPSConfig(
+            max_bond_dim=2,
+            ctm=CTMConfig(chi=8, max_iter=20, min_iter=5),
+            gs_num_steps=10,
+            gs_learning_rate=1e-2,
+            gs_optimizer="lbfgs",
+            gs_line_search=True,
+            gs_line_search_method="armijo",
+            gs_c4v=True,
+            gs_explicit_ad=True,
+            gs_explicit_ad_steps=10,
+            gs_explicit_ad_warmup=3,
+            gs_metric_precond=False,
+            gs_verbose=False,
+            su_init=False,
+            cg_gates=gates,
+        )
+        # Pass a dummy gate with correct d_eff shape for the Hamiltonian placeholder
+        dummy_gate = jnp.zeros((4, 4, 4, 4))
+        _, _, E_gs = optimize_gs_ad(dummy_gate, None, config)
+        assert np.isfinite(E_gs), f"E_gs = {E_gs} is not finite"
+        assert E_gs < 0.0, f"E_gs = {E_gs} should be negative"
+
+
+# ---------------------------------------------------------------------------
+# Kagome coarse-grained gate tests
+# ---------------------------------------------------------------------------
+
+
+class TestKagomeCGGates:
+    def test_returns_cg_gates(self):
+        gates = kagome_cg_gates()
+        assert isinstance(gates, CGGates)
+        assert gates.n_sites == 3
+
+    def test_h_intra_shape_and_hermiticity(self):
+        gates = kagome_cg_gates()
+        assert gates.h_intra.shape == (8, 8)
+        np.testing.assert_allclose(gates.h_intra, gates.h_intra.conj().T, atol=1e-14)
+
+    def test_h_intra_eigenvalues(self):
+        """H_tri = S_u.S_v + S_u.S_w + S_v.S_w.
+
+        S_total(S_total+1)/2 - 3*s(s+1)/2 gives:
+          S_total=3/2 (quadruplet): (15/4 - 9/4)/2 = 3/4
+          S_total=1/2 (two doublets): (3/4 - 9/4)/2 = -3/4
+        """
+        gates = kagome_cg_gates()
+        eigvals = np.sort(np.linalg.eigvalsh(np.array(gates.h_intra)))
+        expected = np.array([-0.75, -0.75, -0.75, -0.75, 0.75, 0.75, 0.75, 0.75])
+        np.testing.assert_allclose(eigvals, expected, atol=1e-12)
+
+    def test_h_inter_keys_and_shapes(self):
+        gates = kagome_cg_gates()
+        assert set(gates.h_inter.keys()) == {"h", "v", "diag"}
+        for key in ("h", "v", "diag"):
+            assert gates.h_inter[key].shape == (8, 8, 8, 8)
+
+    def test_h_inter_hermiticity(self):
+        gates = kagome_cg_gates()
+        for key in ("h", "v", "diag"):
+            H = np.array(gates.h_inter[key]).reshape(64, 64)
+            np.testing.assert_allclose(H, H.conj().T, atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# Diagonal (NNN) RDM tests
+# ---------------------------------------------------------------------------
+
+
+def _make_product_state_cg_tensor_3site(s_u, s_v, s_w, D=1):
+    """Build a D=1 CG tensor |s_u>x|s_v>x|s_w> as a DenseTensor.
+
+    The effective physical dimension is d_eff = 2^3 = 8 for spin-1/2.
+    Virtual indices are trivial (D=1, charge=0).
+    """
+    phys = np.kron(np.kron(s_u, s_v), s_w)
+    d_eff = len(phys)
+    data = np.zeros((D, D, D, D, d_eff))
+    data[0, 0, 0, 0, :] = phys
+
+    sym = U1Symmetry()
+    charges_D = np.zeros(D, dtype=np.int32)
+    charges_phys = np.zeros(d_eff, dtype=np.int32)
+    indices = (
+        TensorIndex.from_charges(sym, charges_D.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, charges_D.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, charges_D.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, charges_D.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(
+            sym, charges_phys.copy(), FlowDirection.IN, label="phys"
+        ),
+    )
+    return DenseTensor(jnp.array(data), indices)
+
+
+class TestRDMDiagonal:
+    """Tests for the diagonal (NNN) reduced density matrix."""
+
+    def test_product_state_trace_and_factorization(self):
+        """D=1 product state: diagonal RDM should factorize as rho_A x rho_B."""
+        up = np.array([1.0, 0.0])
+        A = _make_product_state_cg_tensor_3site(up, up, up)
+
+        env = _converge_ctm_env(A, chi=4, max_iter=20)
+        rdm = _rdm_diagonal_tensor(A, env)
+
+        assert rdm.shape == (8, 8, 8, 8)
+
+        rdm_mat = rdm.reshape(64, 64)
+        # Trace should be 1
+        np.testing.assert_allclose(jnp.trace(rdm_mat), 1.0, atol=1e-10)
+
+        # For a product state, rho_{TL,BR} = rho_TL x rho_BR
+        rdm_1 = _rdm_1site_tensor(A, env)
+        expected = np.einsum("ij,kl->ikjl", rdm_1, rdm_1)
+        np.testing.assert_allclose(rdm, expected, atol=1e-6)
+
+    def test_product_state_pure_state(self):
+        """D=1 product state: diagonal RDM reshaped is a projector (rho^2=rho)."""
+        up = np.array([1.0, 0.0])
+        down = np.array([0.0, 1.0])
+        A = _make_product_state_cg_tensor_3site(up, down, up)
+
+        env = _converge_ctm_env(A, chi=4, max_iter=20)
+        rdm = _rdm_diagonal_tensor(A, env)
+        rdm_mat = rdm.reshape(64, 64)
+
+        # Pure state: rho^2 = rho
+        rdm2 = rdm_mat @ rdm_mat
+        np.testing.assert_allclose(rdm2, rdm_mat, atol=1e-10)
+
+
+class TestCGGatesValidation:
+    def test_cg_gates_requires_1x1_unit_cell(self):
+        from tenax.algorithms.ipeps_config import iPEPSConfig
+
+        gates = honeycomb_cg_gates()
+        with pytest.raises(ValueError, match="cg_gates requires unit_cell='1x1'"):
+            iPEPSConfig(unit_cell="2site", cg_gates=gates)
+
+    def test_cg_gates_rejects_su_init(self):
+        from tenax.algorithms.ipeps_config import iPEPSConfig
+
+        gates = honeycomb_cg_gates()
+        with pytest.raises(ValueError, match="incompatible with su_init=True"):
+            iPEPSConfig(cg_gates=gates, su_init=True)


### PR DESCRIPTION
## Summary

Forward-port of #335 onto the new CTM AD API (post-PR-#341). The CG approach maps non-square lattices (honeycomb d_eff=4, kagome d_eff=8) onto the existing 1-site square-lattice CTM pipeline by partitioning the Hamiltonian into intra-CG (1-site RDM) and inter-CG (2-site RDM) effective operators.

CG slots in via the existing `energy_fn=...` hookpoint on `ctm_energy_explicit` / `ctm_energy_implicit` — no changes to CTM convergence. The implicit-AD path inherits the trifecta (`svd + phase + elementwise`) enforced by `resolve_projector_backward`.

## Why a forward-port and not a merge

#335 was last touched 2026-04-21 and predates a major CTM AD rewrite (PRs #340–#348). A direct `git merge main` produced 10 conflict regions (~600 lines) in `ipeps_optimize.py` because the dispatch path was completely restructured. Forward-porting onto the new `energy_fn=` hookpoint (added during the rewrite) was substantially cleaner than reconciling the conflicts.

## Module layout

- `src/tenax/algorithms/coarse_grain.py` — `CGGates` dataclass, `honeycomb_cg_gates()` (n_sites=2, d_eff=4), `kagome_cg_gates()` (n_sites=3, d_eff=8), `compute_energy_cg(A, env, gates, d_eff)`.
- `src/tenax/algorithms/_ctm_tensor_energy.py` — re-add `_rdm_1site_tensor` and `_rdm_diagonal_tensor` (label-based Tensor contractions, used only by `compute_energy_cg`).
- `src/tenax/algorithms/ipeps_config.py` — new `cg_gates: object | None = None` field with `unit_cell="1x1"` + `not su_init` validation.
- `src/tenax/algorithms/ipeps_optimize.py`:
  - `_params_to_A_norm` helper centralizes params→A handling for the three branches (CG-with-map_fn, C4v, default).
  - CG energy callable built once and threaded through `energy_fn=`.
  - CG init path: when `cg_gates.init_fn` is set and `A_init is None`, generate raw site-tensor params and contract via `cg_gates.map_fn`.
  - `_normalize_stall_recovery` defaults to `"reset"` (not `"noise"`) for CG-with-map_fn since the noise path expects a single-tensor params.
- `src/tenax/__init__.py` — `CGGates`, `compute_energy_cg`, `honeycomb_cg_gates`, `kagome_cg_gates` added to lazy imports + `__all__`.

## Verification

- **19 CG tests pass** (gate construction, RDM correctness, energy normalization for product states, validation, slow honeycomb D=2 χ=8 AD integration).
- **731 core tests pass with no regressions.**
- Slow honeycomb D=2 χ=8 AD test runs in ~56 s and produces a finite negative energy.

## Open follow-up (already open on #335)

The 2-tensor parameterization for honeycomb has known gauge-fixing gaps that limit best variational energy. The honeycomb D=2 χ=16 benchmark against variPEPS E=-0.5376 is deferred to a follow-up PR.

## Test plan

- [x] CG unit + integration tests pass locally
- [x] Core test suite passes locally
- [ ] CI passes (Tests Python 3.11 / 3.12 / macOS 3.12)
- [ ] Manual smoke: `optimize_gs_ad` with `honeycomb_cg_gates()` produces decreasing energy

## Closes

Closes #335 design intent; supersedes that branch (which can be closed once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)