### PR TITLE
fix(ctm): stop_gradient norm in phase-fix to unblock fermionic AD

### DIFF
--- a/src/tenax/algorithms/_ctm_compiled_moves.py
+++ b/src/tenax/algorithms/_ctm_compiled_moves.py
@@ -30,9 +30,16 @@ from tenax.algorithms.ad_utils import _fix_svd_signs, truncated_svd_ad
 
 
 def _phase_fix_normalize_raw(arr: jnp.ndarray) -> jnp.ndarray:
-    """Frobenius-normalize + phase-fix a raw array (matches variPEPS)."""
+    """Frobenius-normalize + phase-fix a raw array (matches variPEPS).
+
+    Norm is wrapped in ``stop_gradient`` to avoid NaN gradients in the
+    backward pass through divide-by-norm — see ``_phase_fix_normalize_tensor``
+    in ``_ctm_tensor_moves.py`` for the rationale (#362).
+    """
+    import jax
+
     norm = jnp.linalg.norm(arr)
-    arr = arr / (norm + 1e-30)
+    arr = arr / jax.lax.stop_gradient(norm + 1e-30)
     flat = arr.ravel()
     idx = jnp.argmax(jnp.abs(flat))
     phase = flat[idx] / (jnp.abs(flat[idx]) + 1e-30)
@@ -453,9 +460,14 @@ def _frob_phase_fix_raw(arr: jnp.ndarray) -> jnp.ndarray:
     Uses the threshold-based approach from ``_phase_fix_ctm_tensor``
     (first element with |x| >= 0.1 * max), NOT the simpler argmax(abs)
     used in per-absorption normalization.
