### PR TITLE
test: drop "doesn't crash" smoke tests in hotrg/idmrg/block-sparse

### DIFF
--- a/tests/test_block_sparse_ctm_ad.py
+++ b/tests/test_block_sparse_ctm_ad.py
@@ -127,26 +127,6 @@ class TestBlockSparseImplicitAD:
         assert jnp.all(jnp.isfinite(grad_data)), "Gradient contains non-finite values"
         assert jnp.any(jnp.abs(grad_data) > 0), "Gradient is all zeros"
 
-    @pytest.mark.slow
-    def test_u1_implicit_ad_energy_is_scalar(self):
-        """Implicit AD forward pass with SymmetricTensor returns scalar energy."""
-        A_sym = _make_u1_symmetric_ipeps()
-        gate = heisenberg_gate()
-        neighbors = SINGLE_SITE_NEIGHBORS
-
-        site_tensors = {(0, 0): A_sym}
-        energy = ctm_energy_implicit(
-            site_tensors,
-            neighbors,
-            gate,
-            chi=4,
-            max_iter=30,
-            conv_tol=1e-8,
-        )
-        assert jnp.isfinite(energy), f"Energy is not finite: {energy}"
-        assert energy.shape == (), f"Energy should be scalar, got shape {energy.shape}"
-        # Energy from a random tensor need not be negative, just finite and scalar
-
 
 # ------------------------------------------------------------------ #
 # Test 3: Dense vs block-sparse energy match                          #

--- a/tests/test_hotrg.py
+++ b/tests/test_hotrg.py
@@ -124,16 +124,6 @@ class TestHOTRGRun:
     def ising_tensor_high_temp(self):
         return compute_ising_tensor(beta=0.2)
 
-    def test_hotrg_runs_without_error(self, ising_tensor_high_temp):
-        config = HOTRGConfig(max_bond_dim=4, num_steps=3)
-        result = hotrg(ising_tensor_high_temp, config)
-        assert jnp.isfinite(result)
-
-    def test_result_is_scalar(self, ising_tensor_high_temp):
-        config = HOTRGConfig(max_bond_dim=4, num_steps=3)
-        result = hotrg(ising_tensor_high_temp, config)
-        assert result.shape == ()
-
     def test_high_temp_free_energy(self):
         """At high temperature (beta=0.2), HOTRG chi=16 should be within 0.5%."""
         beta = 0.2
@@ -198,41 +188,6 @@ class TestHOTRGRun:
             f"exact {exact_free_energy:.6f} (rel err={relative_error:.4f})"
         )
 
-    def test_horizontal_only(self):
-        """HOTRG with direction_order='horizontal' should run."""
-        tensor = compute_ising_tensor(beta=0.3)
-        config = HOTRGConfig(max_bond_dim=4, num_steps=4, direction_order="horizontal")
-        result = hotrg(tensor, config)
-        assert np.isfinite(float(result))
-
-    def test_vertical_only(self):
-        """HOTRG with direction_order='vertical' should run."""
-        tensor = compute_ising_tensor(beta=0.3)
-        config = HOTRGConfig(max_bond_dim=4, num_steps=4, direction_order="vertical")
-        result = hotrg(tensor, config)
-        assert np.isfinite(float(result))
-
-    def test_alternating_direction(self):
-        """Default alternating should give same sign as horizontal-only (finite result)."""
-        tensor = compute_ising_tensor(beta=0.3)
-        config = HOTRGConfig(max_bond_dim=4, num_steps=4, direction_order="alternating")
-        result = hotrg(tensor, config)
-        assert np.isfinite(float(result))
-
-    def test_single_step(self):
-        tensor = compute_ising_tensor(beta=0.3)
-        config = HOTRGConfig(max_bond_dim=4, num_steps=1)
-        result = hotrg(tensor, config)
-        assert np.isfinite(float(result))
-
-    def test_dense_tensor_input(self):
-        """hotrg() should accept DenseTensor as input."""
-        tensor = compute_ising_tensor(beta=0.3)
-        assert isinstance(tensor, DenseTensor)
-        config = HOTRGConfig(max_bond_dim=4, num_steps=3)
-        result = hotrg(tensor, config)
-        assert np.isfinite(float(result))
-
     def test_hotrg_vs_trg_sign(self):
         """HOTRG and TRG log(Z)/N should have the same sign."""
         from tenax.algorithms.trg import TRGConfig, trg
