### PR TITLE
fix(pess-ad): accept Tensor-valued bond gates in 3-site multisite path (#402)

### DIFF
--- a/src/tenax/algorithms/pess_optimize.py
+++ b/src/tenax/algorithms/pess_optimize.py
@@ -563,6 +563,18 @@ def optimize_pess_3site_multisite_ad(
     """
     import optax
 
+    # Promote Tensor-valued gates to ndarray once at the optimizer entry
+    # so both the loss closure and the warm-start helper below see a
+    # uniform jax.Array type — issue #402 / PR #405 review.  Without this
+    # hoist, ``_build_site_tensors_for_warm_start`` would do
+    # ``next(iter(bond_gates.values())).shape[0]`` on the un-promoted dict
+    # and crash on Tensor inputs *after* the first loss eval succeeds,
+    # leaving the advertised Tensor-valued multisite path unusable.
+    bond_gates_arr = {
+        k: (g.todense() if isinstance(g, Tensor) else g) for k, g in bond_gates.items()
+    }
+    d = int(next(iter(bond_gates_arr.values())).shape[0])
+
     # Env warm-start cache. Analogous to but simpler than
     # _optimize_gs_ad_multisite — no stall recovery, no best_env_cache
     # snapshot, no fresh-CTM final eval. The env never escapes back to
@@ -570,7 +582,7 @@ def optimize_pess_3site_multisite_ad(
     # currently harmless.
     _env_cache: dict[str, dict] = {}
     loss_fn_state = build_pess_loss_3site_multisite(
-        bond_gates, config, env_cache=_env_cache
+        bond_gates_arr, config, env_cache=_env_cache
     )
 
     params = {
@@ -604,7 +616,6 @@ def optimize_pess_3site_multisite_ad(
             p["lambdas"],
         )
         D = sites["u"].shape[0]
-        d = int(next(iter(bond_gates.values())).shape[0])
         indices = _make_multisite_indices(D, d)
         site_tensors = {}
         for name, A in sites.items():

--- a/src/tenax/algorithms/pess_optimize.py
+++ b/src/tenax/algorithms/pess_optimize.py
@@ -39,7 +39,7 @@ from tenax.algorithms.pess import (
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.lattice import kagome
 from tenax.core.symmetry import U1Symmetry
-from tenax.core.tensor import DenseTensor
+from tenax.core.tensor import DenseTensor, Tensor
 
 __all__ = [
     "build_pess_loss",
@@ -444,8 +444,17 @@ def build_pess_loss_3site_multisite(
         through the implicit-AD multisite CTM; ``T_d`` participates in the
         gradient.
     """
+    # Promote Tensor-valued gates to ndarray at entry so the rest of the
+    # closure (and the .shape inference below) sees a uniform jax.Array
+    # type — issue #402.  ``compute_energy_pess_3site_multisite`` accepts
+    # both, but its ``.shape[0]`` access here would otherwise crash on
+    # symmetry-aware / Tensor-protocol gates before reaching the supported
+    # downstream code path.
+    bond_gates_arr = {
+        k: (g.todense() if isinstance(g, Tensor) else g) for k, g in bond_gates.items()
+    }
     # Infer physical dimension from any bond gate (each is shape (d,d,d,d)).
-    d = int(next(iter(bond_gates.values())).shape[0])
+    d = int(next(iter(bond_gates_arr.values())).shape[0])
 
     def _energy_fn(site_tensors_coord, envs_coord, _gate):
         site_tensors_name = {
@@ -456,7 +465,7 @@ def build_pess_loss_3site_multisite(
             site_tensors_name,
             envs_name,
             _MULTISITE_LATTICE.neighbor_map,
-            bond_gates,
+            bond_gates_arr,
             d=d,
         )
 

--- a/tests/test_pess_ad.py
+++ b/tests/test_pess_ad.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from tenax.algorithms._pess_multisite_energy import kagome_3site_bond_gates
@@ -24,6 +25,9 @@ from tenax.algorithms.pess_optimize import (
     optimize_pess_3site_multisite_ad,
     optimize_pess_ad,
 )
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import U1Symmetry
+from tenax.core.tensor import DenseTensor
 
 
 def _make_test_config(chi: int) -> CTMConfig:
@@ -219,3 +223,60 @@ def test_optimize_pess_3site_multisite_ad_preserves_shapes_and_optimises_T_d():
         "T_d unchanged after L-BFGS in the multisite path — the optimiser "
         "is silently freezing T_d (regression: it should be a live param)."
     )
+
+
+# ---------------------------------------------------------------------------
+# Tensor-valued bond gates (issue #402)
+# ---------------------------------------------------------------------------
+
+
+def _wrap_gate_as_dense_tensor(H: jnp.ndarray) -> DenseTensor:
+    """Wrap a (d,d,d,d) ndarray gate as a DenseTensor with trivial U(1)
+    charges, mirroring the convention used by ``ipeps.heisenberg_gate`` /
+    ``ipeps.xxz_gate``.
+
+    ``compute_energy_pess_3site_multisite`` accepts ``Tensor`` valued
+    gates and demotes them via ``.todense().reshape(d,d,d,d)``; this
+    helper exists so we can construct that branch's input from the test
+    side without depending on a public wrapper function.
+    """
+    d = int(H.shape[0])
+    sym = U1Symmetry()
+    charges = np.zeros(d, dtype=np.int32)
+    indices = (
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.IN, label="si"),
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.IN, label="sj"),
+        TensorIndex.from_charges(
+            sym, charges.copy(), FlowDirection.OUT, label="si_out"
+        ),
+        TensorIndex.from_charges(
+            sym, charges.copy(), FlowDirection.OUT, label="sj_out"
+        ),
+    )
+    return DenseTensor(jnp.asarray(H), indices)
+
+
+def test_pess_loss_3site_multisite_accepts_tensor_bond_gates():
+    """Closure builder accepts DenseTensor-valued gates (issue #402).
+
+    The downstream energy fn ``compute_energy_pess_3site_multisite``
+    already advertises ``jax.Array | Tensor`` and routes Tensor through
+    ``.todense().reshape(d,d,d,d)``.  ``build_pess_loss_3site_multisite``
+    must therefore not reject Tensor inputs at the entry-point
+    ``int(... .shape[0])`` access — that broke symmetry-aware /
+    Tensor-protocol gates before they ever reached the supported code
+    path.  Test feeds a ``DenseTensor``-wrapped gate dict and asserts the
+    loss closure builds and returns a finite real scalar.
+    """
+    state = IPESSState.random(D=2, d=3, key=jax.random.PRNGKey(0))
+    array_gates = kagome_3site_bond_gates(delta=1.0, d=3)
+    bond_gates = {k: _wrap_gate_as_dense_tensor(g) for k, g in array_gates.items()}
+    assert all(isinstance(g, DenseTensor) for g in bond_gates.values())
+    config = _make_test_config(chi=8)
+
+    loss_fn = build_pess_loss_3site_multisite(bond_gates, config)
+    e0 = loss_fn(state)
+
+    assert jnp.shape(e0) == ()
+    assert jnp.isfinite(e0)
+    assert jnp.isrealobj(e0) or jnp.allclose(e0.imag, 0.0, atol=1e-10)

