### PR TITLE
fix(ctm): _flow_flip_no_conj works on SymmetricTensor

### DIFF
--- a/src/tenax/algorithms/_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_ctm_tensor_moves.py
@@ -47,11 +47,25 @@ def _normalize_tensor(T: Tensor) -> Tensor:
 
 
 def _flow_flip_no_conj(t):
-    """Flip flow direction on every leg WITHOUT conjugating the data."""
+    """Flip flow direction on every leg WITHOUT conjugating the data.
+
+    For ``SymmetricTensor``, flipping every leg's flow preserves the
+    conservation law ``sum(flow_i * charge_i) = 0`` (the sign flips on
+    both sides), so block keys are unchanged.  The flat buffer and
+    block metadata can be reused via ``_raw``, mirroring how
+    :meth:`SymmetricTensor.bar` constructs its result (only the data
+    conjugation is dropped).
+    """
     new_indices = tuple(idx.flip_flow() for idx in t.indices)
     if isinstance(t, DenseTensor):
         return DenseTensor(t._data, new_indices)
-    return SymmetricTensor(t._data, new_indices)
+    return SymmetricTensor._raw(
+        indices=new_indices,
+        data=t._data,
+        block_keys=t._block_keys,
+        block_shapes=t._block_shapes,
+        block_offsets=t._block_offsets,
+    )
 
 
 def _phase_fix_normalize_tensor(T: Tensor) -> Tensor:

