### PR TITLE
fix(ipeps): #455 Codex follow-ups (stall-cap off-by-one + multisite warmup)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -117,9 +117,12 @@ def _advance_chi_stage_if_due(
         - ``steps_in_stage >= max_steps`` (budget; existing).
         - ``_converged_outer(config, delta_energy, grad_norm)``
           (NEW PR 2 — reuses user's gs_conv_criterion).
-        - ``stall_count >= config.gs_stall_recovery_retries`` AND
+        - ``stall_count > config.gs_stall_recovery_retries`` AND
           ``config.gs_stall_recovery == "reset"`` (NEW PR 2 —
           gated to reset path; noise path has its own retries).
+          Mirrors the existing reset-budget exit logic (the third
+          retry only counts as exhausted on the *fourth* failed
+          attempt, not the third — codex review #467).
 
     At the final stage all three trigger ``should_break=True`` with
     no bump (matches existing exit semantics).
@@ -134,7 +137,7 @@ def _advance_chi_stage_if_due(
 
     stall_exhausted = (
         config.gs_stall_recovery == "reset"
-        and stall_count >= config.gs_stall_recovery_retries
+        and stall_count > config.gs_stall_recovery_retries
     )
 
     should_advance = budget_exhausted or converged or stall_exhausted

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -3730,6 +3730,15 @@ def _optimize_gs_ad_multisite(
                 if grad_norm_val is not None
                 else (_grad_l2_norm(grads) if config.gs_conv_criterion != "dE" else 0.0)
             )
+            # Codex P2 review on PR #467: the convergence-block above
+            # is gated on ``warmup_ok`` to prevent ``dE ≈ 0`` early
+            # steps and post-stall resets from acting on a false
+            # convergence signal.  This end-of-step bump bypasses that
+            # gate, so inject a synthetic large ``delta_energy`` when
+            # ``not warmup_ok`` to keep the dE trigger inside
+            # ``_advance_chi_stage_if_due`` from firing prematurely.
+            # Grad-norm and stall-cap signals are unaffected.
+            _dE_for_bump = delta_energy if warmup_ok else float("inf")
             ctm_cfg, _env_cache, new_stage_idx, _bump_fired, _should_break = (
                 _advance_chi_stage_if_due(
                     ctm_cfg,
@@ -3739,7 +3748,7 @@ def _optimize_gs_ad_multisite(
                     steps_in_stage=steps_in_stage,
                     config=config,
                     grad_norm=_gn_for_bump,
-                    delta_energy=delta_energy,
+                    delta_energy=_dE_for_bump,
                     stall_count=stall_count,
                     base_charges=_bump_base_charges_multi,
                 )

--- a/tests/test_ipeps_chi_adaptive_bump_unit.py
+++ b/tests/test_ipeps_chi_adaptive_bump_unit.py
@@ -103,7 +103,12 @@ def test_dE_signal_non_final_advances():
 
 @pytest.mark.core
 def test_stall_cap_reset_advances():
-    """Test #4: stall_count ≥ retries with recovery=reset → bump."""
+    """Test #4: stall_count > retries with recovery=reset → bump.
+
+    Codex review (PR #467): mirror the existing reset-budget exit
+    logic — ``retries=3`` allows three rollback retries and only the
+    *fourth* failed attempt (``stall_count=4``) exhausts the budget.
+    """
     ctm = CTMConfig(chi=2, chi_max=8)
     schedule = [(2, 30), (4, 30)]
 
@@ -116,7 +121,7 @@ def test_stall_cap_reset_advances():
         config=_make_config(stall_recovery="reset", stall_retries=3),
         grad_norm=1.0,
         delta_energy=1.0,
-        stall_count=3,
+        stall_count=4,
     )
     assert bump_fired is True
     assert new_idx == 1


### PR DESCRIPTION
## Summary

Two Codex P2 fixes that landed locally too late for PR #467 (merge fired while the implementer was still working on these).

### Fix 1 — stall-cap off-by-one (`c63e206`)

[Codex thread](https://github.com/tenax-lab/tenax/pull/467#discussion_r3238666619). The helper used `stall_count >= retries` to advance χ, but the existing reset-budget exit uses `>`. With `gs_stall_recovery_retries=3` the documented semantics is "give up on the 4th attempt"; the helper was advancing on the 3rd. Changed `>=` → `>` in `_advance_chi_stage_if_due` (line 137) and updated `test_stall_cap_reset_advances` to use `stall_count=4`.

### Fix 2 — multisite warmup_ok bypass (`aaa0b70`)

[Codex thread](https://github.com/tenax-lab/tenax/pull/467#discussion_r3238666621). Multisite has a `warmup_ok` guard preventing convergence acts on false `dE ≈ 0` during early steps / post-stall resets. The end-of-step scheduled bump passed `delta_energy` straight to the helper's new `dE`-criterion convergence trigger, bypassing the guard. For `gs_conv_criterion ∈ {"dE","both"}` users, that could prematurely advance a stage during warmup.

Inject `_dE_for_bump = delta_energy if warmup_ok else float("inf")` at the multisite end-of-step call site. 1-site and 2-site paths have no upstream `warmup_ok` guard so they need no change.

## Test plan

- [x] 8/8 truth-table unit tests pass (test #4 updated to match corrected semantics).
- [x] 2/2 wiring tests pass.
- [x] Cherry-pick clean from PR #467's pre-merge branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)