### PR TITLE
refactor(core): move BlockArray to tenax.core, break contraction↔linalg cycle

### DIFF
--- a/src/tenax/algorithms/dmrg.py
+++ b/src/tenax/algorithms/dmrg.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 if TYPE_CHECKING:
-    from tenax.algorithms._block_array import BlockArray
+    from tenax.core._block_array import BlockArray
 
 import jax
 import jax.numpy as jnp
@@ -874,7 +874,7 @@ def dmrg(
 
     # Build result MPS as FiniteMPS.
     # Convert any BlockArray tensors back to SymmetricTensor for storage.
-    from tenax.algorithms._block_array import BlockArray, ba_to_symmetric
+    from tenax.core._block_array import BlockArray, ba_to_symmetric
 
     final_tensors = [
         ba_to_symmetric(t) if isinstance(t, BlockArray) else t for t in mps_tensors
@@ -1407,7 +1407,7 @@ def _svd_and_truncate_site(
     Returns:
         (A_tensor, singular_values, B_tensor, truncation_error)
     """
-    from tenax.algorithms._block_array import BlockArray
+    from tenax.core._block_array import BlockArray
 
     if isinstance(theta, BlockArray):
         labels = tuple(idx.label for idx in theta.indices)
@@ -1442,10 +1442,10 @@ def _svd_and_truncate_site(
     # Returns BlockArray directly — avoids JAX array creation in the sweep loop.
     # The sweep loop stores these as BlockArray; env updates accept either type.
     # Only converted to SymmetricTensor at the end of dmrg() for the result.
-    from tenax.algorithms._block_array import BlockArray
+    from tenax.core._block_array import BlockArray
 
     if config.numpy_blockwise and isinstance(theta, (SymmetricTensor, BlockArray)):
-        from tenax.algorithms._block_array import ba_to_symmetric
+        from tenax.core._block_array import ba_to_symmetric
         from tenax.linalg import _truncated_svd_symmetric_np
 
         # _truncated_svd_symmetric_np needs SymmetricTensor for index metadata
@@ -1643,7 +1643,7 @@ def _lanczos_solve_np(
     Returns:
         (eigenvalue, eigenvector) for the ground state as BlockArray.
     """
-    from tenax.algorithms._block_array import (
+    from tenax.core._block_array import (
         ba_add,
         ba_inner,
         ba_norm,
@@ -1960,7 +1960,7 @@ def _blockwise_contract(
         output_blocks[key] = total
 
     if return_ba:
-        from tenax.algorithms._block_array import BlockArray
+        from tenax.core._block_array import BlockArray
 
         return BlockArray(blocks=output_blocks, indices=output_indices)
 
@@ -1974,7 +1974,7 @@ def _blockwise_contract(
 
 def _assert_symmetric(*tensors: Tensor, context: str) -> None:
     """Assert all tensors are SymmetricTensor or BlockArray; raise TypeError otherwise."""
-    from tenax.algorithms._block_array import BlockArray
+    from tenax.core._block_array import BlockArray
 
     for i, t in enumerate(tensors):
         if not isinstance(t, (SymmetricTensor, BlockArray)):
@@ -2184,7 +2184,7 @@ def _scale_bond_axis_ba(ba: BlockArray, bond_label: str, s: np.ndarray) -> Block
     with numpy singular values. Used after SVD to absorb singular values
     into A or B for canonical form.
     """
-    from tenax.algorithms._block_array import BlockArray as _BA
+    from tenax.core._block_array import BlockArray as _BA
 
     bond_axis = None
     for i, idx in enumerate(ba.indices):
@@ -2228,7 +2228,7 @@ def _svd_and_truncate_site_np(
     Returns:
         (A_ba, singular_values, B_ba, truncation_error) -- all numpy.
     """
-    from tenax.algorithms._block_array import ba_to_symmetric
+    from tenax.core._block_array import ba_to_symmetric
     from tenax.linalg import _truncated_svd_symmetric_np
 
     labels = [idx.label for idx in theta_ba.indices]
@@ -2449,7 +2449,7 @@ def _execute_matvec_combos(
     are transposed once per matvec call (outside the combo loop) using the
     ``theta_perm`` / ``theta_shape_2d`` stored in each descriptor.
     """
-    from tenax.algorithms._block_array import BlockArray
+    from tenax.core._block_array import BlockArray
 
     n_slots = len(output_keys)
 
@@ -2556,7 +2556,7 @@ def _two_site_update_symmetric_np(
     signature) and returns SymmetricTensor + float. BlockArray is used
     internally to avoid JAX overhead in the Lanczos iterations.
     """
-    from tenax.algorithms._block_array import (
+    from tenax.core._block_array import (
         BlockArray,
         symmetric_to_ba,
     )
@@ -2705,7 +2705,7 @@ def _one_site_update_symmetric_np(
     signature) and returns SymmetricTensor + float. BlockArray is used
     internally to avoid JAX overhead in the Lanczos iterations.
     """
-    from tenax.algorithms._block_array import (
+    from tenax.core._block_array import (
         BlockArray,
         ba_to_symmetric,
         symmetric_to_ba,
@@ -2805,7 +2805,7 @@ def _update_left_env_np(
     mpo_site: Tensor,
 ) -> SymmetricTensor:
     """Update left environment, accepting BlockArray or SymmetricTensor for MPS site."""
-    from tenax.algorithms._block_array import BlockArray, ba_bar
+    from tenax.core._block_array import BlockArray, ba_bar
 
     if isinstance(mps_site, BlockArray):
         A = mps_site
@@ -2837,7 +2837,7 @@ def _update_right_env_np(
     mpo_site: Tensor,
 ) -> SymmetricTensor:
     """Update right environment, accepting BlockArray or SymmetricTensor for MPS site."""
-    from tenax.algorithms._block_array import BlockArray, ba_bar
+    from tenax.core._block_array import BlockArray, ba_bar
 
     if isinstance(mps_site, BlockArray):
         B = mps_site
@@ -3109,7 +3109,7 @@ def compute_mps_sector(mps_tensors: list[Tensor]) -> int | None:
         The total charge if consistently detectable, or None if the
         MPS is in a mixed sector (or contains no block-sparse tensor).
     """
-    from tenax.algorithms._block_array import BlockArray
+    from tenax.core._block_array import BlockArray
 
     for site in mps_tensors:
         if not isinstance(site, (SymmetricTensor, BlockArray)):

--- a/src/tenax/algorithms/idmrg.py
+++ b/src/tenax/algorithms/idmrg.py
@@ -1225,12 +1225,12 @@ def _idmrg_sweep_symmetric(
         _theta_buf_idx = 1  # theta is the 2nd tensor (index 1)
 
         if config.numpy_blockwise:
-            from tenax.algorithms._block_array import (
+            from tenax.algorithms.dmrg import _lanczos_solve_np
+            from tenax.core._block_array import (
                 BlockArray,
                 ba_to_symmetric,
                 symmetric_to_ba,
             )
-            from tenax.algorithms.dmrg import _lanczos_solve_np
             from tenax.linalg import _truncated_svd_symmetric_np
 
             # Convert envs to BlockArray BEFORE plan — avoids JAX _get_block

--- a/src/tenax/core/_block_array.py
+++ b/src/tenax/core/_block_array.py
@@ -13,24 +13,43 @@ from __future__ import annotations
 import math
 import os
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 
 from tenax.core.index import TensorIndex
 
-# Cache the import check once at module load time.
-_HAS_CYTHON_BA = False
-if os.environ.get("TENAX_DISABLE_CYTHON_BLAS", "0") != "1":
-    try:
-        from tenax.contraction._cython_blas import cython_ba_axpy as _c_axpy
-        from tenax.contraction._cython_blas import cython_ba_inner as _c_inner
-        from tenax.contraction._cython_blas import (
-            cython_ba_scale_inplace as _c_scale_inplace,
-        )
+# Cython BLAS handles are loaded lazily on first use to avoid a static
+# import edge from ``tenax.core`` into ``tenax.contraction`` (which would
+# invert the package layering).
+_HAS_CYTHON_BA: bool | None = None
+_c_axpy: Any = None
+_c_inner: Any = None
+_c_scale_inplace: Any = None
 
-        _HAS_CYTHON_BA = True
+
+def _ensure_cython_ba_loaded() -> bool:
+    """Lazily resolve the Cython BlockArray helpers; returns True if available."""
+    global _HAS_CYTHON_BA, _c_axpy, _c_inner, _c_scale_inplace
+    if _HAS_CYTHON_BA is not None:
+        return _HAS_CYTHON_BA
+    if os.environ.get("TENAX_DISABLE_CYTHON_BLAS", "0") == "1":
+        _HAS_CYTHON_BA = False
+        return False
+    try:
+        from tenax.contraction._cython_blas import (
+            cython_ba_axpy,
+            cython_ba_inner,
+            cython_ba_scale_inplace,
+        )
     except ImportError:
-        pass
+        _HAS_CYTHON_BA = False
+        return False
+    _c_axpy = cython_ba_axpy
+    _c_inner = cython_ba_inner
+    _c_scale_inplace = cython_ba_scale_inplace
+    _HAS_CYTHON_BA = True
+    return True
 
 
 @dataclass
@@ -118,7 +137,7 @@ def ba_inner(a: BlockArray, b: BlockArray) -> float | complex:
 
     Returns float for real inputs, complex for complex inputs.
     """
-    if _HAS_CYTHON_BA and a.blocks:
+    if a.blocks and _ensure_cython_ba_loaded():
         return _c_inner(a.blocks, b.blocks)
     total: float | complex = 0.0
     is_complex = False
@@ -138,7 +157,7 @@ def ba_axpy(x: BlockArray, y: BlockArray, alpha: float) -> None:
     For shared keys only; keys present in x but not y are ignored.
     This is the pattern needed by Lanczos reorthogonalization.
     """
-    if _HAS_CYTHON_BA:
+    if _ensure_cython_ba_loaded():
         _c_axpy(x.blocks, y.blocks, alpha)
     else:
         for k in x.blocks:
@@ -149,7 +168,7 @@ def ba_axpy(x: BlockArray, y: BlockArray, alpha: float) -> None:
 
 def ba_scale_inplace(ba: BlockArray, scalar: float) -> None:
     """Scale all blocks in-place.  Uses BLAS dscal when available."""
-    if _HAS_CYTHON_BA:
+    if _ensure_cython_ba_loaded():
         _c_scale_inplace(ba.blocks, scalar)
     else:
         for v in ba.blocks.values():

--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -372,10 +372,10 @@ def _truncated_svd_symmetric_np(
 
     Same algorithm as ``_truncated_svd_symmetric`` but returns
     ``(U_ba, s_final, Vh_ba, s_full)`` where U_ba and Vh_ba are
-    :class:`~tenax.algorithms._block_array.BlockArray` objects and
+    :class:`~tenax.core._block_array.BlockArray` objects and
     s_final, s_full are ``np.ndarray``.
     """
-    from tenax.algorithms._block_array import BlockArray
+    from tenax.core._block_array import BlockArray
 
     all_labels = tensor.labels()
     label_to_axis = {lbl: i for i, lbl in enumerate(all_labels)}
@@ -601,9 +601,9 @@ def _qr_symmetric_np(
 
     Same algorithm as ``_qr_symmetric`` but returns
     ``(Q_ba, R_ba)`` where Q_ba and R_ba are
-    :class:`~tenax.algorithms._block_array.BlockArray` objects.
+    :class:`~tenax.core._block_array.BlockArray` objects.
     """
-    from tenax.algorithms._block_array import BlockArray
+    from tenax.core._block_array import BlockArray
 
     all_labels = tensor.labels()
     label_to_axis = {lbl: i for i, lbl in enumerate(all_labels)}

--- a/tests/test_block_array.py
+++ b/tests/test_block_array.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from tenax import U1Symmetry
-from tenax.algorithms._block_array import (
+from tenax.core._block_array import (
     BlockArray,
     ba_add,
     ba_axpy,

--- a/tests/test_dmrg_cython.py
+++ b/tests/test_dmrg_cython.py
@@ -1086,12 +1086,12 @@ class TestCythonLanczosGround:
             cython_lanczos_ground,
         )
 
-        from tenax.algorithms._block_array import BlockArray
         from tenax.algorithms.dmrg import (
             _execute_matvec_combos,
             _lanczos_solve_np,
             _precompute_matvec_combos,
         )
+        from tenax.core._block_array import BlockArray
 
         rng = np.random.default_rng(42)
         subs = TWO_SITE_SUBSCRIPTS
@@ -1193,12 +1193,12 @@ class TestCythonLanczosGround:
             cython_lanczos_ground,
         )
 
-        from tenax.algorithms._block_array import BlockArray
         from tenax.algorithms.dmrg import (
             _execute_matvec_combos,
             _lanczos_solve_np,
             _precompute_matvec_combos,
         )
+        from tenax.core._block_array import BlockArray
 
         rng = np.random.default_rng(999)
         subs = TWO_SITE_SUBSCRIPTS

--- a/tests/test_lanczos_np.py
+++ b/tests/test_lanczos_np.py
@@ -6,7 +6,6 @@ import jax
 import numpy as np
 import pytest
 
-from tenax.algorithms._block_array import ba_to_symmetric, symmetric_to_ba
 from tenax.algorithms.dmrg import (
     _blockwise_contract,
     _build_trivial_left_env_symmetric,
@@ -19,6 +18,7 @@ from tenax.algorithms.dmrg import (
     build_mpo_heisenberg,
 )
 from tenax.contraction.contractor import contract
+from tenax.core._block_array import ba_to_symmetric, symmetric_to_ba
 from tenax.core.mps import FiniteMPS
 from tenax.core.symmetry import U1Symmetry
 

--- a/tests/test_linalg_np.py
+++ b/tests/test_linalg_np.py
@@ -7,9 +7,9 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from tenax.algorithms._block_array import BlockArray, ba_to_symmetric
 from tenax.algorithms._tensor_utils import scale_bond_axis
 from tenax.contraction.contractor import contract
+from tenax.core._block_array import BlockArray, ba_to_symmetric
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.symmetry import U1Symmetry
 from tenax.core.tensor import SymmetricTensor


### PR DESCRIPTION
## Summary

Resolves item 3 of #351.

The cross-layer cycle:

- `src/tenax/contraction/contractor.py:639` re-exports linear algebra from `tenax.linalg`.
- `src/tenax/linalg.py:378` and `:606` import `BlockArray` from `tenax.algorithms._block_array`.
- `src/tenax/algorithms/_block_array.py:25` imports the Cython BLAS helpers from `tenax.contraction._cython_blas`.

So `algorithms → linalg → contraction → algorithms` formed a static SCC.

Two changes break it:

1. **Move `_block_array.py` to `tenax.core._block_array`.** It only uses `tenax.core.index.TensorIndex` at module level, so the lowest layer is the natural home — both `linalg` and the algorithms layer can depend on it without going through `algorithms`.
2. **Defer the optional `tenax.contraction._cython_blas` import** behind a lazy `_ensure_cython_ba_loaded()` helper. The static AST of `_block_array` no longer has any edge into `contraction`, so the cycle disappears even though the runtime BLAS fast path is preserved (BLAS ddot / daxpy / dscal still kick in on first call when the extension is available).

All in-tree consumers (`linalg.py`, `algorithms/dmrg.py`, `algorithms/idmrg.py`, four test files) were updated to the new import path. The module name has a leading underscore, so no public API is affected.

## Test plan
- [x] `tests/test_block_array.py` — passes
- [x] `tests/test_lanczos_np.py` — passes (numpy fast path)
- [x] `tests/test_linalg_np.py` — passes (numpy SVD / QR through BlockArray)
- [x] `tests/test_dmrg_cython.py` — passes (Cython BLAS path with lazy loader)
- [x] `tests/test_dmrg.py -k "small or basic or simple or heisenberg"` — passes
- [x] `tests/test_architecture_imports.py` — passes
- [x] Static AST check: `tenax/core/_block_array.py` has no module-level edge into `tenax.contraction`