### PR TITLE
test(ipeps): narrow nontrivial-U(1) xfail to specific shape mismatch (#437 review)

### DIFF
--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -1295,16 +1295,6 @@ class TestADSymmetric:
             f"expected DenseTensor, got {type(A_dense_opt).__name__}"
         )
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "Non-trivial U(1) charges in 2x2 dense fallback wrap (Issue #435): "
-            "AD-traced symmetric inputs route through the dense fallback, which "
-            "currently wraps output projectors with trivial charges. Downstream "
-            "contractions fail with shape mismatch on non-trivial sectors. "
-            "Tracked as Issue #435."
-        ),
-    )
     def test_optimize_gs_ad_nontrivial_u1_preserves_symmetric_type(self):
         """Regression for #297: optimizer shell must accept a SymmetricTensor
         with *non-trivial* U(1) charges and return a SymmetricTensor (not
@@ -1326,6 +1316,21 @@ class TestADSymmetric:
         (viable on M-series macOS, not on x86 Linux); ``gs_num_steps=0``
         brings it under 2s without losing the input-side regression
         coverage.
+
+        Currently blocked by **Issue #435**: the 2x2 dense-fallback wrap
+        emits trivial-charge projectors, so a contraction downstream of
+        the optimizer shell raises ``ValueError: Size of label ... does
+        not match previous terms ...``. The narrow ``pytest.raises``
+        matches *only* that exception text so:
+
+        * any other regression in this path (e.g. silent ``DenseTensor``
+          downgrade, NaN energy, unrelated ``TypeError``) still fails
+          loudly — unlike ``xfail(strict=False)``, which would have
+          swallowed them;
+        * when #435 lands, the absent exception fails the
+          ``pytest.raises`` block — surfacing a green-to-red flip that
+          prompts re-enabling the type-preservation assertions
+          commented out at the end of the body.
         """
         from tenax.core.index import FlowDirection, TensorIndex
         from tenax.core.symmetry import U1Symmetry
@@ -1353,15 +1358,19 @@ class TestADSymmetric:
             gs_num_steps=0,
             gs_learning_rate=0.01,
         )
-        A_opt, _env, E_gs = optimize_gs_ad(gate, A_sym, config)
+        # Narrow regression hold: catch the specific #435 shape-mismatch
+        # only.  When #435 is fixed, this raises will fail (no exception)
+        # — replace it with the post-#435 assertions commented below.
+        with pytest.raises(ValueError, match=r"Size of label .* does not match"):
+            optimize_gs_ad(gate, A_sym, config)
 
-        # Core assertion: the optimizer shell did not silently downgrade
-        # the SymmetricTensor input to a DenseTensor.  Prior to #297 this
-        # would fail because the shell dense-wrapped A upfront.
-        assert isinstance(A_opt, SymmetricTensor), (
-            f"expected SymmetricTensor, got {type(A_opt).__name__}"
-        )
-        assert np.isfinite(E_gs)
+        # Post-#435 assertions to re-enable once the 2x2 dense-fallback
+        # wrap emits sector-aware charges:
+        # A_opt, _env, E_gs = optimize_gs_ad(gate, A_sym, config)
+        # assert isinstance(A_opt, SymmetricTensor), (
+        #     f"expected SymmetricTensor, got {type(A_opt).__name__}"
+        # )
+        # assert np.isfinite(E_gs)
 
 
 class TestTensor2SiteSimpleUpdate:

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -1320,17 +1320,24 @@ class TestADSymmetric:
         Currently blocked by **Issue #435**: the 2x2 dense-fallback wrap
         emits trivial-charge projectors, so a contraction downstream of
         the optimizer shell raises ``ValueError: Size of label ... does
-        not match previous terms ...``. The narrow ``pytest.raises``
-        matches *only* that exception text so:
+        not match previous terms ...``.
 
