### PR TITLE
fix(ctm): SymmetricTensor SVD projector gauge + n_blocks==0 fallback (#408)

### DIFF
--- a/src/tenax/algorithms/_ctm_projector.py
+++ b/src/tenax/algorithms/_ctm_projector.py
@@ -717,7 +717,13 @@ def _svd_projector_symmetric(
     p2_blocks: dict[tuple[int, ...], jax.Array] = {}
 
     for fq in sorted(sector_keep.keys()):
-        keep_indices = sorted(sector_keep[fq], reverse=True)
+        # SVD returns singular values in descending order, so kept indices
+        # in ascending order = top singular values first. This matches the
+        # dense path's ``[:k]`` convention and keeps the chi_new gauge
+        # consistent across the four corner moves. (Cf. eigh path, which
+        # uses descending-index because jnp.linalg.eigh returns ascending
+        # eigenvalues — the opposite of SVD.)
+        keep_indices = sorted(sector_keep[fq])
         n_q = len(keep_indices)
         chi_new_charges.extend([fq] * n_q)
 
@@ -816,12 +822,23 @@ def _compute_projector_tensor(
     # Reference: Fishman et al., PRB 98, 235148 (2018);
     #            YASTN proj_corners + regularize_1site_corners.
     if projector_method == "svd":
-        # Block-sparse SVD for SymmetricTensor (non-tracer)
+        # Block-sparse SVD for SymmetricTensor (non-tracer).
+        # The dense fallback below is intended only for DenseTensor inputs
+        # and the AD-traced backward path; for any non-traced SymmetricTensor
+        # pair, _svd_projector_symmetric handles per-sector SVD correctly,
+        # *including* the n_blocks==0 case (returns properly-shaped zero
+        # projectors via the M_q.size==0 skip). Earlier this condition was
+        # ``C1g.n_blocks > 0 and C4g.n_blocks > 0``, which dropped into the
+        # dense fallback whenever one corner was zero-truncated. Then
+        # ``C1g.todense() @ C4g.todense()`` could fail shape compatibility
+        # because the fused TensorIndex charges (and therefore dense sizes)
+        # differ between the two corners — producing the ``dot_general
+        # (24,) vs (20,)`` shape error reported in issue #408.
         if isinstance(C1g, SymmetricTensor) and isinstance(C4g, SymmetricTensor):
             has_tracers = isinstance(C1g._data, jax.core.Tracer) or isinstance(
                 C4g._data, jax.core.Tracer
             )
-            if not has_tracers and C1g.n_blocks > 0 and C4g.n_blocks > 0:
+            if not has_tracers:
                 fused_pos_chk = C1g.labels().index("fused")
                 c1_charges = C1g.indices[fused_pos_chk].charges
                 c4_charges = C4g.indices[fused_pos_chk].charges


### PR DESCRIPTION
## Summary

Fixes 4 SymmetricTensor + paired-sweep CTM tests that have been silently failing on `main` since PR #399 flipped the default forward-CTM `projector_method` from `eigh` to `svd`. CI didn't catch them because they're auto-marked `algorithm` and core gate runs only `pytest -m core`.

Two latent bugs in `src/tenax/algorithms/_ctm_projector.py`:

1. **`_svd_projector_symmetric` column order** — `keep_indices = sorted(..., reverse=True)` was copy-pasted from the eigh path, where descending-index = top eigenvalues (`jnp.linalg.eigh` returns ascending). For SVD the convention is *opposite* — `jnp.linalg.svd` returns descending — so reverse-index ordering picked the *worst* singular vectors first, reversing the projector's `chi_new` gauge. The dense path uses `[:k]` (ascending index = top SVs), so sym vs. dense gauges drifted; subsequent corner moves cross-producted mis-gauged corners that happened to be orthogonal, zeroing the next projector. Fix: sort ascending.

2. **`_compute_projector_tensor` block-sparse gate (SVD branch)** — gated on `C1g.n_blocks > 0 and C4g.n_blocks > 0`, dropping into the dense fallback when either corner was zero-truncated. The dense fallback computes `C1g.todense().conj().T @ C4g.todense()`, which only matches when both corners have identical fused dimension. After a horizontal sweep zero-truncates one corner's chi-leg, the vertical sweep sees fused dims 24 vs. 20 → `dot_general (24,) vs (20,)`. Fix: gate only on `not has_tracers` — `_svd_projector_symmetric` already handles `n_blocks==0` via its `M_q.size == 0` skip. Matches the eigh path's gating.

Bisect confirms the regressing commit is 5a83c76 (PR #399). Tests pass at parent ae247e7 and fail from #399 onward through current main (cd2d0aa).

## Test plan

- [x] `pytest tests/test_ctm_tensor.py::TestConvergence::test_energy_symmetric_matches_dense tests/test_ctm_tensor.py::TestTwoSiteCTM::test_2site_symmetric_energy_matches_dense tests/test_ctm_paired.py::TestPairedSweepFermionic::test_paired_sweep_fermionic_energy_converged tests/test_ctm_paired.py::TestPairedSweepU1::test_paired_sweep_u1_stable` — 4 passed (was 4 failed on main).
- [x] `pytest -m core --no-cov` — 761 passed, 1 skipped, 1155 deselected.
- [x] Full CTM suite (`test_ctm_tensor.py`, `test_ctm_paired.py`, `test_ctm_tensor_c4v.py`, `test_ctm_python_loop.py`, `test_split_ctm_tensor.py`) — 97 passed, 2 skipped, 1 pre-existing failure (`test_split_ctm_tensor::TestSplitRDMs::test_rdm1x2_2site_matches_shim[2-8]`, fails identically on origin/main, out of scope).
- [ ] CI: `Tests (Python 3.11)`, `Tests (Python 3.12)`, `Tests (macOS, Python 3.12)`.

## Follow-up (deferred to separate PR)

Issue #408 step 3 suggests promoting these 4 tests to the `core` marker so future regressions in the symmetric paired-sweep gate CI. Left out of this fix to keep the change minimal — that's a testing-strategy decision worth its own discussion.

Closes #408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)