### PR TITLE
test(fpeps): unblock bucket E + sharpen B precheck skip from #354

### DIFF
--- a/tests/test_ad_utils.py
+++ b/tests/test_ad_utils.py
@@ -1569,13 +1569,14 @@ class TestArnoldiConfig:
 class TestArnoldiPrecheckIntegration:
     @pytest.mark.skip(
         reason=(
-            "Setup no longer crosses the rho >= 5.0 raise threshold "
-            "(default since #334). The qr-forward, chi=4, max_iter=10 "
-            "config produces a non-contractive (rho >= 1) but "
-            "below-threshold backward, so the precheck logs but does "
-            "not raise. Tracking in #354 — needs either a more "
-            "aggressive non-contractive fixture or a threshold-aware "
-            "rewrite."
+            "The qr-forward, chi=4, max_iter=10 fixture used to be "
+            "non-contractive (rho >= 1) but is now contractive: with "
+            "adjoint_arnoldi_threshold=1.0 the precheck still does not "
+            "raise. Building a deterministic non-contractive fixture is "
+            "more involved than threshold tuning — needs a setup that "
+            "actively exhibits rho >= 1.0 (e.g. larger D, deliberately "
+            "non-converged forward, or a synthetic vjp_env_fn). Tracked "
+            "in #354 bucket B."
         )
     )
     def test_raises_on_non_contractive_backward(self):
@@ -1590,6 +1591,7 @@ class TestArnoldiPrecheckIntegration:
             conv_tol=1e-6,
             forward_gauge="qr",
             adjoint_arnoldi_precheck=True,
+            adjoint_arnoldi_threshold=1.0,
         )
 
         def _energy(A_tensor):

--- a/tests/test_fpeps_ad.py
+++ b/tests/test_fpeps_ad.py
@@ -107,8 +107,9 @@ class TestOptimizeFpepsAd:
         A_opt, env, E_gs = optimize_fpeps_ad(
             H, A_init=A_init, config=ipeps_config_short
         )
