### PR TITLE
fix(ipeps): two codex P2 follow-ups on #449 (c4v_reference + multisite warmup)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -718,6 +718,7 @@ def _optimize_gs_ad_tensor_reference_c4v(
     opt_state = None if optimizer is None else optimizer.init(params)
     best_energy = float("inf")
     best_params = params
+    prev_energy = float("inf")
 
     def _project_c4v_and_normalize(A_data: jax.Array) -> jax.Array:
         coeffs = c4v_coeffs_from_tensor(A_data, c4v_basis)
@@ -776,6 +777,31 @@ def _optimize_gs_ad_tensor_reference_c4v(
         ):
             best_energy = E
             best_params = params
+
+        # Outer convergence (issue #448).  Mirrors the other dispatchers
+        # so ``gs_conv_criterion`` and ``gs_conv_tol`` are honoured on the
+        # reference-C4v path too — until this commit they were silently
+        # ignored and every run consumed ``gs_num_steps``.  Grad-norm is
+        # computed only when the chosen criterion needs it.
+        delta_energy = abs(E - prev_energy)
+        prev_energy = E
+        grad_norm_val = (
+            _grad_l2_norm(grads)
+            if config.gs_conv_criterion in ("grad_norm", "both")
+            else None
+        )
+        if _converged_outer(config, delta_energy, grad_norm_val):
+            if config.gs_verbose:
+                _log_ad_converged(
+                    "c4v_reference",
+                    _step,
+                    delta_energy,
+                    config.gs_conv_tol,
+                    grad_norm=grad_norm_val,
+                    grad_norm_tol=config.gs_grad_norm_tol,
+                    criterion=config.gs_conv_criterion,
+                )
+            break
 
     final_energy, (final_env, final_A) = _loss_fn(best_params)
     return final_A, final_env, float(final_energy)

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -753,23 +753,14 @@ def _optimize_gs_ad_tensor_reference_c4v(
                 )
             continue
         grads = jnp.where(jnp.isfinite(grads), grads, 0.0)
-        if use_cg:
-            params = _normalize_params(params - config.gs_learning_rate * grads)
-        else:
-            assert optimizer is not None
-            if config.gs_optimizer.lower() == "lbfgs":
-                updates, opt_state = optimizer.update(
-                    grads,
-                    opt_state,
-                    params,
-                    value=energy_val,
-                    grad=grads,
-                    value_fn=lambda p: _loss_fn(p)[0],
-                )
-            else:
-                updates, opt_state = optimizer.update(grads, opt_state, params)
-            params = _normalize_params(optax.apply_updates(params, updates))
         E = float(energy_val)
