### PR TITLE
fix(docs): exclude superpowers/ from Sphinx build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ source_suffix = {
     ".rst": "restructuredtext",
     ".md": "markdown",
 }
-exclude_patterns = ["_build", "plans"]
+exclude_patterns = ["_build", "plans", "superpowers", "superpowers/**"]
 
 # Suppress third-party deprecation warnings during build
 warnings.filterwarnings(


### PR DESCRIPTION
## Summary
- PR #412 (auto-chi-bump) committed the plan file at `docs/superpowers/plans/2026-05-08-auto-chi-bump.md`. Sphinx with `-W` flagged it as `document isn't included in any toctree`, failing the Build documentation CI check on main.
- Add `"superpowers"` and `"superpowers/**"` to `exclude_patterns` in `docs/conf.py` so the whole subtree is skipped (process docs, not user-facing reference).

## Test plan
- [x] `uv run --extra docs sphinx-build -W -b html docs docs/_build/html` — `build succeeded` locally
- [ ] CI Build documentation check goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)