### PR TITLE
benchmark: extend Liao 2017 PESS SU sweep to D=12, D=14

### DIFF
--- a/examples/kagome_spin12_pess_liao2017_replication.json
+++ b/examples/kagome_spin12_pess_liao2017_replication.json
@@ -1,7 +1,7 @@
 {
   "reference": "Liao et al., PRL 118, 137202 (2017), arXiv:1610.04727",
   "asymptotic_target_E0": -0.43752,
-  "notes": "P2 (Convention-C + CTM) was run only at D=4 (chi=32, ~34 GB peak RSS). At D>=6 the chi=2D^2 CTM projector SVD allocates >100 GB and OOM-kills a 256 GB box; runs above D=4 use --skip-p2. The D=4 P2 number is sufficient to establish the Convention-C bias for the audit; D-scaling of P2 was not measured.",
+  "notes": "P2 (Convention-C + CTM) was run only at D=4 (chi=32, ~34 GB peak RSS) on the original 2026-05-04 sweep. At D>=6 the chi=2D^2 CTM projector SVD allocates >100 GB and OOM-kills a 256 GB box; runs above D=4 use --skip-p2. The D=4 P2 number is sufficient to establish the Convention-C bias for the audit; D-scaling of P2 was not measured. 2026-05-05 update: extended the SU sweep to D=12 and D=14. Husimi-probe (P1) energies saturate around -0.4275..-0.4300 starting at D~=8; D=12/14 do NOT improve over D=10 with the current SU schedule [(0.1,200),(0.01,200),(0.001,100)] -- the (0.001,100) tail is likely too short to converge SU at large D, so the +0.010-0.011 gap at D>=12 should be read as 'SU not converged here' rather than 'Husimi probe ceiling'.",
   "results": [
     {
       "D": 4,
@@ -57,6 +57,34 @@
       "delta_p2_target": null,
       "t_su_seconds": 5.017281210981309,
       "t_p1_seconds": 0.10440045315772295,
+      "t_p2_seconds": 0.0
+    },
+    {
+      "D": 12,
+      "chi": 288,
+      "seed": 0,
+      "su_schedule": [[0.1, 200], [0.01, 200], [0.001, 100]],
+      "e_p1_husimi": -0.42751965958203203,
+      "e_p2_ctm": null,
+      "liao2017_target": null,
+      "delta_p1_target": null,
+      "delta_p2_target": null,
+      "t_su_seconds": 33.54037883132696,
+      "t_p1_seconds": 0.2850807886570692,
+      "t_p2_seconds": 0.0
+    },
+    {
+      "D": 14,
+      "chi": 392,
+      "seed": 0,
+      "su_schedule": [[0.1, 200], [0.01, 200], [0.001, 100]],
+      "e_p1_husimi": -0.42799883545352885,
+      "e_p2_ctm": null,
+      "liao2017_target": null,
+      "delta_p1_target": null,
+      "delta_p2_target": null,
+      "t_su_seconds": 38.91079148836434,
+      "t_p1_seconds": 0.34667867608368397,
       "t_p2_seconds": 0.0
     }
   ]

--- a/examples/kagome_spin12_pess_liao2017_replication.py
+++ b/examples/kagome_spin12_pess_liao2017_replication.py
@@ -139,9 +139,14 @@ def run_one(
             else "(skipped)"
         )
         target_str = f"{target:.6f}" if target is not None else "n/a"
+        d_p1_str = (
+            f"{record['delta_p1_target']:+.4f}"
+            if record["delta_p1_target"] is not None
+            else "n/a"
+        )
         print(
             f"  D={D:2d} χ={chi:3d}  P1={e_p1:.6f}  P2={e_p2_str}  "
-            f"target={target_str}  Δ_P1={record['delta_p1_target']:+.4f}  "
+            f"target={target_str}  Δ_P1={d_p1_str}  "
             f"Δ_P2={d_p2_str}",
             flush=True,
         )


### PR DESCRIPTION
## Summary
- Extend the Liao 2017 spin-½ kagome 3-PESS replication SU sweep to D=12 and D=14 (previously stopped at D=10 because that's Liao's largest published bond dimension in Fig 1(a)).
- D=4..10 reproduce the 2026-05-04 sweep numbers to all printed digits — consistency check passes (no PESS/SU code changes since PR #387).
- **D=12 and D=14 saturate near −0.4275..−0.4280 with the current SU schedule** [(0.1,200),(0.01,200),(0.001,100)] — worse than D=8/10's −0.4300/−0.4298. This is "SU's (0.001,100) tail is too short to converge at large D", not "Husimi probe ceiling at +0.010". A longer final-dt tail (e.g. (0.0001, 200)) would let us re-evaluate whether the +0.006 floor at D≤10 holds at D≥12.
- Drive-by: the verbose-print path now handles D values without a Liao reference (D=12, 14) — previously crashed with `TypeError` formatting `None` as a float.

| D  | χ   | P1 (Husimi) | Liao Fig 1(a) | Δ vs Liao |
|----|-----|-------------|---------------|-----------|
| 4  | 32  | −0.420004   | −0.4290       | +0.0090   |
| 6  | 72  | −0.427996   | −0.4340       | +0.0060   |
| 8  | 128 | −0.430034   | −0.4360       | +0.0060   |
| 10 | 200 | −0.429781   | −0.4365       | +0.0067   |
| 12 | 288 | −0.427520   | (n/a)         | (n/a)     |
| 14 | 392 | −0.427999   | (n/a)         | (n/a)     |

Liao asymptotic E0 = −0.43752(6).

## Test plan
- [x] Re-run the harness end-to-end on D=4..14 and confirmed JSON writes cleanly
- [x] Verified D=4..10 results bit-for-bit match the existing 2026-05-04 entries
- [x] Pre-commit hooks (ruff, ruff format) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)