### PR TITLE
test(ctm): full-rank env in projector biorthogonality tests (#422 follow-up)

### DIFF
--- a/tests/test_ctm_projector.py
+++ b/tests/test_ctm_projector.py
@@ -9,9 +9,12 @@ import pytest
 
 from tenax.algorithms._ctm_projector import _compute_projector_tensor
 from tenax.algorithms._ctm_tensor import (
+    _build_double_layer_tensor,
+    _ctm_tensor_sweep_multisite,
     _fuse_pair_by_label,
     initialize_ctm_tensor_env,
 )
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.symmetry import FermionParity, U1Symmetry
 from tenax.core.tensor import DenseTensor, SymmetricTensor
@@ -87,6 +90,45 @@ def _build_grown_corners(A, chi):
     return C1g, C4g
 
 
+def _build_grown_corners_converged(A, chi, n_sweeps=2):
+    """Like :func:`_build_grown_corners` but with ``n_sweeps`` CTM sweeps first.
+
+    PR #422 (c42c60d) + PR #424 (d752077) intentionally made CTM init rank-1
+    (variPEPS-style ``chi_init=1`` + diagonal δ_{ket=bra} edge tensors) to fix
+    random-init convergence. The grown corners ``C·T`` built directly from the
+    cold init are therefore rank-1, so the Fishman SVD projector formula
+    ``P = C·V·S^{-1/2}`` (with the safe ``S^{-1/2}`` mask) correctly produces
+    rank-1 outputs and ``P_L @ P_R = diag(1,0,…,0)`` rather than identity.
+
+    Running a couple of CTM sweeps through the multisite path lifts the env
+    off the rank-1 cold init into the full-rank geometry that real CTM
+    convergence (``python_loop_ctm_converge``, which uses the multisite
+    sweep) sees, which is what biorthogonality tests need.  Note: the
+    single-site ``_ctm_tensor_sweep`` is a fixed point on rank-1 input, so
+    we use ``_ctm_tensor_sweep_multisite`` here even for a single coord —
+    this matches the production CTM driver.
+    """
+    from tenax.contraction.contractor import contract
+
+    envs = {(0, 0): initialize_ctm_tensor_env(A, chi)}
+    double_layers = {(0, 0): _build_double_layer_tensor(A)}
+    for _ in range(n_sweeps):
+        envs, _ = _ctm_tensor_sweep_multisite(
+            envs, double_layers, SINGLE_SITE_NEIGHBORS, chi, True, "svd"
+        )
+    env = envs[(0, 0)]
+
+    C1_r = env.C1.relabel("c1_r", "t1_l")
+    C1g = contract(C1_r, env.T1)
+    C1g = _fuse_pair_by_label(C1g, "c1_d", "u2", "fused", FlowDirection.IN)
+
+    C4_u = env.C4.relabel("c4_u", "t3_r")
+    C4g = contract(C4_u, env.T3)
+    C4g = _fuse_pair_by_label(C4g, "c4_r", "d2", "fused", FlowDirection.IN)
+
+    return C1g, C4g
+
+
 # ------------------------------------------------------------------ #
 # Tests                                                                 #
 # ------------------------------------------------------------------ #
@@ -112,7 +154,11 @@ class TestSVDProjectorSymmetric:
         """P1^H @ P2 should be close to identity."""
         A = small_peps_symmetric
         chi = 4
-        C1g, C4g = _build_grown_corners(A, chi)
+        # Lift the rank-1 cold init (PR #422/#424) into a full-rank env before
+        # testing biorthogonality — the projector formula correctly produces
+        # rank-1 outputs on rank-1 inputs (mathematically), so the assertion
+        # needs full-rank input geometry.
+        C1g, C4g = _build_grown_corners_converged(A, chi)
 
         P1, P2, _ = _compute_projector_tensor(C1g, C4g, chi, projector_method="svd")
 
@@ -161,7 +207,11 @@ class TestSVDProjectorSymmetric:
         """SVD projector works with FermionParity (nontrivial charges)."""
         A = fpeps_tensor
         chi = 4
-        C1g, C4g = _build_grown_corners(A, chi)
+        # Lift the rank-1 cold init (PR #422/#424) into a full-rank env before
+        # testing biorthogonality — the projector formula correctly produces
+        # rank-1 outputs on rank-1 inputs (mathematically), so the assertion
+        # needs full-rank input geometry.
+        C1g, C4g = _build_grown_corners_converged(A, chi)
 
         P1, P2, _ = _compute_projector_tensor(C1g, C4g, chi, projector_method="svd")
 


### PR DESCRIPTION
## Summary

Fixes 2 tests in `test_ctm_projector.py::TestSVDProjectorSymmetric` that have been failing in `Full tests` on main since PR #422 + #424 landed:

- `test_svd_projector_biorthogonality`
- `test_svd_projector_fpeps_returns_symmetric`

Root cause is **not** a projector bug — the test fixture was relying on a pre-#422 init geometry that happened to give full-rank corners. PR #422 made T1/T3 edges diagonal-only (δ_{ket=bra}); PR #424 made C corners rank-1 (`chi_init=1`). Both are intentional behavior changes for random-init convergence robustness.

With rank-1 grown corners, the Fishman SVD projector formula `P = C·V·S^{-1/2}` correctly produces rank-1 outputs (with the safe `S^{-1/2}` mask zeroing the kernel). The test's biorthogonality assertion `P_L @ P_R == I` is a load-bearing property only on full-rank inputs.

## Fix

Add `_build_grown_corners_converged` helper that runs 2 `_ctm_tensor_sweep_multisite` iterations from the rank-1 cold init before measuring biorthogonality, and use it from the two failing tests. The multisite sweep — which is what `python_loop_ctm_converge` itself uses — lifts the env off rank-1 in a single step; the single-site `_ctm_tensor_sweep` is a fixed point on rank-1 input and cannot break out, so we use the multisite variant even for a single coord (matches production CTM).

No source-code changes. Other tests in the file still use the original `_build_grown_corners` (they assert different properties that survive rank-1 inputs).

## Test plan

- [x] `tests/test_ctm_projector.py::TestSVDProjectorSymmetric` — all 7 pass
- [x] `tests/test_ctm_projector.py` — all pass
- [x] `pytest -m core` — 803 passed, 1 skipped (unrelated), 0 failed
- [ ] `Full tests` jobs: failure set goes from prior baseline by 2

Generated with [Claude Code](https://claude.com/claude-code)