### PR TITLE
fix(split-ctm): route fermionic energy through the shim path (#392)

### DIFF
--- a/src/tenax/algorithms/_split_ctm_tensor_energy.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_energy.py
@@ -24,7 +24,23 @@ from tenax.algorithms._tensor_utils import fuse_indices
 from tenax.contraction.contractor import contract
 from tenax.core import EPS
 from tenax.core.index import FlowDirection
-from tenax.core.tensor import Tensor
+from tenax.core.tensor import SymmetricTensor, Tensor
+
+
+def _is_fermionic_site(A: Tensor) -> bool:
+    """Return True iff *A* is a SymmetricTensor with a fermionic symmetry.
+
+    Used by ``compute_energy_split_ctm_tensor*`` to detect when the split-aware
+    energy path would carry a stale ``A.bar_super()`` Koszul phase that the
+    standard double-layer path's ``fuse_indices`` would otherwise cancel (see
+    issue #392).  In that regime we fall back to the shim path, accepting the
+    chi²·D⁸ peak in exchange for a fermion-correct result.
+    """
+    if not isinstance(A, SymmetricTensor):
+        return False
+    sym = A.indices[0].symmetry if A.indices else None
+    return bool(sym is not None and getattr(sym, "is_fermionic", False))
+
 
 # ------------------------------------------------------------------ #
 # Energy computation (split, no double-layer)                          #
@@ -1065,6 +1081,13 @@ def compute_energy_split_ctm_tensor(
     ``(T_ket, T_bra, A, A.bar_super())``, without merging ket/bra to the
     standard double-layer env. Bounded peak intermediate ~chi^2 * D^4.
 
+    For fermionic sites the split-aware path carries a stale ``bar_super``
+    Koszul phase that ``fuse_indices`` would otherwise cancel; until that
+    convention mismatch is resolved (issue #392) the function falls back to
+    the shim path, which routes ``compute_energy_ctm_tensor`` through
+    ``_split_env_to_tensor_standard``.  The shim peaks at chi²·D⁸ but is
+    fermion-correct.
+
     Args:
         A:                iPEPS site tensor with labels ``(u, d, l, r, phys)``.
         env:              Converged SplitCTMTensorEnv.
@@ -1074,6 +1097,13 @@ def compute_energy_split_ctm_tensor(
     Returns:
         Scalar energy per site.
     """
+    if _is_fermionic_site(A):
+        from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
+
+        return compute_energy_ctm_tensor(
+            A, _split_env_to_tensor_standard(env), hamiltonian_gate, d
+        )
+
     if d is None:
         phys_idx = [i for i in A.indices if i.label == "phys"]
         d = phys_idx[0].dim if phys_idx else A.indices[-1].dim
@@ -1100,6 +1130,9 @@ def compute_energy_split_ctm_tensor_2site(
 ) -> jax.Array:
     """Compute energy per site for a 2-site checkerboard iPEPS, split-aware.
 
+    Falls back to the shim path for fermionic sites (issue #392) — see
+    :func:`compute_energy_split_ctm_tensor` for details.
+
     Args:
         A:                Site tensor for sublattice A.
         B:                Site tensor for sublattice B.
@@ -1111,6 +1144,18 @@ def compute_energy_split_ctm_tensor_2site(
     Returns:
         Scalar energy per site.
     """
+    if _is_fermionic_site(A) or _is_fermionic_site(B):
+        from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor_2site
+
+        return compute_energy_ctm_tensor_2site(
+            A,
+            B,
+            _split_env_to_tensor_standard(env_A),
+            _split_env_to_tensor_standard(env_B),
+            hamiltonian_gate,
+            d,
+        )
+
     if d is None:
         phys_idx = [i for i in A.indices if i.label == "phys"]
         d = phys_idx[0].dim if phys_idx else A.indices[-1].dim
@@ -1138,6 +1183,9 @@ def compute_energy_split_ctm_tensor_multisite(
 
     Each bond is counted once. Energy is normalized by the number of sites.
 
+    Falls back to the shim path when any site is fermionic (issue #392) — see
+    :func:`compute_energy_split_ctm_tensor` for details.
+
     Args:
         site_tensors: ``{coord: Tensor}`` mapping coordinates to iPEPS site tensors.
         envs:         ``{coord: SplitCTMTensorEnv}`` converged split environments per site.
@@ -1149,6 +1197,18 @@ def compute_energy_split_ctm_tensor_multisite(
     Returns:
         Scalar energy per site.
     """
+    if any(_is_fermionic_site(site) for site in site_tensors.values()):
+        from tenax.algorithms._ctm_tensor_energy import (
+            compute_energy_ctm_tensor_multisite,
+        )
+
+        std_envs = {
+            coord: _split_env_to_tensor_standard(env) for coord, env in envs.items()
+        }
+        return compute_energy_ctm_tensor_multisite(
+            site_tensors, std_envs, neighbors, gate, d
+        )
+
     # Infer physical dimension
     if d is None:
         first_A = next(iter(site_tensors.values()))

--- a/tests/test_split_ctm_tensor.py
+++ b/tests/test_split_ctm_tensor.py
@@ -942,30 +942,22 @@ class TestSplitRDMsFermionic:
     """Parity vs shim with FermionParity site tensors (Tier 2).
 
     Bosonic parity tests don't exercise ``A.bar_super()``'s Koszul-twist /
-    flow-flip handling.  The shim path also routes through ``bar_super()``
-    (inside ``_build_double_layer_open_tensor``); if both paths produce the
-    same energy on a fermionic site, the new path's per-leg twist handling
-    is equivalent to the old path's bake-then-fuse handling.
+    flow-flip handling.  The split-aware path's per-leg ``A.bar_super()``
+    absorption carries a stale Koszul phase that ``_build_double_layer_open_tensor``'s
+    raw ``fuse_indices`` would otherwise cancel; until the convention mismatch
+    in the split-aware RDM functions is resolved (issue #392),
+    ``compute_energy_split_ctm_tensor`` falls back to the shim path
+    automatically when the site is fermionic.  This parity test verifies
+    that the fall-back is wired up correctly: split-CTM-on-fermionic must
+    return the shim's energy to machine precision.
 
     Note on chi choice: with ``FermionParity`` virtual charges (alternating
     0/1), ``ctm_split_tensor`` converges cleanly at every chi after the
     fix for issue #391 (canonical SVD-bond charges shared between ket and
     bra).  Pre-fix this test only exercised chi=6 and chi=12 because
     intermediate chi values crashed in the projector path.
-
-    Status (2026-05-05): the assertion is currently expected to fail —
-    once the bra populates with non-trivial blocks (after issue #391),
-    ``compute_energy_split_ctm_tensor`` and the shim+standard path
-    disagree.  Pre-#391 they agreed only because the misaligned SVD bond
-    left the bra at exactly zero, so both energies were 0.0.  See
-    issue #392 for the energy-path discrepancy investigation.
     """
 
-    @pytest.mark.xfail(
-        reason="Issue #392: split vs shim energies disagree once #391 lets "
-        "the bra populate with non-trivial blocks; pre-#391 both were 0.0.",
-        strict=True,
-    )
     @pytest.mark.parametrize("D, chi", [(2, 6), (3, 12)])
     def test_fermionic_energy_matches_shim(self, D, chi, heisenberg_gate):
         from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor


### PR DESCRIPTION
## Summary

- Route `compute_energy_split_ctm_tensor[_2site|_multisite]` through the shim path (`_split_env_to_tensor_standard` + `compute_energy_ctm_tensor*`) when the site tensor is fermionic, via a new `_is_fermionic_site(A)` helper.
- Removes the `xfail(strict=True)` marker on `TestSplitRDMsFermionic::test_fermionic_energy_matches_shim` and updates its docstring.

## Why

The split-aware energy path (PR #390) absorbs `A.bar_super()` directly through the Koszul-aware fermionic contractor. Unlike `_build_double_layer_open_tensor`, there is no matching `fuse_indices` raw transpose to cancel `bar_super`'s `(-1)^S` phase, so the split path's per-block factors disagree with the shim's. PR #391 (merged as #393, c0666f6) exposed this by letting the bra populate with non-trivial blocks; before that the misaligned SVD bond left both energies at exactly 0.0 and the parity test passed vacuously.

Empirical probes from this session:
- `_rdm_1site_split_tensor` produces `diag(1.51, -0.51)` (negative diagonal — unphysical) for `make_random_fermionic_site(D=2, d=2, seed=70)`; the shim gives `diag(0.69, 0.31)`.
- Replacing `bar_super()` with `bar()` in the split path alone makes the 2x1 RDM discrepancy worse, not better, so a one-line "swap the bra primitive" fix is not it.
- Switching both the convergence and the energy path to `bar()` also fails to make split == shim.

The deeper fix (likely a Koszul-aware fuse_indices, or a corrective per-block sign on the absorbed `A_bra`) was beyond what I could localise in this session. The pragmatic, fermion-correct fall-back ships now; the χ²·D⁴ recovery is tracked in the issue's "open work" notes.

## Test plan

- [x] `JAX_PLATFORMS=cpu uv run pytest tests/test_split_ctm_tensor.py::TestSplitRDMsFermionic -xvs` — both `[2-6]` and `[3-12]` parametrisations pass with `atol=1e-10`.
- [x] `JAX_PLATFORMS=cpu uv run pytest tests/test_split_ctm_tensor.py -x` — 51 passed, no regressions on the bosonic χ²·D⁴ path.
- [x] `JAX_PLATFORMS=cpu uv run pytest tests/test_ctm_tensor.py tests/test_split_ctm_large_d_memory.py -x` — 28 passed, 3 skipped.

## Notes

- The fall-back peaks at χ²·D⁸ (the cost #390 was designed to avoid). For bosonic large-D users the split-aware path is unchanged. For fermionic large-D users this is a perf regression in exchange for correctness.
- Issue #392 should remain **open** with a follow-up scope: localise the missing Koszul correction in `_rdm{2x1,1x2,1site,diagonal}_split_tensor*` and remove the fermionic fall-back.