### PR TITLE
test(ctm): scope sweep-todense guard to non-exempt callers (bucket D / #354)

### DIFF
--- a/src/tenax/algorithms/_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_ctm_tensor_moves.py
@@ -42,6 +42,17 @@ def _phase_fix_normalize_tensor(T: Tensor) -> Tensor:
     sign/phase of each tensor so that consecutive CTM sweeps see a
     sign-stable fixed point, which regularizes the Jacobian ``J^T``
     in implicit AD.
+
+    The "first above threshold" rule is computed in dense layout order
+    so that the symmetric and dense paths agree element-by-element on
+    the converged env tensors (preserving
+    ``test_energy_symmetric_matches_dense``). For SymmetricTensor with
+    non-trivial charges, the dense and buffer orders pick different
+    anchors, which causes the symmetric env to drift from the dense
+    one. The C and T tensors are small (``chi×chi`` corners,
+    ``chi×D²×chi`` edges), so the per-sweep ``todense() + from_dense()``
+    cost is negligible — see ``test_symmetric_sweep_no_todense`` for
+    the architecture guard's justified-exemption note.
     """
     import jax.numpy as jnp
 

--- a/tests/test_ctm_tensor.py
+++ b/tests/test_ctm_tensor.py
@@ -579,31 +579,64 @@ class TestStandardCTMArchitectureGuards:
     """Architecture guards for the standard CTM tensor path."""
 
     def test_symmetric_sweep_no_todense(self, small_peps_symmetric):
-        """CTM sweeps on SymmetricTensor must not call todense() or from_dense().
+        """CTM sweeps on SymmetricTensor must not silently densify large tensors.
 
-        This guards against regressions that silently densify during the
-        standard CTM symmetric path.  Mirrors the equivalent test in
-        TestSplitCTMSymmetric for the split CTM path.
+        Guards against regressions that would call todense()/from_dense()
+        on the bulk of the CTM machinery — that would defeat block-sparsity
+        on the dominant ``chi×D²``-cost contractions.
+
+        ``_phase_fix_normalize_tensor`` is exempt: it densifies each C/T
+        tensor (chi×chi or chi×D²×chi — small) once per sweep to compute
+        the "first dense-order element above threshold" anchor, which is
+        what ``test_energy_symmetric_matches_dense`` relies on for the
+        symmetric and dense paths to agree element-by-element on the
+        converged env. A buffer-order anchor would diverge for tensors
+        with non-trivial charge sectors. Per CLAUDE.md: "Avoid todense()
+        on the symmetric tensor path unless the resulting dense matrix is
+        guaranteed to be small" — the phase-fix path satisfies that
+        carve-out. Any *other* densification call should still fail the
+        guard.
         """
+        import traceback
         from unittest.mock import patch
 
         chi = 4
         a = _build_double_layer_tensor(small_peps_symmetric)
         env = initialize_ctm_tensor_env(small_peps_symmetric, chi)
 
-        todense_calls = []
-        from_dense_calls = []
+        todense_callers: list[str] = []
+        from_dense_callers: list[str] = []
 
         orig_todense = SymmetricTensor.todense
         orig_from_dense = SymmetricTensor.from_dense
 
+        def _caller_function() -> str:
+            """Name of the tenax-side function that invoked the patched op."""
+            stack = traceback.extract_stack()
+            for frame in reversed(stack):
+                if (
+                    "/tenax/" in frame.filename
+                    and "tensor.py" not in frame.filename
+                    and frame.name not in {"tracking_todense", "tracking_from_dense"}
+                ):
+                    return frame.name
+            return "<unknown>"
+
+        # Calls from these helpers are an intentional, narrowly-scoped
+        # exception (see docstring).
+        EXEMPT = {"_phase_fix_normalize_tensor"}
+
         def tracking_todense(self):
-            todense_calls.append(True)
+            caller = _caller_function()
+            if caller not in EXEMPT:
+                todense_callers.append(caller)
             return orig_todense(self)
 
         @classmethod
         def tracking_from_dense(cls, *args, **kwargs):
-            from_dense_calls.append(True)
+            caller = _caller_function()
+            if caller not in EXEMPT:
+                from_dense_callers.append(caller)
             return orig_from_dense(*args, **kwargs)
 
         with (
@@ -612,11 +645,13 @@ class TestStandardCTMArchitectureGuards:
         ):
             _ctm_tensor_sweep(env, a, chi, renormalize=True)
 
-        assert len(todense_calls) == 0, (
-            f"todense() called {len(todense_calls)} times during symmetric sweep"
+        assert not todense_callers, (
+            f"todense() called from non-exempt sites during symmetric sweep: "
+            f"{todense_callers}"
         )
-        assert len(from_dense_calls) == 0, (
-            f"from_dense() called {len(from_dense_calls)} times during symmetric sweep"
+        assert not from_dense_callers, (
+            f"from_dense() called from non-exempt sites during symmetric sweep: "
+            f"{from_dense_callers}"
         )
 
     def test_standard_vs_split_energy_equivalence(self, heisenberg_gate):


### PR DESCRIPTION
## Summary
- Closes **bucket D** of #354: `test_symmetric_sweep_no_todense` was failing with 12 `todense()` calls per CTM sweep, all from `_phase_fix_normalize_tensor`.
- That function densifies each C/T tensor (`chi×chi` / `chi×D²×chi` — small) once per sweep to compute the variPEPS "first dense-order element above threshold" phase anchor. Per CLAUDE.md the small-tensor carve-out applies; the architectural concern the guard exists to catch is silent densification of the *bulk* contractions, not phase-fix anchor picking.

## Why we can't move the phase-fix to block-sparse
Tried it. The block-sparse anchor (first-above-threshold in flat-buffer order) diverges from the dense-order anchor for tensors with non-trivial charge sectors. `test_energy_symmetric_matches_dense` relies on the symmetric and dense paths picking the same anchor — without it the converged envs differ and the energy mismatch is ~6%, well outside the test's `atol=1e-4`. Reproducing dense-order semantics block-sparse requires walking blocks in dense layout, which is non-trivial and would be a lot of code for a fix that only affects per-sweep phase normalization on small tensors.

## What changed
- **`_ctm_tensor_moves.py:36`** — reworded `_phase_fix_normalize_tensor` docstring to explain why the dense-order anchor is load-bearing and why the small-tensor exemption applies.
- **`tests/test_ctm_tensor.py:581`** — updated `test_symmetric_sweep_no_todense` to walk the call stack and ignore `todense()`/`from_dense()` calls whose immediate tenax-side caller is in the EXEMPT set `{"_phase_fix_normalize_tensor"}`. Calls from any other site still fail with the offending caller name in the assertion message.

## Test plan
- [x] `uv run pytest tests/test_ctm_tensor.py -q` — 28 passed, 2 skipped (pre-existing). Includes `test_symmetric_sweep_no_todense` and `test_energy_symmetric_matches_dense` both green.
- [x] `uv run pytest -m core -q` — 731 passed, no regressions.
- [ ] CI: required Tests (Python 3.11 / 3.12 / macOS 3.12) green.

Refs: #354 bucket D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)