@@ -278,27 +233,17 @@ class TestHOTRGRun:
 class TestHOTRGSymmetric:
     """Tests for HOTRG with SymmetricTensor (Z₂-symmetric Ising tensor)."""
 
-    def test_symmetric_hotrg_runs(self):
-        """HOTRG should run on a symmetric Ising tensor without error."""
-        tensor = compute_ising_tensor(beta=0.3, symmetric=True)
-        assert isinstance(tensor, SymmetricTensor)
-        config = HOTRGConfig(max_bond_dim=8, num_steps=5)
-        result = hotrg(tensor, config)
-        assert jnp.isfinite(result)
-
     def test_symmetric_hotrg_preserves_blocks(self):
         """HOTRG should not collapse Z₂ block sectors during coarse-graining."""
         tensor = compute_ising_tensor(beta=0.3, symmetric=True)
         initial_blocks = tensor.n_blocks
         assert initial_blocks == 8  # sanity check
 
-        T = tensor
-        for _ in range(3):
-            T, _ = _hotrg_step_horizontal(T, max_bond_dim=8)
-            assert isinstance(T, SymmetricTensor)
-            assert T.n_blocks >= initial_blocks, (
-                f"Block count collapsed from {initial_blocks} to {T.n_blocks}"
-            )
+        T, _ = _hotrg_step_horizontal(tensor, max_bond_dim=8)
+        assert isinstance(T, SymmetricTensor)
+        assert T.n_blocks >= initial_blocks, (
+            f"Block count collapsed from {initial_blocks} to {T.n_blocks}"
+        )
 
     def test_symmetric_hotrg_matches_exact(self):
         """Symmetric HOTRG at beta=0.3 should match exact free energy within 1%."""
@@ -346,27 +291,17 @@ def _compute_ising_tensor_fermionic(beta: float, J: float = 1.0) -> SymmetricTen
 class TestHOTRGFermionic:
     """Tests for HOTRG with FermionParity (fermionic Koszul signs)."""
 
-    def test_fermionic_hotrg_runs(self):
-        """HOTRG should run on a FermionParity tensor without error."""
-        tensor = _compute_ising_tensor_fermionic(beta=0.3)
-        assert isinstance(tensor, SymmetricTensor)
-        config = HOTRGConfig(max_bond_dim=8, num_steps=5)
-        result = hotrg(tensor, config)
-        assert jnp.isfinite(result)
-
     def test_fermionic_hotrg_preserves_blocks(self):
         """HOTRG should preserve FermionParity block sectors."""
         tensor = _compute_ising_tensor_fermionic(beta=0.3)
         initial_blocks = tensor.n_blocks
         assert initial_blocks == 8
 
