### PR TITLE
refactor(ctm): replace wildcard re-exports in _split_ctm_tensor shim

### DIFF
--- a/src/tenax/algorithms/_split_ctm_tensor.py
+++ b/src/tenax/algorithms/_split_ctm_tensor.py
@@ -1,9 +1,137 @@
-"""Split CTM with Tensor protocol — re-export shim."""
+"""Split CTM with Tensor protocol — public re-export shim.
+
+Internal code should import directly from the concrete modules:
+  - ``_split_ctm_tensor_init``        (SplitCTMTensorEnv, initialize_split_ctm_tensor_env, ...)
+  - ``_split_ctm_tensor_moves``       (directional moves, projector application, edge growth)
+  - ``_split_ctm_tensor_convergence`` (ctm_split_tensor, sweeps, renormalization)
+  - ``_split_ctm_tensor_energy``      (compute_energy_split_ctm_tensor, env conversion)
+  - ``_ctm_projector``                (_compute_projector_tensor)
+
+This module re-exports public names so that
+``from tenax.algorithms._split_ctm_tensor import X`` keeps working for
+downstream / notebook code.
+"""
 
 from tenax.algorithms._ctm_projector import (
-    _compute_projector_tensor as _compute_projector_tensor,  # noqa: F401
+    _compute_projector_tensor as _compute_projector_tensor,
 )
-from tenax.algorithms._split_ctm_tensor_convergence import *  # noqa: F401,F403
-from tenax.algorithms._split_ctm_tensor_energy import *  # noqa: F401,F403
-from tenax.algorithms._split_ctm_tensor_init import *  # noqa: F401,F403
-from tenax.algorithms._split_ctm_tensor_moves import *  # noqa: F401,F403
+from tenax.algorithms._split_ctm_tensor_convergence import (
+    _renormalize_split_env as _renormalize_split_env,
+)
+from tenax.algorithms._split_ctm_tensor_convergence import (
+    _split_ctm_tensor_sweep as _split_ctm_tensor_sweep,
+)
+from tenax.algorithms._split_ctm_tensor_convergence import (
+    ctm_split_tensor as ctm_split_tensor,
+)
+from tenax.algorithms._split_ctm_tensor_energy import (
+    _split_env_to_tensor_standard as _split_env_to_tensor_standard,
+)
+from tenax.algorithms._split_ctm_tensor_energy import (
+    compute_energy_split_ctm_tensor as compute_energy_split_ctm_tensor,
+)
+from tenax.algorithms._split_ctm_tensor_init import (
+    _EDGE_BRA_SPECS as _EDGE_BRA_SPECS,
+)
+from tenax.algorithms._split_ctm_tensor_init import (
+    _EDGE_KET_SPECS as _EDGE_KET_SPECS,
+)
+from tenax.algorithms._split_ctm_tensor_init import (
+    SplitCTMTensorEnv as SplitCTMTensorEnv,
+)
+from tenax.algorithms._split_ctm_tensor_init import (
+    _init_symmetric_corner as _init_symmetric_corner,
+)
+from tenax.algorithms._split_ctm_tensor_init import (
+    _init_symmetric_edge_bra as _init_symmetric_edge_bra,
+)
+from tenax.algorithms._split_ctm_tensor_init import (
+    _init_symmetric_edge_ket as _init_symmetric_edge_ket,
+)
+from tenax.algorithms._split_ctm_tensor_init import (
+    _make_dense_edge_bra as _make_dense_edge_bra,
+)
+from tenax.algorithms._split_ctm_tensor_init import (
+    _make_dense_edge_ket as _make_dense_edge_ket,
+)
+from tenax.algorithms._split_ctm_tensor_init import (
+    initialize_split_ctm_tensor_env as initialize_split_ctm_tensor_env,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _apply_projector as _apply_projector,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _ensure_corner_flows as _ensure_corner_flows,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _ensure_edge_flows as _ensure_edge_flows,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _ensure_tensor_flows as _ensure_tensor_flows,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _fused_charge_permutation as _fused_charge_permutation,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _grow_edge_no_double_layer as _grow_edge_no_double_layer,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _project_grown_edge_tensor as _project_grown_edge_tensor,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _reembed_target_for_projector as _reembed_target_for_projector,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _select_bond_entries as _select_bond_entries,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _split_ctm_move_bottom as _split_ctm_move_bottom,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _split_ctm_move_left as _split_ctm_move_left,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _split_ctm_move_right as _split_ctm_move_right,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _split_ctm_move_top as _split_ctm_move_top,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _svd_split_edge_tensor as _svd_split_edge_tensor,
+)
+from tenax.algorithms._split_ctm_tensor_moves import (
+    _truncate_svd_per_sector as _truncate_svd_per_sector,
+)
+
+__all__ = [
+    "SplitCTMTensorEnv",
+    "_EDGE_BRA_SPECS",
+    "_EDGE_KET_SPECS",
+    "_apply_projector",
+    "_compute_projector_tensor",
+    "_ensure_corner_flows",
+    "_ensure_edge_flows",
+    "_ensure_tensor_flows",
+    "_fused_charge_permutation",
+    "_grow_edge_no_double_layer",
+    "_init_symmetric_corner",
+    "_init_symmetric_edge_bra",
+    "_init_symmetric_edge_ket",
+    "_make_dense_edge_bra",
+    "_make_dense_edge_ket",
+    "_project_grown_edge_tensor",
+    "_reembed_target_for_projector",
+    "_renormalize_split_env",
+    "_select_bond_entries",
+    "_split_ctm_move_bottom",
+    "_split_ctm_move_left",
+    "_split_ctm_move_right",
+    "_split_ctm_move_top",
+    "_split_ctm_tensor_sweep",
+    "_split_env_to_tensor_standard",
+    "_svd_split_edge_tensor",
+    "_truncate_svd_per_sector",
+    "compute_energy_split_ctm_tensor",
+    "ctm_split_tensor",
+    "initialize_split_ctm_tensor_env",
+]


### PR DESCRIPTION
## Summary

Resolves item 2 of #351.

`src/tenax/algorithms/_split_ctm_tensor.py` previously used `import *` from four submodules:

- `_split_ctm_tensor_convergence`
- `_split_ctm_tensor_energy`
- `_split_ctm_tensor_init`
- `_split_ctm_tensor_moves`

This made the shim's public API surface implicit and dependency edges hidden — changes to internal modules could silently move or remove names from the shim's exports.

This PR replaces the four `import *` lines with explicit per-name re-exports (matching the existing style of `_ctm_tensor.py`) and defines an explicit `__all__`. All 30 names previously reachable via `import *` remain available; no consumer of the shim used star-imports, so nothing downstream changes.

## Test plan
- [x] `tests/test_split_ctm_tensor.py` — passes (15 tests)
- [x] `tests/test_architecture_imports.py` — passes (3 tests, allowlist still satisfied)
- [x] Smoke import of all 30 names in `__all__`