### PR TITLE
ci: add merge_group trigger for GitHub Merge Queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Add `merge_group:` to the CI workflow's `on:` block so required Tests checks run on the queue group commit when GitHub Merge Queue is enabled.

## Why

The merge queue groups PRs into a single combined commit and dispatches workflows via the `merge_group` event. Without this trigger, required checks never fire on the queue group commit and the merge times out.

The existing `pull_request` and `push` triggers are kept so individual PRs and direct pushes to main/dev still run CI.

## Test plan

- [ ] PR's own required Tests checks pass (via the existing `pull_request` trigger — bootstraps merge-queue support on its own merge)
- [ ] After merge: subsequent PRs queued via merge queue show CI running on the `merge_group` ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)