+
+        # Score / convergence-check on the *pre-step* params.  ``energy_val``
+        # and ``grads`` describe ``params`` before the optimizer update, so
+        # ``best_params`` and the convergence break must use that snapshot —
+        # not the post-update value.  The 1-site / 2-site / multisite
+        # dispatchers check before stepping for the same reason (codex
+        # follow-up on PR #449 / #451).
         if _should_accept_best(
             current_best=best_energy,
             candidate=E,
@@ -802,6 +793,23 @@ def _optimize_gs_ad_tensor_reference_c4v(
                     criterion=config.gs_conv_criterion,
                 )
             break
+
+        if use_cg:
+            params = _normalize_params(params - config.gs_learning_rate * grads)
+        else:
+            assert optimizer is not None
+            if config.gs_optimizer.lower() == "lbfgs":
+                updates, opt_state = optimizer.update(
+                    grads,
+                    opt_state,
+                    params,
+                    value=energy_val,
+                    grad=grads,
+                    value_fn=lambda p: _loss_fn(p)[0],
+                )
+            else:
+                updates, opt_state = optimizer.update(grads, opt_state, params)
+            params = _normalize_params(optax.apply_updates(params, updates))
 
     final_energy, (final_env, final_A) = _loss_fn(best_params)
     return final_A, final_env, float(final_energy)

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2664,18 +2664,26 @@ def _optimize_gs_ad_multisite(
 
         prev_energy = energy_float
 
-        # Skip convergence check on early steps and right after a stall
-        # (stall resets prev_energy ≈ current, giving false dE ≈ 0).
+        # Early-step / post-stall warmup gate.  For dE-based criteria the
+        # gate protects against false ``dE ≈ 0`` exits on step 0
+        # (``prev_energy = inf`` → ``delta_energy = inf`` actually fails
+        # the dE check, but a stall reset can leave ``prev_energy ≈
+        # current`` and produce a real false-zero) and right after a
+        # stall recovery.  Grad-norm is variationally meaningful, so if
+        # the user's initial multisite state already satisfies
+        # ``||grad||_2 < tol`` we should respect that and exit on step 0
+        # — gating it would silently force the optimizer through up to
+        # ``gs_num_steps`` even when the user explicitly opted into a
+        # loose ``gs_grad_norm_tol`` for early-stop (codex #449
+        # follow-up).
         grad_norm_val = (
             _grad_l2_norm(grads)
             if config.gs_conv_criterion in ("grad_norm", "both")
             else None
         )
-        if (
-            _converged_outer(config, delta_energy, grad_norm_val)
-            and step > 5
-            and stall_count == 0
-        ):
+        needs_warmup = config.gs_conv_criterion in ("dE", "both")
+        warmup_ok = (not needs_warmup) or (step > 5 and stall_count == 0)
+        if _converged_outer(config, delta_energy, grad_norm_val) and warmup_ok:
             if config.gs_verbose:
                 if not logged:
                     _log_ad_step(

--- a/tests/test_ipeps_ad_conv_criterion.py
+++ b/tests/test_ipeps_ad_conv_criterion.py
@@ -258,3 +258,53 @@ def test_c4v_reference_honors_grad_norm_criterion(capsys):
     captured = capsys.readouterr().out
     assert "[iPEPS-AD:c4v_reference] converged at step" in captured, captured
     assert "||grad||=" in captured, captured
+
+
+# --- multisite dispatcher: warmup gate is criterion-aware ------------------
+#
+# Codex review on #449 flagged that the multisite dispatcher kept the legacy
+# ``step > 5 and stall_count == 0`` warmup unconditionally.  With
+# ``gs_conv_criterion='grad_norm'`` that warmup defeats early-stationarity
+# exits — a user setting a loose ``gs_grad_norm_tol`` to bail out of an
+# already-converged init still pays up to six expensive AD/CTM iterations,
+# and runs with ``gs_num_steps <= 6`` never exit via grad-norm.
+# The fix gates the warmup only for dE-based criteria.
+
+
+def test_multisite_warmup_is_criterion_aware():
+    """The warmup gate in ``_optimize_gs_ad_multisite`` must skip the
+    ``step > 5`` guard under ``gs_conv_criterion='grad_norm'`` and keep
+    it under ``"dE"``/``"both"`` (codex follow-up on #449).
+
+    Source-text pin rather than an end-to-end run because spinning up
+    the multisite optimizer for an inf-dE step-0 case requires a real
+    Lattice + iPEPS env which dominates the test runtime; the helper
+    invariant below (paired with ``_converged_outer`` unit tests above)
+    is enough to lock the behaviour.
+    """
+    import importlib
+
+    mod = importlib.import_module("tenax.algorithms.ipeps_optimize")
+    with open(mod.__file__, encoding="utf-8") as fp:
+        text = fp.read()
+    assert 'needs_warmup = config.gs_conv_criterion in ("dE", "both")' in text
+    assert "(not needs_warmup) or (step > 5 and stall_count == 0)" in text
+
+
+def test_converged_outer_grad_norm_exits_at_step_zero():
+    """Under ``gs_conv_criterion='grad_norm'`` the helper returns True
+    even on step 0 (``prev_energy = inf`` → ``delta_energy = inf``).
+    The multisite warmup gate must respect that invariant."""
+    import math
+
+    cfg = iPEPSConfig(gs_conv_criterion="grad_norm", gs_grad_norm_tol=1e30)
+    assert _converged_outer(cfg, delta_energy=math.inf, grad_norm=1.0) is True
+
+
+def test_converged_outer_dE_still_needs_finite_delta():
+    """Sanity: under ``"dE"`` the step-0 inf dE never converges, so the
+    multisite warmup gate exists for a reason on that path."""
+    import math
+
+    cfg = iPEPSConfig(gs_conv_criterion="dE", gs_conv_tol=1.0)
+    assert _converged_outer(cfg, delta_energy=math.inf, grad_norm=None) is False

--- a/tests/test_ipeps_ad_conv_criterion.py
+++ b/tests/test_ipeps_ad_conv_criterion.py
@@ -190,3 +190,71 @@ def test_both_criterion_requires_both_to_pass():
     # Did not converge under "both" because the grad-norm half can't be met.
     assert history["converged"] is False
     assert history["num_steps"] == cfg.gs_num_steps
+
+
+# --- integration: c4v_reference dispatcher honors the criterion ------------
+#
+# Codex review on #449 flagged that ``_optimize_gs_ad_tensor_reference_c4v``
+# had no convergence check at all — even ``gs_conv_tol`` was silently ignored
+# and every run consumed ``gs_num_steps``. These tests pin the fix.
+
+
+def _c4v_reference_cfg(num_steps: int = 6, **overrides) -> iPEPSConfig:
+    # Mirrors tests/test_c4v_reference_ad.py
+    # ::test_optimize_gs_ad_reference_mode_nonzero_steps_runs — only the
+    # default ``projector_method='svd'`` survives the implicit-AD policy
+    # check on this path.
+    base = iPEPSConfig(
+        max_bond_dim=2,
+        ctm=CTMConfig(
+            chi=4,
+            max_iter=8,
+            min_iter=2,
+            ctm_ad_mode="c4v_reference",
+        ),
+        gs_num_steps=num_steps,
+        gs_learning_rate=1e-2,
+        gs_implicit_ad=True,
+        gs_c4v=True,
+        unit_cell="1x1",
+        su_init=False,
+        gs_optimizer="adam",
+        gs_verbose=True,  # so we can grep stdout for the converged-log line.
+    )
+    return replace(base, **overrides)
+
+
+@pytest.mark.algorithm
+def test_c4v_reference_honors_dE_criterion(capsys):
+    """Loose ``gs_conv_tol`` must trigger the dE exit in the C4v-reference
+    dispatcher (issue #448 codex follow-up)."""
+    import jax
+
+    A0 = jax.random.normal(jax.random.PRNGKey(2), (2, 2, 2, 2, 2))
+    cfg = _c4v_reference_cfg(
+        num_steps=5,
+        gs_conv_criterion="dE",
+        gs_conv_tol=1.0,  # loose → fires on first step.
+    )
+    optimize_gs_ad(_heisenberg_gate(), A0, cfg)
+    captured = capsys.readouterr().out
+    assert "[iPEPS-AD:c4v_reference] converged at step" in captured, captured
+
+
+@pytest.mark.algorithm
+def test_c4v_reference_honors_grad_norm_criterion(capsys):
+    """Loose ``gs_grad_norm_tol`` must trigger the grad-norm exit on the
+    C4v-reference path too."""
+    import jax
+
+    A0 = jax.random.normal(jax.random.PRNGKey(3), (2, 2, 2, 2, 2))
+    cfg = _c4v_reference_cfg(
+        num_steps=5,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e30,  # any finite grad-norm satisfies.
+        gs_conv_tol=1e-30,  # dE can't trip first.
+    )
+    optimize_gs_ad(_heisenberg_gate(), A0, cfg)
+    captured = capsys.readouterr().out
+    assert "[iPEPS-AD:c4v_reference] converged at step" in captured, captured
+    assert "||grad||=" in captured, captured

--- a/tests/test_ipeps_ad_conv_criterion.py
+++ b/tests/test_ipeps_ad_conv_criterion.py
@@ -260,6 +260,63 @@ def test_c4v_reference_honors_grad_norm_criterion(capsys):
     assert "||grad||=" in captured, captured
 
 
+@pytest.mark.algorithm
+def test_c4v_reference_returns_pre_step_best_on_grad_norm_exit():
+    """``best_params`` returned by the C4v-reference dispatcher must be the
+    tensor that satisfied the convergence criterion, not the post-optimizer
+    update (codex P2 on PR #451).
+
+    Sets a deliberately-huge learning rate plus a loose
+    ``gs_grad_norm_tol`` so the criterion fires on step 0; an Adam update at
+    that point would move ``params`` somewhere off the cheap GS line
+    and ``best_params`` would inherit the bad update if the check ran
+    post-step. We verify the returned ``A_opt`` is exactly the C4v
+    projection of ``A0`` (no optimizer step applied).
+    """
+    import jax
+    import jax.numpy as jnp
+    import numpy as np
+
+    A0 = jax.random.normal(jax.random.PRNGKey(7), (2, 2, 2, 2, 2))
+    cfg = _c4v_reference_cfg(
+        num_steps=3,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e30,  # converged on step 0
+        gs_conv_tol=1e-30,
+        gs_learning_rate=10.0,  # a post-step accept would be dramatically off
+    )
+    A_opt, _env, _E = optimize_gs_ad(_heisenberg_gate(), A0, cfg)
+
+    # Expected: A_opt is the C4v projection of A0, normalised — i.e. the
+    # pre-step starting tensor that the conv check actually evaluated.
+    from tenax.algorithms.ipeps import (
+        build_c4v_basis,
+        c4v_coeffs_from_tensor,
+        c4v_tensor_from_coeffs,
+    )
+
+    D_bond, d_loc = 2, 2
+    A0_norm = A0 / (jnp.linalg.norm(A0) + 1e-10)
+    basis = jnp.array(build_c4v_basis(D_bond, d_loc))
+    coeffs = c4v_coeffs_from_tensor(A0_norm, basis)
+    A_expected = c4v_tensor_from_coeffs(
+        coeffs, basis, (D_bond, D_bond, D_bond, D_bond, d_loc)
+    )
+    A_expected = A_expected / (jnp.linalg.norm(A_expected) + 1e-10)
+
+    np.testing.assert_allclose(
+        np.asarray(A_opt.todense()),
+        np.asarray(A_expected),
+        atol=1e-10,
+        rtol=1e-8,
+        err_msg=(
+            "C4v-reference dispatcher returned a post-step tensor on a "
+            "step-0 grad-norm exit; the conv check is firing AFTER the "
+            "optimizer update (codex P2 on PR #451)."
+        ),
+    )
+
+
 # --- multisite dispatcher: warmup gate is criterion-aware ------------------
 #
 # Codex review on #449 flagged that the multisite dispatcher kept the legacy


### PR DESCRIPTION
## Summary

Two related fixes from codex's re-review of #449 — both flagged after the squash-merge of that PR landed at `dbef56d` (a commit on the PR branch addressing the first issue did not get included in the squash). Each commit is independently testable.

### 1. `c4v_reference` dispatcher honors `gs_conv_criterion`

`_optimize_gs_ad_tensor_reference_c4v` had no outer convergence check at all on `main` after #449: even the legacy `gs_conv_tol` was silently ignored and every run consumed `gs_num_steps`. The new `gs_conv_criterion` knob inherited that gap. Wire `_converged_outer` into the dispatcher loop, mirroring the 1-site / 2-site / multisite branches.

### 2. Multisite warmup gate is criterion-aware

`_optimize_gs_ad_multisite` kept its `step > 5 and stall_count == 0` warmup unconditionally. That gate protects dE-based criteria from false `dE ≈ 0` exits right after a stall reset (where `prev_energy ≈ current`); it makes no sense for `grad_norm`, which is variationally meaningful. Without this fix, a user setting a loose `gs_grad_norm_tol` to bail out of an already-stationary multisite init still pays up to six expensive AD/CTM iterations, and runs with `gs_num_steps <= 6` never exit via the grad-norm criterion at all.

Gate the warmup only for `"dE"`/`"both"` criteria. `"grad_norm"` exits as soon as `_converged_outer` agrees.

## Test plan

Four new tests in `tests/test_ipeps_ad_conv_criterion.py`:

- `test_c4v_reference_honors_dE_criterion` — verbose-log inspection confirms exit on the reference path under `"dE"`.
- `test_c4v_reference_honors_grad_norm_criterion` — same under `"grad_norm"`, plus the `||grad||=` annotation in the log.
- `test_multisite_warmup_is_criterion_aware` — source-text pin on the gating expression (full multisite run is too slow for an end-to-end stationary-init test cheaply; paired with the `_converged_outer` unit checks below).
- `test_converged_outer_grad_norm_exits_at_step_zero` / `test_converged_outer_dE_still_needs_finite_delta` — `_converged_outer` honors / rejects the step-0 inf-dE case per criterion.

All 16 tests in the file pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)