--- a/tests/test_ctm_tensor_flow_flip.py
+++ b/tests/test_ctm_tensor_flow_flip.py
@@ -1,0 +1,99 @@
+"""Tests for ``_flow_flip_no_conj`` in CTM absorption.
+
+The helper flips every leg's flow direction without conjugating the data
+(since ``_compute_2x2_projector`` already returns ``U^H``).  The dense
+branch was correct; the SymmetricTensor branch crashed because the
+constructor expects a blocks dict but received the flat data buffer
+(see PR #422 review thread).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+
+from tenax.algorithms._ctm_tensor_moves import _flow_flip_no_conj
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import U1Symmetry
+from tenax.core.tensor import DenseTensor, SymmetricTensor
+
+
+def test_flow_flip_no_conj_dense_preserves_data_flips_flow():
+    sym = U1Symmetry()
+    idx_a = TensorIndex.from_charges(
+        sym, np.zeros(3, dtype=np.int32), FlowDirection.IN, label="a"
+    )
+    idx_b = TensorIndex.from_charges(
+        sym, np.zeros(3, dtype=np.int32), FlowDirection.OUT, label="b"
+    )
+    rng = np.random.RandomState(0)
+    data = jnp.array(rng.standard_normal((3, 3)) + 1j * rng.standard_normal((3, 3)))
+    t = DenseTensor(data, (idx_a, idx_b))
+
+    flipped = _flow_flip_no_conj(t)
+
+    assert isinstance(flipped, DenseTensor)
+    np.testing.assert_array_equal(np.asarray(flipped._data), np.asarray(t._data))
+    assert flipped.indices[0].flow == FlowDirection.OUT
+    assert flipped.indices[1].flow == FlowDirection.IN
+
+
+def test_flow_flip_no_conj_symmetric_trivial_charges():
+    """SymmetricTensor with trivial U(1) charges: data preserved, flows flipped."""
+    sym = U1Symmetry()
+    idx_a = TensorIndex.from_charges(
+        sym, np.zeros(3, dtype=np.int32), FlowDirection.IN, label="a"
+    )
+    idx_b = TensorIndex.from_charges(
+        sym, np.zeros(3, dtype=np.int32), FlowDirection.OUT, label="b"
+    )
+    rng = np.random.RandomState(1)
+    data = jnp.array(rng.standard_normal((3, 3)) + 1j * rng.standard_normal((3, 3)))
+    t = SymmetricTensor.from_dense(data, (idx_a, idx_b))
+
+    flipped = _flow_flip_no_conj(t)
+
+    assert isinstance(flipped, SymmetricTensor)
+    assert flipped.indices[0].flow == FlowDirection.OUT
+    assert flipped.indices[1].flow == FlowDirection.IN
+    np.testing.assert_allclose(
+        np.asarray(flipped.todense()),
+        np.asarray(t.todense()),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def test_flow_flip_no_conj_symmetric_nontrivial_charges():
+    """SymmetricTensor with non-trivial U(1) charges: keys preserved (flipping every
+    flow leaves ``sum(flow_i * c_i) = 0`` invariant), block data uncon­jugated."""
+    sym = U1Symmetry()
+    idx_a = TensorIndex.from_charges(
+        sym, np.array([0, 1], dtype=np.int32), FlowDirection.OUT, label="a"
+    )
+    idx_b = TensorIndex.from_charges(
+        sym, np.array([0, 1], dtype=np.int32), FlowDirection.IN, label="b"
+    )
+    rng = np.random.RandomState(7)
+    raw = rng.standard_normal((2, 2)) + 1j * rng.standard_normal((2, 2))
+    # Conservation (OUT, IN) with charges (0/1, 0/1) requires c_a == c_b,
+    # so only diagonal entries belong to allowed sectors.
+    raw[0, 1] = 0.0
+    raw[1, 0] = 0.0
+    data = jnp.array(raw)
+    t = SymmetricTensor.from_dense(data, (idx_a, idx_b))
+
+    flipped = _flow_flip_no_conj(t)
+
+    assert isinstance(flipped, SymmetricTensor)
+    assert flipped.indices[0].flow == FlowDirection.IN
+    assert flipped.indices[1].flow == FlowDirection.OUT
+    # Block keys unchanged.
+    assert set(flipped._block_keys) == set(t._block_keys)
+    for k in t._block_keys:
+        np.testing.assert_allclose(
+            np.asarray(flipped.blocks[k]),
+            np.asarray(t.blocks[k]),
+            rtol=1e-12,
+            atol=1e-12,
+        )


### PR DESCRIPTION
## Summary

`_flow_flip_no_conj` (added in #422) crashed for any `SymmetricTensor` input — including trivial U(1) charges. Codex bot called this out on the PR review thread (https://github.com/tenax-lab/tenax/pull/422#discussion_r3215000625). This patch fixes the helper and adds direct unit tests.

The helper reconstructed `SymmetricTensor(t._data, new_indices)`, but `SymmetricTensor.__init__` expects a `dict[BlockKey, jax.Array]` and `t._data` is the packed flat buffer, so `_init_flat_buffer` raises `'ArrayImpl' object has no attribute 'keys'`.

Latent on `main`: `_compute_2x2_projector` only supports trivial charges and the SymmetricTensor 2x2 projector tests are xfailed (#416), so absorption never receives a non-dense projector today. The helper would trip the moment that path is unblocked.

## Fix

Mirror `SymmetricTensor.bar`'s `_raw` reconstruction. Flipping every leg's flow simultaneously preserves the conservation law `sum(flow_i * c_i) = 0` (both sides flip sign), so block keys, shapes, and offsets are unchanged — reuse them along with the existing flat buffer.

```python
def _flow_flip_no_conj(t):
    new_indices = tuple(idx.flip_flow() for idx in t.indices)
    if isinstance(t, DenseTensor):
        return DenseTensor(t._data, new_indices)
    return SymmetricTensor._raw(
        indices=new_indices,
        data=t._data,
        block_keys=t._block_keys,
        block_shapes=t._block_shapes,
        block_offsets=t._block_offsets,
    )
```

## Test plan
- [x] New `tests/test_ctm_tensor_flow_flip.py` (3/3 pass): dense preservation, SymmetricTensor trivial charges, SymmetricTensor non-trivial U(1). The trivial-charges test reproduces the codex-reported crash before the fix.
- [ ] CI `Tests (Python 3.11)` / `Tests (Python 3.12)` / `Tests (macOS, Python 3.12)`
- Pre-existing failures on `test_ctm_tensor.py::TestSweep::test_one_sweep_*_finite` and `TestProjectorSymmetric::test_qr_projector_symmetric_matches_eigh` reproduce on `origin/main` without this patch — not regressions from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)