### PR TITLE
refactor(ctm): switch CTM sweep order to variPEPS convention (left→top→right→bottom)

### DIFF
--- a/src/tenax/algorithms/_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_ctm_tensor_convergence.py
@@ -90,14 +90,14 @@ def _ctm_tensor_sweep(
     projector_method: str = "svd",
     projector_backward: str = "auto",
 ) -> CTMTensorEnv:
-    """One full CTM sweep: left, right, top, bottom + optional renormalize."""
+    """One full CTM sweep: left, top, right, bottom (variPEPS order) + optional renormalize."""
     env = _ctm_tensor_move_left(
         env, env, a, chi, projector_method, projector_backward=projector_backward
     )
-    env = _ctm_tensor_move_right(
+    env = _ctm_tensor_move_top(
         env, env, a, chi, projector_method, projector_backward=projector_backward
     )
-    env = _ctm_tensor_move_top(
+    env = _ctm_tensor_move_right(
         env, env, a, chi, projector_method, projector_backward=projector_backward
     )
     env = _ctm_tensor_move_bottom(
@@ -168,8 +168,8 @@ def make_neighbors(nx: int, ny: int) -> dict[Coord, dict[str, Coord]]:
 
 _DIRECTION_MOVES = [
     ("left", _ctm_tensor_move_left),
-    ("right", _ctm_tensor_move_right),
     ("top", _ctm_tensor_move_top),
+    ("right", _ctm_tensor_move_right),
     ("bottom", _ctm_tensor_move_bottom),
 ]
 
@@ -183,8 +183,8 @@ _DIRECTION_MOVES = [
 # 4 sites at offsets {(0,0), (1,0), (0,1), (1,1)} relative to that anchor.
 _DIRECTION_MOVES_2X2 = [
     ("left", _ctm_tensor_move_left_2x2),
-    ("right", _ctm_tensor_move_right_2x2),
     ("top", _ctm_tensor_move_top_2x2),
+    ("right", _ctm_tensor_move_right_2x2),
     ("bottom", _ctm_tensor_move_bottom_2x2),
 ]
 
@@ -319,7 +319,7 @@ def _ctm_tensor_sweep_multisite(
         # direction would see partially-updated env tensors used to build
         # the plaquette (a stale-projector vs fresh-absorbed inconsistency
         # known to destabilise multisite CTM convergence).
-        for direction in ("left", "right", "top", "bottom"):
+        for direction in ("left", "top", "right", "bottom"):
             envs_old = dict(envs)
             # Phase 1: precompute projector pairs anchored at every cell.
             projectors: dict[Coord, tuple] = {}


### PR DESCRIPTION
## Summary

- Changes Tenax's CTMRG absorption sweep order from `(left, right, top, bottom)` to `(left, top, right, bottom)` — variPEPS's canonical convention (`varipeps/ctmrg/absorption.py:660-665`).
- Single-file change in `src/tenax/algorithms/_ctm_tensor_convergence.py`, 4 call sites.

## Why

Empirical comparison of Tenax vs variPEPS on square Heisenberg at matched (D, χ) showed Tenax disagreeing with variPEPS by ~2×10⁻³ on a random 2-site iPEPS state. Sweep order is the most likely source of intermediate-gauge differences. Switching to variPEPS's order shrinks the gap by ~4× at central χ values for asymmetric states.

## Quantitative impact (D=2, χ ∈ {8, 16, 24, 32})

Probe: `examples/dev/p4_square_heisenberg_tenax_vs_varipeps.py` (uncommitted scratch). Random-normalised A, B at D=2; same iPEPS state in both libraries (axes permuted); Heisenberg gate on H+V bonds; CTM-only forward, no AD.

| case | χ | diff_old (LRTB) | diff_new (LTRB) | factor |
|---|---|---|---|---|
| A≠B random | 16 | -1.50e-03 | **-4.25e-04** | ~3.5× closer |
| A≠B random | 24 | -1.98e-03 | **-3.50e-04** | ~5.7× closer |
| A=B uniform | 16 | +4.92e-03 | +4.18e-03 | modest |
| A=B uniform | 32 | +4.57e-03 | +4.19e-03 | modest |

The A≠B asymmetric case improves substantially. The A=B uniform case improves only modestly — the remaining O(4×10⁻³) gap is presumably from bond-RDM contraction conventions and Tenax's chi-instability at χ ≫ D² (variPEPS settles to ≥6 decimals from χ=16; Tenax fluctuates by ~5×10⁻⁴).

## Test plan

- [x] `tests/test_ctm_tensor.py`, `tests/test_ctm_tensor_projector_2x2.py`, `tests/test_ctm_paired.py`, `tests/test_ctm_python_loop.py`, `tests/test_ctm_tensor_c4v.py` — same 4 pre-existing failures as `origin/main`. **No new failures introduced** (verified by stashing the diff and re-running — identical failure set).
- [x] Probe re-run on the new sweep order showing the gap reduction in the table above.
- [ ] CI required checks (Python 3.11, 3.12, macOS 3.12) on this PR.

## Notes

- The 4 pre-existing failures on main (`test_energy_symmetric_matches_dense`, `test_2site_symmetric_energy_matches_dense`, `test_paired_sweep_fermionic_energy_converged`, `test_paired_sweep_u1_stable`) are a separate concern — they fail on `origin/main` (post-PR #406 merge) too.
- `forward-CTM SVD default` (PR #399, 2026-05-07) and `2x2 plaquette projector` (PR #406, 2026-05-08) preceded this. The remaining variPEPS-parity gap on uniform states warrants follow-up — likely candidates: bond-RDM contraction order in `_rdm{2x1,1x2}_tensor_2site`, or a `truncation_eps` parameter analogous to variPEPS's `ctmrg_truncation_eps` heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)