### PR TITLE
test: xfail 7 SymmetricTensor tests blocked on _compute_2x2_projector (#416)

### DIFF
--- a/tests/test_fpeps_ad.py
+++ b/tests/test_fpeps_ad.py
@@ -205,6 +205,14 @@ class TestTodenseGradientFlow:
         assert float(jnp.linalg.norm(grad_data)) > 0, "DenseTensor gradient is zero"
 
     @pytest.mark.algorithm
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "_compute_2x2_projector lacks symmetric-tensor support (PR #406, "
+            "design doc docs/plans/2026-05-07-ctm-multisite-2x2-projector-design.md); "
+            "tracked as Issue #416."
+        ),
+    )
     def test_symmetric_nontrivial_energy_finite(self):
         """SymmetricTensor with non-trivial fermionic charges produces a
         finite forward energy through the implicit CTM path.
@@ -264,6 +272,14 @@ class TestTodenseGradientFlow:
         )
 
     @pytest.mark.algorithm
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "_compute_2x2_projector lacks symmetric-tensor support (PR #406, "
+            "design doc docs/plans/2026-05-07-ctm-multisite-2x2-projector-design.md); "
+            "tracked as Issue #416."
+        ),
+    )
     def test_symmetric_nontrivial_gradient_finite(self):
         """SymmetricTensor with non-trivial charges should produce finite gradients.
 

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -1045,6 +1045,14 @@ class TestOptimizeGsAdLogging:
 class TestOptimizeGsAdDenseOnly:
     """Verify optimize_gs_ad 2-site rejects SymmetricTensor inputs."""
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "_compute_2x2_projector lacks symmetric-tensor support (PR #406, "
+            "design doc docs/plans/2026-05-07-ctm-multisite-2x2-projector-design.md); "
+            "tracked as Issue #416."
+        ),
+    )
     def test_symmetric_tensor_2site_runs(self):
         """2-site AD optimization accepts SymmetricTensor inputs."""
         from tenax.core.index import FlowDirection, TensorIndex
@@ -1200,6 +1208,14 @@ class TestADSymmetric:
         assert isinstance(grad, SymmetricTensor)
         assert grad.norm() > 0
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "_compute_2x2_projector lacks symmetric-tensor support (PR #406, "
+            "design doc docs/plans/2026-05-07-ctm-multisite-2x2-projector-design.md); "
+            "tracked as Issue #416."
+        ),
+    )
     def test_optimize_gs_ad_symmetric_runs(self):
         """optimize_gs_ad accepts SymmetricTensor and returns SymmetricTensor.
 
@@ -1230,6 +1246,14 @@ class TestADSymmetric:
         )
         assert np.isfinite(E_gs)
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "_compute_2x2_projector lacks symmetric-tensor support (PR #406, "
+            "design doc docs/plans/2026-05-07-ctm-multisite-2x2-projector-design.md); "
+            "tracked as Issue #416."
+        ),
+    )
     def test_optimize_gs_ad_symmetric_energy_decreases(self):
         """AD optimization with SymmetricTensor decreases energy."""
         gate = self._heisenberg_gate()
@@ -1261,6 +1285,14 @@ class TestADSymmetric:
             f"expected SymmetricTensor, got {type(A_opt).__name__}"
         )
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "_compute_2x2_projector lacks symmetric-tensor support (PR #406, "
+            "design doc docs/plans/2026-05-07-ctm-multisite-2x2-projector-design.md); "
+            "tracked as Issue #416."
+        ),
+    )
     def test_optimize_gs_ad_symmetric_matches_dense(self):
         """Symmetric AD gives comparable energy to dense AD."""
         gate = self._heisenberg_gate()
@@ -1295,6 +1327,14 @@ class TestADSymmetric:
             f"expected DenseTensor, got {type(A_dense_opt).__name__}"
         )
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "_compute_2x2_projector lacks symmetric-tensor support (PR #406, "
+            "design doc docs/plans/2026-05-07-ctm-multisite-2x2-projector-design.md); "
+            "tracked as Issue #416."
+        ),
+    )
     def test_optimize_gs_ad_nontrivial_u1_preserves_symmetric_type(self):
         """Regression for #297: optimizer shell must accept a SymmetricTensor
         with *non-trivial* U(1) charges and return a SymmetricTensor (not


### PR DESCRIPTION
## Summary
- 7 algorithm-marked tests have been hard-failing on every Full-tests CI run since PR #406 (2026-05-08) — `_compute_2x2_projector` doesn't support symmetric tensors with non-trivial U(1) charges yet.
- Required CI checks (`-m core`) stayed green throughout, masking the issue. Mark all 7 as `xfail(strict=False)` citing the design doc and tracking Issue #416.
- No production code changes; tracker work belongs on #416.

## Test plan
- [x] Spot-check 3 of 7 tests run as `xfailed` locally
- [ ] CI Full tests matrix completes with 7 xfailed instead of 7 failed
- [ ] Required `Tests` checks remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)