### PR TITLE
fix(ipeps): refresh Arnoldi precheck test seed for current CTM (#469)

### DIFF
--- a/tests/test_ipeps_ad_adjoint_methods.py
+++ b/tests/test_ipeps_ad_adjoint_methods.py
@@ -92,15 +92,14 @@ def test_fixed_point_arnoldi_rejects_high_rho():
     ``forward_gauge="none"`` at chi=4), the backward must raise
     ``CTMRGGradientError`` instead of looping to ``gmres_maxiter``.
 
-    ``seed=1`` is chosen because it lands on ρ(J^T) ≈ 1.58 on the
-    post-#422-#424 CTM iteration — comfortably above the rejection
-    threshold but not pathological. The original ``seed=7`` fixture
-    drifted to ρ < 1 when the CTM-iteration fixes shipped, so the
-    precheck stopped firing (issue #428). Other rejecting seeds at
-    this config: 1, 3, 8, 12, 15, 19, 21, 22, 25, 26, 27, ...
+    ``seed=42`` is chosen because it lands on ρ(J^T) ≈ 3.20 on the
+    current CTM iteration — comfortably above the rejection threshold
+    (1.0) and not borderline. The previous ``seed=1`` fixture drifted to
+    ρ ≈ 0.54 < 1 after later CTM-iteration fixes shipped, so the precheck
+    stopped firing (issue #469). Other rejecting seeds at this config: 25.
     """
     H = _heisenberg_gate()
-    A = _wrap_as_dense_tensor(_random_peps(seed=1))
+    A = _wrap_as_dense_tensor(_random_peps(seed=42))
 
     def loss(A_):
         return ctm_energy_implicit(


### PR DESCRIPTION
## Summary
- Fixes \`tests/test_ipeps_ad_adjoint_methods.py::test_fixed_point_arnoldi_rejects_high_rho\` (`Failed: DID NOT RAISE CTMRGGradientError`).
- **Decision (case a — fixture fix):** the precheck gate at \`_ctm_energy_ad.py:1030\` (\`if rho >= 1.0: raise CTMRGGradientError(rho)\`) is correct and unchanged. The test's \`seed=1\` fixture had drifted: it produced ρ(J^T) ≈ 1.58 when calibrated against PRs #422–#424, but later fixes (PR #447 \`stop_gradient\` on 2x2 projectors et al.) shifted the CTM Jacobian so \`seed=1\` now lands at ρ ≈ 0.545, below the 1.0 rejection threshold. The precheck simply never fires.
- **Fix:** update the test fixture to \`seed=42\`, which reproducibly yields ρ ≈ 3.20 (3.2× the threshold, comfortably above). Docstring updated with the new ρ value, the drift history, and a backup seed (\`25\`, ρ ≈ 1.30) for future maintainers if seed=42 ever drifts too.

Refs #469.

## Test plan
- [x] \`uv run pytest tests/test_ipeps_ad_adjoint_methods.py\` green (2 tests pass)
- [x] \`uv run pytest -m "not slow"\` green except for \`test_qr_projector_symmetric_matches_eigh\` (separate #469 failure being addressed in PR-3 of this series)
- [ ] CI required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)