+
+    Norm is wrapped in ``stop_gradient``; see ``_phase_fix_normalize_tensor``
+    for rationale (#362).
     """
+    import jax
+
     norm = jnp.linalg.norm(arr)
-    arr = arr / (norm + 1e-30)
+    arr = arr / jax.lax.stop_gradient(norm + 1e-30)
     flat = arr.ravel()
     abs_flat = jnp.abs(flat)
     abs_max = jnp.max(abs_flat)

--- a/src/tenax/algorithms/_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_ctm_tensor_moves.py
@@ -53,12 +53,22 @@ def _phase_fix_normalize_tensor(T: Tensor) -> Tensor:
     ``chi×D²×chi`` edges), so the per-sweep ``todense() + from_dense()``
     cost is negligible — see ``test_symmetric_sweep_no_todense`` for
     the architecture guard's justified-exemption note.
+
+    The Frobenius norm is wrapped in ``stop_gradient`` so the backward
+    sees only the tangential gradient. At the converged fixed point
+    ``||T||=1`` already, so the radial component of the cotangent is
+    discarded by the outer unit-sphere projection anyway. Without this,
+    SymmetricTensor inputs with empty charge sectors (e.g. fermionic
+    fpeps tensors) produce NaN gradients through the implicit-AD
+    backward — the radial-gradient path interacts with the dense
+    layout's out-of-block zeros to create 0/0 leaves. (#362)
     """
+    import jax
     import jax.numpy as jnp
 
     arr = T.todense()
     norm = jnp.linalg.norm(arr)
-    arr = arr / (norm + 1e-30)
+    arr = arr / jax.lax.stop_gradient(norm + 1e-30)
     flat = arr.ravel()
     abs_flat = jnp.abs(flat)
     threshold = 0.1 * jnp.max(abs_flat)

--- a/src/tenax/algorithms/ad_utils.py
+++ b/src/tenax/algorithms/ad_utils.py
@@ -897,9 +897,15 @@ def _phase_fix_ctm_tensor(env):
     EPS_PHASE = 0.1  # threshold fraction for "large" element (variPEPS default)
 
     def _frob_phase_fix(arr):
-        """Frobenius-normalize and fix phase of a dense array."""
+        """Frobenius-normalize and fix phase of a dense array.
+
+        Norm is wrapped in ``stop_gradient`` so the backward only sees
+        the tangential gradient component. See #362 for why the radial
+        path through divide-by-norm produces NaN on SymmetricTensor
+        with empty charge sectors.
+        """
         norm = jnp.linalg.norm(arr)
-        arr = arr / (norm + 1e-30)
+        arr = arr / jax.lax.stop_gradient(norm + 1e-30)
         # Find first element with |x| >= EPS_PHASE * max(|arr|)
         flat = arr.ravel()
         abs_flat = jnp.abs(flat)

--- a/tests/test_fpeps_ad.py
+++ b/tests/test_fpeps_ad.py
@@ -38,10 +38,18 @@ def ipeps_config_short():
 
 @pytest.fixture
 def ipeps_config_medium():
-    """iPEPSConfig for medium runs (energy decrease test)."""
+    """iPEPSConfig for medium runs (energy decrease test).
+
+    ``chi=8`` is required: at ``chi=4`` the CTM converges to a
+    non-physical metastable fixed point (E ≈ -4.44 vs E ≈ +0.18 at
+    chi=8) and the perturbed-A energy landscape is wildly non-smooth
+    — descent breaks out of that artifact basin and looks like
+    "uphill" optimization. ``chi=8`` lands in the physical basin
+    where the energy varies smoothly and Adam can descend.
+    """
     return iPEPSConfig(
         max_bond_dim=2,
-        ctm=CTMConfig(chi=4, max_iter=15, conv_tol=1e-4),
+        ctm=CTMConfig(chi=8, max_iter=30, conv_tol=1e-4),
         gs_num_steps=10,
         gs_learning_rate=1e-2,
         gs_optimizer="adam",
@@ -112,30 +120,26 @@ class TestOptimizeFpepsAd:
         assert isinstance(A_opt, type(A_init))
         assert np.isfinite(E_gs)
 
-    @pytest.mark.xfail(
-        reason=(
-            "After #361 (Koszul twist) and the divide-by-norm gauge-fix-AD "
-            "fix below, the gradient is now finite (test_symmetric_nontrivial_"
-            "gradient_finite passes) but Adam over 10 steps still moves "
-            "uphill: E_init=-4.44, E_final≈-1.49. The remaining "
-            "wrong-direction component is most likely the argmax-based "
-            "phase pick in the per-absorption gauge fix — unstable for "
-            "SymmetricTensor with non-trivial charges (suspect (A) in #362). "
-            "Tracked as a separate follow-up to #362."
-        ),
-        strict=False,
-    )
     def test_optimize_fpeps_ad_energy_decreases(
         self, fpeps_config, ipeps_config_medium
     ):
-        """10 AD steps: final energy should be lower than the initial energy."""
+        """10 AD steps: final energy should be lower than the initial energy.
+
+        Uses ``chi=8`` (see ``ipeps_config_medium`` fixture); ``chi=4``
+        lands on a non-physical metastable CTM fixed point and the
+        perturbed-A landscape is non-smooth, which made the original
+        version of this test xfail under #362 with the misdiagnosis
+        "wrong-direction gradient". With ``chi=8`` the landscape is
+        smooth and the divide-by-norm gauge-fix-AD fix
+        (PR #363 / ``_phase_fix_normalize_tensor``) is sufficient.
+        """
         H = spinless_fermion_gate(fpeps_config)
         A_init = _build_initial_fpeps_tensor(fpeps_config, jax.random.PRNGKey(0))
 
-        # Compute initial energy via a short 0-step run
+        # Compute initial energy via a short 0-step run with the same chi.
         config_0 = iPEPSConfig(
             max_bond_dim=2,
-            ctm=CTMConfig(chi=4, max_iter=15, conv_tol=1e-4),
+            ctm=CTMConfig(chi=8, max_iter=30, conv_tol=1e-4),
             gs_num_steps=0,
             gs_learning_rate=1e-2,
             gs_verbose=False,

--- a/tests/test_fpeps_ad.py
+++ b/tests/test_fpeps_ad.py
@@ -114,19 +114,14 @@ class TestOptimizeFpepsAd:
 
     @pytest.mark.xfail(
         reason=(
-            "Pre-#357 this test passed because the broken bar() (no "
-            "Koszul twist on fermionic SymmetricTensor) made the "
-            "fermionic CTM energy collapse to ~0; near-zero energy "
-            "plus near-zero gradient meant L-BFGS took small steps "
-            "that satisfied E_final < E_init by numerical noise. After "
-            "#357 the forward energy is correct (E_init ~ -4.44), but "
-            "the implicit-AD backward through the gauge-fix path still "
-            "produces wrong gradients for SymmetricTensor with "
-            "non-trivial charges (same root cause as "
-            "test_symmetric_nontrivial_gradient_finite below) — the "
-            "optimizer now moves uphill with a correct landscape and a "
-            "broken gradient. Will pass once the gauge-fix-AD issue is "
-            "resolved; that's tracked in #354 bucket E follow-up."
+            "After #361 (Koszul twist) and the divide-by-norm gauge-fix-AD "
+            "fix below, the gradient is now finite (test_symmetric_nontrivial_"
+            "gradient_finite passes) but Adam over 10 steps still moves "
+            "uphill: E_init=-4.44, E_final≈-1.49. The remaining "
+            "wrong-direction component is most likely the argmax-based "
+            "phase pick in the per-absorption gauge fix — unstable for "
+            "SymmetricTensor with non-trivial charges (suspect (A) in #362). "
+            "Tracked as a separate follow-up to #362."
         ),
         strict=False,
     )
@@ -302,26 +297,20 @@ class TestTodenseGradientFlow:
         )
 
     @pytest.mark.algorithm
-    @pytest.mark.xfail(
-        reason=(
-            "Implicit-AD backward through the gauge-fix path "
-            "(_phase_fix_ctm_tensor / _wrap_tensor with "
-            "from_dense(..., tol=inf), or the argmax-based phase pick) "
-            "is not differentiation-safe for SymmetricTensor with "
-            "non-trivial charges. Forward energy is now finite (#357 "
-            "fixed the bar() Koszul twist), but the implicit VJP still "
-            "produces all-NaN gradients on this fixture. Separate from "
-            "#357; tracked in #354 bucket E."
-        ),
-        strict=True,
-    )
     def test_symmetric_nontrivial_gradient_finite(self):
         """SymmetricTensor with non-trivial charges should produce finite gradients.
 
-        The Koszul-twist part of this contract is now covered by
-        ``test_symmetric_nontrivial_energy_finite`` (no xfail). What
-        remains is the implicit-AD backward through the gauge-fix path,
-        which is the bug the xfail marker documents.
+        Regression for the implicit-AD backward through the gauge-fix
+        path (#362): pre-fix, ``jax.value_and_grad`` returned all-NaN
+        gradient leaves on a fermionic ``SymmetricTensor`` with empty
+        charge sectors. Root cause was the differentiable
+        ``arr / (norm + 1e-30)`` step in ``_phase_fix_normalize_tensor``
+        and ``_phase_fix_ctm_tensor`` — JAX evaluated both branches of
+        ``jnp.where`` in the SVD/divide backward, and the dense layout's
+        out-of-block zeros produced a 0/0 NaN at the fixed point. Fixed
+        by wrapping the norm in ``jax.lax.stop_gradient`` (the radial
+        component of the cotangent is discarded by the outer unit-sphere
+        projection anyway).
         """
         from tenax.algorithms._ctm_tensor import initialize_ctm_tensor_env
         from tenax.algorithms.ad_utils import _config_to_tuple


### PR DESCRIPTION
## Summary

Closes both acceptance gates of #362.

**Commit 1 — divide-by-norm fix (gradient finiteness gate):**
Wraps `jnp.linalg.norm(arr)` in `jax.lax.stop_gradient` inside the four phase-fix functions used by the implicit-AD CTM path so the radial-gradient path no longer produces NaN on fermionic `SymmetricTensor` with empty charge sectors.

**Commit 2 — chi=4→8 fixture upgrade (energy-decrease gate):**
The `test_optimize_fpeps_ad_energy_decreases` xfail under the misdiagnosis "wrong-direction gradient" was actually a fixture bug. At `chi=4` the CTM converges to a non-physical metastable fixed point (E ≈ -4.44) and the perturbed-A landscape is wildly non-smooth — Adam looked like it was moving uphill because each step broke out of the artifact basin. At `chi=8` the landscape is smooth and Adam descends.

## Investigation

### Gradient finiteness (resolved by commit 1)

Bisection inside `_phase_fix_normalize_tensor` (`/tmp/diag_362j.py`) isolated the NaN to the `arr / (norm + 1e-30)` divide:

| Variant | Gradient |
|---|---|
| ORIG (`arr / (norm + 1e-30)`) | NaN |
| `variant_no_phase` (only normalize) | NaN |
| `variant_no_round_trip` (still has from_dense) | NaN |
| `variant_no_norm` (skip normalize, keep phase fix) | finite, ‖g‖=0.4654 |
| `variant_no_divide` (compute norm, don't divide) | finite, ‖g‖=0.4654 |
| `variant_stop_gradient_norm` | finite, ‖g‖=0.4654 |
| `variant_inverse_norm` (manual rsqrt) | finite, ‖g‖=0.4654 |
| identity | finite, ‖g‖=0.4654 |

All four working variants produce the *same* gradient — confirming the divide-by-norm path was the only buggy step. The "true" radial gradient is discarded by the outer unit-sphere projection in `optimize_*` anyway, so `stop_gradient` is safe.

### Energy-decrease misdiagnosis (resolved by commit 2)

After commit 1 the gradient is finite but Adam was still moving "uphill" (-4.44 → -1.49). The issue text framed this as a wrong-direction gradient (suspect (A) argmax-phase-pick or (B) `from_dense(tol=inf)` round-trip).

Diagnostic (`/tmp/diag_362_basin.py`) showed otherwise:

```
chi=4:  E(A_init) = -4.44   (non-physical metastable fixed point)
chi=8:  E(A_init) ≈ +0.18   (physical fixed point)
```

The chi=4 sweep was non-smooth: `eps=-1e-2` jumped to `E=+24` (basin flip). At chi=8 the same sweep varied smoothly by 0.02. Adam at chi=4 broke out of the artifact basin, which looked like uphill motion against a fictitious -4.44 baseline. With chi=8 the divide-by-norm fix from commit 1 is sufficient — neither suspect (A) nor (B) is needed.

## Files changed

- `src/tenax/algorithms/_ctm_tensor_moves.py` — `_phase_fix_normalize_tensor`
- `src/tenax/algorithms/ad_utils.py` — `_phase_fix_ctm_tensor` inner `_frob_phase_fix`
- `src/tenax/algorithms/_ctm_compiled_moves.py` — `_phase_fix_normalize_raw`, `_frob_phase_fix_raw`
- `tests/test_fpeps_ad.py` — drop both xfails; rewrite docstrings; raise `ipeps_config_medium` chi 4→8

## Test plan

- [x] `pytest tests/test_fpeps_ad.py::TestTodenseGradientFlow` (3/3 pass natively)
- [x] `pytest tests/test_fpeps_ad.py::TestOptimizeFpepsAd::test_optimize_fpeps_ad_energy_decreases` (4m20s on CPU at chi=8)
- [x] `pytest -m core` — 735 passed
- [ ] CI required checks (Tests Python 3.11 / 3.12 / macOS) — to run on PR

## Closes

#362 (both gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
