### PR TITLE
test(ctm): fix tuple-unpack regressions in CTM sweep tests

### DIFF
--- a/tests/test_ctm_compiled.py
+++ b/tests/test_ctm_compiled.py
@@ -178,7 +178,7 @@ class TestCompiledSweep:
         dl = _build_double_layer_tensor(A)
 
         # Tensor sweep
-        envs_tensor = _ctm_tensor_sweep_multisite(
+        envs_tensor, _ = _ctm_tensor_sweep_multisite(
             {coord: env},
             {coord: dl},
             neighbors,
@@ -228,7 +228,7 @@ class TestCompiledSweep:
         dl_B = _build_double_layer_tensor(B)
 
         # Tensor sweep
-        envs_tensor = _ctm_tensor_sweep_multisite(
+        envs_tensor, _ = _ctm_tensor_sweep_multisite(
             {c0: env_A, c1: env_B},
             {c0: dl_A, c1: dl_B},
             neighbors,

--- a/tests/test_ctm_python_loop.py
+++ b/tests/test_ctm_python_loop.py
@@ -74,7 +74,7 @@ class TestJitCtmStep:
         site_tensors = {(0, 0): A}
         envs = {(0, 0): initialize_ctm_tensor_env(A, chi=4)}
         step = _make_jit_ctm_step(SINGLE_SITE_NEIGHBORS)
-        new_envs = step(site_tensors, envs, chi=4)
+        new_envs, _ = step(site_tensors, envs, chi=4)
         # Environments should differ after a sweep
         old_c1 = envs[(0, 0)].C1.todense()
         new_c1 = new_envs[(0, 0)].C1.todense()

--- a/tests/test_ctm_tensor.py
+++ b/tests/test_ctm_tensor.py
@@ -219,7 +219,7 @@ class TestSweep:
         chi = 4
         a = _build_double_layer_tensor(small_peps_dense)
         env = initialize_ctm_tensor_env(small_peps_dense, chi)
-        env = _ctm_tensor_sweep(env, a, chi, renormalize=True)
+        env, _ = _ctm_tensor_sweep(env, a, chi, renormalize=True)
         for field in env:
             assert jnp.all(jnp.isfinite(field.todense())), (
                 f"Non-finite values in {field.labels()}"
@@ -229,7 +229,7 @@ class TestSweep:
         chi = 4
         a = _build_double_layer_tensor(small_peps_symmetric)
         env = initialize_ctm_tensor_env(small_peps_symmetric, chi)
-        env = _ctm_tensor_sweep(env, a, chi, renormalize=True)
+        env, _ = _ctm_tensor_sweep(env, a, chi, renormalize=True)
         for field in env:
             assert jnp.all(jnp.isfinite(field.todense()))
 
@@ -237,7 +237,7 @@ class TestSweep:
         chi = 4
         a = _build_double_layer_tensor(fpeps_tensor)
         env = initialize_ctm_tensor_env(fpeps_tensor, chi)
-        env = _ctm_tensor_sweep(env, a, chi, renormalize=True)
+        env, _ = _ctm_tensor_sweep(env, a, chi, renormalize=True)
         for field in env:
             assert jnp.all(jnp.isfinite(field.todense()))
 

--- a/tests/test_integration_regression.py
+++ b/tests/test_integration_regression.py
@@ -165,7 +165,7 @@ class TestBlockPreservation:
         assert init_blocks > 0
 
         for sweep in range(10):
-            env = _ctm_tensor_sweep(env, a, chi, renormalize=True)
+            env, _ = _ctm_tensor_sweep(env, a, chi, renormalize=True)
 
         for t in env:
             assert isinstance(t, SymmetricTensor), (


### PR DESCRIPTION
## Summary

Fixes 5 test failures (and partially fixes 2 more) that have been red in the `Full tests` workflow on main since PR #412 (`450b836`, auto-χ_E bump) landed. PR #412 changed `_ctm_tensor_sweep`'s return signature from `CTMTensorEnv` to `(CTMTensorEnv, max_eps)`; the affected tests didn't update their unpacking.

These failures were not visible in PR CI because `Full tests` is not in branch protection (only `Tests (Python 3.11/3.12, macOS 3.12)` are required).

## Tests fixed (now passing)

- `test_ctm_tensor.py::TestSweep::test_one_sweep_{dense,symmetric,fpeps}_finite`
- `test_integration_regression.py::TestBlockPreservation::test_ctm_tensor_symmetric_blocks_preserved`
- `test_ctm_python_loop.py::TestJitCtmStep::test_step_changes_env`

## Tests partially fixed (unpack resolved, deeper bug remains)

- `test_ctm_compiled.py::TestCompiledSweep::test_{single_site,two_site}_sweep`

The `tuple indices must be integers or slices, not tuple` error is resolved by unpacking `_ctm_tensor_sweep_multisite`'s `(envs, max_eps)` return. After that, both tests still fail with `assert_allclose` mismatches between `_ctm_tensor_sweep_multisite` and `compiled_ctm_sweep_raw` (C1 corner entries differ by ~0.3 absolute). This is a separate pre-existing parity bug between the Tensor-sweep and raw-sweep code paths and should be filed/tracked separately.

## Test plan

- [x] All 5 fully-fixed tests pass locally
- [x] `pytest -m core` clean (803 passed, 1 skipped, 1210 deselected)
- [ ] `Full tests` jobs go from 25 failures → ~20 (the 2 compiled-sweep tests and other unrelated failures tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)