-        T = tensor
-        for _ in range(3):
-            T, _ = _hotrg_step_horizontal(T, max_bond_dim=8)
-            assert isinstance(T, SymmetricTensor)
-            assert T.n_blocks >= initial_blocks, (
-                f"Block count collapsed from {initial_blocks} to {T.n_blocks}"
-            )
+        T, _ = _hotrg_step_horizontal(tensor, max_bond_dim=8)
+        assert isinstance(T, SymmetricTensor)
+        assert T.n_blocks >= initial_blocks, (
+            f"Block count collapsed from {initial_blocks} to {T.n_blocks}"
+        )
 
     def test_fermionic_hotrg_koszul_signs_active(self):
         """FermionParity HOTRG should give a finite result.

--- a/tests/test_idmrg.py
+++ b/tests/test_idmrg.py
@@ -140,12 +140,6 @@ class TestBuildBulkMPO:
 
 
 class TestiDMRGRun:
-    def test_runs_without_error(self):
-        W = build_bulk_mpo_heisenberg()
-        cfg = iDMRGConfig(max_bond_dim=8, max_iterations=5, lanczos_max_iter=10)
-        result = idmrg(W, cfg)
-        assert isinstance(result, iDMRGResult)
-
     def test_dense_two_site_uses_tolerance_aware_lanczos(self, monkeypatch):
         """Dense 2-site path should route through tol-aware Lanczos."""
         idmrg_mod = importlib.import_module("tenax.algorithms.idmrg")
@@ -410,16 +404,6 @@ class TestBuildBulkMPOSymmetric:
 
 
 class TestiDMRGSymmetric:
-    def test_symmetric_idmrg_runs(self, numpy_blockwise):
-        """Symmetric iDMRG should run without error."""
-        W = build_bulk_mpo_heisenberg_symmetric()
-        cfg = iDMRGConfig(
-            max_bond_dim=8, max_iterations=10, numpy_blockwise=numpy_blockwise
-        )
-        result = idmrg(W, cfg)
-        assert isinstance(result, iDMRGResult)
-        assert np.isfinite(result.energy_per_site)
-
     @pytest.mark.slow
     def test_symmetric_idmrg_energy_accuracy(self, numpy_blockwise):
         """Symmetric iDMRG at chi=16 should match exact within 0.5%."""


### PR DESCRIPTION
## Summary

Continuing the post-#350 smoke-test cleanup (after #366 fpeps and #367 ctm-python-loop). All deleted tests assert only "didn't crash + finite + correct return type" and are covered by anchor tests in the same file with real numerical gates.

**Local:** 88 passed in 663s. **Estimated `Full tests` savings:** ~150-200s (mostly from the preserves_blocks shrink).

## tests/test_hotrg.py — 10 deleted, 2 shrunk

**Deleted (smoke):**
| Class | Test | Replacement coverage |
|---|---|---|
| TestHOTRGRun | `test_hotrg_runs_without_error`, `test_result_is_scalar` | All four `test_*_free_energy` (chi=16, num_steps=20) |
| TestHOTRGRun | `test_horizontal_only`, `test_vertical_only`, `test_alternating_direction` | direction-order paths exercised by `test_high/mid/near/low_temp_free_energy` |
| TestHOTRGRun | `test_single_step`, `test_dense_tensor_input` | Forward path covered by anchors |
| TestHOTRGSymmetric | `test_symmetric_hotrg_runs` | `test_symmetric_hotrg_matches_exact` |
| TestHOTRGFermionic | `test_fermionic_hotrg_runs` | `test_fermionic_hotrg_koszul_signs_active` |

**Shrunk:**
- `test_symmetric_hotrg_preserves_blocks`, `test_fermionic_hotrg_preserves_blocks` — inner `for _ in range(3)` reduced to a single `_hotrg_step_horizontal` call. Block-preservation invariant detected on iteration 1.

## tests/test_idmrg.py — 2 deleted

| Class | Test | Replacement coverage |
|---|---|---|
| TestiDMRGRun | `test_runs_without_error` | `test_energy_is_finite` + `test_energy_per_site_negative` + `test_energy_converges_toward_bethe_ansatz` |
| TestiDMRGSymmetric | `test_symmetric_idmrg_runs` | `test_symmetric_idmrg_energy_accuracy` (chi=16 vs exact 0.5%) + `test_symmetric_matches_dense_energy` |

## tests/test_block_sparse_ctm_ad.py — 1 deleted

- `test_u1_implicit_ad_energy_is_scalar` — pure shape/finite smoke; covered by `test_implicit_ad_energy_match` (parity vs dense).

Kept the architectural guards: `test_u1_ctm_env_stays_symmetric_tensor` (no-todense leak), `test_u1_implicit_ad_gradient_is_finite` (block-sparse gradient invariant).

## Test plan

- [x] Local: `uv run pytest tests/test_hotrg.py tests/test_idmrg.py tests/test_block_sparse_ctm_ad.py` — 88 passed in 663s
- [ ] Required CI green
- [ ] Post-merge `Full tests` shows wall-clock reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)