-        * any other regression in this path (e.g. silent ``DenseTensor``
-          downgrade, NaN energy, unrelated ``TypeError``) still fails
-          loudly — unlike ``xfail(strict=False)``, which would have
-          swallowed them;
-        * when #435 lands, the absent exception fails the
-          ``pytest.raises`` block — surfacing a green-to-red flip that
-          prompts re-enabling the type-preservation assertions
-          commented out at the end of the body.
+        Test policy chosen to satisfy three constraints together:
+
+        1. **No CI red while #435 is open** — the known shape mismatch
+           is converted to ``pytest.xfail`` inside the except block.
+        2. **A bug fix is not a CI failure** — when #435 lands the
+           except block isn't reached, so the real type-preservation
+           assertions run normally. The test transitions XFAIL → PASS,
+           not green → red.
+        3. **Other regressions still fail loudly** — a different
+           ``ValueError`` text, an unrelated exception type, a silent
+           ``DenseTensor`` downgrade, or a NaN energy all propagate
+           past this guard.
+
+        (Addresses both codex P2 reviews on PR #437 and PR #438: the
+        previous ``xfail(strict=False)`` was too loose; a bare
+        ``pytest.raises`` would have flipped CI on the fix.)
         """
         from tenax.core.index import FlowDirection, TensorIndex
         from tenax.core.symmetry import U1Symmetry
@@ -1358,19 +1365,22 @@ class TestADSymmetric:
             gs_num_steps=0,
             gs_learning_rate=0.01,
         )
-        # Narrow regression hold: catch the specific #435 shape-mismatch
-        # only.  When #435 is fixed, this raises will fail (no exception)
-        # — replace it with the post-#435 assertions commented below.
-        with pytest.raises(ValueError, match=r"Size of label .* does not match"):
-            optimize_gs_ad(gate, A_sym, config)
-
-        # Post-#435 assertions to re-enable once the 2x2 dense-fallback
-        # wrap emits sector-aware charges:
-        # A_opt, _env, E_gs = optimize_gs_ad(gate, A_sym, config)
-        # assert isinstance(A_opt, SymmetricTensor), (
-        #     f"expected SymmetricTensor, got {type(A_opt).__name__}"
-        # )
-        # assert np.isfinite(E_gs)
+        try:
+            A_opt, _env, E_gs = optimize_gs_ad(gate, A_sym, config)
+        except ValueError as exc:
+            # Narrow guard: only swallow the specific #435 shape
+            # mismatch text. Any other ValueError surfaces.
+            msg = str(exc)
+            if "Size of label" not in msg or "does not match" not in msg:
+                raise
+            pytest.xfail(f"Blocked on #435: {exc}")
+        else:
+            # No exception → #435 is fixed (or never triggered for this
+            # config). Run the original type-preservation assertions.
+            assert isinstance(A_opt, SymmetricTensor), (
+                f"expected SymmetricTensor, got {type(A_opt).__name__}"
+            )
+            assert np.isfinite(E_gs)
 
 
 class TestTensor2SiteSimpleUpdate:


### PR DESCRIPTION
## Summary

Follow-up to PR #437's codex P2 review. The previous ``@pytest.mark.xfail(strict=False)`` on ``test_optimize_gs_ad_nontrivial_u1_preserves_symmetric_type`` was too loose — it accepted **any** failure in the regression path, defeating the test's purpose of catching:

- silent ``DenseTensor`` downgrade (the type-preservation contract from #297),
- NaN energy,
- unrelated ``TypeError`` / ``AttributeError`` from a refactor regression,
- silent XPASS once #435 is fixed (assertions never re-enabled).

Replace with a narrow ``pytest.raises(ValueError, match=r"Size of label .* does not match")`` that only swallows the known #435 shape-mismatch text:

```python
with pytest.raises(ValueError, match=r"Size of label .* does not match"):
    optimize_gs_ad(gate, A_sym, config)

# Post-#435 assertions to re-enable once the 2x2 dense-fallback
# wrap emits sector-aware charges:
# A_opt, _env, E_gs = optimize_gs_ad(gate, A_sym, config)
# assert isinstance(A_opt, SymmetricTensor), ...
# assert np.isfinite(E_gs)
```

## Test plan

- [x] Test passes locally (catches the exact #435 ValueError).
- [x] Sanity-checked the regex actually matches: a non-matching pattern produces ``AssertionError: Regex pattern did not match``, confirming an unrelated regression would surface loudly.
- [x] When #435 is fixed, the absent exception will fail the ``pytest.raises`` block — a clear green-to-red flip that prompts re-enabling the commented-out type-preservation assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)