### PR TITLE
fix(ipeps): bump auto-χ_E at end of iter to preserve Wolfe invariant (#419)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1068,10 +1068,7 @@ def _optimize_gs_ad_tensor(
         # Update env cache for warm-starting next step
         _update_env_cache(params)
 
-        # variPEPS §2.8.2 auto-χ_E bump (between L-BFGS steps; never mid-step).
-        last_eps_t = float(_env_cache.get("max_truncation_error", 0.0))
-        ctm_cfg, _env_cache = _maybe_bump_chi(ctm_cfg, _env_cache, last_eps_t)
-
+        _accepted_best_this_iter = False
         if _should_accept_best(
             current_best=best_energy,
             candidate=energy_float,
@@ -1080,6 +1077,7 @@ def _optimize_gs_ad_tensor(
             best_energy = energy_float
             best_params = params
             best_env_cache = dict(_env_cache)  # snapshot for warm-start (#317)
+            _accepted_best_this_iter = True
 
         delta_energy = abs(energy_float - prev_energy)
         logged = False
@@ -1330,6 +1328,24 @@ def _optimize_gs_ad_tensor(
             params = optax.apply_updates(params, direction)
             if not use_c4v and not (_use_cg and _cg_map_fn is not None):
                 params = params * (1.0 / (params.norm() + 1e-10))
+
+        # variPEPS §2.8.2 auto-χ_E bump — must fire AFTER the line search
+        # and parameter update so that ``value_and_grad`` (start of next
+        # iteration), the metric preconditioner (when L-BFGS) and the
+        # Hager-Zhang ``_phi`` / ``_dphi`` closures all evaluate at the
+        # SAME χ. Otherwise the Wolfe sufficient-decrease and curvature
+        # conditions compare ``f(0)`` / ``f'(0)`` at OLD χ against
+        # ``f(α)`` at NEW χ — a valid step gets rejected (or an invalid
+        # one accepted) purely because of the χ-induced discontinuity.
+        # Issue #419.
+        last_eps_t = float(_env_cache.get("max_truncation_error", 0.0))
+        ctm_cfg, _env_cache = _maybe_bump_chi(ctm_cfg, _env_cache, last_eps_t)
+        # If best was accepted at this iter's pre-line-search params, refresh
+        # the snapshot so its env matches the new ctm_cfg.chi. ``_env_cache``
+        # still holds envs for those params (line search updates ``params``
+        # but does not touch ``_env_cache``), padded to the new χ by the bump.
+        if _accepted_best_this_iter:
+            best_env_cache = dict(_env_cache)
 
     # Re-evaluate both final A and best_A with fully converged fresh CTM.
     # In-loop energies use warm-started CTM that can produce unphysical values

--- a/tests/test_ipeps_chi_bump_integration.py
+++ b/tests/test_ipeps_chi_bump_integration.py
@@ -63,3 +63,80 @@ def test_optimize_gs_ad_auto_bump_raises_chi_under_pressure():
     assert final_chi > 2, f"auto-bump never fired (final_chi={final_chi})"
     assert final_chi <= 8, f"chi exceeded chi_max=8 (final_chi={final_chi})"
     assert math.isfinite(float(e_opt)), f"final energy is not finite: {e_opt}"
+
+
+def test_optimize_gs_ad_auto_bump_fires_after_line_search():
+    """Regression for issue #419.
+
+    The auto-χ_E bump must fire *between* L-BFGS iterations, never
+    *within* one. The Wolfe line search compares ``f(0) = energy_val``
+    and ``f'(0) = slope`` (both at the OLD χ from ``value_and_grad``)
+    with ``f(α) = _phi(α)`` (closure that reads ``ctm_cfg`` lazily).
+    If the bump runs between ``value_and_grad`` and the line search,
+    the closures evaluate at the NEW χ and the three quantities come
+    from two different objectives — a step can be rejected purely
+    because of the χ discontinuity, or accepted spuriously when the
+    NEW χ's energy is artificially lower.
+
+    Spy on ``_maybe_bump_chi`` and ``hager_zhang_line_search`` and
+    assert the line search runs first on the first iteration. Before
+    the fix the order was ``[bump, line_search, ...]``; after the
+    fix it is ``[line_search, bump, ...]``.
+    """
+    from tenax.algorithms import _line_search as ls_mod
+    from tenax.algorithms import ipeps_optimize as opt_mod
+
+    call_order: list[str] = []
+    real_bump = opt_mod._maybe_bump_chi
+    real_ls = ls_mod.hager_zhang_line_search
+
+    def spy_bump(*args, **kwargs):
+        call_order.append("bump")
+        return real_bump(*args, **kwargs)
+
+    def spy_ls(*args, **kwargs):
+        call_order.append("line_search")
+        return real_ls(*args, **kwargs)
+
+    opt_mod._maybe_bump_chi = spy_bump
+    ls_mod.hager_zhang_line_search = spy_ls
+    try:
+        gate = heisenberg_gate()
+        key = jax.random.PRNGKey(42)
+        k1, k2 = jax.random.split(key)
+        A_init = jax.random.normal(k1, (2, 2, 2, 2, 2)) + 1j * jax.random.normal(
+            k2, (2, 2, 2, 2, 2)
+        )
+
+        cfg = iPEPSConfig(
+            max_bond_dim=2,
+            ctm=CTMConfig(
+                chi=2,
+                chi_auto_bump=True,
+                chi_auto_bump_eps=1e-5,
+                chi_auto_bump_step=2,
+                chi_max=8,
+                max_iter=10,
+                min_iter=2,
+                conv_tol=1e-3,
+            ),
+            gs_num_steps=2,
+            gs_implicit_ad=True,
+            gs_verbose=False,
+            su_init=False,
+        )
+        optimize_gs_ad(gate, A_init, cfg)
+    finally:
+        opt_mod._maybe_bump_chi = real_bump
+        ls_mod.hager_zhang_line_search = real_ls
+
+    assert call_order, "neither _maybe_bump_chi nor hager_zhang_line_search ran"
+    assert "bump" in call_order, "bump never fired — test premise invalid"
+    assert "line_search" in call_order, (
+        "line search never fired — Hager-Zhang path not exercised; test premise invalid"
+    )
+    assert call_order[0] == "line_search", (
+        f"_maybe_bump_chi fired before the first hager_zhang_line_search call "
+        f"in iteration 1 — the Wolfe line-search invariant requires both to run "
+        f"at the same χ. Call order observed: {call_order}. (Issue #419.)"
+    )


### PR DESCRIPTION
## Summary

In ``_optimize_gs_ad_tensor`` the auto-χ_E bump fired *between* ``jax.value_and_grad(loss_fn)(params)`` and the Hager-Zhang line search. The bump rebinds ``ctm_cfg`` (read lazily by the line search's ``_phi`` / ``_dphi`` closures), so ``f(0) = energy_val`` and ``f'(0) = slope`` came from the OLD χ while ``f(α) = _phi(α)`` came from the NEW χ. The Wolfe sufficient-decrease and curvature conditions silently compared values from two different objectives — a valid step could be rejected because of the χ discontinuity, or an invalid step accepted when the NEW χ artificially lowered the energy at the trial point.

Move ``_maybe_bump_chi`` to the end of the iteration, after the line search and parameter update. ``value_and_grad``, the L-BFGS metric preconditioner, ``_phi`` / ``_dphi``, and the parameter update now all evaluate at the same χ; the bump fires once per iteration and only affects the next one.

Pre-fix ``best_env_cache = dict(_env_cache)`` happened *after* the bump, so its env tensors always matched ``ctm_cfg.chi``. Post-fix the bump comes later, so we also refresh ``best_env_cache`` after the bump when ``best`` was accepted this iteration — otherwise the final ``_eval_fresh`` call would warm-start at the new χ from a stale env at the old χ and crash with a shape mismatch.

## Regression test

``test_optimize_gs_ad_auto_bump_fires_after_line_search`` (algorithm marker) spies on ``_maybe_bump_chi`` and ``hager_zhang_line_search`` and asserts the first observed call is the line search.

- **Pre-fix** call sequence: ``[bump, line_search, bump, line_search]``
- **Post-fix** call sequence: ``[line_search, bump, line_search, bump]``

## Test plan

- [x] New regression test green; verified RED before fix.
- [x] ``tests/test_chi_auto_bump.py`` + ``tests/test_ipeps_chi_bump_integration.py`` — 13 passed.
- [x] ``uv run pytest -m core`` — 789 passed, 1 skipped, 1183 deselected.
- [ ] Wait for full-suite CI on this PR.

Closes #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)