### PR TITLE
fix(ipeps): chi_schedule shim off-by-one — bumps were one stage late (#453 followup)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -564,11 +564,16 @@ def optimize_gs_ad_chi_schedule(
     chi_max = max(chi for chi, _ in chi_schedule)
     total_steps = sum(n for _, n in chi_schedule)
 
+    # Build (cum_step_boundary, target_chi_to_bump_to) pairs.  Each entry
+    # says: "after this many cumulative steps complete, bump to this chi".
+    # Stage 0 is the initial chi (no bump needed); each subsequent stage
+    # is reached by bumping when the previous stage's cumulative step
+    # boundary is crossed.
     cum = 0
     schedule_targets: list[tuple[int, int]] = []
-    for chi, n in chi_schedule:
-        cum += n
-        schedule_targets.append((cum, chi))
+    for i in range(1, len(chi_schedule)):
+        cum += chi_schedule[i - 1][1]
+        schedule_targets.append((cum, chi_schedule[i][0]))
 
     ctm_cfg = replace(config.ctm, chi=chi_schedule[0][0], chi_max=chi_max)
     step_cfg = replace(

--- a/tests/test_optimize_gs_ad_chi_schedule_shim.py
+++ b/tests/test_optimize_gs_ad_chi_schedule_shim.py
@@ -59,10 +59,56 @@ def test_chi_schedule_shim_invokes_optimize_gs_ad_once(monkeypatch):
     assert inner_cfg.gs_num_steps == 10, (
         f"expected gs_num_steps=10 (sum of stage budgets), got {inner_cfg.gs_num_steps}"
     )
-    assert inner_cfg.gs_chi_schedule_steps == [(3, 4), (6, 8), (10, 16)], (
-        f"expected schedule_targets=[(3,4),(6,8),(10,16)], got {inner_cfg.gs_chi_schedule_steps}"
+    # schedule_targets entries are (cumulative_step_boundary, chi_to_bump_TO).
+    # For chi_schedule=[(4, 3), (8, 3), (16, 4)] the intended stages are:
+    #   - steps 1-3 at chi=4 (initial)
+    #   - after step 3 (cum=3), bump to chi=8
+    #   - steps 4-6 at chi=8
+    #   - after step 6 (cum=6), bump to chi=16
+    #   - steps 7-10 at chi=16
+    # So schedule_targets is the (cum, next-stage-chi) pairs for bumps only —
+    # the initial stage has no bump entry.
+    assert inner_cfg.gs_chi_schedule_steps == [(3, 8), (6, 16)], (
+        f"expected schedule_targets=[(3, 8), (6, 16)] (bump-to-next-stage), "
+        f"got {inner_cfg.gs_chi_schedule_steps}"
     )
     assert inner_cfg.ctm.chi == 4, f"expected initial chi=4, got {inner_cfg.ctm.chi}"
     assert inner_cfg.ctm.chi_max == 16, (
         f"expected chi_max=16, got {inner_cfg.ctm.chi_max}"
     )
+
+
+@pytest.mark.core
+def test_chi_schedule_single_stage_has_no_bumps():
+    """A single-stage chi_schedule should produce an empty schedule_targets list:
+    no boundaries, no bumps. The optimizer simply runs gs_num_steps at the
+    initial chi."""
+    captured = []
+
+    def _spy(gate, A_init, cfg):
+        captured.append(cfg)
+        return (A_init, None, 0.0)
+
+    import pytest as _pytest
+
+    base_cfg = iPEPSConfig(
+        unit_cell="1x1",
+        ctm=CTMConfig(chi=8),
+        gs_num_steps=200,
+        su_init=False,
+    )
+    with _pytest.MonkeyPatch.context() as mp:
+        mp.setattr(_opt, "optimize_gs_ad", _spy)
+        _opt.optimize_gs_ad_chi_schedule(
+            _trivial_gate(),
+            jnp.zeros((2, 2, 2, 2, 2), dtype=jnp.complex128),
+            base_cfg,
+            chi_schedule=[(8, 10)],
+        )
+    assert captured[0].gs_chi_schedule_steps == [], (
+        f"single-stage schedule should produce no bumps, "
+        f"got {captured[0].gs_chi_schedule_steps}"
+    )
+    assert captured[0].gs_num_steps == 10
+    assert captured[0].ctm.chi == 8
+    assert captured[0].ctm.chi_max == 8


### PR DESCRIPTION
## Summary

The unified χ-schedule shim from PR #459 was building `schedule_targets` incorrectly, causing all stage bumps to fire one stage later than intended.

## Bug

`optimize_gs_ad_chi_schedule` constructed:
\`\`\`python
cum = 0
schedule_targets = []
for chi, n in chi_schedule:
    cum += n
    schedule_targets.append((cum, chi))   # ← (cum_steps, this_stage_chi)
\`\`\`

But `_maybe_scheduled_bump` treats each entry as `(boundary, target_chi_to_bump_TO)`:

\`\`\`python
for boundary, chi_target in schedule_targets:
    if step >= boundary and chi_target > target_chi:
        target_chi = chi_target
\`\`\`

So for `chi_schedule=[(8, 30), (16, 30), (24, 20)]` the shim generated `[(30, 8), (60, 16), (80, 24)]`:

- `(30, 8)`: no-op (chi already 8)
- `(60, 16)`: bumps chi=8 → 16 at step 60 (should have been step 30)
- `(80, 24)`: bumps chi=16 → 24 at step 80 (after loop ends)

Effective stages: **59 steps at χ=8, 21 at χ=16, 0 at χ=24**. The intended split is 30/30/20.

## Observed impact (v3 benchmark)

Re-running the production benchmark with PRs #457 + #459 (and now #461) revealed this: the optimizer hit the stall cap at step 30 trying to converge chi=8 past its natural floor — because no bump to chi=16 was firing. The cap correctly bounded the runaway (PR #457 doing its job), but the chi-ramp wasn't actually advancing.

Trace from `/tmp/heisenberg_ipeps_v3.log`:
\`\`\`
[chi-ramp] unified: chi_max=24, total_steps=80, boundaries=[(30, 8), (60, 16), (80, 24)]
...
[iPEPS-AD:2site-tensor] step 30/80 E=-0.6623256925 dE=0.000e+00 E_best=-0.6623256925
[iPEPS-AD] stall #3, reset L-BFGS history (rollback to best, retry 3/5)
[iPEPS-AD] stall #4, reset L-BFGS history (rollback to best, retry 4/5)
[iPEPS-AD] stall #5, reset L-BFGS history (rollback to best, retry 5/5)
[iPEPS-AD] stall budget exhausted after 5 resets, returning best E=-0.6623256925
\`\`\`

The cap+rollback mechanism (PR #457) is proven correct on this trace, but the chi schedule wasn't doing its job.

## Fix

`schedule_targets` should encode only the bumps (one entry per stage boundary), with `(cum_steps_completed, next_stage_chi)`:

\`\`\`python
for i in range(1, len(chi_schedule)):
    cum += chi_schedule[i - 1][1]
    schedule_targets.append((cum, chi_schedule[i][0]))
\`\`\`

For `[(8, 30), (16, 30), (24, 20)]` this yields `[(30, 16), (60, 24)]` — the correct bumps at the correct steps.

## Why the existing test missed this

The shim's `test_chi_schedule_shim_invokes_optimize_gs_ad_once` asserted:

\`\`\`python
assert inner_cfg.gs_chi_schedule_steps == [(3, 4), (6, 8), (10, 16)]
\`\`\`

That was a tautology — checked that my buggy construction matches my buggy expectation. Rewrote it to verify the semantically-correct expected list `[(3, 8), (6, 16)]`. Added a single-stage no-bump test (`test_chi_schedule_single_stage_has_no_bumps`) to lock the invariant that one stage means zero bumps.

## Test plan

- [x] 12/12 fast unit tests pass (`test_optimize_gs_ad_chi_schedule_shim.py`, `test_maybe_scheduled_bump.py`, `test_apply_chi_bump.py`, `test_ctm_env_pad_chi_schedule.py`).
- [ ] v4 benchmark re-running with this fix (launched in parallel with this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)