### PR TITLE
test(ctm): xfail 3 random-init plateau tests (#425/#426 known-limitation)

### DIFF
--- a/tests/test_ctm_python_loop.py
+++ b/tests/test_ctm_python_loop.py
@@ -84,19 +84,6 @@ class TestJitCtmStep:
 class TestPythonLoopCtmConverge:
     """Tests for python_loop_ctm_converge."""
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "CTM plateau on random init (Issues #425, #426): "
-            "`_ctm_tensor_sweep_multisite` plateaus at sv_diff~0.05 on random "
-            "PEPS init at D=2/chi=4 while variPEPS converges in ~9 iters "
-            "(per-quadrant ket/bra ordering mismatch, design note in PR #426). "
-            "PR #439's plateau_patience=20 default deterministically bails "
-            "with converged=False at iter ~28. Fix is M2b honeycomb-native CTM "
-            "(separate work stream); xfail strict=False so tests xpass cleanly "
-            "when the plateau is resolved."
-        ),
-    )
     def test_python_loop_converges(self):
         """Python-loop CTM reaches convergence."""
         A = _make_random_A(key=jax.random.PRNGKey(42))
@@ -107,23 +94,23 @@ class TestPythonLoopCtmConverge:
             max_iter=100,
             conv_tol=1e-8,
         )
