### PR TITLE
ci: split Full tests matrix into fast + slow buckets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
   test-full:
-    name: Full tests (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    name: Full tests (${{ matrix.os }}, Python ${{ matrix.python-version }}, ${{ matrix.bucket }})
     needs: [changes]
     if: |
       always() &&
@@ -80,9 +80,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.11", "3.12"]
+        bucket: ["fast", "slow"]
         include:
           - os: macos-latest
             python-version: "3.12"
+            bucket: "fast"
+          - os: macos-latest
+            python-version: "3.12"
+            bucket: "slow"
 
     steps:
       - uses: actions/checkout@v6
@@ -98,15 +103,23 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
-      - name: Run non-core tests (algorithm + slow + integration)
+      - name: Run non-core tests (${{ matrix.bucket }} bucket)
         # Skip ``-m core`` since the required ``test`` job already covers it.
-        # Running everything-not-core here avoids duplicating the core suite
-        # (which was contributing to OOM / runner-lost-communication flakes
-        # when the full suite ran end-to-end).
+        # Split into ``fast`` (algorithm/integration without slow) and
+        # ``slow`` (everything tagged ``@pytest.mark.slow``) buckets so each
+        # job stays under the ~1h GitHub-runner reaper window that was
+        # killing the previous single ``-m "not core"`` invocation
+        # (see #354).
         env:
           JAX_PLATFORMS: cpu
+          BUCKET: ${{ matrix.bucket }}
         run: |
-          uv run pytest tests/ -m "not core" \
+          if [ "$BUCKET" = "slow" ]; then
+            FILTER='slow'
+          else
+            FILTER='not core and not slow'
+          fi
+          uv run pytest tests/ -m "$FILTER" \
             --cov=tenax \
             --cov-report=xml \
             --cov-report=term-missing \

--- a/tests/test_fpeps_ad.py
+++ b/tests/test_fpeps_ad.py
@@ -65,6 +65,7 @@ def ipeps_config_medium():
 class TestOptimizeFpepsAd:
     """Tests for the AD-based fermionic iPEPS optimization entry point."""
 
+    @pytest.mark.slow
     def test_optimize_fpeps_ad_with_explicit_init(
         self, fpeps_config, ipeps_config_short
     ):
@@ -80,6 +81,7 @@ class TestOptimizeFpepsAd:
         assert isinstance(A_opt, type(A_init))
         assert np.isfinite(E_gs)
 
+    @pytest.mark.slow
     def test_optimize_fpeps_ad_energy_decreases(
         self, fpeps_config, ipeps_config_medium
     ):
@@ -159,6 +161,7 @@ class TestTodenseGradientFlow:
         return loss_fn
 
     @pytest.mark.algorithm
+    @pytest.mark.slow
     def test_dense_tensor_gradient_finite(self):
         """DenseTensor (the workaround path) produces finite gradients."""
         from tenax.algorithms._ctm_tensor import initialize_ctm_tensor_env

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -775,6 +775,7 @@ class TestOptimizeGsAd2Site:
         assert abs(A_norm - 1.0) < 1e-4, f"||A_opt|| = {A_norm}, expected ~1.0"
         assert abs(B_norm - 1.0) < 1e-4, f"||B_opt|| = {B_norm}, expected ~1.0"
 
+    @pytest.mark.slow
     def test_tangent_project_unit_complex_is_hermitian(self):
         """Regression for PR #330 review: _tangent_project_unit must use
         the Hermitian inner product (vdot) so complex-valued tensors get


### PR DESCRIPTION
## Summary

The single \`Full tests\` matrix step (\`pytest -m \"not core\"\`) has been hitting the **~1h GitHub-runner reaper** on Linux 3.11 since the post-#350 baseline. Cleanup waves (#366/#367/#368) clipped ~17 min off the worst case but the remaining algorithm+slow run is still ~62-65 min — one new slow test pushes us back over.

This PR splits the matrix into two buckets so each job stays comfortably under the reaper.

## Change

Matrix axis \`bucket\`:
- **\`fast\`** — \`pytest -m \"not core and not slow\"\` (~30 min, 1011 tests)
- **\`slow\`** — \`pytest -m \"slow\"\` (~25-35 min, 34 tests)

macOS 3.12 gets both buckets via the matrix \`include\` block.

## Marker additions

To put the top wall-clock offenders into the slow bucket, three tests get \`@pytest.mark.slow\`:

| Test | Wall-clock |
|---|---|
| \`test_ipeps.py::test_tangent_project_unit_complex_is_hermitian\` | 385s |
| \`test_fpeps_ad.py::test_optimize_fpeps_ad_with_explicit_init\` | ~136s |
| \`test_fpeps_ad.py::test_dense_tensor_gradient_finite\` | ~116s |

Plus the existing \`@pytest.mark.slow\` tests already in place.

## Branch protection

Unaffected. Required CI (\`Tests (Python 3.11)\`, \`Tests (Python 3.12)\`, \`Tests (macOS, Python 3.12)\`) does not include the \`Full tests\` jobs. The Full tests job names change from \`Full tests (os, py)\` to \`Full tests (os, py, bucket)\` — only post-merge \`Full tests\` runs see the rename.

## Test plan

- [x] Local: \`pytest --collect-only -m \"not core and not slow\"\` → 1011 tests
- [x] Local: \`pytest --collect-only -m \"slow\"\` → 34 tests
- [ ] Required CI green
- [ ] Both fast and slow bucket jobs complete on first post-merge \`Full tests\` matrix run

🤖 Generated with [Claude Code](https://claude.com/claude-code)