--- a/tests/test_pess_ad.py
+++ b/tests/test_pess_ad.py
@@ -299,6 +299,35 @@ def test_pess_loss_3site_multisite_accepts_tensor_bond_gates():
     assert jnp.isrealobj(e0) or jnp.allclose(e0.imag, 0.0, atol=1e-10)
 
 
+def test_optimize_pess_3site_multisite_ad_accepts_tensor_bond_gates():
+    """``optimize_pess_3site_multisite_ad`` must work with Tensor gates.
+
+    Regression for issue #402 follow-up (PR #405 review): the loss closure
+    promotes Tensor gates locally, but the optimizer's warm-start helper
+    ``_build_site_tensors_for_warm_start`` separately did
+    ``next(iter(bond_gates.values())).shape[0]`` on the un-promoted dict.
+    The first ``loss(params)`` call succeeds, then the immediate
+    ``_update_env_cache(params)`` raises ``AttributeError`` and the
+    advertised Tensor-valued multisite optimisation path stays unusable.
+
+    One L-BFGS step is enough to drive both the loss path and
+    ``_update_env_cache``; we don't assert on energy descent (covered by
+    ``test_optimize_pess_3site_multisite_ad_decreases_energy`` for arrays).
+    """
+    state0 = IPESSState.random(D=2, d=3, key=jax.random.PRNGKey(0))
+    array_gates = kagome_3site_bond_gates(delta=1.0, d=3)
+    bond_gates = {k: _wrap_gate_as_dense_tensor(g) for k, g in array_gates.items()}
+    config = _make_test_config(chi=8)
+
+    state_opt, e_opt = optimize_pess_3site_multisite_ad(
+        state0, bond_gates, config, max_iter=1, verbose=False
+    )
+
+    assert jnp.isfinite(e_opt)
+    assert state_opt.R_a.shape == state0.R_a.shape
+    assert state_opt.T_d.shape == state0.T_d.shape
+
+
 def test_build_pess_loss_3site_multisite_passes_env_init_from_cache():
     """When ``env_cache`` is provided, the loss reads ``envs`` from it and
     forwards them as ``env_init=`` to the CTM AD entry point."""


### PR DESCRIPTION
Closes #402.

## Summary

- Promote ``Tensor``-valued bond gates to ``ndarray`` at the entry of ``build_pess_loss_3site_multisite`` so the ``int(... .shape[0])`` access does not crash on ``DenseTensor`` / ``SymmetricTensor`` inputs.
- The promoted dict is captured in the closure so ``compute_energy_pess_3site_multisite`` sees ``ndarray`` gates uniformly — avoids a double ``.todense()`` inside the AD-traced energy contraction.

## Why

``compute_energy_pess_3site_multisite`` already advertises ``jax.Array | Tensor`` and routes ``Tensor`` gates through ``.todense().reshape(d,d,d,d)``, but ``build_pess_loss_3site_multisite`` did ``next(iter(bond_gates.values())).shape[0]`` *before* execution reached the supported path. Symmetry-aware / Tensor-protocol gates raised ``AttributeError`` at construction, making the new multisite AD loss unusable for that legitimate input shape.

## Test plan

- [x] ``test_pess_loss_3site_multisite_accepts_tensor_bond_gates`` in ``tests/test_pess_ad.py`` builds a ``DenseTensor``-wrapped gate dict and asserts the closure returns a finite real scalar. Fails on main with ``AttributeError: 'DenseTensor' object has no attribute 'shape'``, passes here.
- [x] Existing array-gate path (``test_pess_loss_3site_multisite_returns_finite_real_scalar``) still passes.

## Out of scope

- Issue #401 (line-search ``alpha=0`` stall) ships separately on PR #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)