### PR TITLE
ci: include workflow edits in change-detection filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,11 @@ jobs:
           fetch-depth: 2
       - id: filter
         run: |
-          if git diff --name-only HEAD~1 HEAD | grep -qE '^(src/|tests/|pyproject\.toml)'; then
+          # Workflow edits under ``.github/workflows/`` are included so
+          # CI-config changes (e.g. a new test bucket) are exercised by
+          # the matrix on the merge commit instead of waiting for an
+          # unrelated code push to validate them.
+          if git diff --name-only HEAD~1 HEAD | grep -qE '^(src/|tests/|pyproject\.toml|\.github/workflows/)'; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The `changes` job that gates `test-full` only sets `code=true` when files matching `^(src/|tests/|pyproject\.toml)` change. So a CI-config-only PR like #383 (which split the fast bucket) lands on main, the merge commit's `changes` job exits with `code=false`, and `test-full` is **skipped** — the new matrix isn't actually validated until an unrelated code push happens to come along.

This adds `.github/workflows/` to the path filter so workflow edits also trigger the Full tests matrix on the merge commit. That is the path most likely to introduce CI changes that need validation, so the gate should never block them.

After this merges, the next CI-config change (or this very PR's merge) will exercise the new `fast-ipeps` / `fast-other` / `slow` buckets end-to-end on main.

## Test plan
- [ ] Merge this PR and verify the resulting main run actually executes `test-full` (i.e. `code=true` on a workflow-only diff).