### PR TITLE
fix(ctm-ad): fall back to eager GMRES on slow Neumann (#420)

### DIFF
--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -1001,18 +1001,29 @@ def _make_implicit_vjp_fn(
 
         if adjoint_method == "fixed_point":
             # F3 fused JIT: dE/denv + adjoint fixed-point + chain rule
-            # in one trace. Returns final grads directly; if the in-loop
-            # divergence guard fired we fall back to eager GMRES below
-            # (same path as adjoint_method=="gmres").
+            # in one trace. Returns final grads directly; if the fused
+            # loop did not solve the system (diverged or hit
+            # gmres_maxiter without reaching gmres_tol) we fall back
+            # to eager GMRES below (same path as adjoint_method=="gmres").
             grads_tuple, diverged, _converged, _n_iter = _jit_fused_fixed_point_bwd(
                 params_data_tuple, env_leaves, g
             )
             _F3_LAST_DIAGNOSTICS["diverged"] = bool(jax.device_get(diverged))
             _F3_LAST_DIAGNOSTICS["converged"] = bool(jax.device_get(_converged))
             _F3_LAST_DIAGNOSTICS["n_iter"] = int(jax.device_get(_n_iter))
-            if _F3_LAST_DIAGNOSTICS["diverged"]:
-                # Diverged inside the JIT loop — fall back to eager GMRES
-                # using the surviving _jit_apply_Jt closure.
+            if (
+                _F3_LAST_DIAGNOSTICS["diverged"]
+                or not _F3_LAST_DIAGNOSTICS["converged"]
+            ):
+                # Either the in-loop divergence guard fired (diff
+                # increasing past k>5) or the loop ran out of
+                # gmres_maxiter without diff crossing gmres_tol. The
+                # latter is the contractive-but-slow regime — the
+                # in-loop guard cannot detect it because diff stays
+                # monotonically decreasing. Without this branch the
+                # truncated Neumann iterate would be silently consumed
+                # by _jit_chain_rule as if (I - J^T) λ = b had been
+                # solved, biasing the gradient (issue #420).
                 rhs = _eager_dE_denv()
                 lam, _info = gmres_pytree_jax(
                     _eager_apply_I_minus_Jt,

--- a/tests/test_ipeps_ad_f3_fused_bwd.py
+++ b/tests/test_ipeps_ad_f3_fused_bwd.py
@@ -36,7 +36,7 @@ def _random_peps(seed=2026, D=2, d=2):
     return A / (jnp.linalg.norm(A) + 1e-10)
 
 
-def _grad_for_method(method: str):
+def _grad_for_method(method: str, gmres_maxiter: int = 200):
     H = _heisenberg_gate()
     A = _wrap_as_dense_tensor(_random_peps())
 
@@ -50,7 +50,7 @@ def _grad_for_method(method: str):
             conv_tol=1e-6,
             forward_gauge="phase",
             gmres_tol=1e-6,
-            gmres_maxiter=200,
+            gmres_maxiter=gmres_maxiter,
             # Parity test: skip the divergence guard so both methods
             # actually run the solve. The chi=8 phase-gauge config is
             # well-posed (variPEPS converges here in <30 Neumann iters).
@@ -106,4 +106,64 @@ def test_fused_bwd_converges_without_fallback():
     )
     assert _F3_LAST_DIAGNOSTICS["n_iter"] > 1, (
         f"Suspicious n_iter (=initial value?): {_F3_LAST_DIAGNOSTICS}"
+    )
+
+
+@pytest.mark.algorithm
+def test_slow_neumann_falls_back_to_gmres():
+    """Regression for issue #420.
+
+    When the fused Neumann iteration exits at ``gmres_maxiter`` without
+    reaching ``gmres_tol`` and without tripping the divergence guard,
+    the truncated iterate must NOT be silently consumed by the chain
+    rule. Before the fix, ``converged=False & diverged=False`` skipped
+    the eager-GMRES fallback and returned a biased gradient.
+
+    Test construction:
+
+    * Set ``gmres_maxiter=2``. The in-loop divergence guard is
+      ``(diff > prev_diff) & (k > 5)``, so with ``k`` at most 2 the
+      guard is structurally inactive and ``diverged`` is guaranteed
+      ``False``.
+    * ``gmres_tol=1e-6`` cannot be reached in two Neumann steps for
+      this Heisenberg problem, so ``converged`` is ``False``.
+    * Diagnostics therefore show ``converged=False & diverged=False`` —
+      precisely the issue-#420 scenario, independent of ``ρ(J^T)``.
+
+    Reference is the eager-GMRES adjoint path, which solves the same
+    ``(I - J^T) λ = b`` system to the same tolerance and is unaffected
+    by the fixed-point gate.
+    """
+    from tenax.algorithms._ctm_energy_ad import _F3_LAST_DIAGNOSTICS
+
+    # Reference: eager-GMRES adjoint — gives the true (I - J^T)^{-1} b.
+    g_ref = _grad_for_method("gmres", gmres_maxiter=200)
+
+    # Starve the fused Neumann iteration. maxiter=2 < 6 ⇒ the
+    # divergence guard cannot fire, regardless of ρ(J^T).
+    _F3_LAST_DIAGNOSTICS.clear()
+    g_starved = _grad_for_method("fixed_point", gmres_maxiter=2)
+    assert not _F3_LAST_DIAGNOSTICS.get("diverged"), (
+        "Starved Neumann recorded diverged=True — guard should be "
+        f"structurally inactive at k<=2. Diagnostics: {_F3_LAST_DIAGNOSTICS}"
+    )
+    assert not _F3_LAST_DIAGNOSTICS.get("converged"), (
+        "Starved Neumann unexpectedly converged in two iterations — pick "
+        f"a tighter starvation budget. Diagnostics: {_F3_LAST_DIAGNOSTICS}"
+    )
+
+    g_ref_arr = np.asarray(g_ref.todense() if hasattr(g_ref, "todense") else g_ref)
+    g_starved_arr = np.asarray(
+        g_starved.todense() if hasattr(g_starved, "todense") else g_starved
+    )
+    np.testing.assert_allclose(
+        g_starved_arr,
+        g_ref_arr,
+        rtol=1e-5,
+        atol=1e-7,
+        err_msg=(
+            "Issue #420: starved Neumann returned a biased gradient. The "
+            "eager-GMRES fallback must fire on converged=False & "
+            "diverged=False, not only on the diverging case."
+        ),
     )


### PR DESCRIPTION
## Summary

- The F3 fused fixed-point adjoint in `_ctm_energy_ad._make_implicit_vjp_fn` only routed to the eager-GMRES fallback when the in-loop divergence guard fired. That guard, `(diff > prev_diff) & (k > 5)`, cannot detect a contractive-but-slow regime where `diff` decreases monotonically without ever crossing `gmres_tol` within `gmres_maxiter`. In that regime the truncated Neumann iterate was silently consumed by `_jit_chain_rule` as if `(I − J^T) λ = b` had been solved, biasing the gradient.
- Gate the fallback on `diverged OR not converged` so the same `gmres_pytree_jax` rescue handles both failure modes. One-line behavioral change plus an inline-comment refresh explaining the new gate.
- Regression test `test_slow_neumann_falls_back_to_gmres` sets `gmres_maxiter=2`. Because the in-loop guard only fires for `k > 5`, the starved run is structurally guaranteed `diverged=False`; the chi=8 Heisenberg problem cannot reach `gmres_tol=1e-6` in two steps so `converged=False`. This isolates the bug-#420 scenario independent of `ρ(J^T)`.
- Pre-fix: starved gradient mismatches the eager-GMRES reference at 100% of elements (max abs diff 0.88, max rel 32×). Post-fix: agrees within `rtol=1e-5, atol=1e-7`.

Closes #420.

## Test plan
- [x] New regression test `test_slow_neumann_falls_back_to_gmres` fails pre-fix and passes post-fix (red→green verified).
- [x] Existing parity test `test_fused_bwd_matches_gmres_at_chi8` still passes.
- [x] `uv run pytest -m core` — 789 passed, 1 skipped, 1182 deselected.
- [ ] Wait for full-suite CI on this PR to confirm no regression on the algorithm/slow markers.

## Notes
- Two pre-existing failures on `main` are unrelated to this fix and were not folded in per the "separate branches per concern" rule:
  - `tests/test_ipeps_ad_f3_fused_bwd.py::test_fused_bwd_converges_without_fallback`
  - `tests/test_ipeps_ad_adjoint_methods.py::test_fixed_point_arnoldi_rejects_high_rho`

  Both appear to be downstream of the CTM iteration fixes shipped in #422–#424, which changed the natural Neumann/Arnoldi spectrum on the test seeds. I'll open a separate issue for them after this PR is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)