### PR TITLE
fix(ctm): three iteration bugs that prevent random-init convergence

### DIFF
--- a/src/tenax/algorithms/_ctm_python_loop.py
+++ b/src/tenax/algorithms/_ctm_python_loop.py
@@ -95,7 +95,7 @@ def _make_jit_ctm_step(
         *,
         chi: int,
         projector_method: str = "svd",
-        renormalize: bool = True,
+        renormalize: bool = False,
         projector_backward: str = "auto",
     ) -> tuple[dict[Coord, CTMTensorEnv], jax.Array]:
         double_layers = {
@@ -124,7 +124,7 @@ def python_loop_ctm_converge(
     min_iter: int = 10,
     conv_tol: float = 1e-8,
     conv_method: str = "sv",
-    renormalize: bool = True,
+    renormalize: bool = False,
     projector_method: str = "svd",
     qr_warmup_steps: int = 3,
     projector_backward: str = "auto",

--- a/src/tenax/algorithms/_ctm_tensor_init.py
+++ b/src/tenax/algorithms/_ctm_tensor_init.py
@@ -187,10 +187,18 @@ def _make_dense_standard_edge(
     from tenax.core.symmetry import U1Symmetry
 
     sym = U1Symmetry()
-    T_chi = min(chi, D2)
+    # Identity-like edge: T1[i, ket, bra, j] = δ_{i=j} · δ_{ket=bra}.  After
+    # fusing (ket, bra) → fused_idx = ket*D + bra, only fused_idx = j*(D+1)
+    # for j ∈ 0..D-1 is non-zero. The previous all-ones init (T[i, :, i] = 1
+    # across the full D² axis) implements the wrong boundary (1_ket ⊗ 1_bra
+    # instead of δ_{ket=bra}) and traps CTM at a degenerate fixed point.
+    D = int(np.round(np.sqrt(D2)))
+    assert D * D == D2, f"D² leg dim {D2} is not a perfect square"
+    diag_idx = np.arange(D, dtype=np.int32) * (D + 1)
     T = jnp.zeros((chi, D2, chi), dtype=dtype)
-    for i in range(min(T_chi, chi)):
-        T = T.at[i, :, i].add(jnp.ones(D2, dtype=dtype))
+    T_chi = min(chi, D)
+    for i in range(T_chi):
+        T = T.at[i, diag_idx, i].set(jnp.ones(D, dtype=dtype))
     return DenseTensor(
         T,
         (
@@ -255,10 +263,16 @@ def _init_symmetric_standard_edge(
     idx_D2 = TensorIndex.from_charges(sym, D2_charges, flow_D2, label=label_D2)
     idx_chi2 = TensorIndex.from_charges(sym, chi2_charges, flow_chi2, label=label_chi2)
 
+    # Identity-like edge: T[i, ket, bra, j] = δ_{i=j} · δ_{ket=bra}.  After
+    # fusing (ket, bra) → fused = ket*D + bra, only fused = j*(D+1) for
+    # j ∈ 0..D-1 is non-zero. See `_make_dense_standard_edge` for the
+    # rationale (the previous all-ones init traps CTM at a degenerate
+    # fixed point on generic complex iPEPS).
+    diag_idx = np.arange(D, dtype=np.int32) * (D + 1)
     T = jnp.zeros((chi, D2, chi), dtype=A.dtype)
-    T_chi = min(chi, D2)
-    for i in range(min(T_chi, chi)):
-        T = T.at[i, :, i].add(jnp.ones(D2, dtype=A.dtype))
+    T_chi = min(chi, D)
+    for i in range(T_chi):
+        T = T.at[i, diag_idx, i].set(jnp.ones(D, dtype=A.dtype))
     return SymmetricTensor.from_dense(T, (idx_chi1, idx_D2, idx_chi2), tol=float("inf"))
 
 

--- a/src/tenax/algorithms/_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_ctm_tensor_moves.py
@@ -46,6 +46,14 @@ def _normalize_tensor(T: Tensor) -> Tensor:
     return T * (1.0 / (norm + EPS))
 
 
+def _flow_flip_no_conj(t):
+    """Flip flow direction on every leg WITHOUT conjugating the data."""
+    new_indices = tuple(idx.flip_flow() for idx in t.indices)
+    if isinstance(t, DenseTensor):
+        return DenseTensor(t._data, new_indices)
+    return SymmetricTensor(t._data, new_indices)
+
+
 def _phase_fix_normalize_tensor(T: Tensor) -> Tensor:
     """Frobenius-normalize + phase-fix a single C or T tensor.
 
@@ -379,19 +387,19 @@ def _ctm_tensor_absorb_left_2plaq(
     T4g = _fuse_pair_by_label(T4g, "t4_u", "d2", "fr", OUT)
 
     # ---- C1: project with P_bot_above only ----
-    P_bot_above_bar = P_bot_above.bar()  # contracts on "fused"
+    P_bot_above_bar = _flow_flip_no_conj(P_bot_above)  # contracts on "fused"
     C1_new = contract(P_bot_above_bar, C1g)  # (chi_new, t1_r)
     C1_new = C1_new.relabels({"chi_new": "c1_d", "t1_r": "c1_r"})
 
     # ---- C4: project with P_top_curr only ----
-    P_top_curr_bar = P_top_curr.bar()
+    P_top_curr_bar = _flow_flip_no_conj(P_top_curr)
     C4_new = contract(P_top_curr_bar, C4g)  # (chi_new, t3_l)
     C4_new = C4_new.relabels({"chi_new": "c4_r", "t3_l": "c4_u"})
 
     # ---- T4: sandwiched by P_top_above (top side, fl) and P_bot_curr (bottom side, fr) ----
     # P_top_above acts on the top face of s_src (fl = t4_d ⊕ u2).
     # P_bot_curr acts on the bottom face of s_src (fr = t4_u ⊕ d2).
-    P_top_above_bar = P_top_above.bar()
+    P_top_above_bar = _flow_flip_no_conj(P_top_above)
     P_left = P_top_above_bar.relabel("fused", "fl")
     step = contract(P_left, T4g)  # (chi_new, fr, r2)
 
@@ -468,18 +476,18 @@ def _ctm_tensor_absorb_right_2plaq(
     T2g = _fuse_pair_by_label(T2g, "t2_d", "d2", "fr", OUT)
 
     # ---- C2: project with P_top_above only (≡ variPEPS .bottom of above) ----
-    P_top_above_bar = P_top_above.bar()
+    P_top_above_bar = _flow_flip_no_conj(P_top_above)
     C2_new = contract(P_top_above_bar, C2g)
     C2_new = C2_new.relabels({"chi_new": "c2_l", "t1_l": "c2_d"})
 
     # ---- C3: project with P_bot_curr only (≡ variPEPS .top of curr) ----
-    P_bot_curr_bar = P_bot_curr.bar()
+    P_bot_curr_bar = _flow_flip_no_conj(P_bot_curr)
     C3_new = contract(P_bot_curr_bar, C3g)
     C3_new = C3_new.relabels({"chi_new": "c3_u", "t3_r": "c3_l"})
 
     # ---- T2: sandwiched by P_bot_above (fl side, ≡ variPEPS .top of above)
     #          and P_top_curr (fr side, ≡ variPEPS .bottom of curr) ----
-    P_bot_above_bar = P_bot_above.bar()
+    P_bot_above_bar = _flow_flip_no_conj(P_bot_above)
     P_left = P_bot_above_bar.relabel("fused", "fl")
     step = contract(P_left, T2g)
 
@@ -543,18 +551,18 @@ def _ctm_tensor_absorb_top_2plaq(
     T1g = _fuse_pair_by_label(T1g, "t1_r", "r2", "fr", OUT)
 
     # ---- C1: project with P_top_left (≡ variPEPS .right of left-plaq) ----
-    P_top_left_bar = P_top_left.bar()
+    P_top_left_bar = _flow_flip_no_conj(P_top_left)
     C1_new = contract(P_top_left_bar, C1g)
     C1_new = C1_new.relabels({"chi_new": "c1_d", "t4_u": "c1_r"})
 
     # ---- C2: project with P_bot_curr (≡ variPEPS .left of curr) ----
-    P_bot_curr_bar = P_bot_curr.bar()
+    P_bot_curr_bar = _flow_flip_no_conj(P_bot_curr)
     C2_new = contract(P_bot_curr_bar, C2g)
     C2_new = C2_new.relabels({"chi_new": "c2_l", "t2_d": "c2_d"})
 
     # ---- T1: sandwiched by P_bot_left (fl side, ≡ variPEPS .left of left-plaq)
     #          and P_top_curr (fr side, ≡ variPEPS .right of curr) ----
-    P_bot_left_bar = P_bot_left.bar()
+    P_bot_left_bar = _flow_flip_no_conj(P_bot_left)
     P_left = P_bot_left_bar.relabel("fused", "fl")
     step = contract(P_left, T1g)
 
@@ -598,17 +606,17 @@ def _ctm_tensor_absorb_bottom_2plaq(
     T3g = _fuse_pair_by_label(T3g, "t3_l", "r2", "fr", OUT)
 
     # ---- C4: project with P_bot_left ----
-    P_bot_left_bar = P_bot_left.bar()
+    P_bot_left_bar = _flow_flip_no_conj(P_bot_left)
     C4_new = contract(P_bot_left_bar, C4g)
     C4_new = C4_new.relabels({"chi_new": "c4_r", "t4_d": "c4_u"})
 
     # ---- C3: project with P_top_curr ----
-    P_top_curr_bar = P_top_curr.bar()
+    P_top_curr_bar = _flow_flip_no_conj(P_top_curr)
     C3_new = contract(P_top_curr_bar, C3g)
     C3_new = C3_new.relabels({"chi_new": "c3_u", "t2_u": "c3_l"})
 
     # ---- T3: sandwiched by P_top_left (fl) + P_bot_curr (fr) ----
-    P_top_left_bar = P_top_left.bar()
+    P_top_left_bar = _flow_flip_no_conj(P_top_left)
     P_left = P_top_left_bar.relabel("fused", "fl")
     step = contract(P_left, T3g)
 


### PR DESCRIPTION
## Summary

Three bugs in the multisite CTM path made `python_loop_ctm_converge` fail to reach 1e-5 tolerance on random complex iPEPS at any chi. variPEPS converges in 9 iters at chi=4 on the same input. Diagnosed via direct side-by-side comparison with variPEPS using identical inputs.

The chi=16 iPEPS-AD benchmark timeout (memory entry `project_tenax_ctm_doesnt_converge_random_init.md`) follows directly: every L-BFGS line-search probe ran CTM to `max_iter=100` because the iteration never converged on random complex iPEPS at cold init.

## Bug 1 — edge init wrote `1_ket ⊗ 1_bra` instead of `δ_{ket=bra}`

`_make_dense_standard_edge` and `_init_symmetric_standard_edge` filled `T[i, :, i] = 1` across the full D² fused leg. After unfusing `(ket, bra) ← fused = ket*D + bra`, that's a non-physical outer-product boundary — every `(ket, bra)` pair gets weight 1. The correct identity boundary writes only on the diagonal `fused = j*(D+1)` for `j ∈ 0..D-1`. The old init traps CTM at a degenerate fixed point where every corner SV equals the others.

## Bug 2 — extra `_renormalize_tensor_env` after every sweep

Each `_ctm_tensor_absorb_*_2plaq` already calls `_phase_fix_normalize_tensor` (Frobenius-normalize + phase fix), matching variPEPS's `_post_process_CTM_tensors`. The sweep then ran `_renormalize_tensor_env` (max-abs / inf-norm) on top — a different normalization that breaks the Frob norm, causing element magnitudes to drift across iterations.

variPEPS has no second renormalize; the per-absorption Frob is enough. Flipped the default to `renormalize=False` in `python_loop_ctm_converge` and `_make_jit_ctm_step._step`. Callers that pass `renormalize=True` explicitly retain the old behavior — no test changes required.

## Bug 3 — `.bar()` conjugated the projector before contraction

`_compute_2x2_projector` already constructs the projector with `U^H` (conjugate-transpose of M_prime's left singular vectors). The four `_ctm_tensor_absorb_*_2plaq` functions then called `P.bar()` (= conj data + flip flows) on the returned projector, conjugating the data **a second time**. variPEPS's `apply_contraction("ctmrg_absorption_left_C1", ...)` etc. apply the projector tensor directly without conjugation.

Replaced `P.bar()` with `_flow_flip_no_conj(P)` at the six sites that absorb a projector into a C·T or T·a tensor. The flow flip is preserved (needed for contract auto-pair); the conjugation is dropped.

**Why this slipped past the test suite:** for real-valued or Hermitian-symmetric iPEPS the spurious conjugation is a no-op or self-inverse. Generic complex iPEPS — which is what the chi=16 cold-from-random benchmark uses — is the case that exposes it.

## Verification

`chi=4, D=2 random complex iPEPS, seed 0`:

| metric                       | before  | after     | variPEPS reference |
|------------------------------|---------|-----------|--------------------|
| Cold init: leading C1 SV     | osc 1.20 | 0.948    | 0.948              |
| Cold init: sv_diff iter 30   | 4–6e-2  | 4.4e-12   | 4.4e-12            |
| Warm-start from variPEPS fp  | drifts  | preserves | n/a                |

Local `tests/test_ctm_tensor_projector_2x2.py` — 17/17 pass. Other CTM tests have pre-existing failures on main (`'CTMTensorEnv' object has no attribute 'todense'` etc.) that are not caused by this branch.

## Out of scope (follow-up)

**Sub-bug 3a** — chi_init=full padded-identity init has a Z₂ symmetry that traps both libraries at a degenerate fixed point. variPEPS avoids it via `chi_init=1` default and grows chi organically through absorption-and-truncation. Tenax's `initialize_ctm_tensor_env` always pads to chi_target, so even with this PR's three fixes a cold run from `chi_init=4` settles at the symmetric fixed point `[0.68, 0.68, 0.20, 0.20]` (where variPEPS does too with the same forced init) instead of the physical `[0.95, 0.22, 0.19, 0.13]`. Touches the convergence loop's chi-grow handling and warrants its own PR.

## Test plan
- [x] `tests/test_ctm_tensor_projector_2x2.py` 17/17 pass locally
- [ ] CI `Tests (Python 3.11)` / `Tests (Python 3.12)` / `Tests (macOS, Python 3.12)`
- [ ] CI may surface fixes for some existing NaN-gradient failures on `test_pess_ad`, `test_explicit_ad_warmup_gradient_finite`, etc. — those NaN gradients are consistent with the bug-3 spurious conjugation on complex inputs, so they may resolve here as a side-effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)