### PR TITLE
fix(linalg): fill unused base_charges budget in traced symmetric SVD

### DIFF
--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -394,7 +394,14 @@ def _truncated_svd_symmetric_traced(
       * If both ``base_charges`` and ``max_singular_values`` are provided:
         ``k_q = min(target_count[q], available_q)`` where
         ``target_count[q]`` is the count of ``q`` in
-        ``_derive_charges(base_charges, max_singular_values)``.
+        ``_derive_charges(base_charges, max_singular_values)``.  When
+        ``target_count`` over-allocates a sector (target exceeds
+        available), the unused budget is greedily redistributed to
+        sectors with remaining capacity, ordered by largest unused
+        capacity first, ties broken by smallest q for determinism.  This
+        matches the eager-path :func:`_retruncate_by_base_charges` so
+        traced bond dimension agrees with the forward (eager) path under
+        AD (codex P2 review on PR #440).
       * If ``max_singular_values`` is None: ``k_q = min(rows_q, cols_q)``
         (full spectrum per sector).
       * Else (defensive fallback, base_charges=None and truncating):
@@ -510,6 +517,29 @@ def _truncated_svd_symmetric_traced(
         k_per_sector = {
             q: min(target_count.get(q, 0), r[5]) for q, r in sector_results.items()
         }
+        # Greedy fill: if base_charges over-allocates a sector (target_count[q]
+        # > available_q), distribute the unused budget to sectors with
+        # remaining capacity. Mirrors _retruncate_by_base_charges in
+        # _ctm_tensor_projector_2x2.py:744-753, so traced bond dim matches the
+        # eager path under AD (codex P2 review on PR #440 / comment 3223755136).
+        # Order: largest unused capacity first, ties broken by smallest q for
+        # determinism.
+        remaining = max_singular_values - sum(k_per_sector.values())
+        if remaining > 0:
+            for q in sorted(
+                sector_results.keys(),
+                key=lambda qq: (
+                    -(sector_results[qq][5] - k_per_sector.get(qq, 0)),
+                    qq,
+                ),
+            ):
+                if remaining <= 0:
+                    break
+                capacity_left = sector_results[q][5] - k_per_sector.get(q, 0)
+                take = min(remaining, capacity_left)
+                if take > 0:
+                    k_per_sector[q] = k_per_sector.get(q, 0) + take
+                    remaining -= take
     else:
         # Defensive fallback: proportional to per-sector available capacity.
         total_avail = sum(r[5] for r in sector_results.values()) or 1

--- a/tests/test_ctm_2x2_projector_symmetric.py
+++ b/tests/test_ctm_2x2_projector_symmetric.py
@@ -420,6 +420,55 @@ def test_truncated_svd_symmetric_traced_proportional_fallback_respects_cap():
     assert jnp.isfinite(g)
 
 
+def test_truncated_svd_symmetric_traced_fills_unused_base_charges_budget():
+    """When base_charges over-allocates a sector, the traced path's greedy
+    fill should match eager `_retruncate_by_base_charges` bond dim.
+
+    Codex P2 review on PR #440 flagged the eager-vs-traced divergence: if
+    base_charges=[0,0,0,0] but the tensor has 2 q=0 + 2 q=1 singular vectors,
+    the eager path fills the remaining 2 budget from q=1, returning bond
+    dim 4; the traced path was clamping to dim 2 (no fill), causing
+    forward-vs-backward bond-dim mismatch under AD.
+    """
+    from tenax.linalg import svd as tensor_svd
+
+    sym = U1Symmetry()
+    left_charges = np.array([0, 0, 1, 1], dtype=np.int32)
+    right_charges = np.array([0, 0, 1, 1], dtype=np.int32)
+    left_idx = TensorIndex.from_charges(
+        sym, left_charges, FlowDirection.IN, label="left"
+    )
+    right_idx = TensorIndex.from_charges(
+        sym, right_charges, FlowDirection.OUT, label="right"
+    )
+    M_T = SymmetricTensor.random_normal((left_idx, right_idx), jax.random.PRNGKey(0))
+
+    # target_count = {0: 4} after _derive_charges. Sector 0 has only 2 SVs;
+    # the 2 unused budget slots should fill from sector 1.
+    base_charges = np.array([0, 0, 0, 0], dtype=np.int32)
+
+    def loss(alpha: jax.Array) -> jax.Array:
+        new_blocks = {k: alpha * b for k, b in M_T.blocks.items()}
+        M_scaled = SymmetricTensor._from_blocks_unchecked(new_blocks, M_T.indices)
+        _, s, _, _ = tensor_svd(
+            M_scaled,
+            left_labels=("left",),
+            right_labels=("right",),
+            new_bond_label="bond",
+            max_singular_values=4,
+            base_charges=base_charges,
+        )
+        # Bond dim should be 4 (matching eager), not 2.
+        assert s.shape[0] == 4, (
+            f"greedy-fill should distribute unused budget across sectors, "
+            f"got bond dim {s.shape[0]}"
+        )
+        return jnp.sum(s)
+
+    g = jax.grad(loss)(jnp.asarray(1.0))
+    assert jnp.isfinite(g)
+
+
 def test_2plaq_path_threads_base_charges_through_helpers(
     symmetric_corners, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Follow-up to merged PR #440 addressing codex P2 review thread (https://github.com/tenax-lab/tenax/pull/440#discussion_r3223755136).

When \`base_charges\` over-allocates a sector in \`_truncated_svd_symmetric_traced\` (e.g. \`base_charges=[0,0,0,0]\` on a tensor with 2 q=0 + 2 q=1 SVs), the eager path's \`_retruncate_by_base_charges\` fills the unused 2-slot budget greedily from q=1, returning bond dim 4. The traced path was clamping to \`available_q\` without filling, returning bond dim 2 — a forward-vs-backward mismatch under AD.

## Fix

Add a greedy-fill round in \`_truncated_svd_symmetric_traced\` mirroring \`_retruncate_by_base_charges\` (\`_ctm_tensor_projector_2x2.py:744-753\`): after \`min(target_count, available_q)\`, distribute any remaining budget across sectors with unused capacity, ordered by largest unused capacity desc, ties broken by smallest q for determinism.

## Test plan

- [x] New regression test \`test_truncated_svd_symmetric_traced_fills_unused_base_charges_budget\` builds a 2-sector tensor + over-allocating \`base_charges=[0,0,0,0]\` and asserts \`s.shape[0] == max_singular_values\` (was 2, now 4)
- [x] All 18 tests in \`tests/test_ctm_2x2_projector_symmetric.py\` pass locally
- [x] No regressions in \`pytest -m core\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)