### PR TITLE
fix(ipeps): pad stale best_env_cache to post-bump chi (#469)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1901,17 +1901,29 @@ def _optimize_gs_ad_tensor(
 
     A_final, env_final, E_final = _eval_fresh(params, _env_cache.get("envs", None))
 
+    # Pad best_env_cache envs to the current ctm_cfg.chi before use.
+    # best_env_cache is a snapshot taken when best_energy was recorded, so its
+    # env tensors may be at a smaller chi if the reactive auto-bump or the chi
+    # schedule fired after that snapshot.  pad_dense_env_chi is a no-op when
+    # chi_new == chi_old, so this is safe to call unconditionally.  Fixes #469.
+    _best_env_init = best_env_cache.get("envs", None)
+    if _best_env_init is not None:
+        _best_env_init = {
+            c: pad_dense_env_chi(
+                _best_env_init[c], ctm_cfg.chi, base_charges=_bump_base_charges
+            )
+            for c in _best_env_init
+        }
+
     if best_params is not params:
-        _, env_best, E_best_fresh = _eval_fresh(
-            best_params, best_env_cache.get("envs", None)
-        )
+        _, env_best, E_best_fresh = _eval_fresh(best_params, _best_env_init)
     else:
         E_best_fresh = E_final
 
     if E_final <= E_best_fresh:
         env, E_gs = env_final, E_final
     else:
-        A_final, _, _ = _eval_fresh(best_params, best_env_cache.get("envs", None))
+        A_final, _, _ = _eval_fresh(best_params, _best_env_init)
         env, E_gs = env_best, E_best_fresh
     if config.gs_verbose:
         print(f"[iPEPS-AD:1site-tensor] final E={E_gs:.10f}", flush=True)
@@ -3002,9 +3014,22 @@ def _optimize_gs_ad_tensor_2site(
     )
     env_A_last, env_B_last = envs_last[(0, 0)], envs_last[(1, 0)]
 
+    # Pad best_env_cache_2s envs to the current ctm_cfg_2s.chi before use.
+    # Mirrors the same fix on the 1-site path — see comment there.  Fixes #469.
+    _best_env_init_2s = best_env_cache_2s.get("envs", None)
+    if _best_env_init_2s is not None:
+        _best_env_init_2s = {
+            c: pad_dense_env_chi(
+                _best_env_init_2s[c],
+                ctm_cfg_2s.chi,
+                base_charges=_bump_base_charges_2s,
+            )
+            for c in _best_env_init_2s
+        }
+
     if best_params is not params:
         A_best, B_best, envs_best, E_best_fresh = _eval_fresh_2site(
-            best_params, best_env_cache_2s.get("envs", None)
+            best_params, _best_env_init_2s
         )
         env_A_best = envs_best[(0, 0)]
         env_B_best = envs_best[(1, 0)]
@@ -3898,9 +3923,23 @@ def _optimize_gs_ad_multisite(
 
     sites_last, envs_last, E_last = _eval_fresh(params, _env_cache.get("envs", None))
 
+    # Pad best_env_cache envs to the current ctm_cfg.chi before use.
+    # Mirrors the same fix on the 1-site and 2-site paths — see comment there.
+    # Fixes #469.
+    _best_env_init_multi = best_env_cache.get("envs", None)
+    if _best_env_init_multi is not None:
+        _best_env_init_multi = {
+            c: pad_dense_env_chi(
+                _best_env_init_multi[c],
+                ctm_cfg.chi,
+                base_charges=_bump_base_charges_multi,
+            )
+            for c in _best_env_init_multi
+        }
+
     if best_params is not params:
         sites_best, envs_best, E_best_fresh = _eval_fresh(
-            best_params, best_env_cache.get("envs", None)
+            best_params, _best_env_init_multi
         )
     else:
         E_best_fresh = E_last

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1906,8 +1906,11 @@ def _optimize_gs_ad_tensor(
     # env tensors may be at a smaller chi if the reactive auto-bump or the chi
     # schedule fired after that snapshot.  pad_dense_env_chi is a no-op when
     # chi_new == chi_old, so this is safe to call unconditionally.  Fixes #469.
+    # NOTE: if a new _eval_fresh(best_params, best_env_cache["envs"]) call site
+    # is added later, it must reapply this padding — there's no producer-side
+    # guarantee that the snapshot is at ctm_cfg.chi.
     _best_env_init = best_env_cache.get("envs", None)
-    if _best_env_init is not None:
+    if _best_env_init:
         _best_env_init = {
             c: pad_dense_env_chi(
                 _best_env_init[c], ctm_cfg.chi, base_charges=_bump_base_charges
@@ -3016,8 +3019,11 @@ def _optimize_gs_ad_tensor_2site(
 
     # Pad best_env_cache_2s envs to the current ctm_cfg_2s.chi before use.
     # Mirrors the same fix on the 1-site path — see comment there.  Fixes #469.
+    # NOTE: if a new _eval_fresh_2site(best_params, best_env_cache_2s["envs"])
+    # call site is added later, it must reapply this padding — there's no
+    # producer-side guarantee that the snapshot is at ctm_cfg_2s.chi.
     _best_env_init_2s = best_env_cache_2s.get("envs", None)
-    if _best_env_init_2s is not None:
+    if _best_env_init_2s:
         _best_env_init_2s = {
             c: pad_dense_env_chi(
                 _best_env_init_2s[c],
@@ -3926,8 +3932,11 @@ def _optimize_gs_ad_multisite(
     # Pad best_env_cache envs to the current ctm_cfg.chi before use.
     # Mirrors the same fix on the 1-site and 2-site paths — see comment there.
     # Fixes #469.
+    # NOTE: if a new _eval_fresh(best_params, best_env_cache["envs"]) call site
+    # is added later, it must reapply this padding — there's no producer-side
+    # guarantee that the snapshot is at ctm_cfg.chi.
     _best_env_init_multi = best_env_cache.get("envs", None)
-    if _best_env_init_multi is not None:
+    if _best_env_init_multi:
         _best_env_init_multi = {
             c: pad_dense_env_chi(
                 _best_env_init_multi[c],


### PR DESCRIPTION
## Summary
- Fixes `tests/test_ipeps_chi_bump_integration.py::test_optimize_gs_ad_auto_bump_raises_chi_under_pressure` — `ValueError: Size of label 'd' for operand 1 (6) does not match previous terms (8).`
- Root cause: `best_env_cache = dict(_env_cache)` is a shallow snapshot. When a reactive chi-bump (or chi-schedule) later rebinds `_env_cache["envs"]` to a new chi-padded dict, `best_env_cache["envs"]` still points to the old pre-bump dict. The post-loop `_eval_fresh(best_params, best_env_cache["envs"])` then mixes new `ctm_cfg.chi` with stale envs, and the next CTM sweep fails the einsum shape check inside `_build_enlarged_corner`.
- Fix: at each of the three `_eval_fresh(best_params, …)` call sites (1-site, 2-site, multisite), pad `best_env_cache["envs"]` to `ctm_cfg.chi` via the existing `pad_dense_env_chi` helper. The helper is a no-op when `chi_new == chi_old`, so the call is safe unconditionally.

Refs #469.

## Test plan
- [x] `uv run pytest tests/test_ipeps_chi_bump_integration.py` green locally
- [x] `uv run pytest -m "not slow"` green locally
- [x] `pre-commit run --all-files` green
- [ ] CI required checks green
- [ ] CI Full-tests-fast-other green (the bucket the failing test runs in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)