### PR TITLE
fix(ipeps): also reset stall_count on reactive auto-bump (PR #464 codex follow-up)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1358,6 +1358,11 @@ def _optimize_gs_ad_tensor(
             # ctm_cfg.chi at exit — same behaviour as before the #419
             # move-to-end refactor. (PR #432 codex review; not picked up
             # in #432's squash, so re-included here.)
+            # Snapshot χ before either bump fires; the reset below triggers
+            # on EITHER reactive (_maybe_bump_chi) or scheduled
+            # (_maybe_scheduled_bump) bump changing it — both are landscape
+            # transitions (#464 codex review).
+            chi_before_bump = ctm_cfg.chi
             last_eps_t = float(_env_cache.get("max_truncation_error", 0.0))
             ctm_cfg, _env_cache = _maybe_bump_chi(
                 ctm_cfg,
@@ -1368,7 +1373,6 @@ def _optimize_gs_ad_tensor(
             # Scheduled outer-loop χ bump (#453).  Composes with the
             # reactive bump above; ctm_cfg.chi_max caps both.
             if config.gs_chi_schedule_steps is not None:
-                chi_before = ctm_cfg.chi
                 ctm_cfg, _env_cache = _maybe_scheduled_bump(
                     ctm_cfg,
                     _env_cache,
@@ -1376,19 +1380,20 @@ def _optimize_gs_ad_tensor(
                     config.gs_chi_schedule_steps,
                     base_charges=_bump_base_charges,
                 )
-                if ctm_cfg.chi != chi_before:
-                    # Bump fired — fresh landscape, fresh stall budget.
-                    stall_count = 0
-                    if is_metric_lbfgs:
-                        lbfgs_history.clear()
-                        prev_A_flat = None
-                        prev_grad_flat = None
-                    if is_cg:
-                        cg_direction = None
-                        prev_grad = None
-                        prev_precond_grad = None
-                    if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
-                        opt_state = optimizer.init(params)
+            if ctm_cfg.chi != chi_before_bump:
+                # Reactive or scheduled bump fired — fresh landscape,
+                # fresh stall budget (#464 codex review).
+                stall_count = 0
+                if is_metric_lbfgs:
+                    lbfgs_history.clear()
+                    prev_A_flat = None
+                    prev_grad_flat = None
+                if is_cg:
+                    cg_direction = None
+                    prev_grad = None
+                    prev_precond_grad = None
+                if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                    opt_state = optimizer.init(params)
             if _accepted_best_this_iter:
                 best_env_cache = dict(_env_cache)
             if config.gs_verbose:
@@ -1652,6 +1657,9 @@ def _optimize_gs_ad_tensor(
         # ``f(α)`` at NEW χ — a valid step gets rejected (or an invalid
         # one accepted) purely because of the χ-induced discontinuity.
         # Issue #419.
+        # Snapshot χ before either bump fires; the reset below triggers
+        # on EITHER reactive or scheduled bump changing it (#464 codex review).
+        chi_before_bump = ctm_cfg.chi
         last_eps_t = float(_env_cache.get("max_truncation_error", 0.0))
         ctm_cfg, _env_cache = _maybe_bump_chi(
             ctm_cfg,
@@ -1662,7 +1670,6 @@ def _optimize_gs_ad_tensor(
         # Scheduled outer-loop χ bump (#453).  Composes with the reactive
         # bump above; ctm_cfg.chi_max caps both.
         if config.gs_chi_schedule_steps is not None:
-            chi_before = ctm_cfg.chi
             ctm_cfg, _env_cache = _maybe_scheduled_bump(
                 ctm_cfg,
                 _env_cache,
@@ -1670,19 +1677,20 @@ def _optimize_gs_ad_tensor(
                 config.gs_chi_schedule_steps,
                 base_charges=_bump_base_charges,
             )
-            if ctm_cfg.chi != chi_before:
-                # Bump fired — fresh landscape, fresh stall budget.
-                stall_count = 0
-                if is_metric_lbfgs:
-                    lbfgs_history.clear()
-                    prev_A_flat = None
-                    prev_grad_flat = None
-                if is_cg:
-                    cg_direction = None
-                    prev_grad = None
-                    prev_precond_grad = None
-                if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
-                    opt_state = optimizer.init(params)
+        if ctm_cfg.chi != chi_before_bump:
+            # Reactive or scheduled bump fired — fresh landscape, fresh
+            # stall budget (#464 codex review).
+            stall_count = 0
+            if is_metric_lbfgs:
+                lbfgs_history.clear()
+                prev_A_flat = None
+                prev_grad_flat = None
+            if is_cg:
+                cg_direction = None
+                prev_grad = None
+                prev_precond_grad = None
+            if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                opt_state = optimizer.init(params)
         # If best was accepted at this iter's pre-line-search params, refresh
         # the snapshot so its env matches the new ctm_cfg.chi. ``_env_cache``
         # still holds envs for those params (line search updates ``params``


### PR DESCRIPTION
## Summary

Addresses Codex inline review on PR #464 ([discussion_r3233535031](https://github.com/tenax-lab/tenax/pull/464#discussion_r3233535031)) — PR #464's stall_count reset missed two related cases on the 1-site path:

1. **Reactive auto-bump (`_maybe_bump_chi`, variPEPS §2.8.2 `chi_auto_bump`) was not snapshotted.** The `chi_before = ctm_cfg.chi` snapshot happened *after* `_maybe_bump_chi` already ran, so a reactive chi change was invisible to the equality check and the reset never fired.

2. **With `gs_chi_schedule_steps=None` (chi_auto_bump-only configuration), the reset block was unreachable.** The reset lived entirely inside `if config.gs_chi_schedule_steps is not None`.

The benchmark trajectory that prompted PR #464 used `chi_auto_bump=False` with `gs_chi_schedule_steps` set, so neither bug affected it. But the 1-site auto-bump path used by §2.8.2 production runs hits both.

## Fix

Hoist the `chi_before` snapshot *before* `_maybe_bump_chi`, then check `ctm_cfg.chi != chi_before_bump` unconditionally (outside any schedule guard):

\`\`\`python
chi_before_bump = ctm_cfg.chi
last_eps_t = ...
ctm_cfg, _env_cache = _maybe_bump_chi(...)  # reactive
if config.gs_chi_schedule_steps is not None:
    ctm_cfg, _env_cache = _maybe_scheduled_bump(...)
if ctm_cfg.chi != chi_before_bump:
    stall_count = 0
    # ...clear L-BFGS / opt_state...
\`\`\`

Applied at both 1-site sites (converged-exit path L1362 and step-end path L1661).

2-site (`_optimize_gs_ad_tensor_2site`) and multisite (`_optimize_gs_ad_multisite`) don't call `_maybe_bump_chi` at all — only scheduled bumps — so they're already correct and untouched.

## Test plan

- [x] All 12 fast unit tests pass.
- v5 benchmark (in flight on `chi_auto_bump=False`) unaffected.

## Related

- PR #464 — the original stall_count reset.
- Codex thread: [pull/464#discussion_r3233535031](https://github.com/tenax-lab/tenax/pull/464#discussion_r3233535031).

🤖 Generated with [Claude Code](https://claude.com/claude-code)