### PR TITLE
fix(ipeps): codex follow-ups — CTM-error cap (#457) + 1-site SymTensor base_charges (#459)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1183,7 +1183,7 @@ def _optimize_gs_ad_tensor(
     # this once outside the loop. (PR #430 codex review on
     # ``_ctm_env_pad.py``.)
     _bump_base_charges: np.ndarray | None = None
-    if ctm_cfg.chi_auto_bump:
+    if ctm_cfg.chi_auto_bump or config.gs_chi_schedule_steps is not None:
         _A_init = _params_to_A_norm(params)
         if isinstance(_A_init, SymmetricTensor):
             from tenax.algorithms._ctm_tensor_convergence import _get_base_charges
@@ -1272,6 +1272,20 @@ def _optimize_gs_ad_tensor(
                     prev_grad = None
                     prev_precond_grad = None
             elif config.gs_stall_recovery == "reset":
+                # Cap on CTMRGGradientError-driven reset path (#454 follow-up,
+                # codex review on PR #457).  Same retry budget as the
+                # post-line-search reset block; without this, an Arnoldi
+                # precheck failure loop could spin for all gs_num_steps.
+                if stall_count > config.gs_stall_recovery_retries:
+                    n_resets_done = stall_count - 1
+                    if config.gs_verbose:
+                        print(
+                            f"[iPEPS-AD] CTM-error stall budget exhausted after "
+                            f"{n_resets_done} resets, "
+                            f"returning best E={best_energy:.10f}",
+                            flush=True,
+                        )
+                    break
                 params = best_params
                 _env_cache.update(best_env_cache)
                 if is_metric_lbfgs:
@@ -2119,6 +2133,18 @@ def _optimize_gs_ad_tensor_2site(
                     prev_grad = None
                     prev_precond_grad = None
             elif config.gs_stall_recovery == "reset":
+                # Cap on CTMRGGradientError-driven reset path (#454 follow-up,
+                # codex review on PR #457).
+                if stall_count > config.gs_stall_recovery_retries:
+                    n_resets_done = stall_count - 1
+                    if config.gs_verbose:
+                        print(
+                            f"[iPEPS-AD] CTM-error stall budget exhausted after "
+                            f"{n_resets_done} resets, "
+                            f"returning best E={best_energy:.10f}",
+                            flush=True,
+                        )
+                    break
                 params = best_params
                 _env_cache_2s.update(best_env_cache_2s)
                 if is_metric_lbfgs:
@@ -2791,6 +2817,18 @@ def _optimize_gs_ad_multisite(
                 )
             stall_count += 1
             if config.gs_stall_recovery == "reset":
+                # Cap on CTMRGGradientError-driven reset path (#454 follow-up,
+                # codex review on PR #457).
+                if stall_count > config.gs_stall_recovery_retries:
+                    n_resets_done = stall_count - 1
+                    if config.gs_verbose:
+                        print(
+                            f"[iPEPS-AD] CTM-error stall budget exhausted after "
+                            f"{n_resets_done} resets, "
+                            f"returning best E={best_energy:.10f}",
+                            flush=True,
+                        )
+                    break
                 params = best_params
                 _env_cache.update(best_env_cache)
                 if is_metric_lbfgs:

--- a/tests/test_ipeps_ctm_stall_recovery_cap.py
+++ b/tests/test_ipeps_ctm_stall_recovery_cap.py
@@ -1,0 +1,81 @@
+"""Source-inspection test: the gs_stall_recovery_retries cap is applied at
+the CTMRGGradientError-driven reset paths in all three optimizer functions
+(#454 follow-up, codex review on PR #457).
+
+Inspecting the source rather than driving a real run because the failure mode
+(Arnoldi precheck rejecting CTM gradient repeatedly) requires a degenerate
+spectrum that's expensive to construct; the structural assertion that the
+cap exists before the rollback at each site catches regressions without
+needing to JIT-compile + run an iPEPS-AD step.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_SOURCE = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "tenax"
+    / "algorithms"
+    / "ipeps_optimize.py"
+).read_text()
+
+
+def _resets_from_ctm_error_handler() -> list[tuple[str, int]]:
+    """Find each (line, body) for a reset branch inside an except-CTMRGGradientError
+    handler — the path that surfaced this bug.
+
+    Both ``elif config.gs_stall_recovery == "reset":`` (1-site, 2-site) and
+    ``if config.gs_stall_recovery == "reset":`` (multisite) variants count.
+    """
+    pattern = re.compile(
+        r"(?:elif|if) config\.gs_stall_recovery == \"reset\":(?!\s*and stall_count > 0)",
+        re.MULTILINE,
+    )
+    matches = []
+    for m in pattern.finditer(_SOURCE):
+        line_no = _SOURCE[: m.start()].count("\n") + 1
+        # Pull the next ~200 chars of body to inspect.
+        body = _SOURCE[m.end() : m.end() + 1200]
+        matches.append((line_no, body))
+    return matches
+
+
+@pytest.mark.core
+def test_ctm_error_reset_paths_have_retry_cap():
+    """Each CTMRGGradientError-driven reset block must check
+    ``stall_count > config.gs_stall_recovery_retries`` and ``break`` before
+    rolling params back."""
+    sites = _resets_from_ctm_error_handler()
+    assert len(sites) == 3, (
+        f"expected 3 CTMRGGradientError reset sites (1-site, 2-site, multisite); "
+        f"got {len(sites)} at lines {[ln for ln, _ in sites]}"
+    )
+
+    for line_no, body in sites:
+        assert "stall_count > config.gs_stall_recovery_retries" in body, (
+            f"reset path at L{line_no} is missing the retry-budget check; "
+            f"the gs_stall_recovery_retries cap from PR #457 is bypassed at this site"
+        )
+        # The cap-check should occur BEFORE the rollback (params = best_params).
+        cap_idx = body.find("stall_count > config.gs_stall_recovery_retries")
+        rollback_idx = body.find("params = best_params")
+        assert rollback_idx == -1 or cap_idx < rollback_idx, (
+            f"at L{line_no}, the cap check must precede the rollback "
+            f"(cap_idx={cap_idx}, rollback_idx={rollback_idx})"
+        )
+        # The exhaustion log line must be present.
+        assert "CTM-error stall budget exhausted" in body, (
+            f"reset path at L{line_no} is missing the exhaustion log line"
+        )
+        # And a break statement before the closing `continue`.
+        assert (
+            "break" in body[: body.find("continue") if "continue" in body else 1200]
+        ), (
+            f"reset path at L{line_no} must `break` out of the loop on cap exhaustion, "
+            f"not just `continue` (which would loop forever)"
+        )


### PR DESCRIPTION
## Summary

Addresses Codex inline reviews on the now-merged #457 and #459:

1. **PR #457 follow-up — CTM-error reset cap (P2):** The `gs_stall_recovery_retries` cap added in #457 only fired in the post-line-search reset block. The same `gs_stall_recovery == "reset"` path is also used in the `CTMRGGradientError` handler at all three optimizers (1-site `ipeps_optimize.py:1274`, 2-site `:2135`, multisite `:2819`), where `stall_count` is incremented and the loop `continue`s without consulting the cap. A run where the Arnoldi precheck rejects the CTM gradient repeatedly could still reset for all `gs_num_steps`. This PR applies the same cap (with `break` and exhaustion log) before the rollback at all three sites.

2. **PR #459 follow-up — 1-site SymTensor base_charges (P2):** The 1-site `_bump_base_charges` setup was gated on `chi_auto_bump` only, while the 2-site/multisite setups (added in #459 commit `99b8f3d`) use the right `chi_auto_bump or gs_chi_schedule_steps is not None`. A 1-site SymmetricTensor run with `gs_chi_schedule_steps` and `chi_auto_bump=False` (the default after the Task 7 refactor) padded with `base_charges=None`, triggering the legacy post-CTM tiling that can starve later charge sectors. One-line gate fix; matches the 2-site/multisite condition.

## Test plan

- [x] New source-inspection regression test `tests/test_ipeps_ctm_stall_recovery_cap.py` (`@pytest.mark.core`, 3.08s): walks the source file and asserts each CTMRGGradientError reset block has the cap check, exhaustion log, `break`, and the rollback in that order. Fast — no JIT compile required.
- [x] Existing cap tests (`tests/test_ipeps_stall_recovery_cap.py`, `tests/test_ipeps_config_stall_recovery_retries.py`) untouched and still pass.

## Codex thread refs

- PR #457: [discussion_r3231594150](https://github.com/tenax-lab/tenax/pull/457#discussion_r3231594150)
- PR #459: [discussion_r3231890927](https://github.com/tenax-lab/tenax/pull/459#discussion_r3231890927)

Note: a third Codex comment on #459 ([discussion_r3231890925](https://github.com/tenax-lab/tenax/pull/459#discussion_r3231890925)) flagged that `chi` is a JAX `static_argname`, so logical-χ bumps still trigger a small per-stage recompile even with env-shape padding. That's a larger architectural change (pin static-arg to `chi_max` throughout; audit per-block dimensions for SymmetricTensor) — tracked in **#460**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)