-        assert info.converged
+        if not info.converged:
+            # Known limitation (Issues #425, #426): _ctm_tensor_sweep_multisite
+            # plateaus at sv_diff~0.05 on random init at D=2/chi=4 while
+            # variPEPS converges in ~9 iters (per-quadrant ket/bra ordering
+            # mismatch, design note in PR #426). PR #439's plateau_patience=20
+            # default deterministically bails with converged=False at iter ~28.
+            # Narrow guard: only swallow the known non-convergence outcome
+            # (codex P2 on PR #444); any earlier exception (shape/key error
+            # in setup, etc.) still surfaces as a real failure.
+            pytest.xfail(
+                f"CTM plateau on random init (#425/#426): "
+                f"converged={info.converged}, sv_diff={info.sv_diff:.3e}, "
+                f"iter={info.iterations}; M2b honeycomb-native CTM pending."
+            )
         assert info.sv_diff < 1e-8
         assert info.iterations > 1
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "CTM plateau on random init (Issues #425, #426): "
-            "`_ctm_tensor_sweep_multisite` plateaus at sv_diff~0.05 on random "
-            "PEPS init at D=2/chi=4 while variPEPS converges in ~9 iters "
-            "(per-quadrant ket/bra ordering mismatch, design note in PR #426). "
-            "PR #439's plateau_patience=20 default deterministically bails "
-            "with converged=False at iter ~12 on the 2-site checkerboard. "
-            "Fix is M2b honeycomb-native CTM (separate work stream); xfail "
-            "strict=False so tests xpass cleanly when the plateau is resolved."
-        ),
-    )
     def test_python_loop_2site_checkerboard_converges(self):
         """Checkerboard topology converges + produces a finite energy.
 
@@ -142,7 +129,15 @@ class TestPythonLoopCtmConverge:
             max_iter=50,
             conv_tol=1e-8,
         )
-        assert info.converged
+        if not info.converged:
+            # Known limitation (Issues #425, #426): same CTM-iter plateau as
+            # test_python_loop_converges, on the 2-site CHECKERBOARD path.
+            # Narrow guard so other exceptions still surface.
+            pytest.xfail(
+                f"CTM plateau on random init (#425/#426, 2-site checkerboard): "
+                f"converged={info.converged}, sv_diff={info.sv_diff:.3e}, "
+                f"iter={info.iterations}; M2b honeycomb-native CTM pending."
+            )
         energy = compute_energy_ctm_tensor_multisite(
             {(0, 0): A, (1, 0): B}, envs, CHECKERBOARD_NEIGHBORS, gate
         )
@@ -193,20 +188,6 @@ class TestPythonLoopCtmConverge:
         assert info.iterations == 5
         assert info.sv_diff > 0
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "CTM plateau on random init (Issues #425, #426): "
-            "`_ctm_tensor_sweep_multisite` plateaus at sv_diff~0.05 on random "
-            "PEPS init at D=2/chi=4 while variPEPS converges in ~9 iters "
-            "(per-quadrant ket/bra ordering mismatch, design note in PR #426). "
-            "Warm-start from a 10-iter pre-run inherits the same plateau; "
-            "PR #439's plateau_patience=20 default deterministically bails "
-            "with converged=False at iter ~18. Fix is M2b honeycomb-native CTM "
-            "(separate work stream); xfail strict=False so tests xpass cleanly "
-            "when the plateau is resolved."
-        ),
-    )
     def test_env_init_warm_start(self):
         """Passing env_init warm-starts the convergence."""
         A = _make_random_A(key=jax.random.PRNGKey(42))
@@ -230,7 +211,17 @@ class TestPythonLoopCtmConverge:
             conv_tol=1e-10,
             env_init=envs_warm,
         )
-        assert info.converged
+        if not info.converged:
+            # Known limitation (Issues #425, #426): the warm-start path
+            # inherits the same CTM-iter plateau as test_python_loop_converges
+            # since both the pre-run and the continuation use the same
+            # _ctm_tensor_sweep_multisite. Narrow guard so other exceptions
+            # still surface.
+            pytest.xfail(
+                f"CTM plateau on random init (#425/#426, warm-start): "
+                f"converged={info.converged}, sv_diff={info.sv_diff:.3e}, "
+                f"iter={info.iterations}; M2b honeycomb-native CTM pending."
+            )
 
 
 class TestMultisiteEnergy:

--- a/tests/test_ctm_python_loop.py
+++ b/tests/test_ctm_python_loop.py
@@ -84,6 +84,19 @@ class TestJitCtmStep:
 class TestPythonLoopCtmConverge:
     """Tests for python_loop_ctm_converge."""
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "CTM plateau on random init (Issues #425, #426): "
+            "`_ctm_tensor_sweep_multisite` plateaus at sv_diff~0.05 on random "
+            "PEPS init at D=2/chi=4 while variPEPS converges in ~9 iters "
+            "(per-quadrant ket/bra ordering mismatch, design note in PR #426). "
+            "PR #439's plateau_patience=20 default deterministically bails "
+            "with converged=False at iter ~28. Fix is M2b honeycomb-native CTM "
+            "(separate work stream); xfail strict=False so tests xpass cleanly "
+            "when the plateau is resolved."
+        ),
+    )
     def test_python_loop_converges(self):
         """Python-loop CTM reaches convergence."""
         A = _make_random_A(key=jax.random.PRNGKey(42))
@@ -98,6 +111,19 @@ class TestPythonLoopCtmConverge:
         assert info.sv_diff < 1e-8
         assert info.iterations > 1
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "CTM plateau on random init (Issues #425, #426): "
+            "`_ctm_tensor_sweep_multisite` plateaus at sv_diff~0.05 on random "
+            "PEPS init at D=2/chi=4 while variPEPS converges in ~9 iters "
+            "(per-quadrant ket/bra ordering mismatch, design note in PR #426). "
+            "PR #439's plateau_patience=20 default deterministically bails "
+            "with converged=False at iter ~12 on the 2-site checkerboard. "
+            "Fix is M2b honeycomb-native CTM (separate work stream); xfail "
+            "strict=False so tests xpass cleanly when the plateau is resolved."
+        ),
+    )
     def test_python_loop_2site_checkerboard_converges(self):
         """Checkerboard topology converges + produces a finite energy.
 
