### PR TITLE
test(fpeps): drop builder-helper smoke tests + redundant runs smoke

### DIFF
--- a/tests/test_fpeps_ad.py
+++ b/tests/test_fpeps_ad.py
@@ -12,7 +12,7 @@ from tenax.algorithms.fermionic_ipeps import (
 )
 from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
 from tenax.algorithms.ipeps_optimize import optimize_fpeps_ad
-from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+from tenax.core.tensor import DenseTensor, SymmetricTensor
 
 # ------------------------------------------------------------------ #
 # Fixtures                                                             #
@@ -58,52 +58,12 @@ def ipeps_config_medium():
 
 
 # ------------------------------------------------------------------ #
-# _build_initial_fpeps_tensor                                          #
-# ------------------------------------------------------------------ #
-
-
-class TestBuildInitialFPEPSTensor:
-    """Tests for the extracted initialization helper."""
-
-    def test_returns_symmetric_tensor(self, fpeps_config):
-        A = _build_initial_fpeps_tensor(fpeps_config)
-        assert isinstance(A, SymmetricTensor)
-
-    def test_labels(self, fpeps_config):
-        A = _build_initial_fpeps_tensor(fpeps_config)
-        assert A.labels() == ("u", "d", "l", "r", "phys")
-
-    def test_shape(self, fpeps_config):
-        A = _build_initial_fpeps_tensor(fpeps_config)
-        assert A.todense().shape == (2, 2, 2, 2, 2)
-
-    def test_default_key(self, fpeps_config):
-        """Calling with key=None should not raise."""
-        A = _build_initial_fpeps_tensor(fpeps_config, key=None)
-        assert jnp.all(jnp.isfinite(A.todense()))
-
-    def test_explicit_key(self, fpeps_config):
-        key = jax.random.PRNGKey(42)
-        A = _build_initial_fpeps_tensor(fpeps_config, key=key)
-        assert jnp.all(jnp.isfinite(A.todense()))
-
-
-# ------------------------------------------------------------------ #
 # optimize_fpeps_ad                                                    #
 # ------------------------------------------------------------------ #
 
 
 class TestOptimizeFpepsAd:
     """Tests for the AD-based fermionic iPEPS optimization entry point."""
-
-    def test_optimize_fpeps_ad_runs(self, fpeps_config, ipeps_config_short):
-        """Smoke test: 3 AD steps should complete and return finite energy."""
-        H = spinless_fermion_gate(fpeps_config)
-        A_opt, env, E_gs = optimize_fpeps_ad(
-            H, A_init=None, config=ipeps_config_short, fpeps_config=fpeps_config
-        )
-        assert isinstance(A_opt, Tensor)
-        assert np.isfinite(E_gs)
 
     def test_optimize_fpeps_ad_with_explicit_init(
         self, fpeps_config, ipeps_config_short


### PR DESCRIPTION
## Summary

Drop 6 leftover smoke tests in `tests/test_fpeps_ad.py` from when the AD path was new — keep the 6 anchor tests that exercise real invariants.

**Largest individual deletion:** `test_explicit_key` at **626s** (17% of the entire `Full tests` Linux 3.11 run on its own). Only asserts the helper produces a finite tensor for an explicit PRNG key; that path runs in every gradient test that calls `_build_initial_fpeps_tensor(..., PRNGKey(N))`.

**Estimated `Full tests` wall-clock savings: ~13 min.**

## Deleted

`TestBuildInitialFPEPSTensor` (5 tests on the `_build_initial_fpeps_tensor` helper):
- `test_returns_symmetric_tensor`, `test_labels`, `test_shape` — type/shape/labels checks; helper is exercised end-to-end by every other test in the file.
- `test_default_key`, `test_explicit_key` — \"finite tensor produced\"; covered by every gradient test.

`TestOptimizeFpepsAd::test_optimize_fpeps_ad_runs` (~135s):
- Asserts finite energy + return type. Both covered by `test_optimize_fpeps_ad_energy_decreases` with a real numerical descent gate.

## Kept (anchor tests)

| Test | Role |
|---|---|
| `test_optimize_fpeps_ad_with_explicit_init` | #297 polymorphism contract |
| `test_optimize_fpeps_ad_energy_decreases` | Numerical descent anchor |
| `test_optimize_fpeps_ad_requires_fpeps_config` | Error path |
| `test_dense_tensor_gradient_finite` | #362 workaround invariant |
| `test_symmetric_nontrivial_energy_finite` | #357 Koszul anchor |
| `test_symmetric_nontrivial_gradient_finite` | #362 reproducer |

## Test plan

- [x] Local: `uv run pytest tests/test_fpeps_ad.py` — 6 passed in 695s
- [ ] Required CI green
- [ ] `Full tests` post-merge run completes faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)