### PR TITLE
test(ipeps): tighten lbfgs/cg optimizer smoke scope to avoid macOS OOM

### DIFF
--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -1018,24 +1018,40 @@ class TestOptimizeGsAdOptimizers:
         return H.reshape(d, d, d, d)
 
     def test_lbfgs_optimizer_runs(self, heisenberg_gate):
-        """L-BFGS optimizer with line search should produce finite energy."""
+        """L-BFGS optimizer with line search should produce finite energy.
+
+        Scope kept tight: ``chi=2`` and ``gs_num_steps=1`` so the
+        L-BFGS-with-Hager-Zhang trace fits within the macOS Full-tests
+        runner memory budget. At ``chi=4`` + 3 steps + line search the
+        XLA compile blew out (exit 137) when run late in the
+        ``test_ipeps.py`` session — see CI run 25104994256 (after #360
+        merged to main). The contract being tested is "L-BFGS path
+        compiles and produces finite energy"; even one step exercises
+        that path.
+        """
         config = iPEPSConfig(
             max_bond_dim=2,
-            ctm=CTMConfig(chi=4, max_iter=5),
+            ctm=CTMConfig(chi=2, max_iter=3),
             gs_optimizer="lbfgs",
-            gs_num_steps=3,
+            gs_num_steps=1,
             gs_line_search=True,
         )
         _, _, E_gs = optimize_gs_ad(heisenberg_gate, None, config)
         assert np.isfinite(E_gs)
 
     def test_cg_optimizer_runs(self, heisenberg_gate):
-        """CG optimizer should produce finite energy (covers PR beta path)."""
+        """CG optimizer should produce finite energy (covers PR beta path).
+
+        Scope tightened alongside ``test_lbfgs_optimizer_runs`` to keep
+        the optimizer-smoke pair cheap; both tests run late in
+        ``test_ipeps.py`` after long-running benchmarks, so the JAX
+        cache is already heavy.
+        """
         config = iPEPSConfig(
             max_bond_dim=2,
-            ctm=CTMConfig(chi=4, max_iter=5),
+            ctm=CTMConfig(chi=2, max_iter=3),
             gs_optimizer="cg",
-            gs_num_steps=3,
+            gs_num_steps=1,
         )
         _, _, E_gs = optimize_gs_ad(heisenberg_gate, None, config)
         assert np.isfinite(E_gs)


### PR DESCRIPTION
## Summary

- Reduces ``test_lbfgs_optimizer_runs`` and ``test_cg_optimizer_runs`` from ``chi=4 / max_iter=5 / gs_num_steps=3`` to ``chi=2 / max_iter=3 / gs_num_steps=1``.
- Adds inline comments explaining the OOM context so future readers don't re-bump the parameters.

## Background

CI run [25104862892](https://github.com/tenax-lab/tenax/actions/runs/25104862892) → no, the failing run was [25104994256](https://github.com/tenax-lab/tenax/actions/runs/25104994256) (Full tests, push to main after #360 merged). On the macOS runner the ``Full tests`` job hit ``exit code 137`` (OOM kill) during ``tests/test_ipeps.py::TestOptimizeGsAdOptimizers::test_lbfgs_optimizer_runs`` — within 0.09s of the test starting, indicating the OOM was the XLA compile of L-BFGS + Hager-Zhang line search at ``chi=4``.

By the time ``test_lbfgs_optimizer_runs`` ran, the session had already populated JAX's JIT cache via ``test_2site_heisenberg_ad_energy_benchmark`` (~6 min) and ``test_ad_d2_chi_scaling`` (~12 min), leaving the macos-latest runner near its memory budget. Specializing the test to ``chi=2`` shrinks the compiled XLA program enough to fit, while still exercising the contract under test ("L-BFGS path compiles and runs to finite energy").

## Why not skip on macOS

PR #360's bot review flagged the loss of L-BFGS + Hager-Zhang coverage when ``test_ad_d2_energy_lbfgs_hagerzhang_reset`` was deleted — these smoke tests are the only remaining checks that the line-search path compiles. Skipping on macOS would lose macos coverage entirely; reducing scope keeps the path under test on all runners.

## Test plan

- [x] ``pytest tests/test_ipeps.py::TestOptimizeGsAdOptimizers`` passes locally (36s on CPU)
- [ ] CI required checks (Tests Python 3.11 / 3.12 / macOS) — to run on PR
- [ ] CI ``Full tests`` matrix (label ``run-full-tests`` if needed) — should now stay under macOS memory budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)