### PR TITLE
fix(ipeps): reject chi_auto_bump + SymmetricTensor at guard (#418)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -25,7 +25,7 @@ from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.lattice import Lattice
 from tenax.core.symmetry import U1Symmetry
-from tenax.core.tensor import DenseTensor, Tensor
+from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
 
 _logger = logging.getLogger(__name__)
 
@@ -476,6 +476,15 @@ def optimize_gs_ad(
         raise NotImplementedError(
             "chi_auto_bump is currently supported only for unit_cell='1x1'; "
             "multisite and 2-site paths are tracked as follow-up issues."
+        )
+    # SymmetricTensor envs need the v2 follow-up in pad_dense_env_chi
+    # (#410). Reject up-front so the user gets a clear error rather than
+    # paying for one full gradient + CTM step before crashing inside the
+    # padder. See issue #418.
+    if config.ctm.chi_auto_bump and isinstance(A_init, SymmetricTensor):
+        raise NotImplementedError(
+            "chi_auto_bump does not support SymmetricTensor inputs; "
+            "padding block-sparse envs is a v2 follow-up tracked at #410."
         )
     # The reference-C4v sub-path has no bump logic; reject early so the user
     # gets a clear error rather than silent no-op.

--- a/tests/test_chi_auto_bump.py
+++ b/tests/test_chi_auto_bump.py
@@ -216,5 +216,59 @@ def test_maybe_bump_chi_respects_chi_max_ceiling():
     assert new_cfg.chi == 5  # 4+2=6, capped at 5
 
 
+def test_optimize_gs_ad_auto_bump_rejects_symmetric_tensor():
+    """optimize_gs_ad must reject ``chi_auto_bump=True`` + SymmetricTensor.
+
+    Issue #418: the existing early guard in ``optimize_gs_ad`` rejects
+    multisite and 2-site configs with ``chi_auto_bump=True`` but does
+    not check the SymmetricTensor case on the ``"1x1"`` path. Such a
+    run currently proceeds through one full gradient + CTM step before
+    blowing up inside ``pad_dense_env_chi`` with the v2-follow-up
+    NotImplementedError. The user-facing docs already say the feature
+    is dense-only — the guard should match.
+
+    SymmetricTensor support for auto-bump is tracked at #410.
+    """
+    from tenax.algorithms.ipeps import heisenberg_gate
+    from tenax.algorithms.ipeps_config import iPEPSConfig
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+    from tenax.core.tensor import SymmetricTensor
+
+    D = 2
+    d = 2
+    sym = U1Symmetry()
+    charges = np.zeros(D, dtype=np.int32)
+    phys_charges = np.zeros(d, dtype=np.int32)
+    indices = (
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(
+            sym, phys_charges.copy(), FlowDirection.IN, label="phys"
+        ),
+    )
+    import jax
+
+    A_sym = SymmetricTensor.random_normal(indices, jax.random.PRNGKey(0))
+
+    cfg = iPEPSConfig(
+        max_bond_dim=D,
+        ctm=CTMConfig(
+            chi=4,
+            chi_auto_bump=True,
+            chi_auto_bump_eps=1e-5,
+            chi_auto_bump_step=2,
+            chi_max=8,
+            max_iter=5,
+        ),
+        gs_num_steps=1,
+        su_init=False,
+    )
+
+    with pytest.raises(NotImplementedError, match="SymmetricTensor"):
+        optimize_gs_ad(heisenberg_gate(), A_sym, cfg)
+
+
 # Integration test moved to tests/test_ipeps_chi_bump_integration.py
 # (algorithm-marked, ~3 min runtime; kept out of the core suite).


### PR DESCRIPTION
## Summary

``optimize_gs_ad``'s early guard rejects ``chi_auto_bump=True`` combined with multisite or 2-site unit cells, but did not check the SymmetricTensor case on the ``unit_cell=\"1x1\"`` path. Such a run proceeded through one full gradient + CTM step before crashing downstream — either in a Dense/Symmetric mixed contraction or inside ``pad_dense_env_chi`` with the v2-follow-up ``NotImplementedError``. The user-facing docs already say the feature is dense-only.

Extend the existing early guard to also reject ``isinstance(A_init, SymmetricTensor) and config.ctm.chi_auto_bump``, mirroring the existing 2site/multisite pattern. Block-sparse env padding is tracked at #410.

## Test plan
- [x] New regression test ``test_optimize_gs_ad_auto_bump_rejects_symmetric_tensor`` in ``tests/test_chi_auto_bump.py`` (core marker so the required CI check catches future drift).
- [x] Pre-fix the test failed with a confusing ``TypeError: Cannot mix DenseTensor and SymmetricTensor`` from a contraction layer (the wrong-error-mode the issue describes); post-fix it raises a clean ``NotImplementedError(match=\"SymmetricTensor\")`` at the guard.
- [x] ``uv run pytest tests/test_chi_auto_bump.py`` — 12 passed.
- [ ] Wait for CI on this PR.

Closes #418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)