### PR TITLE
fix(ctm): address PR #430 + #432 codex follow-ups for auto-χ_E bump

### DIFF
--- a/src/tenax/algorithms/_ctm_env_pad.py
+++ b/src/tenax/algorithms/_ctm_env_pad.py
@@ -10,6 +10,9 @@ keeping the χ-bond charge pattern consistent across CTM sweeps).
 
 from __future__ import annotations
 
+import itertools
+from collections import Counter
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -18,6 +21,80 @@ from tenax.algorithms._ctm_tensor_init import CTMTensorEnv
 from tenax.algorithms._ctm_utils import _derive_charges
 from tenax.core.index import TensorIndex
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+
+
+def _derive_padded_charges_with_lower_bound(
+    existing_charges: np.ndarray,
+    base_charges: np.ndarray,
+    chi_new: int,
+) -> np.ndarray:
+    """Pad χ-leg charges to ``chi_new`` honouring two constraints.
+
+    1. **Never shrink an existing sector.** The projector can
+       legitimately redistribute budget to non-base sectors when some
+       base sectors lack data (``_svd_projector_symmetric`` lines
+       726-736, eigh analogue at 425-434), so an env's χ-leg can carry
+       sector counts that disagree with the base-charge allocation.
+       Padding must preserve every existing block's data, so per-sector
+       counts in the result are lower-bounded by the existing counts.
+
+    2. **Approach the projector's ideal allocation** when budget allows.
+       The projector emits chi_new charges sorted-by-sector with counts
+       matching ``Counter(_derive_charges(base_charges, chi_new))``.
+       Subsequent CTM sweeps allocate against this pattern, so the
+       padded χ-leg should approximate it where the lower bound permits.
+
+    Returns sorted-by-sector charges of length ``chi_new``.
+
+    Codex follow-up on PR #430 / PR #433: the earlier
+    ``sorted(_derive_charges(base_charges, chi_new))`` policy could
+    shrink an existing sector when redistribution had populated it
+    beyond the projector's ideal, causing ``jnp.pad`` to fail with
+    negative widths.
+    """
+    chi_old = int(len(existing_charges))
+    if chi_new < chi_old:
+        raise ValueError(
+            f"chi_new={chi_new} must be >= chi_old={chi_old} (no shrinking)"
+        )
+
+    existing_counter: Counter[int] = Counter(int(q) for q in existing_charges)
+    target_seq = list(map(int, _derive_charges(base_charges, chi_new)))
+    target_counter: Counter[int] = Counter(target_seq)
+
+    # Start from the existing counts (lower bound).
+    counts: dict[int, int] = dict(existing_counter)
+    budget = chi_new - chi_old
+
+    # Pass 1: top up each sector toward its ideal target.
+    # Iterate ``target_seq`` so most-frequent target sectors fill first.
+    for q in target_seq:
+        if budget <= 0:
+            break
+        if counts.get(q, 0) < target_counter[q]:
+            counts[q] = counts.get(q, 0) + 1
+            budget -= 1
+
+    # Pass 2: any remaining budget — distribute via ``base_charges``
+    # round-robin so the over-allocation pattern follows the projector's
+    # natural ordering. Only reachable when every sector already meets
+    # its target (rare; existing >> target case).
+    if budget > 0:
+        base_int = [int(q) for q in base_charges]
+        for q in itertools.cycle(base_int):
+            if budget <= 0:
+                break
+            counts[q] = counts.get(q, 0) + 1
+            budget -= 1
+
+    # Build sorted-by-sector charge list to match the projector layout.
+    result: list[int] = []
+    for q in sorted(counts):
+        result.extend([q] * counts[q])
+    assert len(result) == chi_new, (
+        f"internal: derived {len(result)} charges, expected {chi_new}"
+    )
+    return np.asarray(result, dtype=np.int32)
 
 
 def _pad_chi_index(
@@ -33,19 +110,17 @@ def _pad_chi_index(
       charges are preserved as a prefix; remaining slots are filled by
       ``_derive_charges`` of the existing pattern. For ``DenseTensor``
       indices (single trivial charge 0) this is plain zero-padding.
-    * ``base_charges`` supplied (symmetric path): new χ charges are
-      ``sorted(_derive_charges(base_charges, chi_new))`` — the same
-      sorted-by-sector layout the symmetric projector produces from
-      ``_derive_charges(base_charges, chi_new)``. Tiling the
-      already-grouped post-CTM pattern (the legacy policy) grows only
-      the first sector and starves later sectors, so the next
-      projector cannot allocate its ideal per-sector budget. Deriving
-      from ``base_charges`` directly fixes that. (Codex review on
-      PR #430.)
+    * ``base_charges`` supplied (symmetric path): per-sector counts
+      satisfy two constraints — never shrink an existing sector
+      (``_pad_symmetric_block_along_axes`` would otherwise hit negative
+      pad widths) and approach the projector's ideal allocation when
+      budget allows. See ``_derive_padded_charges_with_lower_bound``.
     """
     if base_charges is not None:
-        derived = np.asarray(_derive_charges(base_charges, chi_new), dtype=np.int32)
-        new_charges = np.sort(derived).astype(np.int32)
+        existing_charges = np.asarray(idx.charges, dtype=np.int32)
+        new_charges = _derive_padded_charges_with_lower_bound(
+            existing_charges, base_charges, chi_new
+        )
     else:
         old_charges = np.asarray(idx.charges, dtype=np.int32)
         new_charges = _derive_charges(old_charges, chi_new)

--- a/src/tenax/algorithms/_ctm_env_pad.py
+++ b/src/tenax/algorithms/_ctm_env_pad.py
@@ -20,18 +20,35 @@ from tenax.core.index import TensorIndex
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
 
 
-def _pad_chi_index(idx: TensorIndex, chi_new: int) -> TensorIndex:
+def _pad_chi_index(
+    idx: TensorIndex,
+    chi_new: int,
+    base_charges: np.ndarray | None = None,
+) -> TensorIndex:
     """Return a new TensorIndex with dim grown to ``chi_new``.
 
-    The original charges are preserved in the first ``chi_old`` slots;
-    the new slots are filled by ``_derive_charges`` (a tile of the
-    existing pattern), so each charge sector grows by zero or more slots
-    while preserving every existing sector's position.  For DenseTensor
-    indices (single trivial charge 0), this is equivalent to padding with
-    zeros.
+    Two policies:
+
+    * ``base_charges is None`` (legacy / dense path): the original
+      charges are preserved as a prefix; remaining slots are filled by
+      ``_derive_charges`` of the existing pattern. For ``DenseTensor``
+      indices (single trivial charge 0) this is plain zero-padding.
+    * ``base_charges`` supplied (symmetric path): new χ charges are
+      ``sorted(_derive_charges(base_charges, chi_new))`` — the same
+      sorted-by-sector layout the symmetric projector produces from
+      ``_derive_charges(base_charges, chi_new)``. Tiling the
+      already-grouped post-CTM pattern (the legacy policy) grows only
+      the first sector and starves later sectors, so the next
+      projector cannot allocate its ideal per-sector budget. Deriving
+      from ``base_charges`` directly fixes that. (Codex review on
+      PR #430.)
     """
-    old_charges = np.asarray(idx.charges, dtype=np.int32)
-    new_charges = _derive_charges(old_charges, chi_new)
+    if base_charges is not None:
+        derived = np.asarray(_derive_charges(base_charges, chi_new), dtype=np.int32)
+        new_charges = np.sort(derived).astype(np.int32)
+    else:
+        old_charges = np.asarray(idx.charges, dtype=np.int32)
+        new_charges = _derive_charges(old_charges, chi_new)
     return TensorIndex.from_charges(
         idx.symmetry, new_charges, idx.flow, label=idx.label
     )
@@ -104,17 +121,25 @@ def _pad_symmetric_tensor_along_chi(
     return SymmetricTensor._from_blocks_unchecked(new_blocks, new_indices)
 
 
-def _pad_symmetric_corner(t: SymmetricTensor, chi_new: int) -> SymmetricTensor:
+def _pad_symmetric_corner(
+    t: SymmetricTensor,
+    chi_new: int,
+    base_charges: np.ndarray | None = None,
+) -> SymmetricTensor:
     """Block-sparse pad of a corner SymmetricTensor along both χ axes."""
-    idx0 = _pad_chi_index(t.indices[0], chi_new)
-    idx1 = _pad_chi_index(t.indices[1], chi_new)
+    idx0 = _pad_chi_index(t.indices[0], chi_new, base_charges=base_charges)
+    idx1 = _pad_chi_index(t.indices[1], chi_new, base_charges=base_charges)
     return _pad_symmetric_tensor_along_chi(t, (idx0, idx1), chi_axes=(0, 1))
 
 
-def _pad_symmetric_edge(t: SymmetricTensor, chi_new: int) -> SymmetricTensor:
+def _pad_symmetric_edge(
+    t: SymmetricTensor,
+    chi_new: int,
+    base_charges: np.ndarray | None = None,
+) -> SymmetricTensor:
     """Block-sparse pad of an edge SymmetricTensor along axes 0 and 2 only."""
-    idx0 = _pad_chi_index(t.indices[0], chi_new)
-    idx2 = _pad_chi_index(t.indices[2], chi_new)
+    idx0 = _pad_chi_index(t.indices[0], chi_new, base_charges=base_charges)
+    idx2 = _pad_chi_index(t.indices[2], chi_new, base_charges=base_charges)
     return _pad_symmetric_tensor_along_chi(
         t, (idx0, t.indices[1], idx2), chi_axes=(0, 2)
     )
@@ -125,24 +150,50 @@ def _current_chi(t: Tensor) -> int:
     return int(t.indices[0].dim)
 
 
-def pad_dense_env_chi(env: CTMTensorEnv, chi_new: int) -> CTMTensorEnv:
+def pad_dense_env_chi(
+    env: CTMTensorEnv,
+    chi_new: int,
+    *,
+    base_charges: np.ndarray | None = None,
+) -> CTMTensorEnv:
     """Zero-pad the χ axes of a CTMTensorEnv from the current χ to ``chi_new``.
 
     Used by the variPEPS §2.8.2 auto-bump warm-start. Corners' both axes
     grow to ``chi_new``; edges' axes 0 and 2 grow (axis 1, the D² fused
-    leg, is untouched).  For SymmetricTensor envs, new χ-leg charges are
-    derived from the existing pattern via ``_derive_charges`` (the same
-    allocator used by the symmetric projectors), and each block is padded
-    along its χ axes; sectors absent from the old blocks stay implicitly
-    zero in the flat-buffer representation.
+    leg, is untouched).
+
+    For ``DenseTensor`` envs the data is zero-padded and the trivial-
+    charge index is extended.
+
+    For ``SymmetricTensor`` envs new χ-leg charges depend on
+    ``base_charges``:
+
+    * ``base_charges is None``: tile the existing post-CTM χ pattern
+      via ``_derive_charges``. This grows only the first sector when
+      the existing pattern is already sorted-by-sector (the standard
+      post-projector layout), starving later sectors so the next
+      projector cannot allocate its ideal per-sector budget.
+    * ``base_charges`` supplied: new χ charges are
+      ``sorted(_derive_charges(base_charges, chi_new))`` — the same
+      sorted-by-sector layout the symmetric projector produces from
+      ``_derive_charges(base_charges, chi_new)``. Use this whenever
+      the caller knows the iPEPS A-tensor bond charges that drive the
+      projector. (Codex review on PR #430.)
+
+    Each block is then padded along its χ axes; sectors absent from
+    the old blocks stay implicitly zero in the flat-buffer
+    representation.
 
     Returns the same env if ``chi_new`` matches the current χ. Raises
     ``ValueError`` if ``chi_new < chi_old``.
 
     Args:
-        env:     CTMTensorEnv whose corners and edges are uniformly either
-                 ``DenseTensor`` or ``SymmetricTensor``.
-        chi_new: Target bond dimension. Must be >= the current χ.
+        env:          CTMTensorEnv whose corners and edges are uniformly
+                      either ``DenseTensor`` or ``SymmetricTensor``.
+        chi_new:      Target bond dimension. Must be ``>= chi_old``.
+        base_charges: Optional A-tensor bond charges (or any analogue of
+                      the projector's ``base_charges``). Ignored for
+                      DenseTensor envs.
 
     Returns:
         New CTMTensorEnv with all χ legs padded to ``chi_new`` with zeros.
@@ -159,14 +210,14 @@ def pad_dense_env_chi(env: CTMTensorEnv, chi_new: int) -> CTMTensorEnv:
 
     if isinstance(env.C1, SymmetricTensor):
         return CTMTensorEnv(
-            C1=_pad_symmetric_corner(env.C1, chi_new),
-            C2=_pad_symmetric_corner(env.C2, chi_new),
-            C3=_pad_symmetric_corner(env.C3, chi_new),
-            C4=_pad_symmetric_corner(env.C4, chi_new),
-            T1=_pad_symmetric_edge(env.T1, chi_new),
-            T2=_pad_symmetric_edge(env.T2, chi_new),
-            T3=_pad_symmetric_edge(env.T3, chi_new),
-            T4=_pad_symmetric_edge(env.T4, chi_new),
+            C1=_pad_symmetric_corner(env.C1, chi_new, base_charges=base_charges),
+            C2=_pad_symmetric_corner(env.C2, chi_new, base_charges=base_charges),
+            C3=_pad_symmetric_corner(env.C3, chi_new, base_charges=base_charges),
+            C4=_pad_symmetric_corner(env.C4, chi_new, base_charges=base_charges),
+            T1=_pad_symmetric_edge(env.T1, chi_new, base_charges=base_charges),
+            T2=_pad_symmetric_edge(env.T2, chi_new, base_charges=base_charges),
+            T3=_pad_symmetric_edge(env.T3, chi_new, base_charges=base_charges),
+            T4=_pad_symmetric_edge(env.T4, chi_new, base_charges=base_charges),
         )
 
     return CTMTensorEnv(

--- a/src/tenax/algorithms/_ctm_projector.py
+++ b/src/tenax/algorithms/_ctm_projector.py
@@ -305,7 +305,6 @@ def _eigh_projector_symmetric(
         (matches the dense eigh-path convention in
         ``_compute_projector_tensor``).
     """
-    from tenax.algorithms._ctm_truncation_error import compute_truncation_error
 
     fused_pos = C1g.labels().index("fused")
     col_pos = 1 - fused_pos  # the other leg
@@ -378,15 +377,6 @@ def _eigh_projector_symmetric(
     all_eig_pairs.sort(key=lambda x: (-x[0], -x[2]))
     n_keep = min(chi, len(all_eig_pairs))
 
-    # variPEPS §2.8.2 ε_T from the merged per-sector eigenvalue spectrum.
-    # Matches the dense eigh-path convention in ``_compute_projector_tensor``:
-    # eps_T = ‖λ[n_keep:]‖ / ‖λ‖ over |eigvals| in descending order.
-    if all_eig_pairs:
-        eig_array = jnp.asarray([abs(p[0]) for p in all_eig_pairs], dtype=jnp.float64)
-        eps_T = compute_truncation_error(eig_array, n_keep)
-    else:
-        eps_T = jnp.asarray(0.0)
-
     sector_keep: dict[int, list[int]] = {}
 
     if base_charges is not None:
@@ -446,6 +436,30 @@ def _eigh_projector_symmetric(
         # Pure global truncation (no base_charges)
         for _, fq, idx in all_eig_pairs[:n_keep]:
             sector_keep.setdefault(fq, []).append(idx)
+
+    # variPEPS §2.8.2 ε_T from the merged per-sector spectrum, computed
+    # against the COMPLEMENT of the actually kept (fused_charge, index)
+    # pairs in sector_keep. When base_charges is supplied the kept set is
+    # a per-sector allocation that can differ from the global top-n_keep
+    # — using the global top-n cutoff here would under-report truncation
+    # whenever the forced allocation keeps a small value from a required
+    # sector while discarding a larger value from another sector.
+    # (Codex review on PR #430.)
+    kept_pairs = {
+        (int(fq), int(idx)) for fq, idxs in sector_keep.items() for idx in idxs
+    }
+    discarded_sq = 0.0
+    total_sq = 0.0
+    for fq, (_, eigvals, _) in sector_results.items():
+        for idx, val in enumerate(np.array(eigvals)):
+            v2 = float(val) ** 2
+            total_sq += v2
+            if (int(fq), idx) not in kept_pairs:
+                discarded_sq += v2
+    eps_T = jnp.asarray(
+        np.sqrt(discarded_sq / total_sq) if total_sq > 0.0 else 0.0,
+        dtype=jnp.float64,
+    )
 
     # Build projector blocks directly with correct per-sector charges.
     # Each kept eigenvector from sector fq gets chi_new charge = fq
@@ -613,7 +627,6 @@ def _svd_projector_symmetric(
         per-sector singular-value spectrum.
     """
     from tenax.algorithms._ad_primitives import _fix_svd_signs
-    from tenax.algorithms._ctm_truncation_error import compute_truncation_error
 
     fused_pos = C1g.labels().index("fused")
     col_pos = 1 - fused_pos
@@ -696,14 +709,6 @@ def _svd_projector_symmetric(
     all_sv_pairs.sort(key=lambda x: (-x[0], -x[2]))
     n_keep = min(chi, len(all_sv_pairs))
 
-    # variPEPS §2.8.2 ε_T from the merged per-sector singular-value spectrum.
-    # ε_T = ‖S[n_keep:]‖ / ‖S‖ over the descending global spectrum.
-    if all_sv_pairs:
-        sv_array = jnp.asarray([p[0] for p in all_sv_pairs], dtype=jnp.float64)
-        eps_T = compute_truncation_error(sv_array, n_keep)
-    else:
-        eps_T = jnp.asarray(0.0)
-
     sector_keep: dict[int, list[int]] = {}
 
     if base_charges is not None:
@@ -737,6 +742,30 @@ def _svd_projector_symmetric(
     else:
         for _, fq, idx in all_sv_pairs[:n_keep]:
             sector_keep.setdefault(fq, []).append(idx)
+
+    # variPEPS §2.8.2 ε_T from the merged per-sector singular-value
+    # spectrum, computed against the COMPLEMENT of the actually kept
+    # (fused_charge, index) pairs in sector_keep. When base_charges is
+    # supplied the kept set is a per-sector allocation that can differ
+    # from the global top-n_keep — using the global top-n cutoff here
+    # would under-report truncation whenever the forced allocation keeps
+    # a small singular value from a required sector while discarding a
+    # larger one from another sector. (Codex review on PR #430.)
+    kept_pairs = {
+        (int(fq), int(idx)) for fq, idxs in sector_keep.items() for idx in idxs
+    }
+    discarded_sq = 0.0
+    total_sq = 0.0
+    for fq, (_, S_M, _, _, _) in sector_results.items():
+        for idx, val in enumerate(np.array(S_M)):
+            v2 = float(val) ** 2
+            total_sq += v2
+            if (int(fq), idx) not in kept_pairs:
+                discarded_sq += v2
+    eps_T = jnp.asarray(
+        np.sqrt(discarded_sq / total_sq) if total_sq > 0.0 else 0.0,
+        dtype=jnp.float64,
+    )
 
     # Build both projector block dicts
     chi_new_charges: list[int] = []

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -25,7 +25,7 @@ from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.lattice import Lattice
 from tenax.core.symmetry import U1Symmetry
-from tenax.core.tensor import DenseTensor, Tensor
+from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
 
 _logger = logging.getLogger(__name__)
 
@@ -36,6 +36,8 @@ def _maybe_bump_chi(
     ctm_cfg: CTMConfig,
     env_cache: dict,
     last_eps_t: float,
+    *,
+    base_charges: np.ndarray | None = None,
 ) -> tuple[CTMConfig, dict]:
     """variPEPS §2.8.2 reactive χ_E bump.
 
@@ -50,6 +52,13 @@ def _maybe_bump_chi(
     the original dict reference — notably the ``env_cache`` captured by
     ``make_ctm_energy_fn`` in ``optimize_gs_ad`` — sees the updated envs
     without rebinding.
+
+    For SymmetricTensor envs, ``base_charges`` should be the bond
+    charges of the iPEPS A tensor (the same ``base_charges`` the
+    symmetric projector consumes). Passing it forwards to
+    ``pad_dense_env_chi`` ensures the padded χ-leg charges follow the
+    projector's allocation rather than tiling the already-grouped
+    post-CTM pattern. Ignored on the dense path.
     """
     if not ctm_cfg.chi_auto_bump:
         return ctm_cfg, env_cache
@@ -65,7 +74,9 @@ def _maybe_bump_chi(
         # Mutate in-place so closures that captured env_cache by reference
         # (e.g. make_ctm_energy_fn inside optimize_gs_ad) see the padded envs.
         env_cache["envs"] = {
-            c: pad_dense_env_chi(env_cache["envs"][c], chi_new)
+            c: pad_dense_env_chi(
+                env_cache["envs"][c], chi_new, base_charges=base_charges
+            )
             for c in env_cache["envs"]
         }
     return new_cfg, env_cache
@@ -979,6 +990,22 @@ def _optimize_gs_ad_tensor(
     _conv_tol_schedule = config.gs_ctm_conv_tol_schedule
     _current_conv_tol = ctm_cfg.conv_tol
 
+    # variPEPS §2.8.2 auto-χ_E bump padding policy: for a SymmetricTensor
+    # A, derive the same ``base_charges`` the projector uses so the bump
+    # pads χ-leg charges to match the projector's per-sector allocation
+    # rather than tiling the post-projector grouped pattern. A's bond
+    # charges are fixed across optimization iterations, so we compute
+    # this once outside the loop. (PR #430 codex review on
+    # ``_ctm_env_pad.py``.)
+    _bump_base_charges: np.ndarray | None = None
+    if ctm_cfg.chi_auto_bump:
+        _A_init = _params_to_A_norm(params)
+        if isinstance(_A_init, SymmetricTensor):
+            from tenax.algorithms._ctm_tensor_convergence import _get_base_charges
+            from tenax.algorithms._ctm_tensor_init import _build_double_layer_tensor
+
+            _bump_base_charges = _get_base_charges(_build_double_layer_tensor(_A_init))
+
     def _get_scheduled_conv_tol(step_idx, num_steps):
         """Look up conv_tol from schedule based on step fraction."""
         if _conv_tol_schedule is None:
@@ -1097,6 +1124,23 @@ def _optimize_gs_ad_tensor(
         prev_energy = energy_float
 
         if delta_energy < config.gs_conv_tol:
+            # Convergence break short-circuits the end-of-iter bump. If
+            # the energy stalled because χ is too small (high eps_T from
+            # _update_env_cache above), the user-requested auto-bump
+            # would silently no-op and the final env would stay at the
+            # old χ. Fire the bump here so the final state matches
+            # ctm_cfg.chi at exit — same behaviour as before the #419
+            # move-to-end refactor. (PR #432 codex review; not picked up
+            # in #432's squash, so re-included here.)
+            last_eps_t = float(_env_cache.get("max_truncation_error", 0.0))
+            ctm_cfg, _env_cache = _maybe_bump_chi(
+                ctm_cfg,
+                _env_cache,
+                last_eps_t,
+                base_charges=_bump_base_charges,
+            )
+            if _accepted_best_this_iter:
+                best_env_cache = dict(_env_cache)
             if config.gs_verbose:
                 if not logged:
                     _log_ad_step(
@@ -1339,7 +1383,12 @@ def _optimize_gs_ad_tensor(
         # one accepted) purely because of the χ-induced discontinuity.
         # Issue #419.
         last_eps_t = float(_env_cache.get("max_truncation_error", 0.0))
-        ctm_cfg, _env_cache = _maybe_bump_chi(ctm_cfg, _env_cache, last_eps_t)
+        ctm_cfg, _env_cache = _maybe_bump_chi(
+            ctm_cfg,
+            _env_cache,
+            last_eps_t,
+            base_charges=_bump_base_charges,
+        )
         # If best was accepted at this iter's pre-line-search params, refresh
         # the snapshot so its env matches the new ctm_cfg.chi. ``_env_cache``
         # still holds envs for those params (line search updates ``params``

--- a/tests/test_ctm_env_pad.py
+++ b/tests/test_ctm_env_pad.py
@@ -205,3 +205,50 @@ def test_pad_symmetric_rejects_shrink():
     env_old = initialize_ctm_tensor_env(A_sym, chi=4)
     with pytest.raises(ValueError, match="must be >="):
         pad_dense_env_chi(env_old, chi_new=2)
+
+
+def test_pad_symmetric_uses_base_charges_when_supplied():
+    """Regression for PR #430 codex review: when ``base_charges`` is
+    supplied, padded χ charges follow ``sorted(_derive_charges(...))``.
+
+    The legacy policy (no ``base_charges``) tiles the existing χ-leg
+    pattern via ``_derive_charges``. After a CTM sweep the χ-leg is
+    already grouped sector-by-sector (the projector's
+    ``chi_new_charges`` is built as ``[fq] * n_q for fq in sorted``),
+    so tiling that grouped pattern grows only the leading sectors and
+    starves the trailing ones — the next projector then can't allocate
+    its ideal per-sector budget. Deriving the new χ charges from the
+    projector's ``base_charges`` (the u2-fused charges) avoids that.
+    """
+    from tenax.algorithms._ctm_tensor_convergence import _get_base_charges
+    from tenax.algorithms._ctm_tensor_init import _build_double_layer_tensor
+    from tenax.algorithms._ctm_utils import _derive_charges
+
+    A_sym = _make_u1_peps(D=2, d=2)
+    # Same base_charges the symmetric projector consumes — fused
+    # (ket, bra) charges from the double-layer tensor's u2 leg.
+    base_charges = _get_base_charges(_build_double_layer_tensor(A_sym))
+    assert base_charges is not None, "test premise: non-trivial U(1) charges"
+
+    env_old = initialize_ctm_tensor_env(A_sym, chi=4)
+    env_new_legacy = pad_dense_env_chi(env_old, chi_new=6)
+    env_new_with_base = pad_dense_env_chi(env_old, chi_new=6, base_charges=base_charges)
+
+    expected = np.sort(_derive_charges(base_charges, 6)).astype(np.int32)
+    assert np.array_equal(
+        np.asarray(env_new_with_base.C1.indices[0].charges), expected
+    ), (
+        f"χ-leg charges should be sorted(_derive_charges(base_charges, 6)) = "
+        f"{expected}, got {np.asarray(env_new_with_base.C1.indices[0].charges)}"
+    )
+    # Edges share the same chi-charge allocation.
+    assert np.array_equal(np.asarray(env_new_with_base.T1.indices[0].charges), expected)
+    # The two policies must disagree on this χ-leg pattern — otherwise
+    # the fix is a no-op for this configuration.
+    assert not np.array_equal(
+        np.asarray(env_new_legacy.C1.indices[0].charges),
+        np.asarray(env_new_with_base.C1.indices[0].charges),
+    ), (
+        "Legacy tile policy and base_charges policy must produce different "
+        "χ-charges on D=2 init; otherwise this regression test is vacuous."
+    )

--- a/tests/test_ctm_env_pad.py
+++ b/tests/test_ctm_env_pad.py
@@ -207,6 +207,71 @@ def test_pad_symmetric_rejects_shrink():
         pad_dense_env_chi(env_old, chi_new=2)
 
 
+def test_pad_symmetric_base_charges_never_shrinks_existing_sector():
+    """Regression for PR #433 codex review: base_charges allocation must
+    not reduce any existing per-sector count.
+
+    ``_svd_projector_symmetric`` redistributes budget to available
+    sectors when requested base sectors have no data (see
+    ``_ctm_projector.py:726-736`` and the eigh analogue), so an env at
+    χ=3 can legitimately carry charges ``[0, 0, 0]`` (sector 0
+    over-allocated by redistribution). Bumping to χ=4 with
+    ``base_charges=[0, 1, 2, 3]`` previously produced ``[0, 1, 2, 3]``,
+    shrinking the q=0 block from size 3 to 1 and causing
+    ``_pad_symmetric_block_along_axes`` to crash with
+    ``ValueError: index can't contain negative values``.
+
+    The fixed policy lower-bounds per-sector counts by the existing
+    counts; the result for this case is ``[0, 0, 0, 1]`` — sector 0
+    preserved, one new slot added to the next-most-wanted sector.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    from tenax.algorithms._ctm_env_pad import _pad_chi_index
+    from tenax.core.index import FlowDirection, TensorIndex
+    from tenax.core.symmetry import U1Symmetry
+
+    sym = U1Symmetry()
+    existing = TensorIndex.from_charges(
+        sym, np.array([0, 0, 0], dtype=np.int32), FlowDirection.IN, label="chi"
+    )
+
+    # The codex example: chi 3 → 4 with base_charges = [0, 1, 2, 3].
+    base = np.array([0, 1, 2, 3], dtype=np.int32)
+    new_idx = _pad_chi_index(existing, chi_new=4, base_charges=base)
+    assert new_idx.dim == 4
+    assert list(np.asarray(new_idx.charges)) == [0, 0, 0, 1], (
+        f"existing [0,0,0] bumped to χ=4 with base [0,1,2,3] should preserve "
+        f"sector 0 (lower bound) and add one slot to sector 1; got "
+        f"{list(np.asarray(new_idx.charges))}"
+    )
+
+    # And the symmetric end-to-end path (initialize → pad) must not crash.
+    A_sym = _make_u1_peps(D=2, d=2)
+    from tenax.algorithms._ctm_tensor_convergence import _get_base_charges
+    from tenax.algorithms._ctm_tensor_init import _build_double_layer_tensor
+
+    base_real = _get_base_charges(_build_double_layer_tensor(A_sym))
+    env_old = initialize_ctm_tensor_env(A_sym, chi=4)
+    # Padding must succeed for arbitrary chi_new ≥ chi_old, regardless of
+    # whether base_charges would normally reduce some sector count.
+    env_new = pad_dense_env_chi(env_old, chi_new=8, base_charges=base_real)
+    assert env_new.C1.indices[0].dim == 8
+    # Existing block content is preserved (a sufficient condition: the new
+    # corner densifies to embed the old one in its leading χ_old × χ_old
+    # block — under the same sorted-by-sector layout).
+    C1_old = np.asarray(env_old.C1.todense())
+    C1_new = np.asarray(env_new.C1.todense())
+    # We don't assert exact equality of the leading block here because
+    # the sector ordering may differ between the lower-bounded policy
+    # and a naïve prefix-embed; instead, check that no data was lost
+    # via the L2 norm.
+    assert jnp.allclose(jnp.linalg.norm(C1_new), jnp.linalg.norm(C1_old)), (
+        "padding should preserve existing data (Frobenius norm equal)"
+    )
+
+
 def test_pad_symmetric_uses_base_charges_when_supplied():
     """Regression for PR #430 codex review: when ``base_charges`` is
     supplied, padded χ charges follow ``sorted(_derive_charges(...))``.

--- a/tests/test_ctm_truncation_error.py
+++ b/tests/test_ctm_truncation_error.py
@@ -208,3 +208,102 @@ def test_compute_projector_tensor_eps_t_symmetric_zero_when_no_truncation():
     )
     assert float(eps_T_svd) == pytest.approx(0.0, abs=1e-12)
     assert float(eps_T_eigh) == pytest.approx(0.0, abs=1e-12)
+
+
+def _scale_blocks_per_charge(t, scale_per_charge):
+    """Return ``t`` with each block scaled by ``scale_per_charge[fq]``.
+
+    Used by the tests below to amplify one charge sector so that the
+    global top-N truncation differs from the per-sector forced allocation.
+    """
+    from tenax.core.tensor import SymmetricTensor
+
+    new_blocks = {}
+    for key, block in t.blocks.items():
+        scale = float(scale_per_charge.get(int(key[0]), 1.0))
+        new_blocks[key] = block * scale
+    return SymmetricTensor._from_blocks_unchecked(new_blocks, t.indices)
+
+
+def test_compute_projector_tensor_eps_t_symmetric_uses_actual_kept_set_svd():
+    """Regression for PR #430 codex review: ε_T must reflect the kept set.
+
+    When ``base_charges`` forces the per-sector allocation, the kept
+    (fused_charge, index) pairs can differ from the global top-``n_keep``
+    cutoff. ε_T must be computed against the COMPLEMENT of the actually
+    kept pairs — otherwise it under-reports truncation whenever the forced
+    allocation keeps a small singular value while discarding a larger one
+    from another sector.
+
+    Construction: an 8-dim corner with two sectors of dim 4 each, with
+    the q=0 block amplified 10× over q=1. ``chi_target=4`` with
+    ``base_charges=[0, 1]`` forces a 2+2 sector allocation, so two
+    large q=0 singular values are discarded in favour of two small q=1
+    values. The global top-4 cutoff keeps all 4 q=0 SVs and discards
+    the 4 q=1 SVs (small), giving a much smaller ε_T. Pre-fix both
+    paths used the global cutoff and reported the same ε_T.
+    """
+    chi_in = 8
+    chi_target = 4
+    fused_charges = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    col_charges = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    C1g = _scale_blocks_per_charge(
+        _make_symmetric_corner(chi_in, fused_charges, col_charges, seed=0),
+        {0: 10.0, 1: 1.0},
+    )
+    C4g = _scale_blocks_per_charge(
+        _make_symmetric_corner(chi_in, fused_charges, col_charges, seed=1),
+        {0: 10.0, 1: 1.0},
+    )
+
+    _, _, eps_global = _compute_projector_tensor(
+        C1g, C4g, chi_target, projector_method="svd"
+    )
+    _, _, eps_forced = _compute_projector_tensor(
+        C1g,
+        C4g,
+        chi_target,
+        projector_method="svd",
+        base_charges=np.array([0, 1], dtype=np.int32),
+    )
+    # Forced sector allocation discards dominant q=0 values that global
+    # truncation would have kept → strictly more discarded weight.
+    assert float(eps_forced) > 2.0 * float(eps_global), (
+        f"ε_T(base_charges=[0,1])={float(eps_forced):.4e} should be much "
+        f"larger than ε_T(no base_charges)={float(eps_global):.4e} when the "
+        "forced 2+2 allocation discards dominant q=0 SVs. Pre-fix both used "
+        "the global top-N cutoff and reported equal values."
+    )
+
+
+def test_compute_projector_tensor_eps_t_symmetric_uses_actual_kept_set_eigh():
+    """eigh-path counterpart to the SVD regression above (PR #430 codex)."""
+    chi_in = 8
+    chi_target = 4
+    fused_charges = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    col_charges = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    C1g = _scale_blocks_per_charge(
+        _make_symmetric_corner(chi_in, fused_charges, col_charges, seed=2),
+        {0: 10.0, 1: 1.0},
+    )
+    C4g = _scale_blocks_per_charge(
+        _make_symmetric_corner(chi_in, fused_charges, col_charges, seed=3),
+        {0: 10.0, 1: 1.0},
+    )
+
+    _, _, eps_global = _compute_projector_tensor(
+        C1g, C4g, chi_target, projector_method="eigh"
+    )
+    _, _, eps_forced = _compute_projector_tensor(
+        C1g,
+        C4g,
+        chi_target,
+        projector_method="eigh",
+        base_charges=np.array([0, 1], dtype=np.int32),
+    )
+    assert float(eps_forced) > 2.0 * float(eps_global), (
+        f"ε_T(base_charges=[0,1])={float(eps_forced):.4e} should be much "
+        f"larger than ε_T(no base_charges)={float(eps_global):.4e} when the "
+        "forced 2+2 allocation discards dominant q=0 eigenvalues. Pre-fix "
+        "both used the global top-N cutoff and reported equal values."
+    )

--- a/tests/test_ipeps_chi_bump_integration.py
+++ b/tests/test_ipeps_chi_bump_integration.py
@@ -140,3 +140,61 @@ def test_optimize_gs_ad_auto_bump_fires_after_line_search():
         f"in iteration 1 — the Wolfe line-search invariant requires both to run "
         f"at the same χ. Call order observed: {call_order}. (Issue #419.)"
     )
+
+
+def test_optimize_gs_ad_auto_bump_fires_on_convergence_break():
+    """The end-of-iter bump must also fire on the convergence-break path.
+
+    Without this, an iteration that exits via ``delta_energy < gs_conv_tol``
+    would skip the bump even when ``_update_env_cache`` just measured a
+    large ``max_truncation_error``. A run that energy-stalls at too-small
+    χ would return its final env at the old χ instead of re-evaluating
+    at the requested auto-bump χ — codex P2 review comment on PR #432
+    that was lost in #432's squash and is re-included here.
+
+    Setup: ``gs_conv_tol`` is set very loose (100.0) so iteration 1
+    breaks via the conv check. Iteration 0 runs the full body and
+    bumps via the end-of-iter path. The conv-break in iteration 1
+    must also bump for ``final_chi > chi_after_iter_0`` to hold.
+    Without the fix the conv-break path skipped the bump, so
+    ``final_chi`` stayed at the post-iter-0 value
+    (chi=4 with ``chi_auto_bump_step=2``, ``chi_init=2``).
+    """
+    gate = heisenberg_gate()
+    key = jax.random.PRNGKey(42)
+    k1, k2 = jax.random.split(key)
+    A_init = jax.random.normal(k1, (2, 2, 2, 2, 2)) + 1j * jax.random.normal(
+        k2, (2, 2, 2, 2, 2)
+    )
+
+    cfg = iPEPSConfig(
+        max_bond_dim=2,
+        ctm=CTMConfig(
+            chi=2,
+            chi_auto_bump=True,
+            chi_auto_bump_eps=1e-5,
+            chi_auto_bump_step=2,
+            chi_max=8,
+            max_iter=10,
+            min_iter=2,
+            conv_tol=1e-3,
+        ),
+        gs_num_steps=5,
+        gs_conv_tol=100.0,  # force iter-1 conv break
+        gs_implicit_ad=True,
+        gs_verbose=False,
+        su_init=False,
+    )
+
+    _, env, _ = optimize_gs_ad(gate, A_init, cfg)
+    final_chi = env.C1._data.shape[0]
+
+    # Iter 0 bumps chi 2→4 on the normal-flow path. Iter 1 trips the
+    # conv check and must ALSO bump (chi 4→6) for this assertion to
+    # hold. Without the fix the conv-break path skipped the bump
+    # → final_chi=4.
+    assert final_chi >= 6, (
+        f"conv-break path skipped the auto-χ bump (final_chi={final_chi}); "
+        "expected the bump to also fire when delta_energy < gs_conv_tol "
+        "(PR #432 codex review, lost in #432's squash and re-included)."
+    )


### PR DESCRIPTION
## Summary

Bundled follow-up addressing the chatgpt-codex-connector P2 reviews that landed on PR #430 (three comments) and PR #432 (one comment that was lost in #432's squash). All four touch the same auto-χ_E bump code paths so they're cleaner to ship together.

### 1+2 — Symmetric ε_T must reflect the ``base_charges``-forced allocation
``_compute_projector_tensor_symmetric_{eigh,svd}`` computed ε_T from the global top-``n_keep`` cutoff **before** the per-sector ``sector_keep`` allocation was finalized. With imbalanced sectors and ``base_charges`` forcing a particular split (e.g. q0=[100,99], q1=[1], χ=2, base=[0,1] → kept {100, 1}, discarded {99}), the global cutoff under-reports truncation by orders of magnitude and silently suppresses the auto-χ bump exactly when the forced allocation discards large weight.

Fix: compute ε_T after ``sector_keep`` is built, from the complement of the actually kept ``(fused_charge, index)`` pairs over ``sector_results``. Two regression tests amplify q=0 by 10× and assert ε_T(base_charges) > 2 × ε_T(no base_charges) on both the SVD and eigh paths.

### 3 — Symmetric env padding starves trailing sectors
``pad_dense_env_chi`` tiled the existing χ-leg pattern via ``_derive_charges`` to fill new slots. After a CTM sweep the χ-leg is already grouped sector-by-sector (the projector emits ``[fq] * n_q for fq in sorted``), so tiling grew only the leading sectors. Example: ``[0,0,1,1]`` bumped to χ=6 became ``[0,0,1,1,0,0]`` — sector 0 gained two slots while sector 1 got zero, even though the projector's ideal allocation splits new slots evenly.

Fix: add a ``base_charges`` kwarg to ``pad_dense_env_chi``. When supplied (symmetric path), new χ charges are ``sorted(_derive_charges(base_charges, chi_new))`` — the same layout the symmetric projector produces. Threaded through ``_maybe_bump_chi`` (new kwarg) and computed once in ``_optimize_gs_ad_tensor`` via ``_get_base_charges(_build_double_layer_tensor(A))``. Dense path is unaffected.

### 4 — Auto-bump skipped on convergence-break path
PR #432 moved the bump to end-of-iter to preserve the Wolfe invariant. That move short-circuited the bump whenever ``delta_energy < gs_conv_tol`` triggered the convergence ``break``, so a run that energy-stalled at too-small χ returned its final env at the old χ. My amend commit ``d5ce040`` was written **after** PR #432 auto-merged at ``2aba52a`` and never landed on main. Re-included here.

## Test plan
- [x] ``tests/test_ctm_env_pad.py``, ``tests/test_chi_auto_bump.py``, ``tests/test_ctm_truncation_error.py``, ``tests/test_ipeps_chi_bump_integration.py`` — 40 passed locally.
- [x] All four regression tests RED-verified on pre-fix code.
- [x] ``uv run pytest -m core`` — 802 passed, 1 skipped, 1184 deselected.
- [ ] Wait for full-suite CI on this PR.

## Note on pre-existing CI errors on main
The ``Full tests`` matrix is currently failing on main in ``test_block_sparse_ctm_ad``, ``test_complex128_ad``, ``test_ctm_energy_implicit``, ``test_fpeps_ad``, and a couple of ``test_ipeps`` benchmarks. Those failures predate today's PRs (already present on d752077 from PR #424) and are out of scope here; flagging so they're tracked separately.

Closes the codex P2 review comments on PR #430 (eigh ε_T, SVD ε_T, env padding) and PR #432 (conv-break bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)