### PR TITLE
test(ad): re-tune seeds for two AD adjoint tests (#428)

### DIFF
--- a/tests/test_ipeps_ad_adjoint_methods.py
+++ b/tests/test_ipeps_ad_adjoint_methods.py
@@ -91,9 +91,16 @@ def test_fixed_point_arnoldi_rejects_high_rho():
     When the precheck is on and the spectrum is unfavorable (here:
     ``forward_gauge="none"`` at chi=4), the backward must raise
     ``CTMRGGradientError`` instead of looping to ``gmres_maxiter``.
+
+    ``seed=1`` is chosen because it lands on ρ(J^T) ≈ 1.58 on the
+    post-#422-#424 CTM iteration — comfortably above the rejection
+    threshold but not pathological. The original ``seed=7`` fixture
+    drifted to ρ < 1 when the CTM-iteration fixes shipped, so the
+    precheck stopped firing (issue #428). Other rejecting seeds at
+    this config: 1, 3, 8, 12, 15, 19, 21, 22, 25, 26, 27, ...
     """
     H = _heisenberg_gate()
-    A = _wrap_as_dense_tensor(_random_peps(seed=7))
+    A = _wrap_as_dense_tensor(_random_peps(seed=1))
 
     def loss(A_):
         return ctm_energy_implicit(

--- a/tests/test_ipeps_ad_f3_fused_bwd.py
+++ b/tests/test_ipeps_ad_f3_fused_bwd.py
@@ -88,11 +88,38 @@ def test_fused_bwd_converges_without_fallback():
     making the parity test green while F3 does strictly more work than
     F2. This test asserts the fused JIT converges on a well-posed
     config without invoking the fallback.
+
+    The probe config (chi=4, seed=0, forward_gauge="phase") is chosen
+    for ρ(J^T) < 1 on the post-#422-#424 CTM iteration: the Neumann
+    loop is contractive and converges in ~13 steps to gmres_tol=1e-6.
+    The parity helper's chi=8 default is more spectral-radius
+    sensitive — currently divergent on this seed — so we use a
+    dedicated config here. If a future CTM-iteration change shifts
+    ρ ≥ 1 on (chi=4, seed=0, phase) too, re-tune via the seed sweep
+    pattern documented in issue #428.
     """
     from tenax.algorithms._ctm_energy_ad import _F3_LAST_DIAGNOSTICS
 
+    H = _heisenberg_gate()
+    A = _wrap_as_dense_tensor(_random_peps(seed=0))
+
+    def loss(A_):
+        return ctm_energy_implicit(
+            {(0, 0): A_},
+            SINGLE_SITE_NEIGHBORS,
+            H,
+            chi=4,
+            max_iter=40,
+            conv_tol=1e-6,
+            forward_gauge="phase",
+            gmres_tol=1e-6,
+            gmres_maxiter=200,
+            arnoldi_precheck=False,
+            adjoint_method="fixed_point",
+        )
+
     _F3_LAST_DIAGNOSTICS.clear()
-    _ = _grad_for_method("fixed_point")
+    _ = jax.grad(loss)(A)
 
     assert "diverged" in _F3_LAST_DIAGNOSTICS, (
         "f_bwd did not record diagnostics — fused-JIT path may not have run"


### PR DESCRIPTION
## Summary

Two regression tests on the implicit-AD CTM backward path depended on specific spectral-radius behavior of J^T at fixed seeds. The CTM iteration fixes shipped in #422–#424 changed the converged environments on those seeds, invalidating both assumptions. Re-tune fixtures to seeds where the intended invariant holds, with comments documenting the spectral dependence so future re-tuning is cheap.

- ``test_fused_bwd_converges_without_fallback`` (F3 fused JIT must actually solve the system): the original ``chi=8, seed=2026, gauge="phase"`` config now ``diverged=True`` at iter 7. Move to a dedicated ``chi=4, seed=0, gauge="phase"`` config that converges in 13 steps to ``gmres_tol=1e-6``. The chi=8 parity helper used by the matching parity test is left intact — that test still passes because the eager-GMRES fallback rescues the gradient even when Neumann diverges.
- ``test_fixed_point_arnoldi_rejects_high_rho`` (Arnoldi precheck must reject ``ρ(J^T) ≥ 1``): original ``seed=7`` at ``chi=4, gauge="none"`` now lands at ``ρ < 1``. Switch to ``seed=1`` which gives ``ρ ≈ 1.58`` — comfortably above the rejection threshold but not pathological.

Picked via a seed sweep at chi ∈ {4, 8} × gauge ∈ {phase, sigma, none} across seeds 0–59. Other rejecting seeds at the test 2 config: 3, 8, 12, 15, 19, 21, 22, 25, 26, 27, ... — so re-tuning the next time the CTM iteration shifts again should be trivial.

No production-code change.

Closes #428.

## Test plan
- [x] ``tests/test_ipeps_ad_f3_fused_bwd.py::test_fused_bwd_converges_without_fallback`` — green, diagnostics ``{converged: True, diverged: False, n_iter: 13}``.
- [x] ``tests/test_ipeps_ad_adjoint_methods.py::test_fixed_point_arnoldi_rejects_high_rho`` — green, ``CTMRGGradientError(rho ≈ 1.58)`` raised as expected.
- [x] Full ``tests/test_ipeps_ad_adjoint_methods.py`` + ``tests/test_ipeps_ad_f3_fused_bwd.py`` — 5 passed.
- [x] ``uv run pytest -m core`` — 789 passed, 1 skipped, 1182 deselected.
- [ ] Wait for full-suite CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)