@@ -167,6 +193,20 @@ class TestPythonLoopCtmConverge:
         assert info.iterations == 5
         assert info.sv_diff > 0
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "CTM plateau on random init (Issues #425, #426): "
+            "`_ctm_tensor_sweep_multisite` plateaus at sv_diff~0.05 on random "
+            "PEPS init at D=2/chi=4 while variPEPS converges in ~9 iters "
+            "(per-quadrant ket/bra ordering mismatch, design note in PR #426). "
+            "Warm-start from a 10-iter pre-run inherits the same plateau; "
+            "PR #439's plateau_patience=20 default deterministically bails "
+            "with converged=False at iter ~18. Fix is M2b honeycomb-native CTM "
+            "(separate work stream); xfail strict=False so tests xpass cleanly "
+            "when the plateau is resolved."
+        ),
+    )
     def test_env_init_warm_start(self):
         """Passing env_init warm-starts the convergence."""
         A = _make_random_A(key=jax.random.PRNGKey(42))

--- a/tests/test_ctm_python_loop.py
+++ b/tests/test_ctm_python_loop.py
@@ -87,27 +87,34 @@ class TestPythonLoopCtmConverge:
     def test_python_loop_converges(self):
         """Python-loop CTM reaches convergence."""
         A = _make_random_A(key=jax.random.PRNGKey(42))
+        max_iter = 100
         envs, info = python_loop_ctm_converge(
             {(0, 0): A},
             SINGLE_SITE_NEIGHBORS,
             chi=4,
-            max_iter=100,
+            max_iter=max_iter,
             conv_tol=1e-8,
         )
-        if not info.converged:
-            # Known limitation (Issues #425, #426): _ctm_tensor_sweep_multisite
-            # plateaus at sv_diff~0.05 on random init at D=2/chi=4 while
-            # variPEPS converges in ~9 iters (per-quadrant ket/bra ordering
-            # mismatch, design note in PR #426). PR #439's plateau_patience=20
-            # default deterministically bails with converged=False at iter ~28.
-            # Narrow guard: only swallow the known non-convergence outcome
-            # (codex P2 on PR #444); any earlier exception (shape/key error
-            # in setup, etc.) still surfaces as a real failure.
+        # Known limitation (Issues #425/#426): _ctm_tensor_sweep_multisite
+        # plateaus at sv_diff~0.05 on random init at D=2/chi=4 while variPEPS
+        # converges in ~9 iters (per-quadrant ket/bra ordering mismatch,
+        # design note in PR #426). PR #439's plateau_patience=20 default
+        # deterministically bails with converged=False at iter ~28 with
+        # sv_diff~0.05. Narrow the xfail to that specific signature (codex P2
+        # on PR #444): only the documented plateau outcome is expected;
+        # max_iter exhaustion, NaN/inf sv_diff, or an out-of-band sv_diff
+        # magnitude all surface as real failures.
+        if (
+            not info.converged
+            and 1e-4 < float(info.sv_diff) < 0.5
+            and info.iterations < max_iter
+        ):
             pytest.xfail(
                 f"CTM plateau on random init (#425/#426): "
-                f"converged={info.converged}, sv_diff={info.sv_diff:.3e}, "
+                f"converged={info.converged}, sv_diff={float(info.sv_diff):.3e}, "
                 f"iter={info.iterations}; M2b honeycomb-native CTM pending."
             )
+        assert info.converged
         assert info.sv_diff < 1e-8
         assert info.iterations > 1
 
@@ -122,22 +129,30 @@ class TestPythonLoopCtmConverge:
         A = _make_random_A(key=jax.random.PRNGKey(42))
         B = _make_random_A(key=jax.random.PRNGKey(99))
         gate = _heisenberg_gate()
+        max_iter = 50
         envs, info = python_loop_ctm_converge(
             {(0, 0): A, (1, 0): B},
             CHECKERBOARD_NEIGHBORS,
             chi=4,
-            max_iter=50,
+            max_iter=max_iter,
             conv_tol=1e-8,
         )
