### PR TITLE
feat(ctm): auto-χ_E bump on SymmetricTensor path (#410, #418)

### DIFF
--- a/src/tenax/algorithms/_ctm_env_pad.py
+++ b/src/tenax/algorithms/_ctm_env_pad.py
@@ -1,32 +1,37 @@
-"""Zero-pad the χ axes of a dense CTMTensorEnv for auto-χ warm-start.
+"""Zero-pad the χ axes of a CTMTensorEnv for the variPEPS §2.8.2 auto-bump.
 
-Used by the variPEPS §2.8.2 auto-bump protocol (Task 6) to grow an already-
-converged environment from ``chi_old`` to ``chi_new`` before re-running CTM.
-Only the dense path is supported in v1; SymmetricTensor envs raise
-NotImplementedError (v2 follow-up, Task 9).
+Used by the auto-χ_E bump protocol to grow an already-converged environment
+from ``chi_old`` to ``chi_new`` before re-running CTM.  Both the dense path
+(``DenseTensor`` env) and the block-sparse path (``SymmetricTensor`` env)
+are supported; the symmetric path tiles existing χ-leg charges via
+``_derive_charges`` (the same allocator used by the symmetric projectors,
+keeping the χ-bond charge pattern consistent across CTM sweeps).
 """
 
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 
 from tenax.algorithms._ctm_tensor_init import CTMTensorEnv
+from tenax.algorithms._ctm_utils import _derive_charges
 from tenax.core.index import TensorIndex
-from tenax.core.tensor import DenseTensor, SymmetricTensor
+from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
 
 
 def _pad_chi_index(idx: TensorIndex, chi_new: int) -> TensorIndex:
     """Return a new TensorIndex with dim grown to ``chi_new``.
 
     The original charges are preserved in the first ``chi_old`` slots;
-    the new slots receive charge 0 (trivial sector), matching the
-    zero-padded array entries.
+    the new slots are filled by ``_derive_charges`` (a tile of the
+    existing pattern), so each charge sector grows by zero or more slots
+    while preserving every existing sector's position.  For DenseTensor
+    indices (single trivial charge 0), this is equivalent to padding with
+    zeros.
     """
-    chi_old = idx.dim
     old_charges = np.asarray(idx.charges, dtype=np.int32)
-    pad_charges = np.zeros(chi_new - chi_old, dtype=np.int32)
-    new_charges = np.concatenate([old_charges, pad_charges])
+    new_charges = _derive_charges(old_charges, chi_new)
     return TensorIndex.from_charges(
         idx.symmetry, new_charges, idx.flow, label=idx.label
     )
@@ -53,31 +58,96 @@ def _pad_edge(t: DenseTensor, chi_new: int) -> DenseTensor:
     return DenseTensor(arr, (idx0, idx1, idx2))
 
 
+def _sector_dim(idx: TensorIndex, charge: int) -> int:
+    """Number of slots in ``idx`` with the given charge."""
+    return int(np.sum(np.asarray(idx.charges) == charge))
+
+
+def _pad_symmetric_block_along_axes(
+    block: jax.Array,
+    old_shape: tuple[int, ...],
+    new_shape: tuple[int, ...],
+    chi_axes: tuple[int, ...],
+) -> jax.Array:
+    """Zero-pad ``block`` from ``old_shape`` to ``new_shape`` along ``chi_axes``."""
+    pad_widths = [(0, 0)] * block.ndim
+    for ax in chi_axes:
+        pad_widths[ax] = (0, new_shape[ax] - old_shape[ax])
+    return jnp.pad(block, pad_widths)
+
+
+def _pad_symmetric_tensor_along_chi(
+    t: SymmetricTensor,
+    new_indices: tuple[TensorIndex, ...],
+    chi_axes: tuple[int, ...],
+) -> SymmetricTensor:
+    """Rebuild ``t`` with new indices, zero-padding existing blocks along ``chi_axes``.
+
+    Block keys present in the old tensor are preserved (their data is
+    zero-padded along the chi axes).  Block keys valid under the new
+    indices but missing from the old tensor are not materialised — the
+    underlying flat-buffer representation only stores allocated blocks,
+    so absent sectors stay implicitly zero.
+
+    Because ``_derive_charges(c_old, chi_new)`` reproduces ``c_old`` as a
+    strict prefix when ``chi_new >= chi_old``, every old block key remains
+    valid under the new indices.
+    """
+    new_blocks: dict[tuple[int, ...], jax.Array] = {}
+    for key, block in t.blocks.items():
+        new_shape = tuple(
+            _sector_dim(new_indices[ax], int(key[ax])) for ax in range(len(new_indices))
+        )
+        new_blocks[key] = _pad_symmetric_block_along_axes(
+            block, block.shape, new_shape, chi_axes
+        )
+    return SymmetricTensor._from_blocks_unchecked(new_blocks, new_indices)
+
+
+def _pad_symmetric_corner(t: SymmetricTensor, chi_new: int) -> SymmetricTensor:
+    """Block-sparse pad of a corner SymmetricTensor along both χ axes."""
+    idx0 = _pad_chi_index(t.indices[0], chi_new)
+    idx1 = _pad_chi_index(t.indices[1], chi_new)
+    return _pad_symmetric_tensor_along_chi(t, (idx0, idx1), chi_axes=(0, 1))
+
+
+def _pad_symmetric_edge(t: SymmetricTensor, chi_new: int) -> SymmetricTensor:
+    """Block-sparse pad of an edge SymmetricTensor along axes 0 and 2 only."""
+    idx0 = _pad_chi_index(t.indices[0], chi_new)
+    idx2 = _pad_chi_index(t.indices[2], chi_new)
+    return _pad_symmetric_tensor_along_chi(
+        t, (idx0, t.indices[1], idx2), chi_axes=(0, 2)
+    )
+
+
+def _current_chi(t: Tensor) -> int:
+    """Return the current χ (first leg dim) of a corner or edge tensor."""
+    return int(t.indices[0].dim)
+
+
 def pad_dense_env_chi(env: CTMTensorEnv, chi_new: int) -> CTMTensorEnv:
-    """Zero-pad the χ axes of a dense CTMTensorEnv from current χ to ``chi_new``.
+    """Zero-pad the χ axes of a CTMTensorEnv from the current χ to ``chi_new``.
 
     Used by the variPEPS §2.8.2 auto-bump warm-start. Corners' both axes
     grow to ``chi_new``; edges' axes 0 and 2 grow (axis 1, the D² fused
-    leg, is untouched).
+    leg, is untouched).  For SymmetricTensor envs, new χ-leg charges are
+    derived from the existing pattern via ``_derive_charges`` (the same
+    allocator used by the symmetric projectors), and each block is padded
+    along its χ axes; sectors absent from the old blocks stay implicitly
+    zero in the flat-buffer representation.
 
     Returns the same env if ``chi_new`` matches the current χ. Raises
-    ``ValueError`` if ``chi_new < chi_old`` and ``NotImplementedError``
-    if any tensor is a ``SymmetricTensor`` (v2 follow-up).
+    ``ValueError`` if ``chi_new < chi_old``.
 
     Args:
-        env:     CTMTensorEnv whose corners and edges are all DenseTensor.
+        env:     CTMTensorEnv whose corners and edges are uniformly either
+                 ``DenseTensor`` or ``SymmetricTensor``.
         chi_new: Target bond dimension. Must be >= the current χ.
 
     Returns:
         New CTMTensorEnv with all χ legs padded to ``chi_new`` with zeros.
     """
-    # Detect SymmetricTensor before anything else.
-    for field_name in CTMTensorEnv._fields:
-        t = getattr(env, field_name)
-        if isinstance(t, SymmetricTensor):
-            raise NotImplementedError("padding SymmetricTensor envs is a v2 follow-up")
-
-    chi_old = env.C1._data.shape[0]
+    chi_old = _current_chi(env.C1)
 
     if chi_new < chi_old:
         raise ValueError(
@@ -86,6 +156,18 @@ def pad_dense_env_chi(env: CTMTensorEnv, chi_new: int) -> CTMTensorEnv:
 
     if chi_new == chi_old:
         return env
+
+    if isinstance(env.C1, SymmetricTensor):
+        return CTMTensorEnv(
+            C1=_pad_symmetric_corner(env.C1, chi_new),
+            C2=_pad_symmetric_corner(env.C2, chi_new),
+            C3=_pad_symmetric_corner(env.C3, chi_new),
+            C4=_pad_symmetric_corner(env.C4, chi_new),
+            T1=_pad_symmetric_edge(env.T1, chi_new),
+            T2=_pad_symmetric_edge(env.T2, chi_new),
+            T3=_pad_symmetric_edge(env.T3, chi_new),
+            T4=_pad_symmetric_edge(env.T4, chi_new),
+        )
 
     return CTMTensorEnv(
         C1=_pad_corner(env.C1, chi_new),

--- a/src/tenax/algorithms/_ctm_projector.py
+++ b/src/tenax/algorithms/_ctm_projector.py
@@ -270,7 +270,7 @@ def _eigh_projector_symmetric(
     chi: int,
     fused_idx: TensorIndex | None = None,
     base_charges: np.ndarray | None = None,
-) -> SymmetricTensor:
+) -> tuple[SymmetricTensor, jax.Array]:
     r"""Block-sparse projector via per-sector density matrix eigh.
 
     For each charge sector *q* of the ``fused`` leg, accumulates
@@ -299,8 +299,14 @@ def _eigh_projector_symmetric(
             of purely global eigenvalue truncation.
 
     Returns:
-        Projector ``P`` with labels ``(fused, chi_new)``, flows ``(IN, OUT)``.
+        ``(P, eps_T)`` where ``P`` has labels ``(fused, chi_new)``, flows
+        ``(IN, OUT)`` and ``eps_T`` is the variPEPS §2.8.2 truncation error
+        ``‖λ[n_keep:]‖ / ‖λ‖`` over the merged per-sector eigenvalue spectrum
+        (matches the dense eigh-path convention in
+        ``_compute_projector_tensor``).
     """
+    from tenax.algorithms._ctm_truncation_error import compute_truncation_error
+
     fused_pos = C1g.labels().index("fused")
     col_pos = 1 - fused_pos  # the other leg
     if fused_idx is None:
@@ -371,6 +377,15 @@ def _eigh_projector_symmetric(
     # among degenerate eigenvalues).
     all_eig_pairs.sort(key=lambda x: (-x[0], -x[2]))
     n_keep = min(chi, len(all_eig_pairs))
+
+    # variPEPS §2.8.2 ε_T from the merged per-sector eigenvalue spectrum.
+    # Matches the dense eigh-path convention in ``_compute_projector_tensor``:
+    # eps_T = ‖λ[n_keep:]‖ / ‖λ‖ over |eigvals| in descending order.
+    if all_eig_pairs:
+        eig_array = jnp.asarray([abs(p[0]) for p in all_eig_pairs], dtype=jnp.float64)
+        eps_T = compute_truncation_error(eig_array, n_keep)
+    else:
+        eps_T = jnp.asarray(0.0)
 
     sector_keep: dict[int, list[int]] = {}
 
@@ -448,9 +463,8 @@ def _eigh_projector_symmetric(
         V_q = jax.lax.stop_gradient(V_q)
         proj_blocks[(fq, fq)] = V_q
 
-    return _build_symmetric_projector(
-        proj_blocks, chi_new_charges, fused_idx, C1g.dtype
-    )
+    P = _build_symmetric_projector(proj_blocks, chi_new_charges, fused_idx, C1g.dtype)
+    return P, eps_T
 
 
 def _qr_projector_symmetric(
@@ -569,7 +583,7 @@ def _svd_projector_symmetric(
     chi: int,
     fused_idx: TensorIndex | None = None,
     base_charges: np.ndarray | None = None,
-) -> tuple[SymmetricTensor, SymmetricTensor]:
+) -> tuple[SymmetricTensor, SymmetricTensor, jax.Array]:
     r"""Block-sparse two-projector Fishman SVD for SymmetricTensor.
 
     For each charge sector *q* of the ``fused`` leg, forms the
@@ -593,9 +607,13 @@ def _svd_projector_symmetric(
         base_charges: Bond charges for per-sector allocation.
 
     Returns:
-        ``(P1, P2)`` each with labels ``(fused, chi_new)``.
+        ``(P1, P2, eps_T)`` where ``P1``, ``P2`` each have labels
+        ``(fused, chi_new)`` and ``eps_T`` is the variPEPS §2.8.2
+        truncation error ``‖S[n_keep:]‖ / ‖S‖`` over the merged
+        per-sector singular-value spectrum.
     """
     from tenax.algorithms._ad_primitives import _fix_svd_signs
+    from tenax.algorithms._ctm_truncation_error import compute_truncation_error
 
     fused_pos = C1g.labels().index("fused")
     col_pos = 1 - fused_pos
@@ -678,6 +696,14 @@ def _svd_projector_symmetric(
     all_sv_pairs.sort(key=lambda x: (-x[0], -x[2]))
     n_keep = min(chi, len(all_sv_pairs))
 
+    # variPEPS §2.8.2 ε_T from the merged per-sector singular-value spectrum.
+    # ε_T = ‖S[n_keep:]‖ / ‖S‖ over the descending global spectrum.
+    if all_sv_pairs:
+        sv_array = jnp.asarray([p[0] for p in all_sv_pairs], dtype=jnp.float64)
+        eps_T = compute_truncation_error(sv_array, n_keep)
+    else:
+        eps_T = jnp.asarray(0.0)
+
     sector_keep: dict[int, list[int]] = {}
 
     if base_charges is not None:
@@ -754,7 +780,7 @@ def _svd_projector_symmetric(
 
     P1 = _build_symmetric_projector(p1_blocks, chi_new_charges, fused_idx, C1g.dtype)
     P2 = _build_symmetric_projector(p2_blocks, chi_new_charges, fused_idx, C1g.dtype)
-    return P1, P2
+    return P1, P2, eps_T
 
 
 # ------------------------------------------------------------------ #
@@ -859,24 +885,24 @@ def _compute_projector_tensor(
                 c1_charges = C1g.indices[fused_pos_chk].charges
                 c4_charges = C4g.indices[fused_pos_chk].charges
                 if np.array_equal(c1_charges, c4_charges):
-                    P_1, P_2 = _svd_projector_symmetric(
+                    P_1, P_2, eps_T = _svd_projector_symmetric(
                         C1g, C4g, chi, base_charges=base_charges
                     )
-                    return P_1, P_2, jnp.asarray(0.0)
+                    return P_1, P_2, eps_T
                 # Mismatched fused charges: build unified fused index
                 unified_fused_idx = _build_unified_fused_idx(
                     C1g.indices[fused_pos_chk], C4g.indices[fused_pos_chk]
                 )
                 C1g_re = _reembed_fused(C1g, unified_fused_idx)
                 C4g_re = _reembed_fused(C4g, unified_fused_idx)
-                P_1, P_2 = _svd_projector_symmetric(
+                P_1, P_2, eps_T = _svd_projector_symmetric(
                     C1g_re,
                     C4g_re,
                     chi,
                     fused_idx=unified_fused_idx,
                     base_charges=base_charges,
                 )
-                return P_1, P_2, jnp.asarray(0.0)
+                return P_1, P_2, eps_T
 
         # Dense fallback for SVD projector.  Reached in two cases:
         #   1. DenseTensor inputs (no block-sparse structure).
@@ -1042,8 +1068,10 @@ def _compute_projector_tensor(
             c1_charges = C1g.indices[fused_pos].charges
             c4_charges = C4g.indices[fused_pos].charges
             if np.array_equal(c1_charges, c4_charges):
-                P = _eigh_projector_symmetric(C1g, C4g, chi, base_charges=base_charges)
-                return P, P, jnp.asarray(0.0)
+                P, eps_T = _eigh_projector_symmetric(
+                    C1g, C4g, chi, base_charges=base_charges
+                )
+                return P, P, eps_T
             # Mismatched fused charges (e.g. split CTM with different
             # D-leg flows): build a unified fused index covering both
             # corners' charge sectors, re-embed, and use block-sparse eigh.
@@ -1052,14 +1080,14 @@ def _compute_projector_tensor(
             )
             C1g_re = _reembed_fused(C1g, unified_fused_idx)
             C4g_re = _reembed_fused(C4g, unified_fused_idx)
-            P = _eigh_projector_symmetric(
+            P, eps_T = _eigh_projector_symmetric(
                 C1g_re,
                 C4g_re,
                 chi,
                 fused_idx=unified_fused_idx,
                 base_charges=base_charges,
             )
-            return P, P, jnp.asarray(0.0)
+            return P, P, eps_T
 
     # Dense eigh fallback — only reached when SymmetricTensor blocks contain
     # JAX tracers (AD backward) or for DenseTensor inputs.  Block-sparse

--- a/tests/test_chi_auto_bump.py
+++ b/tests/test_chi_auto_bump.py
@@ -200,6 +200,65 @@ def test_maybe_bump_chi_above_threshold_bumps_and_pads():
     assert new_cache["envs"][(0, 0)].C1._data.shape == (6, 6)
 
 
+def test_maybe_bump_chi_above_threshold_bumps_and_pads_symmetric():
+    """variPEPS §2.8.2 auto-bump on SymmetricTensor envs (Issue #410).
+
+    Previously, ``_maybe_bump_chi`` -> ``pad_dense_env_chi`` raised
+    ``NotImplementedError`` for block-sparse envs.  After #410, the
+    symmetric path tiles existing χ-leg charges via ``_derive_charges``
+    and zero-pads each block along its χ axes.
+    """
+    import jax
+    import numpy as np
+
+    from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env
+    from tenax.algorithms.ipeps_optimize import _maybe_bump_chi
+    from tenax.core.index import FlowDirection, TensorIndex
+    from tenax.core.symmetry import U1Symmetry
+    from tenax.core.tensor import SymmetricTensor
+
+    sym = U1Symmetry()
+    bond_charges = np.array([0, 1], dtype=np.int32)
+    phys_charges = np.array([0, 1], dtype=np.int32)
+    indices = (
+        TensorIndex.from_charges(
+            sym, bond_charges.copy(), FlowDirection.OUT, label="u"
+        ),
+        TensorIndex.from_charges(sym, bond_charges.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(
+            sym, bond_charges.copy(), FlowDirection.OUT, label="l"
+        ),
+        TensorIndex.from_charges(sym, bond_charges.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(
+            sym, phys_charges.copy(), FlowDirection.IN, label="phys"
+        ),
+    )
+    A_sym = SymmetricTensor.random_normal(indices, jax.random.PRNGKey(0))
+    env_old = initialize_ctm_tensor_env(A_sym, chi=4)
+
+    cache = {"envs": {(0, 0): env_old}}
+    cfg = CTMConfig(
+        chi=4, chi_auto_bump=True, chi_auto_bump_eps=1e-5, chi_auto_bump_step=2
+    )
+    new_cfg, new_cache = _maybe_bump_chi(cfg, cache, last_eps_t=1e-3)
+    assert new_cfg.chi == 6
+    assert new_cache is cache, (
+        "_maybe_bump_chi must mutate env_cache in-place even on the symmetric path"
+    )
+    env_new = new_cache["envs"][(0, 0)]
+    # χ axes grew to 6; D² leg untouched.
+    assert env_new.C1.indices[0].dim == 6
+    assert env_new.C1.indices[1].dim == 6
+    assert env_new.T1.indices[0].dim == 6
+    assert env_new.T1.indices[2].dim == 6
+    assert env_new.T1.indices[1].dim == env_old.T1.indices[1].dim
+    # Leading χ_old × χ_old block matches the pre-pad corner.
+    chi_old = 4
+    C1_old = env_old.C1.todense()
+    C1_new = env_new.C1.todense()
+    assert np.allclose(np.asarray(C1_new)[:chi_old, :chi_old], np.asarray(C1_old))
+
+
 def test_maybe_bump_chi_respects_chi_max_ceiling():
     """chi_max ceiling caps the bump."""
     from tenax.algorithms.ipeps_optimize import _maybe_bump_chi

--- a/tests/test_ctm_env_pad.py
+++ b/tests/test_ctm_env_pad.py
@@ -97,23 +97,111 @@ def test_pad_rejects_shrink():
         pad_dense_env_chi(env_old, chi_new=2)
 
 
-def test_pad_raises_for_symmetric_tensor_env():
-    """SymmetricTensor envs are out of scope for v1 — must raise cleanly."""
+# ---------------------------------------------------------------------------
+# Issue #410: SymmetricTensor env padding.
+#
+# The single-site dense auto-χ_E bump (PR #412) only knows how to grow the
+# χ axes of a DenseTensor env. Block-sparse envs raised NotImplementedError.
+# Issue #410 lifts that restriction by tiling the existing χ-leg charges
+# via ``_derive_charges`` (the same allocator used by the CTM projectors)
+# and zero-padding each block along its χ axes.
+# ---------------------------------------------------------------------------
+
+
+def _make_u1_peps(D: int, d: int, seed: int = 42) -> SymmetricTensor:
+    """Build a 5-leg U(1) iPEPS site tensor with non-trivial bond charges."""
     sym = U1Symmetry()
-    charges = np.zeros(2, dtype=np.int32)
-    phys_charges = np.zeros(2, dtype=np.int32)
+    # Non-trivial bond charges: half q=0, half q=1.  Tile/truncate to D.
+    bond_charges = np.array([0, 1] * ((D + 1) // 2))[:D].astype(np.int32)
+    phys_charges = np.array([0, 1] * ((d + 1) // 2))[:d].astype(np.int32)
     indices = (
-        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.OUT, label="u"),
-        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.IN, label="d"),
-        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.OUT, label="l"),
-        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(
+            sym, bond_charges.copy(), FlowDirection.OUT, label="u"
+        ),
+        TensorIndex.from_charges(sym, bond_charges.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(
+            sym, bond_charges.copy(), FlowDirection.OUT, label="l"
+        ),
+        TensorIndex.from_charges(sym, bond_charges.copy(), FlowDirection.IN, label="r"),
         TensorIndex.from_charges(
             sym, phys_charges.copy(), FlowDirection.IN, label="phys"
         ),
     )
-    rng = np.random.RandomState(42)
-    data = jnp.array(rng.standard_normal((2, 2, 2, 2, 2)))
-    peps_sym = SymmetricTensor.from_dense(data, indices)
-    env_sym = initialize_ctm_tensor_env(peps_sym, chi=4)
-    with pytest.raises(NotImplementedError, match="v2 follow-up"):
-        pad_dense_env_chi(env_sym, chi_new=6)
+    return SymmetricTensor.random_normal(indices, jax.random.PRNGKey(seed))
+
+
+def test_pad_symmetric_corner_axes_extend_to_new_chi():
+    """Padding a symmetric corner grows both χ axes to ``chi_new``."""
+    A_sym = _make_u1_peps(D=2, d=2)
+    env_old = initialize_ctm_tensor_env(A_sym, chi=4)
+    env_new = pad_dense_env_chi(env_old, chi_new=8)
+    assert env_new.C1.indices[0].dim == 8
+    assert env_new.C1.indices[1].dim == 8
+    assert env_new.C4.indices[0].dim == 8
+
+
+def test_pad_symmetric_edge_chi_axes_only():
+    """Padding a symmetric edge grows axes 0 and 2 (the χ axes); axis 1 (D²) untouched."""
+    A_sym = _make_u1_peps(D=2, d=2)
+    env_old = initialize_ctm_tensor_env(A_sym, chi=4)
+    D2_dim_old = env_old.T1.indices[1].dim
+    env_new = pad_dense_env_chi(env_old, chi_new=8)
+    assert env_new.T1.indices[0].dim == 8
+    assert env_new.T1.indices[2].dim == 8
+    assert env_new.T1.indices[1].dim == D2_dim_old  # D² leg unchanged
+
+
+def test_pad_symmetric_uses_derive_charges_for_new_slots():
+    """New χ-axis charges follow ``_derive_charges`` (tile of old charges)."""
+    from tenax.algorithms._ctm_utils import _derive_charges
+
+    A_sym = _make_u1_peps(D=2, d=2)
+    env_old = initialize_ctm_tensor_env(A_sym, chi=4)
+    env_new = pad_dense_env_chi(env_old, chi_new=10)
+    expected_charges = _derive_charges(env_old.C1.indices[0].charges, 10)
+    assert np.array_equal(env_new.C1.indices[0].charges, expected_charges)
+    # Edges share the same chi-charge tile as the corners.
+    assert np.array_equal(env_new.T1.indices[0].charges, expected_charges)
+
+
+def test_pad_symmetric_preserves_existing_blocks():
+    """Existing block data is preserved under padding (only zeros appended)."""
+    A_sym = _make_u1_peps(D=2, d=2)
+    env_old = initialize_ctm_tensor_env(A_sym, chi=4)
+    env_new = pad_dense_env_chi(env_old, chi_new=8)
+
+    # Densify both envs along the C1 corner and compare leading 4×4 block.
+    C1_old_dense = env_old.C1.todense()
+    C1_new_dense = env_new.C1.todense()
+    # The padded corner should embed the old corner in its leading χ_old × χ_old block.
+    assert C1_new_dense.shape == (8, 8)
+    # Old charge order is preserved as a prefix of the new charge order (tile).
+    chi_old = C1_old_dense.shape[0]
+    assert jnp.allclose(C1_new_dense[:chi_old, :chi_old], C1_old_dense)
+
+
+def test_pad_symmetric_fills_new_block_with_zero():
+    """Newly grown rows/cols of the corner are zero."""
+    A_sym = _make_u1_peps(D=2, d=2)
+    env_old = initialize_ctm_tensor_env(A_sym, chi=4)
+    env_new = pad_dense_env_chi(env_old, chi_new=8)
+    C1_new_dense = env_new.C1.todense()
+    # Beyond χ_old, the corner must be all zero (since the only nonzero entry
+    # in the rank-1 initial corner is at index (0, 0) which is already inside
+    # the χ_old × χ_old block).
+    assert float(jnp.max(jnp.abs(C1_new_dense[4:, :]))) == 0.0
+    assert float(jnp.max(jnp.abs(C1_new_dense[:, 4:]))) == 0.0
+
+
+def test_pad_symmetric_noop_when_chi_unchanged():
+    A_sym = _make_u1_peps(D=2, d=2)
+    env_old = initialize_ctm_tensor_env(A_sym, chi=4)
+    env_new = pad_dense_env_chi(env_old, chi_new=4)
+    assert env_new is env_old
+
+
+def test_pad_symmetric_rejects_shrink():
+    A_sym = _make_u1_peps(D=2, d=2)
+    env_old = initialize_ctm_tensor_env(A_sym, chi=4)
+    with pytest.raises(ValueError, match="must be >="):
+        pad_dense_env_chi(env_old, chi_new=2)

--- a/tests/test_ctm_truncation_error.py
+++ b/tests/test_ctm_truncation_error.py
@@ -102,3 +102,109 @@ def test_compute_projector_tensor_returns_eps_t_for_eigh():
     # eps_T must be positive: chi_target=2 discards 2 of 4 eigenvalues from rho.
     assert float(eps_T) > 0.0, f"Expected eps_T > 0 but got {float(eps_T)}"
     assert float(eps_T) <= 1.0, f"eps_T must be in [0, 1], got {float(eps_T)}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #410: ε_T from the SymmetricTensor projector paths.
+#
+# The single-site dense auto-χ_E bump (PR #412) only surfaces ε_T from the
+# dense projector paths.  The SymmetricTensor SVD and eigh paths still
+# return ``jnp.asarray(0.0)`` as a placeholder, which means auto-χ_E bump
+# cannot fire when the optimizer is run with SymmetricTensor inputs.
+#
+# Issue #410 asks for ε_T extraction from the SymmetricTensor SVD path;
+# the eigh case is included here because ``optimize_gs_ad`` measures ε_T
+# via a one-off ``_ctm_tensor_sweep(..., "eigh")`` call (see
+# ``ipeps_optimize.py:881``) — so the eigh symmetric path is *the* path
+# that decides the bump.  The QR symmetric path is not used for the
+# auto-bump decision and is intentionally left as a 0.0 placeholder.
+# ---------------------------------------------------------------------------
+
+
+def _make_symmetric_corner(
+    chi: int,
+    fused_charges: np.ndarray,
+    col_charges: np.ndarray,
+    seed: int,
+):
+    """Build a random-block SymmetricTensor corner with labels ('fused', 'col').
+
+    Random entries are placed in every symmetry-allowed block, so the
+    underlying matrix is block-sparse but generic within each block.
+    """
+    from tenax.core.tensor import SymmetricTensor
+
+    sym = U1Symmetry()
+    fused_idx = TensorIndex.from_charges(
+        sym, fused_charges.astype(np.int32), FlowDirection.IN, label="fused"
+    )
+    col_idx = TensorIndex.from_charges(
+        sym, col_charges.astype(np.int32), FlowDirection.OUT, label="col"
+    )
+    return SymmetricTensor.random_normal((fused_idx, col_idx), jax.random.PRNGKey(seed))
+
+
+def test_compute_projector_tensor_returns_eps_t_symmetric_svd():
+    """SymmetricTensor SVD path must return ε_T from the merged per-sector spectrum.
+
+    Two charge sectors (q=0, q=1) of dim 4 each → 8 singular values total.
+    Truncating to chi_target=4 must discard at least 4 SVs, giving ε_T > 0.
+    """
+    chi_in = 8
+    chi_target = 4
+    # Two-sector charges: half q=0, half q=1.
+    fused_charges = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    col_charges = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    C1g = _make_symmetric_corner(chi_in, fused_charges, col_charges, seed=0)
+    C4g = _make_symmetric_corner(chi_in, fused_charges, col_charges, seed=1)
+
+    P_1, P_2, eps_T = _compute_projector_tensor(
+        C1g, C4g, chi_target, projector_method="svd"
+    )
+    assert eps_T.shape == ()
+    assert 0.0 < float(eps_T) <= 1.0, (
+        f"Expected 0 < ε_T <= 1 from symmetric SVD truncation, got {float(eps_T)}"
+    )
+
+
+def test_compute_projector_tensor_returns_eps_t_symmetric_eigh():
+    """SymmetricTensor eigh path must return ε_T from the merged per-sector spectrum.
+
+    This is the path optimize_gs_ad uses for the auto-bump decision
+    (ipeps_optimize.py:881 calls _ctm_tensor_sweep with projector_method='eigh'
+    purely to measure ε_T).  Without ε_T here, auto-bump can never fire on
+    symmetric inputs.
+    """
+    chi_in = 8
+    chi_target = 4
+    fused_charges = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    col_charges = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    C1g = _make_symmetric_corner(chi_in, fused_charges, col_charges, seed=0)
+    C4g = _make_symmetric_corner(chi_in, fused_charges, col_charges, seed=1)
+
+    _, _, eps_T = _compute_projector_tensor(
+        C1g, C4g, chi_target, projector_method="eigh"
+    )
+    assert eps_T.shape == ()
+    assert 0.0 < float(eps_T) <= 1.0, (
+        f"Expected 0 < ε_T <= 1 from symmetric eigh truncation, got {float(eps_T)}"
+    )
+
+
+def test_compute_projector_tensor_eps_t_symmetric_zero_when_no_truncation():
+    """No truncation (chi >= n_keep) → ε_T = 0 on the symmetric paths too."""
+    chi_in = 4
+    chi_target = 8  # > spectrum length
+    fused_charges = np.array([0, 0, 1, 1])
+    col_charges = np.array([0, 0, 1, 1])
+    C1g = _make_symmetric_corner(chi_in, fused_charges, col_charges, seed=0)
+    C4g = _make_symmetric_corner(chi_in, fused_charges, col_charges, seed=1)
+
+    _, _, eps_T_svd = _compute_projector_tensor(
+        C1g, C4g, chi_target, projector_method="svd"
+    )
+    _, _, eps_T_eigh = _compute_projector_tensor(
+        C1g, C4g, chi_target, projector_method="eigh"
+    )
+    assert float(eps_T_svd) == pytest.approx(0.0, abs=1e-12)
+    assert float(eps_T_eigh) == pytest.approx(0.0, abs=1e-12)


### PR DESCRIPTION
## Summary

- Extends the variPEPS §2.8.2 auto-χ_E bump (shipped in #412 for dense single-site) to the SymmetricTensor block-sparse path.
- ε_T is now surfaced from \`_svd_projector_symmetric\` and \`_eigh_projector_symmetric\` (computed via \`compute_truncation_error\` on the merged per-sector spectrum, normalised L2 of the discarded tail).
- \`pad_dense_env_chi\` gains a SymmetricTensor branch: χ-leg charges grow via \`_derive_charges\` (mirroring the symmetric projectors' per-sector allocation); each block is zero-padded along its χ axes; sectors absent from old blocks stay implicitly zero in the flat-buffer representation.
- With both pieces in place, \`_maybe_bump_chi\` on a SymmetricTensor env now bumps χ and pads the cached env in place — the temporary config guard that #418 proposed is unnecessary and is not added.

Closes #410, #418.

## Test plan

- [x] \`uv run pytest -m core\` — 799 passed locally.
- [x] New unit tests:
  - \`test_compute_projector_tensor_returns_eps_t_symmetric_svd\` — ε_T > 0 from merged per-sector SVs.
  - \`test_compute_projector_tensor_returns_eps_t_symmetric_eigh\` — ε_T > 0 from merged per-sector eigenvalues (the path \`optimize_gs_ad\` uses for the bump decision).
  - \`test_compute_projector_tensor_eps_t_symmetric_zero_when_no_truncation\` — ε_T = 0 when χ_target ≥ spectrum length.
  - \`test_pad_symmetric_*\` (6 tests) — corner/edge dim growth, \`_derive_charges\` charge tiling, existing-block preservation, new-block zero-fill, no-op, shrink rejection.
  - \`test_maybe_bump_chi_above_threshold_bumps_and_pads_symmetric\` — end-to-end \`_maybe_bump_chi\` on a SymmetricTensor env produced by \`initialize_ctm_tensor_env\`.
- [x] Full algorithm suite (e2e symmetric optimize_gs_ad with auto-bump) deferred — that path is currently xfailed on \`main\` due to #416 (\`_compute_2x2_projector\` lacks symmetric support); reaching auto-bump under L-BFGS will land once #416 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)