-        # SymmetricTensor is wrapped as DenseTensor for AD stability
-        assert isinstance(A_opt, DenseTensor)
+        # optimize_fpeps_ad is polymorphic over the Tensor protocol (#297) —
+        # returns a tensor of the same type as the input.
+        assert isinstance(A_opt, type(A_init))
         assert np.isfinite(E_gs)
 
     def test_optimize_fpeps_ad_energy_decreases(
@@ -187,9 +188,15 @@ class TestTodenseGradientFlow:
         from tenax.algorithms.ad_utils import _config_to_tuple
 
         fpeps_cfg = FPEPSConfig(D=2, t=1.0, V=0.0)
+        # adjoint_arnoldi_precheck=False: this fixture's backward has
+        # rho ~ 6.97 which crosses the default raise threshold (5.0,
+        # default since #334); the precheck tripping is incidental to
+        # the gradient-finiteness contract this test exercises.
         ctm_cfg = iPEPSConfig(
             max_bond_dim=2,
-            ctm=CTMConfig(chi=4, max_iter=10, conv_tol=1e-4),
+            ctm=CTMConfig(
+                chi=4, max_iter=10, conv_tol=1e-4, adjoint_arnoldi_precheck=False
+            ),
         )
 
         # Build a SymmetricTensor then convert to DenseTensor (the workaround)
@@ -218,16 +225,26 @@ class TestTodenseGradientFlow:
         assert float(jnp.linalg.norm(grad_data)) > 0, "DenseTensor gradient is zero"
 
     @pytest.mark.algorithm
+    @pytest.mark.xfail(
+        reason=(
+            "NaN gradient through gauge-fix round-trip for SymmetricTensor "
+            "with non-trivial charges. Reproduces on both forward_gauge='qr' "
+            "(_gauge_fix_ctm_tensor) and 'phase' (_phase_fix_ctm_tensor) — "
+            "the from_dense(..., tol=inf) wrap in _wrap_tensor or the "
+            "argmax-based phase pick is not differentiation-safe in the "
+            "non-trivial-charge regime. Tracked in #354 bucket E."
+        ),
+        strict=True,
+    )
     def test_symmetric_nontrivial_gradient_finite(self):
-        """SymmetricTensor with non-trivial charges now produces finite gradients.
+        """SymmetricTensor with non-trivial charges should produce finite gradients.
 
         Previously the gauge-fixing step called
         ``SymmetricTensor.from_dense(..., tol=inf)`` which broke gradient
         flow for non-trivial charge sectors, forcing ``optimize_fpeps_ad``
-        to convert to DenseTensor before the AD loop.  The NaN has since
-        been fixed, but ``optimize_fpeps_ad`` still wraps as DenseTensor
-        for other stability reasons; this test now asserts the fixed
-        behavior instead of documenting the old limitation.
+        to convert to DenseTensor before the AD loop.  The NaN was thought
+        to be fixed but has regressed under both QR and phase gauge paths
+        — currently xfailed; see marker for details.
         """
         from tenax.algorithms._ctm_tensor import initialize_ctm_tensor_env
         from tenax.algorithms.ad_utils import _config_to_tuple
@@ -235,7 +252,12 @@ class TestTodenseGradientFlow:
         fpeps_cfg = FPEPSConfig(D=2, t=1.0, V=0.0)
         ctm_cfg = iPEPSConfig(
             max_bond_dim=2,
-            ctm=CTMConfig(chi=4, max_iter=10, conv_tol=1e-4),
+            ctm=CTMConfig(
+                chi=4,
+                max_iter=10,
+                conv_tol=1e-4,
+                adjoint_arnoldi_precheck=False,
+            ),
         )
 
         # Use SymmetricTensor directly (non-trivial FermionParity charges)


### PR DESCRIPTION
## Summary
- Closes **3 of 4** bucket E failures from #354 (E1 stale assertion, E3 incidental precheck trip; E2 was already passing locally) and xfail-strict E4 with a clearer diagnosis.
- Sharpens the bucket B precheck-raise skip with the actual root cause that turned up while attempting the 1-line fix [agreed in #355's review](https://github.com/tenax-lab/tenax/pull/355#discussion_r3158594649).

## Bucket E

### E1 — `test_optimize_fpeps_ad_with_explicit_init`
The polymorphic `optimize_fpeps_ad` (#297) returns the same `Tensor` type as its `A_init` input. The test still asserted `DenseTensor` (the pre-polymorphism wrap-as-dense behaviour). Update the assertion to `isinstance(A_opt, type(A_init))`.

### E3 — `test_dense_tensor_gradient_finite`
Disable `adjoint_arnoldi_precheck`. This fixture's backward has `rho ~ 6.97` which crosses the default 5.0 raise threshold (default since #334), but the precheck tripping is incidental to the gradient-finiteness contract the test exercises.

### E4 — `test_symmetric_nontrivial_gradient_finite` *(xfail strict)*
NaN gradient through the gauge-fix round-trip for `SymmetricTensor` with non-trivial charges. Reproduces on **both** `forward_gauge='qr'` (`_gauge_fix_ctm_tensor`) and `'phase'` (`_phase_fix_ctm_tensor`) — the `from_dense(..., tol=inf)` wrap in `_wrap_tensor` or the argmax-based phase pick is not differentiation-safe in the non-trivial-charge regime. Real bug; needs follow-up beyond test plumbing.

## Bucket B

### `TestArnoldiPrecheckIntegration::test_raises_on_non_contractive_backward` *(skip — refreshed)*
Tried the 1-line `adjoint_arnoldi_threshold=1.0` fix agreed in #355's review. Doesn't trigger: with `chi=4`, qr forward, the precheck `rho` is now **< 1.0** (i.e., the fixture is genuinely contractive). Building a deterministic non-contractive fixture is more involved than threshold tuning — needs larger D, deliberately non-converged forward, or a synthetic `vjp_env_fn`. Skip stays, with the rewrite note refreshed.

## Test plan
- [x] `uv run pytest tests/test_fpeps_ad.py::TestOptimizeFpepsAd::test_optimize_fpeps_ad_with_explicit_init tests/test_fpeps_ad.py::TestOptimizeFpepsAd::test_optimize_fpeps_ad_energy_decreases tests/test_fpeps_ad.py::TestTodenseGradientFlow tests/test_ad_utils.py::TestArnoldiPrecheckIntegration -v` — 3 passed, 1 skipped, 1 xfailed.
- [x] `uv run pytest -m core -q` — 731 passed, no regressions.
- [ ] CI: required Tests (Python 3.11 / 3.12 / macOS 3.12) green.

Refs: #354, #355, #297, #334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)