### PR TITLE
feat(ipeps): convergence-triggered adaptive chi ramping (#455)

### DIFF
--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -47,6 +47,16 @@ class CTMConfig:
                             ``chi_auto_bump_eps``.  Mutually exclusive with
                             ``chi_ramp`` (a deterministic schedule).
                             Off by default.
+
+                            For new code, prefer ``chi_schedule`` +
+                            ``optimize_gs_ad_chi_schedule`` with
+                            convergence-triggered ramping (#455);
+                            ``chi_auto_bump`` is retained as an
+                            orthogonal CTM-truncation sentinel for the
+                            case where the optimizer is making progress
+                            but ε_T indicates CTM under-resolution.
+                            These two mechanisms compose (reactive fires
+                            first, scheduled second).
         chi_auto_bump_eps:  Truncation-error threshold that triggers an
                             auto-χ bump.  Default ``1e-5`` follows
                             variPEPS §2.8.2.

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2377,6 +2377,62 @@ def _optimize_gs_ad_tensor_2site(
             else None
         )
         if _converged_outer(config, delta_energy, grad_norm_val):
+            # #455 PR2: at non-final χ stages, treat convergence as a
+            # signal to advance to the next stage rather than exit.
+            # Mirrors the 1-site convergence-block intercept.
+            bump_fired = False
+            if config.gs_chi_schedule_steps is not None:
+                chi_before_bump = ctm_cfg_2s.chi
+                steps_in_stage = (step + 1) - stage_start_step
+                _gn_for_bump = (
+                    grad_norm_val
+                    if grad_norm_val is not None
+                    else (
+                        _grad_l2_norm(grads)
+                        if config.gs_conv_criterion != "dE"
+                        else 0.0
+                    )
+                )
+                (
+                    ctm_cfg_2s,
+                    _env_cache_2s,
+                    new_stage_idx,
+                    bump_fired,
+                    _,
+                ) = _advance_chi_stage_if_due(
+                    ctm_cfg_2s,
+                    _env_cache_2s,
+                    chi_schedule=config.gs_chi_schedule_steps,
+                    current_stage_idx=current_stage_idx,
+                    steps_in_stage=steps_in_stage,
+                    config=config,
+                    grad_norm=_gn_for_bump,
+                    delta_energy=delta_energy,
+                    stall_count=stall_count,
+                    base_charges=_bump_base_charges_2s,
+                )
+                if bump_fired:
+                    current_stage_idx = new_stage_idx
+                    stage_start_step = step + 1
+                    stall_count = 0
+                    if is_metric_lbfgs:
+                        lbfgs_history.clear()
+                        prev_params_flat = None
+                        prev_grad_flat = None
+                    if is_cg:
+                        cg_direction = None
+                        prev_grad = None
+                        prev_precond_grad = None
+                    if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                        opt_state = optimizer.init(params)
+                    if config.gs_verbose:
+                        print(
+                            f"[iPEPS-AD step {step + 1}] converged at "
+                            f"chi={chi_before_bump} → bumping to "
+                            f"chi={ctm_cfg_2s.chi} (#455 PR2)",
+                            flush=True,
+                        )
+                    continue
             if config.gs_verbose:
                 if not logged:
                     _log_ad_step(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1395,7 +1395,7 @@ def _optimize_gs_ad_tensor(
                         else 0.0
                     )
                 )
-                ctm_cfg, _env_cache, new_stage_idx, _bump_fired, _ = (
+                ctm_cfg, _env_cache, new_stage_idx, bump_fired, _ = (
                     _advance_chi_stage_if_due(
                         ctm_cfg,
                         _env_cache,
@@ -1412,6 +1412,8 @@ def _optimize_gs_ad_tensor(
                 if new_stage_idx != current_stage_idx:
                     current_stage_idx = new_stage_idx
                     stage_start_step = step + 1
+            else:
+                bump_fired = False
             if ctm_cfg.chi != chi_before_bump:
                 # Reactive or scheduled bump fired — fresh landscape,
                 # fresh stall budget (#464 codex review).
@@ -1428,6 +1430,20 @@ def _optimize_gs_ad_tensor(
                     opt_state = optimizer.init(params)
             if _accepted_best_this_iter:
                 best_env_cache = dict(_env_cache)
+            if bump_fired:
+                # #455 PR2: converged at non-final stage → advance and
+                # continue, NOT break.  The reset block above already
+                # cleared stall_count, L-BFGS history, and opt_state at
+                # the new χ; let the optimizer keep stepping on the
+                # fresh landscape rather than exit prematurely.
+                if config.gs_verbose:
+                    print(
+                        f"[iPEPS-AD step {step + 1}] converged at "
+                        f"chi={chi_before_bump} → bumping to "
+                        f"chi={ctm_cfg.chi} (#455 PR2)",
+                        flush=True,
+                    )
+                continue
             if config.gs_verbose:
                 if not logged:
                     _log_ad_step(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1387,7 +1387,13 @@ def _optimize_gs_ad_tensor(
             if config.gs_chi_schedule_steps is not None:
                 steps_in_stage = (step + 1) - stage_start_step
                 _gn_for_bump = (
-                    grad_norm_val if grad_norm_val is not None else _grad_l2_norm(grads)
+                    grad_norm_val
+                    if grad_norm_val is not None
+                    else (
+                        _grad_l2_norm(grads)
+                        if config.gs_conv_criterion != "dE"
+                        else 0.0
+                    )
                 )
                 ctm_cfg, _env_cache, new_stage_idx, _bump_fired, _ = (
                     _advance_chi_stage_if_due(
@@ -1700,7 +1706,9 @@ def _optimize_gs_ad_tensor(
         if config.gs_chi_schedule_steps is not None:
             steps_in_stage = (step + 1) - stage_start_step
             _gn_for_bump = (
-                grad_norm_val if grad_norm_val is not None else _grad_l2_norm(grads)
+                grad_norm_val
+                if grad_norm_val is not None
+                else (_grad_l2_norm(grads) if config.gs_conv_criterion != "dE" else 0.0)
             )
             ctm_cfg, _env_cache, new_stage_idx, _bump_fired, _should_break = (
                 _advance_chi_stage_if_due(
@@ -2604,7 +2612,9 @@ def _optimize_gs_ad_tensor_2site(
             steps_in_stage = (step + 1) - stage_start_step
             chi_before = ctm_cfg_2s.chi
             _gn_for_bump = (
-                grad_norm_val if grad_norm_val is not None else _grad_l2_norm(grads)
+                grad_norm_val
+                if grad_norm_val is not None
+                else (_grad_l2_norm(grads) if config.gs_conv_criterion != "dE" else 0.0)
             )
             ctm_cfg_2s, _env_cache_2s, new_stage_idx, _bump_fired, _should_break = (
                 _advance_chi_stage_if_due(
@@ -3316,7 +3326,9 @@ def _optimize_gs_ad_multisite(
             steps_in_stage = (step + 1) - stage_start_step
             chi_before = ctm_cfg.chi
             _gn_for_bump = (
-                grad_norm_val if grad_norm_val is not None else _grad_l2_norm(grads)
+                grad_norm_val
+                if grad_norm_val is not None
+                else (_grad_l2_norm(grads) if config.gs_conv_criterion != "dE" else 0.0)
             )
             ctm_cfg, _env_cache, new_stage_idx, _bump_fired, _should_break = (
                 _advance_chi_stage_if_due(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -3244,6 +3244,62 @@ def _optimize_gs_ad_multisite(
         needs_warmup = config.gs_conv_criterion in ("dE", "both")
         warmup_ok = (not needs_warmup) or (step > 5 and stall_count == 0)
         if _converged_outer(config, delta_energy, grad_norm_val) and warmup_ok:
+            # #455 PR2: at non-final χ stages, treat convergence as a
+            # signal to advance to the next stage rather than exit.
+            # Mirrors the 1-site / 2-site convergence-block intercepts.
+            bump_fired = False
+            if config.gs_chi_schedule_steps is not None:
+                chi_before_bump = ctm_cfg.chi
+                steps_in_stage = (step + 1) - stage_start_step
+                _gn_for_bump = (
+                    grad_norm_val
+                    if grad_norm_val is not None
+                    else (
+                        _grad_l2_norm(grads)
+                        if config.gs_conv_criterion != "dE"
+                        else 0.0
+                    )
+                )
+                (
+                    ctm_cfg,
+                    _env_cache,
+                    new_stage_idx,
+                    bump_fired,
+                    _,
+                ) = _advance_chi_stage_if_due(
+                    ctm_cfg,
+                    _env_cache,
+                    chi_schedule=config.gs_chi_schedule_steps,
+                    current_stage_idx=current_stage_idx,
+                    steps_in_stage=steps_in_stage,
+                    config=config,
+                    grad_norm=_gn_for_bump,
+                    delta_energy=delta_energy,
+                    stall_count=stall_count,
+                    base_charges=_bump_base_charges_multi,
+                )
+                if bump_fired:
+                    current_stage_idx = new_stage_idx
+                    stage_start_step = step + 1
+                    stall_count = 0
+                    if is_metric_lbfgs:
+                        lbfgs_history.clear()
+                        prev_params_flat = None
+                        prev_grad_flat = None
+                    if is_cg:
+                        cg_direction = None
+                        prev_grad = None
+                        prev_precond_grad = None
+                    if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                        opt_state = optimizer.init(params)
+                    if config.gs_verbose:
+                        print(
+                            f"[iPEPS-AD step {step + 1}] converged at "
+                            f"chi={chi_before_bump} → bumping to "
+                            f"chi={ctm_cfg.chi} (#455 PR2)",
+                            flush=True,
+                        )
+                    continue
             if config.gs_verbose:
                 if not logged:
                     _log_ad_step(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -3504,6 +3504,66 @@ def _optimize_gs_ad_multisite(
                 # projector, pre-multisite-CTM rewrite, pre-PR #447 AD
                 # stop_gradient) and no longer applies.
                 if stall_count > config.gs_stall_recovery_retries:
+                    # #455 PR2: at non-final χ stages, treat stall-cap
+                    # exhaustion as a signal to advance the χ schedule
+                    # rather than exit with best_energy.  Mirrors the
+                    # 1-site (07ffe8e) and 2-site (41e590f) intercepts.
+                    if config.gs_chi_schedule_steps is not None:
+                        steps_in_stage = (step + 1) - stage_start_step
+                        _gn_for_bump = (
+                            grad_norm_val
+                            if grad_norm_val is not None
+                            else (
+                                _grad_l2_norm(grads)
+                                if config.gs_conv_criterion != "dE"
+                                else 0.0
+                            )
+                        )
+                        (
+                            ctm_cfg,
+                            _env_cache,
+                            new_stage_idx,
+                            bump_fired,
+                            _,
+                        ) = _advance_chi_stage_if_due(
+                            ctm_cfg,
+                            _env_cache,
+                            chi_schedule=config.gs_chi_schedule_steps,
+                            current_stage_idx=current_stage_idx,
+                            steps_in_stage=steps_in_stage,
+                            config=config,
+                            grad_norm=_gn_for_bump,
+                            delta_energy=delta_energy,
+                            stall_count=stall_count,
+                            base_charges=_bump_base_charges_multi,
+                        )
+                        if bump_fired:
+                            current_stage_idx = new_stage_idx
+                            stage_start_step = step + 1
+                            params = best_params
+                            _env_cache.update(best_env_cache)
+                            stall_count = 0
+                            if is_metric_lbfgs:
+                                lbfgs_history.clear()
+                                prev_params_flat = None
+                                prev_grad_flat = None
+                            if is_cg:
+                                cg_direction = None
+                                prev_grad = None
+                                prev_precond_grad = None
+                            if (
+                                optimizer is not None
+                                and config.gs_optimizer.lower() == "lbfgs"
+                            ):
+                                opt_state = optimizer.init(params)
+                            if config.gs_verbose:
+                                print(
+                                    f"[iPEPS-AD step {step + 1}] stall-cap at "
+                                    f"chi={ctm_cfg.chi} → advancing to next "
+                                    f"stage (#455 PR2)",
+                                    flush=True,
+                                )
+                            continue
                     n_resets_done = stall_count - 1
                     if config.gs_verbose:
                         print(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1428,11 +1428,21 @@ def _optimize_gs_ad_tensor(
                         base_charges=_bump_base_charges,
                     )
                 )
-                if new_stage_idx != current_stage_idx:
+                # Codex review (PR #467): the helper's idempotent-advance
+                # branch returns ``bump_fired=False`` AND
+                # ``new_stage_idx > current_stage_idx`` when a reactive
+                # ε_T-bump already raised χ past the next stage's target.
+                # The schedule index must STILL advance, and the
+                # ``continue`` below must STILL fire — otherwise the
+                # optimizer exits at the previous stage's converged
+                # energy.  ``stage_advanced`` decouples the two signals.
+                stage_advanced = new_stage_idx != current_stage_idx
+                if stage_advanced:
                     current_stage_idx = new_stage_idx
                     stage_start_step = step + 1
             else:
                 bump_fired = False
+                stage_advanced = False
             if ctm_cfg.chi != chi_before_bump:
                 # Reactive or scheduled bump fired — fresh landscape,
                 # fresh stall budget (#464 codex review).
@@ -1449,12 +1459,20 @@ def _optimize_gs_ad_tensor(
                     opt_state = optimizer.init(params)
             if _accepted_best_this_iter:
                 best_env_cache = dict(_env_cache)
-            if bump_fired:
+            if bump_fired or stage_advanced:
                 # #455 PR2: converged at non-final stage → advance and
                 # continue, NOT break.  The reset block above already
                 # cleared stall_count, L-BFGS history, and opt_state at
                 # the new χ; let the optimizer keep stepping on the
                 # fresh landscape rather than exit prematurely.
+                #
+                # Codex review (PR #467): ``stage_advanced`` covers the
+                # idempotent-advance branch where the reactive bump
+                # already raised χ past the next stage's target — the
+                # schedule index moved forward but ``bump_fired=False``.
+                # Without the disjunction, we would fall through to
+                # break and exit at stage N's converged energy without
+                # ever running stage N+1.
                 if config.gs_verbose:
                     print(
                         f"[iPEPS-AD step {step + 1}] converged at "
@@ -1713,9 +1731,20 @@ def _optimize_gs_ad_tensor(
                             stall_count=stall_count,
                             base_charges=_bump_base_charges,
                         )
-                        if bump_fired:
+                        # Codex review (PR #467): treat idempotent
+                        # advance (bump_fired=False AND
+                        # new_stage_idx>current_stage_idx) the same as
+                        # a real bump for control-flow purposes —
+                        # otherwise the stall-cap intercept would still
+                        # break.  The reset block (params rollback,
+                        # stall_count=0, L-BFGS clear, opt_state init)
+                        # stays gated on bump_fired because it only
+                        # makes sense when χ actually changed.
+                        stage_advanced = new_stage_idx != current_stage_idx
+                        if stage_advanced:
                             current_stage_idx = new_stage_idx
                             stage_start_step = step + 1
+                        if bump_fired:
                             # Rollback params to best from the previous
                             # stage; _env_cache stays at the freshly
                             # padded post-bump state (the budget-path
@@ -1742,6 +1771,7 @@ def _optimize_gs_ad_tensor(
                                     f"stage (#455 PR2)",
                                     flush=True,
                                 )
+                        if bump_fired or stage_advanced:
                             continue
                     n_resets_done = stall_count - 1
                     if config.gs_verbose:
@@ -2430,9 +2460,17 @@ def _optimize_gs_ad_tensor_2site(
                     stall_count=stall_count,
                     base_charges=_bump_base_charges_2s,
                 )
-                if bump_fired:
+                # Codex review (PR #467): decouple the schedule index
+                # advance from bump_fired so idempotent advances
+                # (bump_fired=False AND new_stage_idx>current_stage_idx)
+                # still continue rather than fall through to break.
+                # The reset block (stall_count, L-BFGS, opt_state)
+                # stays gated on bump_fired (chi actually changed).
+                stage_advanced = new_stage_idx != current_stage_idx
+                if stage_advanced:
                     current_stage_idx = new_stage_idx
                     stage_start_step = step + 1
+                if bump_fired:
                     stall_count = 0
                     if is_metric_lbfgs:
                         lbfgs_history.clear()
@@ -2451,6 +2489,7 @@ def _optimize_gs_ad_tensor_2site(
                             f"chi={ctm_cfg_2s.chi} (#455 PR2)",
                             flush=True,
                         )
+                if bump_fired or stage_advanced:
                     continue
             if config.gs_verbose:
                 if not logged:
@@ -2755,9 +2794,15 @@ def _optimize_gs_ad_tensor_2site(
                             stall_count=stall_count,
                             base_charges=_bump_base_charges_2s,
                         )
-                        if bump_fired:
+                        # Codex review (PR #467): see 1-site stall-cap
+                        # intercept for rationale.  Decouple schedule
+                        # advance from bump_fired; keep reset block
+                        # gated on bump_fired.
+                        stage_advanced = new_stage_idx != current_stage_idx
+                        if stage_advanced:
                             current_stage_idx = new_stage_idx
                             stage_start_step = step + 1
+                        if bump_fired:
                             # Rollback params to best from the previous
                             # stage; _env_cache_2s stays at the freshly
                             # padded post-bump state (the budget-path
@@ -2784,6 +2829,7 @@ def _optimize_gs_ad_tensor_2site(
                                     f"stage (#455 PR2)",
                                     flush=True,
                                 )
+                        if bump_fired or stage_advanced:
                             continue
                     n_resets_done = stall_count - 1
                     if config.gs_verbose:
@@ -3300,9 +3346,15 @@ def _optimize_gs_ad_multisite(
                     stall_count=stall_count,
                     base_charges=_bump_base_charges_multi,
                 )
-                if bump_fired:
+                # Codex review (PR #467): see 1-site / 2-site
+                # convergence intercept for rationale.  Decouple
+                # schedule advance from bump_fired; keep reset block
+                # gated on bump_fired.
+                stage_advanced = new_stage_idx != current_stage_idx
+                if stage_advanced:
                     current_stage_idx = new_stage_idx
                     stage_start_step = step + 1
+                if bump_fired:
                     stall_count = 0
                     if is_metric_lbfgs:
                         lbfgs_history.clear()
@@ -3321,6 +3373,7 @@ def _optimize_gs_ad_multisite(
                             f"chi={ctm_cfg.chi} (#455 PR2)",
                             flush=True,
                         )
+                if bump_fired or stage_advanced:
                     continue
             if config.gs_verbose:
                 if not logged:
@@ -3559,9 +3612,15 @@ def _optimize_gs_ad_multisite(
                             stall_count=stall_count,
                             base_charges=_bump_base_charges_multi,
                         )
-                        if bump_fired:
+                        # Codex review (PR #467): see 1-site stall-cap
+                        # intercept for rationale.  Decouple schedule
+                        # advance from bump_fired; keep reset block
+                        # gated on bump_fired.
+                        stage_advanced = new_stage_idx != current_stage_idx
+                        if stage_advanced:
                             current_stage_idx = new_stage_idx
                             stage_start_step = step + 1
+                        if bump_fired:
                             # Rollback params to best from the previous
                             # stage; _env_cache stays at the freshly
                             # padded post-bump state (the budget-path
@@ -3588,6 +3647,7 @@ def _optimize_gs_ad_multisite(
                                     f"stage (#455 PR2)",
                                     flush=True,
                                 )
+                        if bump_fired or stage_advanced:
                             continue
                     n_resets_done = stall_count - 1
                     if config.gs_verbose:

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2703,6 +2703,66 @@ def _optimize_gs_ad_tensor_2site(
                 # projector, pre-multisite-CTM rewrite, pre-PR #447 AD
                 # stop_gradient) and no longer applies.
                 if stall_count > config.gs_stall_recovery_retries:
+                    # #455 PR2: at non-final χ stages, treat stall-cap
+                    # exhaustion as a signal to advance the χ schedule
+                    # rather than exit with best_energy.  Mirrors the
+                    # 1-site stall-cap intercept (commit 07ffe8e).
+                    if config.gs_chi_schedule_steps is not None:
+                        steps_in_stage = (step + 1) - stage_start_step
+                        _gn_for_bump = (
+                            grad_norm_val
+                            if grad_norm_val is not None
+                            else (
+                                _grad_l2_norm(grads)
+                                if config.gs_conv_criterion != "dE"
+                                else 0.0
+                            )
+                        )
+                        (
+                            ctm_cfg_2s,
+                            _env_cache_2s,
+                            new_stage_idx,
+                            bump_fired,
+                            _,
+                        ) = _advance_chi_stage_if_due(
+                            ctm_cfg_2s,
+                            _env_cache_2s,
+                            chi_schedule=config.gs_chi_schedule_steps,
+                            current_stage_idx=current_stage_idx,
+                            steps_in_stage=steps_in_stage,
+                            config=config,
+                            grad_norm=_gn_for_bump,
+                            delta_energy=delta_energy,
+                            stall_count=stall_count,
+                            base_charges=_bump_base_charges_2s,
+                        )
+                        if bump_fired:
+                            current_stage_idx = new_stage_idx
+                            stage_start_step = step + 1
+                            params = best_params
+                            _env_cache_2s.update(best_env_cache_2s)
+                            stall_count = 0
+                            if is_metric_lbfgs:
+                                lbfgs_history.clear()
+                                prev_params_flat = None
+                                prev_grad_flat = None
+                            if is_cg:
+                                cg_direction = None
+                                prev_grad = None
+                                prev_precond_grad = None
+                            if (
+                                optimizer is not None
+                                and config.gs_optimizer.lower() == "lbfgs"
+                            ):
+                                opt_state = optimizer.init(params)
+                            if config.gs_verbose:
+                                print(
+                                    f"[iPEPS-AD step {step + 1}] stall-cap at "
+                                    f"chi={ctm_cfg_2s.chi} → advancing to next "
+                                    f"stage (#455 PR2)",
+                                    flush=True,
+                                )
+                            continue
                     n_resets_done = stall_count - 1
                     if config.gs_verbose:
                         print(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1697,11 +1697,11 @@ def _optimize_gs_ad_tensor(
                         if bump_fired:
                             current_stage_idx = new_stage_idx
                             stage_start_step = step + 1
-                            # Rollback to best at the new χ so we keep
-                            # the best params from the previous stage as
-                            # the starting point for this one.
+                            # Rollback params to best from the previous
+                            # stage; _env_cache stays at the freshly
+                            # padded post-bump state (the budget-path
+                            # invariant — see _apply_chi_bump).
                             params = best_params
-                            _env_cache.update(best_env_cache)
                             stall_count = 0
                             if is_metric_lbfgs:
                                 lbfgs_history.clear()
@@ -2739,8 +2739,11 @@ def _optimize_gs_ad_tensor_2site(
                         if bump_fired:
                             current_stage_idx = new_stage_idx
                             stage_start_step = step + 1
+                            # Rollback params to best from the previous
+                            # stage; _env_cache_2s stays at the freshly
+                            # padded post-bump state (the budget-path
+                            # invariant — see _apply_chi_bump).
                             params = best_params
-                            _env_cache_2s.update(best_env_cache_2s)
                             stall_count = 0
                             if is_metric_lbfgs:
                                 lbfgs_history.clear()
@@ -3540,8 +3543,11 @@ def _optimize_gs_ad_multisite(
                         if bump_fired:
                             current_stage_idx = new_stage_idx
                             stage_start_step = step + 1
+                            # Rollback params to best from the previous
+                            # stage; _env_cache stays at the freshly
+                            # padded post-bump state (the budget-path
+                            # invariant — see _apply_chi_bump).
                             params = best_params
-                            _env_cache.update(best_env_cache)
                             stall_count = 0
                             if is_metric_lbfgs:
                                 lbfgs_history.clear()

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1660,6 +1660,70 @@ def _optimize_gs_ad_tensor(
                 # projector, pre-multisite-CTM rewrite, pre-PR #447 AD
                 # stop_gradient) and no longer applies.
                 if stall_count > config.gs_stall_recovery_retries:
+                    # #455 PR2: at non-final χ stages, the stall-cap hit
+                    # means "this χ is too small to make progress" —
+                    # advance to the next stage and keep optimizing
+                    # instead of returning best_energy.  Final stage
+                    # falls through to the existing break.
+                    if config.gs_chi_schedule_steps is not None:
+                        steps_in_stage = (step + 1) - stage_start_step
+                        _gn_for_bump = (
+                            grad_norm_val
+                            if grad_norm_val is not None
+                            else (
+                                _grad_l2_norm(grads)
+                                if config.gs_conv_criterion != "dE"
+                                else 0.0
+                            )
+                        )
+                        (
+                            ctm_cfg,
+                            _env_cache,
+                            new_stage_idx,
+                            bump_fired,
+                            _,
+                        ) = _advance_chi_stage_if_due(
+                            ctm_cfg,
+                            _env_cache,
+                            chi_schedule=config.gs_chi_schedule_steps,
+                            current_stage_idx=current_stage_idx,
+                            steps_in_stage=steps_in_stage,
+                            config=config,
+                            grad_norm=_gn_for_bump,
+                            delta_energy=delta_energy,
+                            stall_count=stall_count,
+                            base_charges=_bump_base_charges,
+                        )
+                        if bump_fired:
+                            current_stage_idx = new_stage_idx
+                            stage_start_step = step + 1
+                            # Rollback to best at the new χ so we keep
+                            # the best params from the previous stage as
+                            # the starting point for this one.
+                            params = best_params
+                            _env_cache.update(best_env_cache)
+                            stall_count = 0
+                            if is_metric_lbfgs:
+                                lbfgs_history.clear()
+                                prev_A_flat = None
+                                prev_grad_flat = None
+                            if is_cg:
+                                cg_direction = None
+                                prev_grad = None
+                                prev_precond_grad = None
+                            if (
+                                optimizer is not None
+                                and config.gs_optimizer.lower() == "lbfgs"
+                            ):
+                                opt_state = optimizer.init(params)
+                            if config.gs_verbose:
+                                print(
+                                    f"[iPEPS-AD step {step + 1}] stall-cap at "
+                                    f"chi={ctm_cfg.chi} → advancing to next "
+                                    f"stage (#455 PR2)",
+                                    flush=True,
+                                )
+                            continue
                     n_resets_done = stall_count - 1
                     if config.gs_verbose:
                         print(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -105,34 +105,24 @@ def _advance_chi_stage_if_due(
     chi_schedule: list[tuple[int, int]] | None,
     current_stage_idx: int,
     steps_in_stage: int,
+    config: iPEPSConfig,
+    grad_norm: float,
+    delta_energy: float,
+    stall_count: int,
     base_charges: np.ndarray | None = None,
 ) -> tuple[CTMConfig, dict, int, bool, bool]:
     """Decide whether to advance to the next χ stage and apply it (#455).
 
-    Inputs:
-        ctm_cfg, env_cache: current CTM state.
-        chi_schedule: per-stage list ``[(target_chi, max_steps), ...]``,
-            or ``None`` (no schedule).
-        current_stage_idx: which stage is currently active (0-based).
-        steps_in_stage: number of completed optimizer steps in the
-            current stage (1-based at end-of-step).
-        base_charges: SymmetricTensor base charges (ignored on dense).
+    Three signals trigger an advance at non-final stages:
+        - ``steps_in_stage >= max_steps`` (budget; existing).
+        - ``_converged_outer(config, delta_energy, grad_norm)``
+          (NEW PR 2 — reuses user's gs_conv_criterion).
+        - ``stall_count >= config.gs_stall_recovery_retries`` AND
+          ``config.gs_stall_recovery == "reset"`` (NEW PR 2 —
+          gated to reset path; noise path has its own retries).
 
-    Returns:
-        (new_ctm_cfg, new_env_cache, new_stage_idx, bump_fired, should_break)
-
-    PR 1 trigger: budget-exhausted only
-    (``steps_in_stage >= chi_schedule[current_stage_idx][1]``).
-    PR 2 will extend to convergence + stall-cap.
-
-    Behavior:
-        - No schedule, or not yet at budget: no-op, returns
-          ``(ctm_cfg, env_cache, current_stage_idx, False, False)``.
-        - Budget hit at non-final stage: bump chi to next stage's
-          target via ``_apply_chi_bump``, advance ``current_stage_idx``,
-          return ``bump_fired=True``.
-        - Budget hit at final stage: return
-          ``should_break=True`` (no bump; caller exits the loop).
+    At the final stage all three trigger ``should_break=True`` with
+    no bump (matches existing exit semantics).
     """
     if not chi_schedule:
         return ctm_cfg, env_cache, current_stage_idx, False, False
@@ -140,12 +130,19 @@ def _advance_chi_stage_if_due(
     _, stage_max_steps = chi_schedule[current_stage_idx]
     budget_exhausted = steps_in_stage >= stage_max_steps
 
-    if not budget_exhausted:
+    converged = _converged_outer(config, delta_energy, grad_norm)
+
+    stall_exhausted = (
+        config.gs_stall_recovery == "reset"
+        and stall_count >= config.gs_stall_recovery_retries
+    )
+
+    should_advance = budget_exhausted or converged or stall_exhausted
+    if not should_advance:
         return ctm_cfg, env_cache, current_stage_idx, False, False
 
     has_next = (current_stage_idx + 1) < len(chi_schedule)
     if not has_next:
-        # Final stage budget exhausted → caller should break out.
         return ctm_cfg, env_cache, current_stage_idx, False, True
 
     next_chi, _ = chi_schedule[current_stage_idx + 1]
@@ -153,8 +150,6 @@ def _advance_chi_stage_if_due(
         next_chi = min(next_chi, ctm_cfg.chi_max)
 
     if next_chi <= ctm_cfg.chi:
-        # Already at or above the next stage's target — advance index
-        # without re-applying a bump (matches old idempotent semantics).
         return ctm_cfg, env_cache, current_stage_idx + 1, False, False
 
     new_ctm_cfg, new_env_cache = _apply_chi_bump(
@@ -1391,6 +1386,9 @@ def _optimize_gs_ad_tensor(
             # PR 2 layers convergence/stall signals on top.
             if config.gs_chi_schedule_steps is not None:
                 steps_in_stage = (step + 1) - stage_start_step
+                _gn_for_bump = (
+                    grad_norm_val if grad_norm_val is not None else _grad_l2_norm(grads)
+                )
                 ctm_cfg, _env_cache, new_stage_idx, _bump_fired, _ = (
                     _advance_chi_stage_if_due(
                         ctm_cfg,
@@ -1398,6 +1396,10 @@ def _optimize_gs_ad_tensor(
                         chi_schedule=config.gs_chi_schedule_steps,
                         current_stage_idx=current_stage_idx,
                         steps_in_stage=steps_in_stage,
+                        config=config,
+                        grad_norm=_gn_for_bump,
+                        delta_energy=delta_energy,
+                        stall_count=stall_count,
                         base_charges=_bump_base_charges,
                     )
                 )
@@ -1697,6 +1699,9 @@ def _optimize_gs_ad_tensor(
         # helper; #455 PR2 will add convergence/stall-cap triggers.
         if config.gs_chi_schedule_steps is not None:
             steps_in_stage = (step + 1) - stage_start_step
+            _gn_for_bump = (
+                grad_norm_val if grad_norm_val is not None else _grad_l2_norm(grads)
+            )
             ctm_cfg, _env_cache, new_stage_idx, _bump_fired, _should_break = (
                 _advance_chi_stage_if_due(
                     ctm_cfg,
@@ -1704,6 +1709,10 @@ def _optimize_gs_ad_tensor(
                     chi_schedule=config.gs_chi_schedule_steps,
                     current_stage_idx=current_stage_idx,
                     steps_in_stage=steps_in_stage,
+                    config=config,
+                    grad_norm=_gn_for_bump,
+                    delta_energy=delta_energy,
+                    stall_count=stall_count,
                     base_charges=_bump_base_charges,
                 )
             )
@@ -2594,6 +2603,9 @@ def _optimize_gs_ad_tensor_2site(
         if config.gs_chi_schedule_steps is not None:
             steps_in_stage = (step + 1) - stage_start_step
             chi_before = ctm_cfg_2s.chi
+            _gn_for_bump = (
+                grad_norm_val if grad_norm_val is not None else _grad_l2_norm(grads)
+            )
             ctm_cfg_2s, _env_cache_2s, new_stage_idx, _bump_fired, _should_break = (
                 _advance_chi_stage_if_due(
                     ctm_cfg_2s,
@@ -2601,6 +2613,10 @@ def _optimize_gs_ad_tensor_2site(
                     chi_schedule=config.gs_chi_schedule_steps,
                     current_stage_idx=current_stage_idx,
                     steps_in_stage=steps_in_stage,
+                    config=config,
+                    grad_norm=_gn_for_bump,
+                    delta_energy=delta_energy,
+                    stall_count=stall_count,
                     base_charges=_bump_base_charges_2s,
                 )
             )
@@ -3299,6 +3315,9 @@ def _optimize_gs_ad_multisite(
         if config.gs_chi_schedule_steps is not None:
             steps_in_stage = (step + 1) - stage_start_step
             chi_before = ctm_cfg.chi
+            _gn_for_bump = (
+                grad_norm_val if grad_norm_val is not None else _grad_l2_norm(grads)
+            )
             ctm_cfg, _env_cache, new_stage_idx, _bump_fired, _should_break = (
                 _advance_chi_stage_if_due(
                     ctm_cfg,
@@ -3306,6 +3325,10 @@ def _optimize_gs_ad_multisite(
                     chi_schedule=config.gs_chi_schedule_steps,
                     current_stage_idx=current_stage_idx,
                     steps_in_stage=steps_in_stage,
+                    config=config,
+                    grad_norm=_gn_for_bump,
+                    delta_energy=delta_energy,
+                    stall_count=stall_count,
                     base_charges=_bump_base_charges_multi,
                 )
             )

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -567,10 +567,29 @@ def optimize_gs_ad_chi_schedule(
                           ``ctm.chi_max``, ``gs_num_steps``, and
                           ``gs_chi_schedule_steps`` are overridden by the
                           shim per the schedule.
-        chi_schedule:     List of ``(chi, num_steps)`` pairs, e.g.
+        chi_schedule:     List of ``(chi, max_steps)`` pairs, e.g.
                           ``[(8, 100), (16, 50), (32, 30)]``.  Each pair
-                          says "run num_steps optimizer steps at logical
-                          chi = chi".  Boundaries are cumulative.
+                          says "run up to max_steps optimizer iterations
+                          at logical chi = chi, then advance to the next
+                          stage".
+
+                          Three signals advance a stage at non-final
+                          stages (#455):
+                              - the per-stage ``max_steps`` budget is
+                                exhausted;
+                              - the user's ``gs_conv_criterion`` (dE,
+                                grad_norm, or both) is met;
+                              - the L-BFGS reset-recovery stall cap
+                                ``gs_stall_recovery_retries`` is hit.
+                          Unused steps from an early-exiting stage are
+                          discarded (each stage's max_steps is an
+                          upper bound, not a fixed quota).
+
+                          Note: when stall-cap triggers a non-final
+                          advance, the next stage starts from the
+                          rolled-back ``best_params`` — fresh landscape,
+                          fresh retry budget (PR #464's intent
+                          preserved).
 
     Returns:
         Same as ``optimize_gs_ad`` at the final chi level.

--- a/tests/test_ipeps_chi_adaptive_bump_unit.py
+++ b/tests/test_ipeps_chi_adaptive_bump_unit.py
@@ -1,0 +1,216 @@
+"""Truth-table unit tests for ``_advance_chi_stage_if_due`` (#455 PR 2).
+
+These tests inject the signal inputs directly and assert state
+transitions on the helper — no optimizer run, no JAX, milliseconds
+each. Per ``feedback_test_mechanism_not_convergence``, convergence on
+a real physics problem is the production benchmark's job, not a
+unit test.
+
+Marker: ``core``.
+"""
+
+import pytest
+
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+from tenax.algorithms.ipeps_optimize import _advance_chi_stage_if_due
+
+
+def _make_config(
+    *,
+    conv_criterion="grad_norm",
+    grad_norm_tol=1e-5,
+    conv_tol=1e-8,
+    stall_recovery="reset",
+    stall_retries=3,
+):
+    """Build an iPEPSConfig pinned to test-relevant fields."""
+    return iPEPSConfig(
+        ctm=CTMConfig(chi=2, chi_max=8),
+        gs_conv_criterion=conv_criterion,
+        gs_grad_norm_tol=grad_norm_tol,
+        gs_conv_tol=conv_tol,
+        gs_stall_recovery=stall_recovery,
+        gs_stall_recovery_retries=stall_retries,
+    )
+
+
+@pytest.mark.core
+def test_budget_exhausted_non_final_advances():
+    """Test #1: budget hit at non-final stage → bump, advance, no break."""
+    ctm = CTMConfig(chi=2, chi_max=8)
+    env = {}
+    schedule = [(2, 3), (4, 3)]
+
+    new_ctm, _new_env, new_idx, bump_fired, should_break = _advance_chi_stage_if_due(
+        ctm,
+        env,
+        chi_schedule=schedule,
+        current_stage_idx=0,
+        steps_in_stage=3,
+        config=_make_config(),
+        grad_norm=1e3,
+        delta_energy=1e3,
+        stall_count=0,
+    )
+    assert bump_fired is True
+    assert should_break is False
+    assert new_idx == 1
+    assert new_ctm.chi == 4
+
+
+@pytest.mark.core
+def test_grad_norm_signal_non_final_advances():
+    """Test #2: grad_norm < tol with criterion=grad_norm → bump."""
+    ctm = CTMConfig(chi=2, chi_max=8)
+    schedule = [(2, 30), (4, 30)]
+
+    _, _, new_idx, bump_fired, should_break = _advance_chi_stage_if_due(
+        ctm,
+        {},
+        chi_schedule=schedule,
+        current_stage_idx=0,
+        steps_in_stage=5,  # well within budget
+        config=_make_config(conv_criterion="grad_norm", grad_norm_tol=1e-3),
+        grad_norm=1e-6,
+        delta_energy=1.0,
+        stall_count=0,
+    )
+    assert bump_fired is True
+    assert should_break is False
+    assert new_idx == 1
+
+
+@pytest.mark.core
+def test_dE_signal_non_final_advances():
+    """Test #3: |dE| < tol with criterion=dE → bump."""
+    ctm = CTMConfig(chi=2, chi_max=8)
+    schedule = [(2, 30), (4, 30)]
+
+    _, _, new_idx, bump_fired, _ = _advance_chi_stage_if_due(
+        ctm,
+        {},
+        chi_schedule=schedule,
+        current_stage_idx=0,
+        steps_in_stage=5,
+        config=_make_config(conv_criterion="dE", conv_tol=1e-3),
+        grad_norm=1.0,
+        delta_energy=1e-6,
+        stall_count=0,
+    )
+    assert bump_fired is True
+    assert new_idx == 1
+
+
+@pytest.mark.core
+def test_stall_cap_reset_advances():
+    """Test #4: stall_count ≥ retries with recovery=reset → bump."""
+    ctm = CTMConfig(chi=2, chi_max=8)
+    schedule = [(2, 30), (4, 30)]
+
+    _, _, new_idx, bump_fired, _ = _advance_chi_stage_if_due(
+        ctm,
+        {},
+        chi_schedule=schedule,
+        current_stage_idx=0,
+        steps_in_stage=5,
+        config=_make_config(stall_recovery="reset", stall_retries=3),
+        grad_norm=1.0,
+        delta_energy=1.0,
+        stall_count=3,
+    )
+    assert bump_fired is True
+    assert new_idx == 1
+
+
+@pytest.mark.core
+def test_stall_cap_noise_does_not_advance():
+    """Test #5: stall_count ≥ retries but recovery=noise → no bump.
+
+    Noise path has its own retry budget; PR 2 explicitly gates the
+    stall-cap bump signal to recovery=reset.
+    """
+    ctm = CTMConfig(chi=2, chi_max=8)
+    schedule = [(2, 30), (4, 30)]
+
+    _, _, new_idx, bump_fired, should_break = _advance_chi_stage_if_due(
+        ctm,
+        {},
+        chi_schedule=schedule,
+        current_stage_idx=0,
+        steps_in_stage=5,
+        config=_make_config(stall_recovery="noise", stall_retries=3),
+        grad_norm=1.0,
+        delta_energy=1.0,
+        stall_count=99,
+    )
+    assert bump_fired is False
+    assert should_break is False
+    assert new_idx == 0
+
+
+@pytest.mark.core
+def test_final_stage_any_signal_breaks():
+    """Test #6: at final stage, any signal returns should_break=True, no bump."""
+    ctm = CTMConfig(chi=4, chi_max=8)
+    schedule = [(2, 3), (4, 3)]
+
+    # Budget signal at final stage.
+    _, _, new_idx, bump_fired, should_break = _advance_chi_stage_if_due(
+        ctm,
+        {},
+        chi_schedule=schedule,
+        current_stage_idx=1,
+        steps_in_stage=3,
+        config=_make_config(),
+        grad_norm=1.0,
+        delta_energy=1.0,
+        stall_count=0,
+    )
+    assert bump_fired is False
+    assert should_break is True
+    assert new_idx == 1
+
+
+@pytest.mark.core
+def test_no_signal_no_action():
+    """Test #7: no signal tripped → no-op."""
+    ctm = CTMConfig(chi=2, chi_max=8)
+    schedule = [(2, 30), (4, 30)]
+
+    new_ctm, _, new_idx, bump_fired, should_break = _advance_chi_stage_if_due(
+        ctm,
+        {},
+        chi_schedule=schedule,
+        current_stage_idx=0,
+        steps_in_stage=5,
+        config=_make_config(),
+        grad_norm=1.0,
+        delta_energy=1.0,
+        stall_count=0,
+    )
+    assert bump_fired is False
+    assert should_break is False
+    assert new_idx == 0
+    assert new_ctm.chi == 2
+
+
+@pytest.mark.core
+def test_simultaneous_signals_advance_once():
+    """Test #8: grad_norm AND stall-cap together → single bump (idempotent)."""
+    ctm = CTMConfig(chi=2, chi_max=8)
+    schedule = [(2, 30), (4, 30)]
+
+    _, _, new_idx, bump_fired, should_break = _advance_chi_stage_if_due(
+        ctm,
+        {},
+        chi_schedule=schedule,
+        current_stage_idx=0,
+        steps_in_stage=5,
+        config=_make_config(grad_norm_tol=1e-3, stall_retries=3),
+        grad_norm=1e-6,
+        delta_energy=1.0,
+        stall_count=99,
+    )
+    assert bump_fired is True
+    assert new_idx == 1  # advanced exactly once, not twice
+    assert should_break is False

--- a/tests/test_ipeps_chi_schedule_wiring.py
+++ b/tests/test_ipeps_chi_schedule_wiring.py
@@ -84,6 +84,91 @@ def test_chi_schedule_bumps_between_stages():
     )
 
 
+@pytest.mark.core
+def test_reactive_plus_scheduled_compose():
+    """Reactive ε_T-bump + scheduled bump compose without crashing (#455 PR2).
+
+    Pins Risk #1 from the design doc: when ``chi_auto_bump=True``
+    AND a ``chi_schedule`` fire on the same step, the reactive bump
+    runs FIRST and the scheduled advance runs SECOND, both inside
+    the same end-of-step block in ``_optimize_gs_ad_tensor`` (and
+    mirrored in 2-site / multisite).  The helper's
+    ``next_chi <= ctm_cfg.chi`` branch turns the scheduled bump
+    into an idempotent stage-index advance whenever the reactive
+    bump already raised χ past the next stage's target.
+
+    A failing compose would crash with a chi-mismatch (env padded to
+    one χ, ctm_cfg.chi tracking another).  The structural assertion
+    is therefore just: the run finishes without error AND ends at
+    the schedule's final χ target.
+
+    Setup:
+        - ``chi_auto_bump=True`` with ``chi_auto_bump_eps=1e-30``
+          so any positive ε_T fires the reactive bump.
+        - ``chi_schedule=[(2, 3), (4, 3)]`` so stage 0 budgets 3
+          steps at chi=2 then advances to chi=4.
+        - D=2 Heisenberg 1-site at chi=2: ``_update_env_cache``
+          measures ε_T > 0 via the non-JIT eigh sweep
+          (rho is chi·D² × chi·D² = 8×8, discards 6 eigenmodes),
+          guaranteeing the reactive bump fires.
+        - ``chi_max=4`` caps both mechanisms at the schedule target.
+
+    chi_auto_bump is currently 1x1-only (see ipeps_optimize.py
+    L641-L649), so this test uses ``unit_cell="1x1"``.
+    """
+    jax.config.update("jax_enable_x64", True)
+
+    d = 2
+    D = 2
+    key = jax.random.PRNGKey(7)
+    k1, k2 = jax.random.split(key)
+    A_init = jax.random.normal(k1, (D, D, D, D, d)) + 1j * jax.random.normal(
+        k2, (D, D, D, D, d)
+    )
+
+    gate = heisenberg_gate()
+
+    cfg = iPEPSConfig(
+        unit_cell="1x1",
+        max_bond_dim=D,
+        ctm=CTMConfig(
+            chi=2,
+            chi_auto_bump=True,
+            chi_auto_bump_eps=1e-30,  # any positive ε_T fires reactive
+            chi_auto_bump_step=2,
+            chi_max=4,  # cap both mechanisms at the schedule target
+            max_iter=10,
+            min_iter=2,
+            conv_tol=1e-3,
+        ),
+        gs_optimizer="lbfgs",
+        gs_implicit_ad=True,
+        gs_verbose=False,
+        gs_conv_tol=1e-30,  # don't early-exit on dE
+        gs_grad_norm_tol=1e-30,  # don't early-exit on grad_norm
+        gs_stall_recovery_retries=99,  # don't trip stall cap
+        su_init=False,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        result = optimize_gs_ad_chi_schedule(
+            gate, A_init, cfg, chi_schedule=[(2, 3), (4, 3)]
+        )
+
+    final_chi = _extract_final_chi(result)
+    # Structural compose property: both mechanisms agreed to land at
+    # chi_max=4 (the schedule target).  A broken compose would either
+    # crash inside `_apply_chi_bump` with a shape mismatch or leave
+    # the final env at a chi different from ctm_cfg.chi.
+    assert final_chi == 4, (
+        f"Expected final chi=4 after reactive + scheduled compose, "
+        f"got chi={final_chi}.  Either the reactive bump did not "
+        f"fire (ε_T below 1e-30) or the scheduled idempotent-advance "
+        f"branch dropped the stage."
+    )
+
+
 def _extract_final_chi(result):
     """Pull final chi out of ``optimize_gs_ad_chi_schedule``'s return value.
 
@@ -107,10 +192,17 @@ def _extract_final_chi(result):
         any_env = next(iter(envs.values()))
         return int(any_env.C1.indices[0].dim)
 
+    # CTMTensorEnv is a NamedTuple, so the 1-site single-env case
+    # ALSO satisfies ``isinstance(envs, tuple)``.  Disambiguate via
+    # ``.C1`` (only the single-env case has it directly).
+    if hasattr(envs, "C1"):
+        # 1-site: single CTMTensorEnv NamedTuple.
+        return int(envs.C1.indices[0].dim)
+
     if isinstance(envs, tuple):
         # 2-site: (env_A, env_B).  Both envs share the same chi.
         env_a = envs[0]
         return int(env_a.C1.indices[0].dim)
 
-    # 1-site: single CTMTensorEnv.
-    return int(envs.C1.indices[0].dim)
+    # Should not happen — defensive.
+    raise AssertionError(f"unrecognised env shape: {type(envs)!r}")

--- a/tests/test_ipeps_chi_schedule_wiring.py
+++ b/tests/test_ipeps_chi_schedule_wiring.py
@@ -98,20 +98,28 @@ def test_reactive_plus_scheduled_compose():
     bump already raised χ past the next stage's target.
 
     A failing compose would crash with a chi-mismatch (env padded to
-    one χ, ctm_cfg.chi tracking another).  The structural assertion
-    is therefore just: the run finishes without error AND ends at
-    the schedule's final χ target.
+    one χ, ctm_cfg.chi tracking another).  Beyond that, this test
+    also exposes a silent-exit bug in the idempotent-advance path:
+    when ``_advance_chi_stage_if_due`` returns
+    ``bump_fired=False`` AND ``new_stage_idx > current_stage_idx``
+    (because the reactive bump already raised χ past the next
+    stage's target), the convergence intercept must STILL keep
+    optimizing on the new stage, not exit at the previous stage's
+    converged energy.
 
-    Setup:
+    Three-stage probe:
         - ``chi_auto_bump=True`` with ``chi_auto_bump_eps=1e-30``
           so any positive ε_T fires the reactive bump.
-        - ``chi_schedule=[(2, 3), (4, 3)]`` so stage 0 budgets 3
-          steps at chi=2 then advances to chi=4.
-        - D=2 Heisenberg 1-site at chi=2: ``_update_env_cache``
-          measures ε_T > 0 via the non-JIT eigh sweep
-          (rho is chi·D² × chi·D² = 8×8, discards 6 eigenmodes),
-          guaranteeing the reactive bump fires.
-        - ``chi_max=4`` caps both mechanisms at the schedule target.
+        - ``chi_schedule=[(2, 2), (4, 2), (8, 2)]`` so stage 0
+          starts at chi=2, stage 1 targets chi=4, stage 2 targets
+          chi=8.
+        - Reactive bump raises χ from 2 to 4; scheduled helper then
+          sees ``next_chi=4 <= ctm_cfg.chi=4`` and advances the
+          stage index idempotently (no chi change, ``bump_fired=False``).
+          If the intercept exits at this point (bug), final_chi=4.
+          If the intercept continues (fix), the next stage bumps to
+          chi=8 and final_chi=8.
+        - ``chi_max=8`` caps both mechanisms at stage 2's target.
 
     chi_auto_bump is currently 1x1-only (see ipeps_optimize.py
     L641-L649), so this test uses ``unit_cell="1x1"``.
@@ -136,7 +144,7 @@ def test_reactive_plus_scheduled_compose():
             chi_auto_bump=True,
             chi_auto_bump_eps=1e-30,  # any positive ε_T fires reactive
             chi_auto_bump_step=2,
-            chi_max=4,  # cap both mechanisms at the schedule target
+            chi_max=8,  # cap both mechanisms at final stage target
             max_iter=10,
             min_iter=2,
             conv_tol=1e-3,
@@ -144,8 +152,11 @@ def test_reactive_plus_scheduled_compose():
         gs_optimizer="lbfgs",
         gs_implicit_ad=True,
         gs_verbose=False,
-        gs_conv_tol=1e-30,  # don't early-exit on dE
-        gs_grad_norm_tol=1e-30,  # don't early-exit on grad_norm
+        # Loose convergence so _converged_outer trips inside the
+        # convergence intercept and exercises the
+        # reactive+idempotent-advance compose (the failure mode).
+        gs_conv_tol=1.0,
+        gs_grad_norm_tol=1.0,
         gs_stall_recovery_retries=99,  # don't trip stall cap
         su_init=False,
     )
@@ -153,19 +164,23 @@ def test_reactive_plus_scheduled_compose():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
         result = optimize_gs_ad_chi_schedule(
-            gate, A_init, cfg, chi_schedule=[(2, 3), (4, 3)]
+            gate, A_init, cfg, chi_schedule=[(2, 2), (4, 2), (8, 2)]
         )
 
     final_chi = _extract_final_chi(result)
-    # Structural compose property: both mechanisms agreed to land at
-    # chi_max=4 (the schedule target).  A broken compose would either
-    # crash inside `_apply_chi_bump` with a shape mismatch or leave
-    # the final env at a chi different from ctm_cfg.chi.
-    assert final_chi == 4, (
-        f"Expected final chi=4 after reactive + scheduled compose, "
-        f"got chi={final_chi}.  Either the reactive bump did not "
-        f"fire (ε_T below 1e-30) or the scheduled idempotent-advance "
-        f"branch dropped the stage."
+    # Structural compose property: stage 0 (chi=2) → reactive bump
+    # to chi=4 → idempotent advance to stage 1 (already at chi=4)
+    # → scheduled bump to chi=8 at stage 2.  A premature exit on
+    # the idempotent-advance branch (bump_fired=False) would leave
+    # final_chi at 4, never reaching stage 2.
+    assert final_chi == 8, (
+        f"Expected final chi=8 after reactive + scheduled compose "
+        f"(3-stage schedule), got chi={final_chi}.  Either the "
+        f"reactive bump did not fire (ε_T below 1e-30) or the "
+        f"idempotent-advance branch dropped the stage advance "
+        f"(bump_fired=False AND new_stage_idx>current_stage_idx → "
+        f"optimizer exited at stage 1 instead of continuing to "
+        f"stage 2)."
     )
 
 


### PR DESCRIPTION
## Summary

Stage advance now fires on three signals at non-final chi stages: budget exhausted (existing from PR #466), `_converged_outer` (convergence — NEW), and `stall_count >= retries` with `gs_stall_recovery="reset"` (stall cap — NEW). At final stage, all three trigger the existing exit semantics unchanged.

Reuses user's `gs_conv_criterion` and `gs_grad_norm_tol` — no new config knobs.

Closes #455.

## What changed

- **Helper** `_advance_chi_stage_if_due` extended with `config`, `grad_norm`, `delta_energy`, `stall_count` params (keyword-only).
- **Three optimizer paths × two break sites = six new intercepts**: at the 1-site, 2-site, multisite paths, both the `_converged_outer` break and the L-BFGS-reset stall-cap break now route through the helper. When `bump_fired=True` at a non-final stage, the loop `continue`s at the new chi instead of breaking.
- **Stall-cap rollback semantics preserved**: `params = best_params` still restores best-known params; `_env_cache` stays at the freshly padded post-bump state (env-shape correctness).
- **`chi_auto_bump` docstring** carries a steering note: prefer `chi_schedule` + convergence-triggered ramping for new code; `chi_auto_bump` retained as orthogonal CTM-truncation sentinel.
- **`optimize_gs_ad_chi_schedule` docstring** documents the three-signal advance semantics + rollback-then-advance behavior.

## Test plan

- [x] 8 truth-table unit tests on `_advance_chi_stage_if_due` (budget / grad-norm / dE / stall-reset / stall-noise-gated / final-stage-break / no-signal / simultaneous-signals) — `tests/test_ipeps_chi_adaptive_bump_unit.py`.
- [x] Wiring smoke test + reactive+scheduled compose test — `tests/test_ipeps_chi_schedule_wiring.py`.
- [x] No regression in `test_chi_auto_bump.py`, `test_ipeps_chi_bump_integration.py`, `test_optimize_gs_ad_chi_schedule_*.py`.
- [x] Full \`pytest -m core\` locally: **823 passed, 1 skipped, 1252 deselected** in 12m05s.
- [ ] **Post-merge production benchmark**: re-run \`examples/heisenberg_ipeps_ad_2x2.py\` with v5 schedule \`[(8,30),(16,30),(24,20)]\` on GPU; assert chi=24 actually runs. Captured in a memory file.

## Trade-offs / open items

- **Only the Wolfe-failure stall-cap path is intercepted** (lines 1662, 2705, 3506). The separate CTM-error stall-cap path (lines 1295, 2311, 3149) is left alone — deliberate, since Arnoldi failure may indicate a deeper problem than too-small chi. Worth a follow-up issue.
- **Integration test gap**: the new break-path intercepts are unit-tested via the helper truth table and smoke-tested via budget-only schedules, but not end-to-end through an optimizer hitting convergence/stall-cap mid-schedule. The production benchmark covers this; if anyone wants a fast integration test, that's a follow-up.

## Design + plan

- Design doc: \`docs/plans/2026-05-14-convergence-triggered-chi-ramp-design.md\` (landed in #466).
- Implementation plan: \`docs/plans/2026-05-14-convergence-triggered-chi-ramp.md\` (landed in #466).

🤖 Generated with [Claude Code](https://claude.com/claude-code)