### PR TITLE
fix(ctm): SV-baseline guard + PESS plateau_patience pass-through

### DIFF
--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -450,6 +450,11 @@ def _sigma_gauged_ctm_converge(
                 prev_envs = {c: envs[c] for c in envs}
             continue
 
+        # ``plateau_metric_valid`` flags whether ``current_diff`` is from
+        # a real baseline this iter — mirrors the python-loop guard added
+        # for the SV ``min_iter <= 1`` case (codex review on PR #439).
+        plateau_metric_valid = False
+
         if conv_method == "elementwise":
             # Element-wise: max absolute difference across all env tensor leaves
             if prev_envs is None:
@@ -461,8 +466,12 @@ def _sigma_gauged_ctm_converge(
             converged = max_diff < conv_tol
             prev_envs = {c: envs[c] for c in envs}
             current_diff = max_diff
+            plateau_metric_valid = True
         else:
-            # SV convergence (default): corner singular value difference
+            # SV convergence (default): corner singular value difference.
+            # First SV check has no baseline (only possible when
+            # ``min_iter <= 1``); skip plateau tracking until next iter.
+            have_prev_svs = bool(prev_svs)
             converged = True
             current_diff = 0.0
             for c in sorted(envs):
@@ -475,11 +484,13 @@ def _sigma_gauged_ctm_converge(
                 else:
                     converged = False
                 prev_svs[c] = sv
+            if have_prev_svs:
+                plateau_metric_valid = True
 
         if converged:
             break
 
-        if plateau_patience is not None:
+        if plateau_patience is not None and plateau_metric_valid:
             if current_diff < best_diff:
                 best_diff = current_diff
                 best_envs = {c: envs[c] for c in envs}

--- a/src/tenax/algorithms/_ctm_python_loop.py
+++ b/src/tenax/algorithms/_ctm_python_loop.py
@@ -258,6 +258,14 @@ def python_loop_ctm_converge(
                 prev_envs = {c: envs[c] for c in envs}
             continue
 
+        # ``plateau_metric_valid`` flags whether ``final_diff`` was computed
+        # from a real comparison this iter (vs left at the sentinel value
+        # because no baseline was available yet).  Without this guard the
+        # plateau block would treat the SV first-iter sentinel ``0.0`` as
+        # ``best_diff``, then bail because no real positive diff can ever
+        # improve on zero (codex review on PR #439).
+        plateau_metric_valid = False
+
         if conv_method == "elementwise":
             # Element-wise convergence: max absolute difference across all
             # env tensor leaves.
@@ -270,8 +278,13 @@ def python_loop_ctm_converge(
             converged = max_diff < conv_tol
             final_diff = max_diff
             prev_envs = {c: envs[c] for c in envs}
+            plateau_metric_valid = True
         else:
-            # SV convergence (default): corner singular value difference
+            # SV convergence (default): corner singular value difference.
+            # On the very first SV check (no entry in ``prev_svs`` yet —
+            # possible when ``min_iter <= 1``), we have no real baseline,
+            # so the plateau block must skip tracking this iter.
+            have_prev_svs = bool(prev_svs)
             converged = True
             max_diff = 0.0
             for c in sorted(envs):
@@ -284,7 +297,12 @@ def python_loop_ctm_converge(
                 else:
                     converged = False
                 prev_svs[c] = sv
-            final_diff = max_diff
+            if have_prev_svs:
+                final_diff = max_diff
+                plateau_metric_valid = True
+            # else: final_diff retains its previous value (inf on entry),
+            # converged is False (no baseline), and the plateau block
+            # below is skipped via plateau_metric_valid.
 
         if converged:
             return envs, CTMConvergeInfo(
@@ -294,7 +312,7 @@ def python_loop_ctm_converge(
                 max_truncation_error=last_max_eps,
             )
 
-        if plateau_patience is not None:
+        if plateau_patience is not None and plateau_metric_valid:
             if final_diff < best_diff:
                 best_diff = final_diff
                 best_envs = {c: envs[c] for c in envs}

--- a/src/tenax/algorithms/pess_optimize.py
+++ b/src/tenax/algorithms/pess_optimize.py
@@ -130,6 +130,7 @@ def build_pess_loss(
             gmres_restart=config.gmres_restart,
             arnoldi_precheck=False,
             adjoint_method=config.adjoint_method,
+            plateau_patience=config.plateau_patience,
         )
 
     return loss_fn
@@ -548,6 +549,7 @@ def build_pess_loss_3site_multisite(
             gmres_restart=config.gmres_restart,
             arnoldi_precheck=False,
             adjoint_method=config.adjoint_method,
+            plateau_patience=config.plateau_patience,
         )
 
     return loss_fn

--- a/tests/test_ctm_python_loop.py
+++ b/tests/test_ctm_python_loop.py
@@ -309,6 +309,45 @@ class TestPlateauPatience:
         # not larger than the very first measurement we could have made.
         assert info.sv_diff < float("inf")
 
+    def test_sv_first_iter_sentinel_does_not_anchor_plateau(self):
+        """SV ``min_iter <= 1`` sentinel ``0.0`` must not become ``best_diff``.
+
+        Codex review on PR #439: with ``conv_method="sv"`` and
+        ``min_iter <= 1``, the first convergence check has no previous
+        singular values, so the SV branch leaves ``final_diff`` at its
+        sentinel value.  Without the ``plateau_metric_valid`` guard, the
+        plateau block would record that sentinel as ``best_diff`` and
+        bail after ``patience`` real measurements because no positive
+        diff can improve on zero.
+        """
+        A = _make_random_A(D=3, key=jax.random.PRNGKey(7))
+        # ``min_iter=1`` exercises the no-baseline first iter.  Run long
+        # enough that any sentinel-anchored bail would fire well before
+        # the loop completes.
+        _, info = python_loop_ctm_converge(
+            {(0, 0): A},
+            SINGLE_SITE_NEIGHBORS,
+            chi=4,
+            max_iter=40,
+            min_iter=1,
+            conv_tol=0.0,  # impossible — force non-convergence
+            conv_method="sv",
+            renormalize=True,
+            projector_method="svd",
+            plateau_patience=3,
+        )
+        # If the sentinel had anchored best_diff at 0.0, every subsequent
+        # real positive diff would have incremented iters_since_best and
+        # the loop would have bailed at iter ~5 with sv_diff=0.0.  With
+        # the guard, the first real diff initializes best_diff to a
+        # positive value, and either: (a) some later iter improves on it
+        # (counter resets) → patience hasn't fired, or (b) patience fires
+        # cleanly with the real best_diff and iter count.
+        assert info.sv_diff > 0.0, (
+            "SV plateau sentinel ``0.0`` must not propagate to best_diff; "
+            f"saw info={info!r}"
+        )
+
     def test_chi_ramp_non_final_fixed_sweeps_ignores_patience(self):
         """Explicit warm-up budgets must run to completion despite patience.
 

--- a/tests/test_pess_ad.py
+++ b/tests/test_pess_ad.py
@@ -475,6 +475,37 @@ def test_build_pess_loss_3site_multisite_default_env_cache_is_none():
     assert seen.get("env_init") is None
 
 
+def test_build_pess_loss_3site_multisite_forwards_plateau_patience():
+    """PESS implicit-AD loss must forward ``CTMConfig.plateau_patience``.
+
+    Codex review on PR #439: prior to the fix, the PESS supersite and
+    multisite loss functions called ``ctm_energy_implicit`` without
+    passing ``config.plateau_patience``, so PESS gradient evaluations
+    silently disabled the user-configured plateau stop-loss while
+    warm-starts through ``ctm_converge_kwargs`` did honor it.  This
+    asserts the kwarg now reaches ``ctm_energy_implicit``.
+    """
+    state = IPESSState.random(D=2, d=3, key=jax.random.PRNGKey(0))
+    bond_gates = kagome_3site_bond_gates(delta=1.0, d=3)
+    config = _make_test_config(chi=4)
+    config.plateau_patience = 7
+
+    seen: dict = {}
+
+    def fake_ctm_energy_implicit(*args, **kwargs):
+        seen.update(kwargs)
+        return jnp.array(0.0)
+
+    loss_fn = build_pess_loss_3site_multisite(bond_gates, config)
+    with _mock_patch(
+        "tenax.algorithms.pess_optimize.ctm_energy_implicit",
+        fake_ctm_energy_implicit,
+    ):
+        loss_fn(state)
+
+    assert seen.get("plateau_patience") == 7
+
+
 def test_optimize_pess_3site_multisite_ad_warm_starts_envs():
     """After the first L-BFGS step, `_update_env_cache` populates the cache,
     so the SECOND gradient evaluation receives a non-None env_init.


### PR DESCRIPTION
## Summary
Follow-up to merged PR #439, addressing the last two codex review threads:

- **SV-baseline guard**: With `conv_method=\"sv\"` and `min_iter <= 1`, the first convergence check has no previous singular values, so the SV branch left `final_diff` at its sentinel value (`0.0`). The plateau block then anchored `best_diff = 0.0` and bailed after `patience` real measurements because no positive diff could improve on zero. Added a `plateau_metric_valid` flag in both `python_loop_ctm_converge` and the implicit-AD `_sigma_gauged_ctm_converge` loops; the plateau state only updates on iters where a real baseline existed.

- **PESS pass-through**: `pess_optimize.py`'s supersite and multisite loss functions called `ctm_energy_implicit` without forwarding `config.plateau_patience`, so PESS gradient evaluations silently bypassed the user-configured plateau stop-loss even though warm-starts via `ctm_converge_kwargs` honored it. Both call sites now pass `plateau_patience=config.plateau_patience`.

## Test plan
- [x] `uv run pytest tests/test_ctm_python_loop.py::TestPlateauPatience tests/test_ipeps_ad_policy.py tests/test_pess_ad.py::test_build_pess_loss_3site_multisite_forwards_plateau_patience` — 26 pass
- [x] `test_sv_first_iter_sentinel_does_not_anchor_plateau` — SV path with `min_iter=1` and `plateau_patience=3`; asserts `info.sv_diff > 0` so the sentinel does not anchor `best_diff`
- [x] `test_build_pess_loss_3site_multisite_forwards_plateau_patience` — patches `ctm_energy_implicit` in the PESS loss closure and asserts `CTMConfig.plateau_patience=7` reaches it

## Context

Codex reviews on PR #439 surfaced after #439 auto-merged:
- https://github.com/tenax-lab/tenax/pull/439#discussion_r3223093085 (SV baseline)
- https://github.com/tenax-lab/tenax/pull/439#discussion_r3223082209 (PESS)

Both threads were replied to with this commit ID (\`f055101\`) before this PR was filed; the commit itself missed the auto-merge window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)