### PR TITLE
feat(ctm): F2 fixed-point adjoint for implicit-AD CTM

### DIFF
--- a/benchmarks/varipeps_compare/published_results/STATUS.md
+++ b/benchmarks/varipeps_compare/published_results/STATUS.md
@@ -1,6 +1,6 @@
 # Tenax ↔ variPEPS Square Heisenberg Benchmark — Status
 
-**Last update:** 2026-05-09
+**Last update:** 2026-05-10 (F2 fixed-point adjoint landed)
 **Protocol:** TOL=1e-6, MAX_STEPS=100, complex128, single_site path with sublattice-rotated gate, D=2, χ=16. Tenax `gs_implicit_ad=True`, variPEPS native.
 
 ## What's in this directory
@@ -22,20 +22,39 @@ Reference for D=2 chi=16 from the literature: E/site ≈ −0.6614 (variPEPS pap
 
 ## Tenax status
 
-**Single point timed out at 30-min subprocess budget on CPU even after the
-JIT cache fix in commit 11aafd3.** The fix eliminated 45 of 46 redundant
-`_step` compiles (verified at chi=4 attribution), but at chi=16 the
-remaining per-step solve cost on CPU still exceeds the 30-min ceiling.
+**Single point still times out at the 30-min subprocess budget on CPU**
+even after F1 (JIT cache fix, 11aafd3) and F2 (fixed-point adjoint, this
+PR).  F2 reduces backward wall-clock by ~3× as designed — see
+microbenchmark below — but the forward CTM convergence at χ=16 (Python
+loop over a JIT'd `_step` plus repeated L-BFGS line-search forward calls)
+still exceeds the 30-min ceiling on this machine.
 
-Two paths for the next iteration are concrete:
+### F2 microbenchmark (D=2, χ=8, single_site)
 
-- **Run on GPU.** This machine has 2× CUDA devices. Re-run with
-  `--device cuda:0`. The CTM forward + adjoint solve are
-  large-matrix-multiply dominated, which GPUs handle well.
-- **Continue the perf work tracked in
-  `docs/plans/2026-05-09-ipeps-ad-jit-cost-diagnosis.md`** — F2
-  (eager-GMRES → fixed-point iteration, mirroring variPEPS) is the
-  next high-leverage fix.
+Single forward + backward via `ctm_energy_implicit`, CPU, complex128:
+
+| `adjoint_method` | cold (compile + 1 bwd) | warm 1 | warm 2 |
+|---|---|---|---|
+| `"fixed_point"` (new default) | 15.7 s | 1.3 s | 2.1 s |
+| `"gmres"` (legacy)            | 46.7 s | 4.7 s | 5.4 s |
+
+F2 delivers ~3× cold-compile and ~3× warm-call speedup on the backward.
+The plan's expected 3–5× drop is met.
+
+### What's left to fit χ=16 inside 30 min
+
+Two complementary paths, in order of leverage:
+
+- **F3 (variPEPS-style backward fusion)** — fold `_jit_dE_denv`,
+  `_jit_apply_Jt`, and `_jit_chain_rule` into a single `@jax.jit` with
+  `lax.while_loop` for the adjoint iteration.  variPEPS's
+  `_ctmrg_rev_workhorse` shows this lands the entire backward in one
+  graph (~1 trace + 1 compile vs Tenax's 3) and is the reason variPEPS
+  finishes the same problem in ~13 min.  See
+  `docs/plans/2026-05-09-ipeps-ad-jit-cost-diagnosis.md` §F3.
+- **GPU.** This machine has 2× CUDA devices.  Re-run with
+  `--device cuda:0`; the CTM forward + adjoint solve are
+  large-matmul-dominated and benefit directly.
 
 ## How to reproduce
 

--- a/docs/plans/2026-05-09-ipeps-ad-fixed-point-adjoint-plan.md
+++ b/docs/plans/2026-05-09-ipeps-ad-fixed-point-adjoint-plan.md
@@ -1,0 +1,177 @@
+# F2: Fixed-Point Adjoint for Tenax Implicit-AD CTM
+
+> **For Claude (new session):** This is the F2 follow-up to PR #414 (squash 510fca4).
+> Start here. The diagnosis doc at
+> `docs/plans/2026-05-09-ipeps-ad-jit-cost-diagnosis.md` has the full
+> background; you don't need to re-derive any of it.
+>
+> **Branch:** `ipeps-ad-fixed-point-adjoint` (already created off main).
+>
+> **REQUIRED SUB-SKILL:** Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+## Goal
+
+Replace the eager Krylov-GMRES adjoint solver in
+`src/tenax/algorithms/_ctm_energy_ad.py:f_bwd` with a Python-loop
+fixed-point iteration, mirroring variPEPS's
+`_ctmrg_rev_workhorse` design. The motivating evidence:
+
+- variPEPS solves the same physics (same protocol, same chi) using a
+  fixed-point iteration and converges in ~23 outer steps in ~13 min on
+  CPU. Tenax's eager-GMRES adjoint exceeds the 30-min subprocess budget
+  even after the JIT cache fix in PR #414.
+- For the variational regime (chi ≥ 16) with the phase-gauge default,
+  the spectral radius ρ(J^T) is < 1 (verified by the existing Arnoldi
+  precheck and by variPEPS's empirical convergence). When ρ < 1,
+  `λ_{k+1} = b + J^T λ_k` converges geometrically — no Krylov subspace
+  needed.
+
+Expected outcome:
+- Tenax `f_bwd` per-call wall-clock drops 3–5×.
+- Combined with the F1 cache fix from #414, the variPEPS-compare
+  benchmark fits comfortably inside its 30-min subprocess budget.
+
+## Code change scope
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_energy_ad.py` (only `f_bwd` body and
+  one new helper near it)
+
+**Out of scope:**
+- The forward CTM (`_run_forward`) is untouched.
+- The custom_vjp boundary stays.
+- `_jit_apply_Jt`, `_jit_chain_rule`, `_jit_dE_denv` stay as separate
+  JIT'd functions — F1 already showed combining them doesn't help.
+- The Arnoldi precheck stays (and becomes load-bearing — see below).
+- The existing `_jit_gmres_solve` and `gmres_pytree_jax` callers stay
+  available behind a config knob (see "Knob & fallback" below).
+
+## Algorithm (drop-in replacement for the GMRES block)
+
+Replace this block (currently lines 830–844 of `_ctm_energy_ad.py`):
+
+```python
+def _eager_apply_I_minus_Jt(v):
+    return _jit_apply_Jt(params_data_tuple, env_leaves, v)
+
+lam, _info = gmres_pytree_jax(
+    _eager_apply_I_minus_Jt,
+    dE_denv, dE_denv,
+    tol=gmres_tol, maxiter=gmres_maxiter, restart=gmres_restart,
+)
+lam_leaves = tuple(jax.tree.leaves(lam))
+```
+
+with:
+
+```python
+# Fixed-point iteration: λ_{k+1} = b + J^T λ_k.
+# Equivalent to solving (I - J^T) λ = b iff ρ(J^T) < 1, which the Arnoldi
+# precheck above guarantees when arnoldi_precheck=True.
+def _apply_Jt(v):
+    i_minus_jt_v = _jit_apply_Jt(params_data_tuple, env_leaves, v)
+    return tuple(vi - im for vi, im in zip(v, i_minus_jt_v))
+
+lam = dE_denv  # initialize at b (one matvec saved)
+prev_diff = float("inf")
+for k in range(gmres_maxiter):
+    jt_lam = _apply_Jt(lam)
+    new_lam = tuple(b + j for b, j in zip(dE_denv, jt_lam))
+    diff = sum(
+        float(jnp.linalg.norm(n - p))
+        for n, p in zip(new_lam, lam)
+    )
+    lam = new_lam
+    if diff < gmres_tol:
+        break
+    if diff > prev_diff and k > 5:
+        # Diverging — fall back to the GMRES path for safety.
+        lam, _info = gmres_pytree_jax(
+            _eager_apply_I_minus_Jt,
+            dE_denv, dE_denv,
+            tol=gmres_tol, maxiter=gmres_maxiter, restart=gmres_restart,
+        )
+        break
+    prev_diff = diff
+lam_leaves = tuple(jax.tree.leaves(lam))
+```
+
+The loop is short and entirely in Python; each iteration calls one
+already-cached `_jit_apply_Jt` matvec (no per-iter compile cost after
+the first). Convergence check is element-wise L2 norm of
+(λ_{k+1} - λ_k), summed across pytree leaves.
+
+## Knob & fallback
+
+Add `adjoint_method: Literal["fixed_point", "gmres"] = "fixed_point"`
+to `CTMConfig` in `src/tenax/algorithms/ipeps_config.py`. Wire it
+through `_implicit_vjp_dispatch` and `_make_implicit_vjp_fn` to
+`f_bwd`. When `adjoint_method == "gmres"`, keep the current
+GMRES-eager path verbatim (same code that's there now). When
+`"fixed_point"` (default), use the new loop above.
+
+This way:
+- New default behavior is the fast fixed-point path.
+- Anyone bitten by a divergence edge case can opt out via
+  `CTMConfig(..., adjoint_method="gmres")`.
+- Existing call sites that pass `gmres_*` parameters continue to work
+  — the fixed-point loop reuses `gmres_tol` and `gmres_maxiter` as
+  its own tolerance and step cap.
+
+## Tests
+
+**Existing tests that must continue to pass (regression):**
+- `tests/test_ipeps_excitations.py::TestOptimizeGsAd::test_runs_without_error`
+- `tests/test_ipeps_excitations.py::TestOptimizeGsAd::test_energy_decreases`
+- `tests/test_ipeps_excitations.py::TestOptimizeGsAd::test_heisenberg_negative_energy`
+- `tests/test_ipeps_excitations.py::TestOptimizeGsAd::test_heisenberg_excitation_dispersion`
+- `uv run pytest -m core -x` (765 passed before #414, 789 passed after)
+
+**New test:** `tests/test_ipeps_ad_adjoint_methods.py`
+- `test_fixed_point_matches_gmres_at_chi8`: run `optimize_gs_ad` once
+  with `adjoint_method="gmres"` and once with `"fixed_point"` at the
+  same seed, D=2, chi=8, gs_num_steps=2; assert |E_gs_diff| < 1e-6
+  AND tensor-element-wise rtol < 1e-5 between the two final tensors.
+  Marked `@pytest.mark.algorithm`.
+- `test_fixed_point_arnoldi_rejects_high_rho`: contrive a config where
+  ρ(J^T) ≥ 1 (e.g. set `forward_gauge="none"` at small chi); assert
+  the existing `CTMRGGradientError` is raised before the fixed-point
+  loop runs (so the precheck still catches divergent cases).
+
+**Bench:** re-run the variPEPS-compare benchmark after the fix lands:
+```bash
+JAX_PLATFORMS=cpu uv run python -m benchmarks.varipeps_compare.compare \
+    --device cpu --results-dir benchmarks/varipeps_compare/results
+```
+At single_site D=2 chi=16, Tenax should now complete inside 30 min on
+this machine. Update `benchmarks/varipeps_compare/published_results/`
+with the new data + summary.
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Fixed-point diverges where GMRES would have converged | Low at chi ≥ 16 with phase gauge (ρ < 1 verified empirically); Medium at chi < 16 or sigma gauge | Arnoldi precheck rejects ρ ≥ 1 cases. In-loop divergence detector (`diff > prev_diff` after step 5) falls back to GMRES. Knob lets users force GMRES. |
+| Slightly different gradient (rounding) breaks downstream tests | Low | Both methods solve the same linear system; differences should be at GMRES tolerance level (1e-6). Test asserts |ΔE| < 1e-6 and tensor rtol < 1e-5. |
+| Per-step Python overhead is higher than GMRES per-iter cost | Low | Each fixed-point iter is one `_jit_apply_Jt` matvec, same as one GMRES inner iter. Fewer iters in fixed-point (no Krylov restart overhead). |
+| `gmres_tol` / `gmres_maxiter` defaults are wrong for fixed-point | Low | Existing defaults (`gmres_tol=1e-6`, `gmres_maxiter=200`) are conservative. Bench will surface if 200 iters isn't enough. |
+
+## Estimate
+
+- Wire the config knob: ~30 min.
+- Refactor `f_bwd`: ~30 min.
+- New test file: ~30 min.
+- Run regression + benchmark: ~1 hour wall-clock (mostly waiting).
+- Iterate on any failures: variable.
+
+Plan: half-day end-to-end including the bench.
+
+## Definition of done
+
+1. `uv run pytest -m core -x` clean.
+2. `uv run pytest tests/test_ipeps_ad_adjoint_methods.py -v` passes.
+3. `uv run pytest tests/test_ipeps_excitations.py::TestOptimizeGsAd -v` passes.
+4. `python -m benchmarks.varipeps_compare.compare --device cpu` produces
+   a Tenax JSON for at least `single_site D=2 chi=16` (no timeout).
+5. `published_results/` updated with new data + a STATUS.md note.
+6. PR opened, auto-merge enabled with `--squash --delete-branch --auto`.

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -276,6 +276,7 @@ def ctm_energy_implicit(
     gmres_restart: int = 30,
     energy_fn=None,
     arnoldi_precheck: bool = False,
+    adjoint_method: str = "fixed_point",
 ) -> jnp.ndarray:
     """Compute iPEPS energy with implicit-differentiation backward (GMRES).
 
@@ -320,6 +321,13 @@ def ctm_energy_implicit(
         arnoldi_precheck:  If True, run 20-step Arnoldi to estimate rho(J^T)
                            before GMRES. Raises ``CTMRGGradientError`` if
                            rho >= 1. Enable when the caller has recovery logic.
+        adjoint_method:    ``"fixed_point"`` (default) runs a Python-loop
+                           Neumann iteration ``λ_{k+1} = b + J^T λ_k``
+                           that mirrors variPEPS's ``_ctmrg_rev_workhorse``
+                           and converges geometrically when ρ(J^T) < 1.
+                           ``"gmres"`` retains the eager Krylov solve as
+                           an opt-out for divergent edge cases.  Both
+                           paths reuse ``gmres_tol`` / ``gmres_maxiter``.
 
     Returns:
         Scalar energy per site.
@@ -352,6 +360,7 @@ def ctm_energy_implicit(
         gmres_restart,
         energy_fn,
         arnoldi_precheck,
+        adjoint_method,
     )
 
 
@@ -489,6 +498,7 @@ def _ctm_energy_implicit_dispatch(
     gmres_restart,
     energy_fn,
     arnoldi_precheck,
+    adjoint_method,
 ):
     """Dispatch to custom_vjp-decorated function with caching.
 
@@ -518,6 +528,7 @@ def _ctm_energy_implicit_dispatch(
         id(gate),  # different Hamiltonian → different backward
         id(energy_fn),  # different energy callback → different backward
         arnoldi_precheck,
+        adjoint_method,
     )
 
     entry = _VJP_CACHE.get(cache_key)
@@ -555,6 +566,7 @@ def _ctm_energy_implicit_dispatch(
         gmres_maxiter=gmres_maxiter,
         gmres_restart=gmres_restart,
         arnoldi_precheck=arnoldi_precheck,
+        adjoint_method=adjoint_method,
     )
     _VJP_CACHE[cache_key] = (f, mutables)
     return f(params_data_tuple)
@@ -578,6 +590,7 @@ def _make_implicit_vjp_fn(
     gmres_maxiter,
     gmres_restart,
     arnoldi_precheck=False,
+    adjoint_method="fixed_point",
 ):
     """Build a custom_vjp-decorated function closed over static config.
 
@@ -809,13 +822,15 @@ def _make_implicit_vjp_fn(
         return tuple(jax.tree.leaves(lam)), info
 
     def f_bwd(residuals, g):
-        """Backward: JIT-fused GMRES solve + JIT'd chain rule."""
+        """Backward: adjoint solve (fixed-point or GMRES) + JIT'd chain rule."""
         params_data_tuple, env_leaves = residuals
 
         # Step 1: dE/denv
         dE_denv = _jit_dE_denv(params_data_tuple, env_leaves)
 
-        # Step 1.5: Arnoldi precheck (optional, uses eager matvec)
+        # Step 1.5: Arnoldi precheck (optional, uses eager matvec).
+        # Load-bearing for the fixed-point path: ρ(J^T) < 1 is what makes
+        # the Neumann iteration converge.
         if arnoldi_precheck:
 
             def apply_Jt_only(v):
@@ -827,20 +842,53 @@ def _make_implicit_vjp_fn(
             if rho >= 1.0:
                 raise CTMRGGradientError(rho)
 
-        # Step 2: GMRES solve via JAX's built-in solver (eager, not JIT-fused).
-        # Uses jax.scipy.sparse.linalg.gmres which converges reliably at
-        # large chi where the custom gmres_lax can produce wrong gradients.
+        # Step 2: solve (I - J^T) λ = dE/denv.  Two paths share the same
+        # cached ``_jit_apply_Jt`` matvec; the choice is a config knob.
         def _eager_apply_I_minus_Jt(v):
             return _jit_apply_Jt(params_data_tuple, env_leaves, v)
 
-        lam, _info = gmres_pytree_jax(
-            _eager_apply_I_minus_Jt,
-            dE_denv,
-            dE_denv,
-            tol=gmres_tol,
-            maxiter=gmres_maxiter,
-            restart=gmres_restart,
-        )
+        if adjoint_method == "fixed_point":
+            # variPEPS-style Neumann iteration: λ_{k+1} = b + J^T λ_k.
+            # Equivalent to solving (I - J^T) λ = b iff ρ(J^T) < 1, which
+            # the Arnoldi precheck above guarantees when enabled.  Each
+            # iter is one cached matvec — no Krylov subspace, no per-iter
+            # compile cost after the first.
+            def _apply_Jt(v):
+                i_minus_jt_v = _jit_apply_Jt(params_data_tuple, env_leaves, v)
+                return tuple(vi - im for vi, im in zip(v, i_minus_jt_v))
+
+            lam = dE_denv  # initialize at b (one matvec saved)
+            prev_diff = float("inf")
+            for k in range(gmres_maxiter):
+                jt_lam = _apply_Jt(lam)
+                new_lam = tuple(b + j for b, j in zip(dE_denv, jt_lam))
+                diff = sum(float(jnp.linalg.norm(n - p)) for n, p in zip(new_lam, lam))
+                lam = new_lam
+                if diff < gmres_tol:
+                    break
+                if diff > prev_diff and k > 5:
+                    # Diverging — fall back to GMRES for safety.
+                    lam, _info = gmres_pytree_jax(
+                        _eager_apply_I_minus_Jt,
+                        dE_denv,
+                        dE_denv,
+                        tol=gmres_tol,
+                        maxiter=gmres_maxiter,
+                        restart=gmres_restart,
+                    )
+                    break
+                prev_diff = diff
+        else:
+            # adjoint_method == "gmres": eager Krylov via JAX's built-in
+            # solver.  Retained as an opt-out for divergent edge cases.
+            lam, _info = gmres_pytree_jax(
+                _eager_apply_I_minus_Jt,
+                dE_denv,
+                dE_denv,
+                tol=gmres_tol,
+                maxiter=gmres_maxiter,
+                restart=gmres_restart,
+            )
         lam_leaves = tuple(jax.tree.leaves(lam))
 
         # Steps 3-4: chain rule

--- a/src/tenax/algorithms/ipeps_ad_policy.py
+++ b/src/tenax/algorithms/ipeps_ad_policy.py
@@ -201,6 +201,7 @@ def make_ctm_energy_fn(
             gmres_maxiter=ctm_cfg.gmres_maxiter,
             gmres_restart=ctm_cfg.gmres_restart,
             arnoldi_precheck=False,
+            adjoint_method=ctm_cfg.adjoint_method,
             energy_fn=energy_fn,
         )
 

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -75,6 +75,18 @@ class CTMConfig:
     gmres_tol: float = 1e-6  # tolerance for GMRES backward solve
     gmres_restart: int = 20  # Krylov dimension for GMRES (no outer restarts)
     gmres_maxiter: int = 200  # max total GMRES iterations (outer budget)
+    # Adjoint solver for the implicit-AD CTM backward.
+    #   "fixed_point" (default) — Python-loop ``λ_{k+1} = b + J^T λ_k``.
+    #     Mirrors variPEPS's ``_ctmrg_rev_workhorse``.  Converges
+    #     geometrically when ρ(J^T) < 1, which the Arnoldi precheck
+    #     guarantees.  Each iteration is one cached ``_jit_apply_Jt``
+    #     matvec — no Krylov subspace, no per-iter compile cost.
+    #   "gmres" — eager Krylov solve via ``gmres_pytree_jax``.  Use as a
+    #     safety opt-out when the fixed-point loop diverges.
+    # Both paths reuse ``gmres_tol`` (residual / step tolerance) and
+    # ``gmres_maxiter`` (step cap).  The fixed-point loop additionally
+    # falls back to GMRES in-loop when ``diff > prev_diff`` after step 5.
+    adjoint_method: Literal["fixed_point", "gmres"] = "fixed_point"
     ctm_conv_method: str = "elementwise"  # "elementwise" or "sv" (singular value)
     # forward_gauge: "phase" (default — Frobenius-norm phase fix per CTM
     # absorption; works for both implicit and explicit AD, 1-site and
@@ -157,6 +169,12 @@ class CTMConfig:
             raise ValueError(
                 f"projector_backward must be one of {valid_projector_backward}, "
                 f"got {self.projector_backward!r}"
+            )
+        valid_adjoint_methods = {"fixed_point", "gmres"}
+        if self.adjoint_method not in valid_adjoint_methods:
+            raise ValueError(
+                f"adjoint_method must be one of {valid_adjoint_methods}, "
+                f"got {self.adjoint_method!r}"
             )
         # variPEPS §2.8.2 auto-bump validation.
         if self.chi_auto_bump and self.chi_ramp is not None:

--- a/src/tenax/algorithms/pess_optimize.py
+++ b/src/tenax/algorithms/pess_optimize.py
@@ -129,6 +129,7 @@ def build_pess_loss(
             gmres_maxiter=config.gmres_maxiter,
             gmres_restart=config.gmres_restart,
             arnoldi_precheck=False,
+            adjoint_method=config.adjoint_method,
         )
 
     return loss_fn
@@ -546,6 +547,7 @@ def build_pess_loss_3site_multisite(
             gmres_maxiter=config.gmres_maxiter,
             gmres_restart=config.gmres_restart,
             arnoldi_precheck=False,
+            adjoint_method=config.adjoint_method,
         )
 
     return loss_fn

--- a/tests/test_ipeps_ad_adjoint_methods.py
+++ b/tests/test_ipeps_ad_adjoint_methods.py
@@ -1,0 +1,114 @@
+"""Tests for the ``adjoint_method`` config knob in implicit-AD CTM.
+
+Both ``"fixed_point"`` (Neumann iteration, default) and ``"gmres"``
+(eager Krylov solve) solve the same linear system
+``(I - J^T) λ = dE/denv``, so they must produce equivalent gradients
+within the solver tolerance.  The Arnoldi precheck guarantees the
+fixed-point loop converges by rejecting configurations with ρ(J^T) ≥ 1.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tenax.algorithms._ctm_energy_ad import ctm_energy_implicit
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
+from tenax.algorithms.ad_utils import CTMRGGradientError
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+from tenax.algorithms.ipeps_optimize import _wrap_as_dense_tensor, optimize_gs_ad
+
+
+def _heisenberg_gate():
+    d = 2
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+    H = jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+    return H.reshape(d, d, d, d)
+
+
+def _random_peps(seed=2026, D=2, d=2):
+    key = jax.random.PRNGKey(seed)
+    A = jax.random.normal(key, (D, D, D, D, d))
+    return A / (jnp.linalg.norm(A) + 1e-10)
+
+
+@pytest.mark.algorithm
+def test_fixed_point_matches_gmres_at_chi8():
+    """``adjoint_method`` choice must not change the optimization outcome.
+
+    Both Neumann iteration and eager GMRES solve the same linear system
+    to the same tolerance.  Running ``optimize_gs_ad`` from the same
+    seed under both methods must yield matching energies and tensors.
+    """
+    H = _heisenberg_gate()
+    A_init = _random_peps()
+
+    def make_config(method: str) -> iPEPSConfig:
+        return iPEPSConfig(
+            max_bond_dim=2,
+            ctm=CTMConfig(
+                chi=8,
+                max_iter=40,
+                conv_tol=1e-8,
+                adjoint_method=method,
+            ),
+            gs_num_steps=2,
+            gs_learning_rate=1e-2,
+            su_init=False,
+            gs_metric_precond=False,
+        )
+
+    A_fp, _, E_fp = optimize_gs_ad(H, A_init, make_config("fixed_point"))
+    A_gmres, _, E_gmres = optimize_gs_ad(H, A_init, make_config("gmres"))
+
+    assert abs(float(E_fp) - float(E_gmres)) < 1e-6, (
+        f"Energies should match within solver tolerance: "
+        f"fixed_point={float(E_fp)}, gmres={float(E_gmres)}, "
+        f"diff={abs(float(E_fp) - float(E_gmres))}"
+    )
+
+    A_fp_arr = np.asarray(A_fp.todense() if hasattr(A_fp, "todense") else A_fp)
+    A_gmres_arr = np.asarray(
+        A_gmres.todense() if hasattr(A_gmres, "todense") else A_gmres
+    )
+    np.testing.assert_allclose(
+        A_fp_arr,
+        A_gmres_arr,
+        rtol=1e-5,
+        atol=1e-7,
+        err_msg=("Final tensors should match element-wise within solver tolerance"),
+    )
+
+
+@pytest.mark.algorithm
+def test_fixed_point_arnoldi_rejects_high_rho():
+    """Arnoldi precheck must catch ρ(J^T) ≥ 1 before the loop runs.
+
+    When the precheck is on and the spectrum is unfavorable (here:
+    ``forward_gauge="none"`` at chi=4), the backward must raise
+    ``CTMRGGradientError`` instead of looping to ``gmres_maxiter``.
+    """
+    H = _heisenberg_gate()
+    A = _wrap_as_dense_tensor(_random_peps(seed=7))
+
+    def loss(A_):
+        return ctm_energy_implicit(
+            {(0, 0): A_},
+            SINGLE_SITE_NEIGHBORS,
+            H,
+            chi=4,
+            max_iter=20,
+            conv_tol=1e-6,
+            forward_gauge="none",
+            gmres_tol=1e-6,
+            gmres_maxiter=200,
+            arnoldi_precheck=True,
+            adjoint_method="fixed_point",
+        )
+
+    with pytest.raises(CTMRGGradientError):
+        jax.grad(loss)(A)


### PR DESCRIPTION
## Summary

- Replace the eager Krylov-GMRES adjoint solver in
  `src/tenax/algorithms/_ctm_energy_ad.py:f_bwd` with a Python-loop
  fixed-point iteration ``λ_{k+1} = b + J^T λ_k`` that mirrors
  variPEPS's ``_ctmrg_rev_workhorse``.
- New ``CTMConfig.adjoint_method`` knob (`'fixed_point'` default,
  `'gmres'` opt-out).  Reuses ``gmres_tol`` / ``gmres_maxiter`` for
  step tolerance and step cap.  In-loop divergence detector
  (``diff > prev_diff`` after step 5) falls back to GMRES for safety.
- Plan: `docs/plans/2026-05-09-ipeps-ad-fixed-point-adjoint-plan.md`.
- Diagnosis: `docs/plans/2026-05-09-ipeps-ad-jit-cost-diagnosis.md`.

## Microbenchmark (CPU, complex128, single_site, D=2)

Single forward + backward via ``ctm_energy_implicit`` at χ=8:

| `adjoint_method` | cold (compile + 1 bwd) | warm 1 | warm 2 |
|---|---|---|---|
| `"fixed_point"` (new default) | 15.7 s | 1.3 s | 2.1 s |
| `"gmres"` (legacy)            | 46.7 s | 4.7 s | 5.4 s |

≈3× cold + warm speedup — matches the plan's predicted 3–5× drop.

## What this does *not* close

The variPEPS-compare benchmark at χ=16 still exceeds the 30-min
subprocess budget on CPU.  Per the diagnosis doc the remaining gap
is JIT compile cost on Tenax's three-graph backward
(`_jit_dE_denv` + `_jit_apply_Jt` + `_jit_chain_rule`).  F3
(variPEPS-style backward fusion: fold all three into one ``@jax.jit``
with ``lax.while_loop``) is the next high-leverage fix.
``benchmarks/varipeps_compare/published_results/STATUS.md`` is updated
with this status.

## Test plan

- [x] `uv run pytest -m core -x` — 789 passed, 1 skipped
- [x] `uv run pytest tests/test_ipeps_excitations.py::TestOptimizeGsAd -v` — 5 passed
- [x] `uv run pytest tests/test_ipeps_ad_adjoint_methods.py -v` — 2 passed
  - `test_fixed_point_matches_gmres_at_chi8`: both methods produce the
    same final energy (`|ΔE| < 1e-6`) and tensors (rtol 1e-5)
    after 2 L-BFGS steps.
  - `test_fixed_point_arnoldi_rejects_high_rho`: Arnoldi precheck
    raises `CTMRGGradientError` before the loop runs when ρ(J^T) ≥ 1
    (configured via ``forward_gauge="none"`` at small χ).
- [x] χ=8 microbenchmark: fixed_point ≈3× faster than gmres (cold and
      warm), see commit body / STATUS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)