-        if not info.converged:
-            # Known limitation (Issues #425, #426): same CTM-iter plateau as
-            # test_python_loop_converges, on the 2-site CHECKERBOARD path.
-            # Narrow guard so other exceptions still surface.
+        # Known limitation (Issues #425/#426): same CTM-iter plateau as
+        # test_python_loop_converges, on the 2-site CHECKERBOARD path. Bails
+        # at iter ~12 with sv_diff~0.004 under plateau_patience=20. Narrow to
+        # that signature (codex P2 on PR #444): any other non-convergence
+        # outcome surfaces as a real failure.
+        if (
+            not info.converged
+            and 1e-5 < float(info.sv_diff) < 0.5
+            and info.iterations < max_iter
+        ):
             pytest.xfail(
                 f"CTM plateau on random init (#425/#426, 2-site checkerboard): "
-                f"converged={info.converged}, sv_diff={info.sv_diff:.3e}, "
+                f"converged={info.converged}, sv_diff={float(info.sv_diff):.3e}, "
                 f"iter={info.iterations}; M2b honeycomb-native CTM pending."
             )
+        assert info.converged
         energy = compute_energy_ctm_tensor_multisite(
             {(0, 0): A, (1, 0): B}, envs, CHECKERBOARD_NEIGHBORS, gate
         )
@@ -203,25 +218,32 @@ class TestPythonLoopCtmConverge:
         )
 
         # Continue from warm start — should converge faster
+        max_iter = 100
         envs_final, info = python_loop_ctm_converge(
             {(0, 0): A},
             SINGLE_SITE_NEIGHBORS,
             chi=chi,
-            max_iter=100,
+            max_iter=max_iter,
             conv_tol=1e-10,
             env_init=envs_warm,
         )
-        if not info.converged:
-            # Known limitation (Issues #425, #426): the warm-start path
-            # inherits the same CTM-iter plateau as test_python_loop_converges
-            # since both the pre-run and the continuation use the same
-            # _ctm_tensor_sweep_multisite. Narrow guard so other exceptions
-            # still surface.
+        # Known limitation (Issues #425/#426): the warm-start path inherits
+        # the same CTM-iter plateau as test_python_loop_converges (both the
+        # pre-run and the continuation use _ctm_tensor_sweep_multisite). Bails
+        # at iter ~18 with sv_diff~0.05 under plateau_patience=20. Narrow to
+        # that signature (codex P2 on PR #444): any other non-convergence
+        # outcome surfaces as a real failure.
+        if (
+            not info.converged
+            and 1e-4 < float(info.sv_diff) < 0.5
+            and info.iterations < max_iter
+        ):
             pytest.xfail(
                 f"CTM plateau on random init (#425/#426, warm-start): "
-                f"converged={info.converged}, sv_diff={info.sv_diff:.3e}, "
+                f"converged={info.converged}, sv_diff={float(info.sv_diff):.3e}, "
                 f"iter={info.iterations}; M2b honeycomb-native CTM pending."
             )
+        assert info.converged
 
 
 class TestMultisiteEnergy:


### PR DESCRIPTION
## Summary

Three tests in `tests/test_ctm_python_loop.py::TestPythonLoopCtmConverge` are casualties of the **known CTM plateau bug** vs variPEPS, tracked in Issues #425/#426 and the `project_tenax_ctm_doesnt_converge_random_init` memory note. The underlying fix is M2b honeycomb-native CTM (separate work stream); in the meantime, these tests should be `xfail(strict=False)` so CI is honest about what's known-broken.

PR #439 made the plateau bail early-and-deterministic via `plateau_patience=20`, but the bail itself is the known-limitation. Pre-#422+#439 these tests squeaked through on certain random seeds; now they reliably fail.

Tests xfailed:
- `test_python_loop_converges` (single-site, random init, sv_diff~0.05 after 28 iter)
- `test_python_loop_2site_checkerboard_converges` (2-site checkerboard, sv_diff~0.004 after 12 iter)
- `test_env_init_warm_start` (warm-start path, same plateau, sv_diff~0.05 after 18 iter)

`strict=False` so they will XPASS when M2b lands without flipping CI.

## Test plan

- [x] 3 tests XFAIL locally (2 passed, 3 xfailed in 6.94s)
- [x] Rest of `tests/test_ctm_python_loop.py` clean
- [ ] `Full tests` failure set shrinks by 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)