### PR TITLE
fix(ipeps): reset stall_count + clear L-BFGS state on chi-schedule bump

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1368,6 +1368,7 @@ def _optimize_gs_ad_tensor(
             # Scheduled outer-loop χ bump (#453).  Composes with the
             # reactive bump above; ctm_cfg.chi_max caps both.
             if config.gs_chi_schedule_steps is not None:
+                chi_before = ctm_cfg.chi
                 ctm_cfg, _env_cache = _maybe_scheduled_bump(
                     ctm_cfg,
                     _env_cache,
@@ -1375,6 +1376,19 @@ def _optimize_gs_ad_tensor(
                     config.gs_chi_schedule_steps,
                     base_charges=_bump_base_charges,
                 )
+                if ctm_cfg.chi != chi_before:
+                    # Bump fired — fresh landscape, fresh stall budget.
+                    stall_count = 0
+                    if is_metric_lbfgs:
+                        lbfgs_history.clear()
+                        prev_A_flat = None
+                        prev_grad_flat = None
+                    if is_cg:
+                        cg_direction = None
+                        prev_grad = None
+                        prev_precond_grad = None
+                    if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                        opt_state = optimizer.init(params)
             if _accepted_best_this_iter:
                 best_env_cache = dict(_env_cache)
             if config.gs_verbose:
@@ -1648,6 +1662,7 @@ def _optimize_gs_ad_tensor(
         # Scheduled outer-loop χ bump (#453).  Composes with the reactive
         # bump above; ctm_cfg.chi_max caps both.
         if config.gs_chi_schedule_steps is not None:
+            chi_before = ctm_cfg.chi
             ctm_cfg, _env_cache = _maybe_scheduled_bump(
                 ctm_cfg,
                 _env_cache,
@@ -1655,6 +1670,19 @@ def _optimize_gs_ad_tensor(
                 config.gs_chi_schedule_steps,
                 base_charges=_bump_base_charges,
             )
+            if ctm_cfg.chi != chi_before:
+                # Bump fired — fresh landscape, fresh stall budget.
+                stall_count = 0
+                if is_metric_lbfgs:
+                    lbfgs_history.clear()
+                    prev_A_flat = None
+                    prev_grad_flat = None
+                if is_cg:
+                    cg_direction = None
+                    prev_grad = None
+                    prev_precond_grad = None
+                if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                    opt_state = optimizer.init(params)
         # If best was accepted at this iter's pre-line-search params, refresh
         # the snapshot so its env matches the new ctm_cfg.chi. ``_env_cache``
         # still holds envs for those params (line search updates ``params``
@@ -2519,6 +2547,7 @@ def _optimize_gs_ad_tensor_2site(
         # so the next iteration's value_and_grad sees the bumped χ — same
         # invariant as the 1-site path.
         if config.gs_chi_schedule_steps is not None:
+            chi_before = ctm_cfg_2s.chi
             ctm_cfg_2s, _env_cache_2s = _maybe_scheduled_bump(
                 ctm_cfg_2s,
                 _env_cache_2s,
@@ -2526,6 +2555,23 @@ def _optimize_gs_ad_tensor_2site(
                 config.gs_chi_schedule_steps,
                 base_charges=_bump_base_charges_2s,
             )
+            if ctm_cfg_2s.chi != chi_before:
+                # χ bump fired: a new landscape begins.  Reset the stall
+                # counter so the next stage gets a fresh retry budget;
+                # also clear L-BFGS curvature history so the first step
+                # at the new χ is plain steepest descent (curvature from
+                # the previous χ landscape isn't valid here).
+                stall_count = 0
+                if is_metric_lbfgs:
+                    lbfgs_history.clear()
+                    prev_params_flat = None
+                    prev_grad_flat = None
+                if is_cg:
+                    cg_direction = None
+                    prev_grad = None
+                    prev_precond_grad = None
+                if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                    opt_state = optimizer.init(params)
 
     # Re-evaluate both final params and best_params with fully converged
     # fresh CTM.  In-loop energies use warm-started CTM that can produce
@@ -3195,6 +3241,7 @@ def _optimize_gs_ad_multisite(
         # so the next iteration's value_and_grad sees the bumped χ — same
         # invariant as the 1-site path.
         if config.gs_chi_schedule_steps is not None:
+            chi_before = ctm_cfg.chi
             ctm_cfg, _env_cache = _maybe_scheduled_bump(
                 ctm_cfg,
                 _env_cache,
@@ -3202,6 +3249,19 @@ def _optimize_gs_ad_multisite(
                 config.gs_chi_schedule_steps,
                 base_charges=_bump_base_charges_multi,
             )
+            if ctm_cfg.chi != chi_before:
+                # Bump fired — fresh landscape, fresh stall budget.
+                stall_count = 0
+                if is_metric_lbfgs:
+                    lbfgs_history.clear()
+                    prev_params_flat = None
+                    prev_grad_flat = None
+                if is_cg:
+                    cg_direction = None
+                    prev_grad = None
+                    prev_precond_grad = None
+                if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                    opt_state = optimizer.init(params)
 
     # ── Final evaluation ─────────────────────────────────────────────────
     def _eval_fresh(p, env_init=None):


### PR DESCRIPTION
## Summary

When `optimize_gs_ad_chi_schedule`'s `_maybe_scheduled_bump` fires (logical χ changes between stages), the optimizer enters a new energy landscape: the chi=N best_params is not a local minimum at chi=M, and the chi=N gradient direction may not be a Wolfe-feasible step at chi=M. The PR #457 stall cap was designed to bound consecutive Wolfe failures *within* one landscape, not *across* landscape transitions.

## Bug

Observed in the v4 benchmark trace (`/tmp/heisenberg_ipeps_v4.log`):

\`\`\`
[iPEPS-AD] stall #1, reset L-BFGS history (rollback to best, retry 1/5)
[iPEPS-AD] stall #2, reset L-BFGS history (rollback to best, retry 2/5)
[iPEPS-AD:2site-tensor] step 30/80 E=-0.6623256925 dE=0.000e+00 E_best=-0.6623256925
[iPEPS-AD] stall #3, reset L-BFGS history (rollback to best, retry 3/5)
\`\`\`

End of χ=8 stage at step 30: `stall_count=2` because the chi=8 trajectory had stalled near convergence. Bump to χ=16 fires at end-of-step-30. Iteration 31's first chi=16 line search fails Wolfe → stall #3 (count carries over). Only 2 more retries until cap exhausts; run terminates at step ~33 with `E_best = chi=8 value`, no actual progress at chi=16.

The chi-stage transition resets the optimization context — curvature history from chi=8 is invalid at chi=16, the gradient direction differs, and cumulative Wolfe failures are landscape-specific. The cap behavior should reset too.

## Fix

When `_maybe_scheduled_bump` fires (detected by `ctm_cfg.chi != chi_before`), reset:

- `stall_count = 0` (fresh retry budget per stage)
- L-BFGS curvature history (`lbfgs_history.clear()`)
- Metric precond state (`prev_*_flat = None`)
- Optax opt_state (`optimizer.init(params)`)
- CG direction (when CG is the optimizer)

Applied at all four `_maybe_scheduled_bump` call sites:
- 1-site converged-exit path (`_optimize_gs_ad_tensor` ~L1370)
- 1-site step-end (`_optimize_gs_ad_tensor` ~L1664)
- 2-site step-end (`_optimize_gs_ad_tensor_2site` ~L2549)
- Multisite step-end (`_optimize_gs_ad_multisite` ~L3243)

## Test plan

- [x] All 12 existing fast unit tests pass.
- [ ] v5 benchmark in progress (launched in parallel).

## Related

- #453 (the χ-schedule shim).
- #457 (the stall cap whose semantics this clarifies).
- PR #462 (the off-by-one schedule fix from earlier today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)