### PR TITLE
feat(ctm): track ε_T in 2x2 plaquette projector (#474)

### DIFF
--- a/src/tenax/algorithms/_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_ctm_tensor_convergence.py
@@ -302,7 +302,9 @@ def _ctm_tensor_sweep_multisite(
     Returns:
         ``(envs, max_eps)`` — updated per-coord env dict and the max
         truncation error (JAX scalar) across all moves in this sweep.
-        The 2x2 path returns ``jnp.asarray(0.0)`` as a placeholder.
+        Tracked on both the 1x1 path (per-move eps_T from the SVD/eigh
+        projector) and the 2x2 path (per-plaquette eps_T from the cross-
+        projector SVD; Issue #474).
     """
     # Extract base charges from any double-layer tensor for projector stabilization
     base_charges = None
@@ -369,12 +371,18 @@ def _ctm_tensor_sweep_multisite(
         for direction in ("left", "top", "right", "bottom"):
             envs_old = dict(envs)
             # Phase 1: precompute projector pairs anchored at every cell.
+            # ``_compute_plaquette_projector_pair`` returns
+            # ``(P_top, P_bot, eps_T)`` (Issue #474).  Strip ``eps_T`` here
+            # and track the running max across all (direction × cell)
+            # computations so the 2x2 branch returns a real
+            # ``max_truncation_error`` instead of the historical
+            # 0.0 placeholder.
             projectors: dict[Coord, tuple] = {}
             for s_anchor in all_coords:
                 s_TR = neighbors[s_anchor]["right"]
                 s_BL = neighbors[s_anchor]["bottom"]
                 s_BR = neighbors[s_TR]["bottom"]
-                projectors[s_anchor] = _compute_plaquette_projector_pair(
+                P_top, P_bot, eps_T_plaq = _compute_plaquette_projector_pair(
                     envs_old[s_anchor],
                     envs_old[s_TR],
                     envs_old[s_BL],
@@ -387,6 +395,8 @@ def _ctm_tensor_sweep_multisite(
                     direction,
                     base_charges=base_charges,
                 )
+                projectors[s_anchor] = (P_top, P_bot)
+                max_eps = jnp.maximum(max_eps, jnp.asarray(eps_T_plaq))
 
             # Phase 2: absorb per cell using TWO plaquettes' projectors.
             new_envs: dict[Coord, CTMTensorEnv] = {}

--- a/src/tenax/algorithms/_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_ctm_tensor_moves.py
@@ -19,6 +19,7 @@ __all__ = [
     "_ctm_tensor_move_top_2x2",
 ]
 
+import jax
 import numpy as np
 
 from tenax.algorithms._ctm_projector import (
@@ -319,8 +320,8 @@ def _compute_plaquette_projector_pair(
     chi: int,
     direction: str,
     base_charges: np.ndarray | None = None,
-) -> tuple[Tensor, Tensor]:
-    """Compute the (P_top, P_bot) projector pair for a 2x2 plaquette and direction.
+) -> tuple[Tensor, Tensor, jax.Array]:
+    """Compute the (P_top, P_bot, eps_T) projector triple for a 2x2 plaquette.
 
     The plaquette is anchored at TL with TR=neighbors[TL]['right'],
     BL=neighbors[TL]['bottom'], BR=neighbors[TR]['bottom'].
@@ -336,6 +337,9 @@ def _compute_plaquette_projector_pair(
 
         P_top labels: ("fused", "chi_new"),   flow IN on "fused"
         P_bot labels: ("chi_new", "fused"),   flow IN on "fused"
+
+    ``eps_T`` is the variPEPS §2.8.2 truncation-error scalar driving
+    ``chi_auto_bump`` (Issue #474); ``stop_gradient`` applied upstream.
 
     For LEFT/RIGHT direction, ``P_top`` projects the BOTTOM face of TL
     (or top face of TR for direction='right') and ``P_bot`` projects the
@@ -353,10 +357,14 @@ def _compute_plaquette_projector_pair(
     Q_BR = _build_enlarged_corner(
         env_BR.C3, env_BR.T3, env_BR.T2, a_BR, position="bottom_right"
     )
-    P_top_raw, P_bot_raw = _compute_2x2_projector(
+    P_top_raw, P_bot_raw, eps_T = _compute_2x2_projector(
         Q_TL, Q_TR, Q_BL, Q_BR, chi, direction=direction, base_charges=base_charges
     )
-    return _half_to_chi_new_top(P_top_raw), _half_to_chi_new_bot(P_bot_raw)
+    return (
+        _half_to_chi_new_top(P_top_raw),
+        _half_to_chi_new_bot(P_bot_raw),
+        eps_T,
+    )
 
 
 def _ctm_tensor_absorb_left_2plaq(

--- a/src/tenax/algorithms/_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_ctm_tensor_moves.py
@@ -932,7 +932,7 @@ def _ctm_tensor_move_left_2x2(
     # ---- Step 2: compute the (P_top, P_bot) projector pair. ----
     # P_top:  (chi_outer [IN], fused_D2 [IN], chi_new_top [OUT])
     # P_bot:  (chi_new_bot [IN], chi_outer [OUT], fused_D2 [OUT])
-    P_top, P_bot = _compute_2x2_projector(
+    P_top, P_bot, _ = _compute_2x2_projector(
         Q_TL, Q_TR, Q_BL, Q_BR, chi, direction="left", base_charges=base_charges
     )
 
@@ -1039,7 +1039,7 @@ def _ctm_tensor_move_right_2x2(
     )
 
     # ---- Step 2: compute the (P_top, P_bot) projector pair. ----
-    P_top, P_bot = _compute_2x2_projector(
+    P_top, P_bot, _ = _compute_2x2_projector(
         Q_TL, Q_TR, Q_BL, Q_BR, chi, direction="right", base_charges=base_charges
     )
 
@@ -1128,7 +1128,7 @@ def _ctm_tensor_move_top_2x2(
     )
 
     # ---- Step 2: compute the (P_top, P_bot) projector pair. ----
-    P_top, P_bot = _compute_2x2_projector(
+    P_top, P_bot, _ = _compute_2x2_projector(
         Q_TL, Q_TR, Q_BL, Q_BR, chi, direction="top", base_charges=base_charges
     )
 
@@ -1217,7 +1217,7 @@ def _ctm_tensor_move_bottom_2x2(
     )
 
     # ---- Step 2: compute the (P_top, P_bot) projector pair. ----
-    P_top, P_bot = _compute_2x2_projector(
+    P_top, P_bot, _ = _compute_2x2_projector(
         Q_TL, Q_TR, Q_BL, Q_BR, chi, direction="bottom", base_charges=base_charges
     )
 

--- a/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
+++ b/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
@@ -319,7 +319,7 @@ def _compute_2x2_projector(
     *,
     direction: str = "left",
     base_charges: np.ndarray | None = None,
-) -> tuple[Tensor, Tensor]:
+) -> tuple[Tensor, Tensor, jax.Array]:
     r"""Fishman 2x2 plaquette cross-projector for the multisite CTM move.
 
     Implements the two-projector recipe of Corboz, Penc, Mila, Lauchli
@@ -352,12 +352,16 @@ def _compute_2x2_projector(
             symmetric branch.  Ignored on the dense path (no charge sectors).
 
     Returns:
-        Pair ``(P_top, P_bot)`` of rank-3 :class:`DenseTensor` projectors:
+        Triple ``(P_top, P_bot, eps_T)`` of rank-3 :class:`DenseTensor`
+        projectors and the variPEPS §2.8.2 truncation-error scalar:
 
         - ``P_top`` axes ``("chi_outer", "fused_D2", "chi_new_top")``,
           dims ``(chi, D**2, chi_new)``, flows ``(IN, IN, OUT)``.
         - ``P_bot`` axes ``("chi_new_bot", "chi_outer", "fused_D2")``,
           dims ``(chi_new, chi, D**2)``, flows ``(IN, OUT, OUT)``.
+        - ``eps_T`` is the discarded-SV norm fraction from the cross-projector
+          SVD truncation at ``chi``; ``stop_gradient`` applied so it never
+          back-propagates through the SVD F-matrix singularity (Issue #474).
 
         ``chi_outer`` and ``fused_D2`` share names so :func:`contract`
         auto-pairs them to give the closure tensor on the free legs
@@ -569,6 +573,11 @@ def _compute_2x2_projector(
 
     U_M, S_M, V_M_h = _gauge_fixed_svd(M_prime)
     k = min(chi, S_M.shape[0])
+    # ε_T from the FULL spectrum (before truncation) — variPEPS §2.8.2
+    # indicator that drives ``chi_auto_bump``.  Issue #474.
+    from tenax.algorithms._ctm_truncation_error import compute_truncation_error
+
+    eps_T = compute_truncation_error(S_M, k)
     U_M = U_M[:, :k]
     S_M = S_M[:k]
     V_M_h = V_M_h[:k, :]
@@ -693,9 +702,12 @@ def _compute_2x2_projector(
     # adjoint solve recovers the env dependence on A without flowing
     # through jnp.linalg.svd, whose F_ij = 1/(s_i² - s_j²) backward NaN-s
     # on near-degenerate singular values of M_prime (typical at small D).
+    # ``eps_T`` is also stop_gradient'd — it's consumed only by the
+    # outer-loop auto-bump (#474), which is non-AD.
     return (
         jax.tree.map(jax.lax.stop_gradient, P_top),
         jax.tree.map(jax.lax.stop_gradient, P_bot),
+        jax.lax.stop_gradient(eps_T),
     )
 
 
@@ -803,7 +815,7 @@ def _compute_2x2_projector_symmetric(
     *,
     direction: str,
     base_charges: np.ndarray | None = None,
-) -> tuple[SymmetricTensor, SymmetricTensor]:
+) -> tuple[SymmetricTensor, SymmetricTensor, jax.Array]:
     """Block-sparse 2x2 Fishman projector for SymmetricTensor inputs.
 
     Mirrors the dense pipeline in :func:`_compute_2x2_projector` stage-for-stage
@@ -821,8 +833,12 @@ def _compute_2x2_projector_symmetric(
             chi_new is allocated per sector (added in Task 5; ignored in Task 2).
 
     Returns:
-        ``(P_top, P_bot)`` SymmetricTensor projectors with the same label /
-        flow conventions as the dense path's output.
+        ``(P_top, P_bot, eps_T)`` SymmetricTensor projectors with the same
+        label / flow conventions as the dense path's output, plus the
+        variPEPS §2.8.2 truncation-error scalar.  ``eps_T`` uses the
+        Frobenius identity ``‖S_full‖² = ‖M_prime‖_F²`` so the discarded
+        singular values aren't required explicitly — the block-sparse
+        SVD already truncates to ``chi`` (Issue #474).
     """
     from tenax.contraction.contractor import contract
     from tenax.linalg import svd as tensor_svd
@@ -969,6 +985,20 @@ def _compute_2x2_projector_symmetric(
             )
     U_Mp_T, Vh_Mp_T = _gauge_fix_symmetric_svd(U_Mp_T, Vh_Mp_T)
 
+    # ε_T via the Frobenius identity (Issue #474).  Block-sparse SVD
+    # truncates to ``chi`` so the discarded SVs aren't materialised; use
+    # ``‖M_prime‖_F² = ∑ σ²`` and subtract the kept tail.  Same metric as
+    # the dense path's ``compute_truncation_error(S_full, k)``.
+    mp_full_norm_sq = M_prime_T.norm() ** 2
+    kept_norm_sq = jnp.sum(jnp.abs(S_Mp) ** 2)
+    discarded_norm_sq = jnp.maximum(mp_full_norm_sq - kept_norm_sq, 0.0)
+    safe_total = jnp.where(mp_full_norm_sq > 0.0, mp_full_norm_sq, 1.0)
+    eps_T = jnp.where(
+        mp_full_norm_sq > 0.0,
+        jnp.sqrt(discarded_norm_sq / safe_total),
+        jnp.array(0.0, dtype=S_Mp.dtype).real,
+    )
+
     # ---- Stage 5: cross-projectors via bar() for the SVD adjoint. ----
     # Under tracing, the bond axis emerges in sector-block order rather than
     # global-descending order, so use jnp.max(S_Mp) for the spectrum max
@@ -1030,9 +1060,10 @@ def _compute_2x2_projector_symmetric(
             for lbl in ("chi_new_bot", "chi_outer", "fused_D2")
         )
     )
-    # Same stop_gradient treatment as the dense path — see the comment at
-    # the end of _compute_2x2_projector.
+    # Same stop_gradient treatment as the dense path — see the comment
+    # at the end of _compute_2x2_projector.  (#474)
     return (
         jax.tree.map(jax.lax.stop_gradient, P_top),
         jax.tree.map(jax.lax.stop_gradient, P_bot),
+        jax.lax.stop_gradient(eps_T),
     )

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2202,16 +2202,9 @@ def _optimize_gs_ad_tensor_2site(
         _env_cache_2s["envs"] = envs
         # Capture ``info.max_truncation_error`` so the end-of-step
         # ``_maybe_bump_chi`` reactive trigger (#472) has an ε_T to
-        # compare against.  Scope caveat: the default forward stack uses
-        # the 2x2 plaquette recipe, which currently returns ε_T = 0.0
-        # (see ``_ctm_tensor_sweep_multisite`` 2x2 branch — eps_T is a
-        # placeholder until the plaquette projector is extended to track
-        # it).  Reactive bumps therefore only fire on the 2-site path
-        # when the forward CTM uses the 1x1 recipe + eigh projector or
-        # when an external caller writes a non-zero value into the cache.
-        # Wiring is present so #472 lands consistently with the 1-site
-        # surface; meaningful ε_T tracking on the 2x2 path is a separate
-        # follow-up.
+        # compare against.  As of #474 the 2x2 plaquette projector
+        # returns a real ε_T (previously a 0.0 placeholder), so reactive
+        # bumps fire on the 2-site forward stack with the default recipe.
         _env_cache_2s["max_truncation_error"] = float(info.max_truncation_error)
 
     params = c4v_coeffs if use_c4v else (A, B)
@@ -3181,10 +3174,9 @@ def _optimize_gs_ad_multisite(
             **ctm_converge_kwargs(ctm_cfg, env_init=_env_cache.get("envs", None)),
         )
         _env_cache["envs"] = envs
-        # See ``_update_env_cache_2s`` (#472): wire ε_T into the cache so
-        # the end-of-step reactive trigger composes correctly.  ε_T from
-        # the 2x2 forward path is currently a 0.0 placeholder; meaningful
-        # tracking is a separate follow-up.
+        # See ``_update_env_cache_2s`` (#472, #474): the 2x2 plaquette
+        # projector tracks ε_T directly so reactive bumps fire on the
+        # multisite forward stack with the default recipe.
         _env_cache["max_truncation_error"] = float(info.max_truncation_error)
 
     def loss_fn_fwd(params_):

--- a/tests/test_ctm_2x2_projector_symmetric.py
+++ b/tests/test_ctm_2x2_projector_symmetric.py
@@ -185,7 +185,7 @@ def test_compute_2x2_projector_symmetric_closure_left(symmetric_corners):
 
     # Task 4 dispatches SymmetricTensor inputs through _compute_2x2_projector
     # to the block-sparse _compute_2x2_projector_symmetric helper.
-    P_top, P_bot = _compute_2x2_projector(
+    P_top, P_bot, _ = _compute_2x2_projector(
         Q_TL, Q_TR, Q_BL, Q_BR, chi=chi, direction="left"
     )
     I_tensor = contract(P_bot, P_top)
@@ -213,7 +213,7 @@ def test_compute_2x2_projector_symmetric_closure_other_directions(
 
     Q_TL, Q_TR, Q_BL, Q_BR = symmetric_corners
     chi = 4
-    P_top, P_bot = _compute_2x2_projector(
+    P_top, P_bot, _ = _compute_2x2_projector(
         Q_TL, Q_TR, Q_BL, Q_BR, chi=chi, direction=direction
     )
     I_tensor = contract(P_bot, P_top)
@@ -245,7 +245,7 @@ def test_compute_2x2_projector_symmetric_base_charges_drive_chi_new(symmetric_co
     chi = 4
     base_charges = np.array([0, 1, 0, 1], dtype=np.int32)
 
-    P_top, P_bot = _compute_2x2_projector(
+    P_top, P_bot, _ = _compute_2x2_projector(
         Q_TL, Q_TR, Q_BL, Q_BR, chi=chi, direction="left", base_charges=base_charges
     )
     expected_chi_new = _derive_charges(base_charges, P_top.indices[2].dim)
@@ -281,7 +281,7 @@ def test_compute_2x2_projector_symmetric_ad_fallback_passes_tracer(symmetric_cor
         Q_TL_perturbed = SymmetricTensor._from_blocks_unchecked(
             new_blocks, Q_TL.indices
         )
-        P_top, P_bot = _compute_2x2_projector(
+        P_top, P_bot, _ = _compute_2x2_projector(
             Q_TL_perturbed, Q_TR, Q_BL, Q_BR, chi=chi, direction="left"
         )
         return jnp.sum(P_top.todense() ** 2) + jnp.sum(P_bot.todense() ** 2)
@@ -309,7 +309,7 @@ def test_compute_2x2_projector_dense_fallback_wraps_as_symmetric(symmetric_corne
         Q_TL_perturbed = SymmetricTensor._from_blocks_unchecked(
             new_blocks, Q_TL.indices
         )
-        P_top, P_bot = _compute_2x2_projector(
+        P_top, P_bot, _ = _compute_2x2_projector(
             Q_TL_perturbed, Q_TR, Q_BL, Q_BR, chi=chi, direction="left"
         )
         return P_top, P_bot
@@ -543,7 +543,7 @@ def test_compute_2x2_projector_tracer_safe_under_grad(symmetric_corners):
         Q_TL_traced = SymmetricTensor._from_blocks_unchecked(
             scaled_blocks, Q_TL.indices
         )
-        P_top, _ = _compute_2x2_projector(
+        P_top, _, _ = _compute_2x2_projector(
             Q_TL_traced,
             Q_TR,
             Q_BL,
@@ -567,7 +567,7 @@ def test_compute_2x2_projector_preserves_non_trivial_charges(symmetric_corners):
     Q_TL, Q_TR, Q_BL, Q_BR = symmetric_corners
     base_charges = np.array([0, 1], dtype=np.int32)
 
-    P_top, P_bot = _compute_2x2_projector(
+    P_top, P_bot, _ = _compute_2x2_projector(
         Q_TL,
         Q_TR,
         Q_BL,
@@ -662,12 +662,12 @@ def test_compute_2x2_projector_eager_vs_traced_trivial(symmetric_corners):
     )
     Qs_trivial = [Q_TL_t, Q_TR_t, Q_BL_t, Q_BR_t]
 
-    P_top_eager, _ = _compute_2x2_projector(*Qs_trivial, chi=4, direction="left")
+    P_top_eager, _, _ = _compute_2x2_projector(*Qs_trivial, chi=4, direction="left")
 
     def get_p_top(alpha):
         scaled = {k: alpha * b for k, b in Qs_trivial[0].blocks.items()}
         Q0 = SymmetricTensor._from_blocks_unchecked(scaled, Qs_trivial[0].indices)
-        P_top, _ = _compute_2x2_projector(
+        P_top, _, _ = _compute_2x2_projector(
             Q0,
             *Qs_trivial[1:],
             chi=4,
@@ -711,7 +711,7 @@ def test_compute_2x2_projector_grad_matches_finite_difference(symmetric_corners)
         Q_TL_traced = SymmetricTensor._from_blocks_unchecked(
             scaled_blocks, Q_TL.indices
         )
-        P_top, _ = _compute_2x2_projector(
+        P_top, _, _ = _compute_2x2_projector(
             Q_TL_traced,
             Q_TR,
             Q_BL,
@@ -759,7 +759,7 @@ def test_compute_2x2_projector_closure_under_tracing(symmetric_corners):
     def get_closure(alpha: jax.Array) -> jax.Array:
         scaled = {k: alpha * b for k, b in Q_TL.blocks.items()}
         Q0 = SymmetricTensor._from_blocks_unchecked(scaled, Q_TL.indices)
-        P_top, P_bot = _compute_2x2_projector(
+        P_top, P_bot, _ = _compute_2x2_projector(
             Q0,
             Q_TR,
             Q_BL,

--- a/tests/test_ctm_tensor_projector_2x2.py
+++ b/tests/test_ctm_tensor_projector_2x2.py
@@ -329,7 +329,9 @@ def test_compute_2x2_projector_left_shape_and_isometry():
 
     from tenax.algorithms._ctm_tensor_projector_2x2 import _compute_2x2_projector
 
-    P_top, P_bot = _compute_2x2_projector(Q_TL, Q_TR, Q_BL, Q_BR, chi, direction="left")
+    P_top, P_bot, _ = _compute_2x2_projector(
+        Q_TL, Q_TR, Q_BL, Q_BR, chi, direction="left"
+    )
 
     # Both projectors should be rank-3 with shared labels chi_outer + fused_D2
     # and distinct chi_new labels (chi_new_top, chi_new_bot).
@@ -370,7 +372,7 @@ def test_compute_2x2_projector_other_directions_isometry(direction):
 
     from tenax.algorithms._ctm_tensor_projector_2x2 import _compute_2x2_projector
 
-    P_top, P_bot = _compute_2x2_projector(
+    P_top, P_bot, _ = _compute_2x2_projector(
         Q_TL, Q_TR, Q_BL, Q_BR, chi, direction=direction
     )
 

--- a/tests/test_ipeps_chi_schedule_wiring.py
+++ b/tests/test_ipeps_chi_schedule_wiring.py
@@ -192,24 +192,21 @@ def test_reactive_plus_scheduled_compose():
 
 @pytest.mark.core
 def test_reactive_plus_scheduled_compose_2site_smoke():
-    """2-site compose smoke (#472): ``chi_auto_bump=True`` runs end-to-end.
+    """2-site compose smoke (#472, #474): reactive bump fires end-to-end.
 
-    The 2-site forward stack populates ``max_truncation_error`` from the
-    2x2 plaquette sweep, which currently returns 0.0 (the plaquette
-    projector doesn't yet track ε_T — issue #474).  Reactive bumps
-    therefore never fire under the default forward CTM, so this test
-    pins the weaker property the #472 wiring guarantees on 2-site today:
-    ``chi_auto_bump=True`` does NOT raise ``NotImplementedError`` (the
-    PR #473 guard drop).
+    With #474 landed, the 2x2 plaquette projector tracks ε_T directly,
+    so reactive bumps fire on the 2-site forward stack with the default
+    recipe.  This test pins:
 
-    A tighter assertion (final_chi == 3, energy < 0, ...) would also
-    exercise the post-loop ``_eval_fresh_2site`` path, which trips a
-    pre-existing 2x2 plaquette chi-mismatch on chi-bumped envs (same
-    bug as the long-standing failure in
-    ``test_optimize_gs_ad_auto_bump_raises_chi_under_pressure`` — see
-    issue #475).  That bug is independent of the #472 wiring, so we
-    only pin the wiring property here and leave the deeper assertion
-    for after #475 lands.
+    - ``chi_auto_bump=True`` does NOT raise ``NotImplementedError`` (the
+      PR #473 guard drop).
+    - The reactive bump actually fires when ``chi_auto_bump_eps`` is
+      tiny — final chi exceeds the starting chi.
+
+    Note: the post-loop ``_eval_fresh_2site`` path can still hit issue
+    #475's pre-existing 2x2 plaquette chi-mismatch on chi-bumped envs
+    (platform-dependent; surfaces on macOS for some configs).  We swallow
+    that specific ValueError as a known-limitation pin until #475 lands.
     """
     jax.config.update("jax_enable_x64", True)
 
@@ -230,9 +227,9 @@ def test_reactive_plus_scheduled_compose_2site_smoke():
         ctm=CTMConfig(
             chi=2,
             chi_auto_bump=True,
-            chi_auto_bump_eps=1e-5,
+            chi_auto_bump_eps=1e-30,  # any positive ε_T fires reactive (#474)
             chi_auto_bump_step=2,
-            chi_max=3,
+            chi_max=4,
             max_iter=10,
             min_iter=2,
             conv_tol=1e-3,
@@ -250,8 +247,8 @@ def test_reactive_plus_scheduled_compose_2site_smoke():
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
-            optimize_gs_ad_chi_schedule(
-                gate, A_init, cfg, chi_schedule=[(2, 2), (3, 2)]
+            result = optimize_gs_ad_chi_schedule(
+                gate, A_init, cfg, chi_schedule=[(2, 2), (4, 2)]
             )
     except NotImplementedError as exc:
         raise AssertionError(
@@ -262,10 +259,21 @@ def test_reactive_plus_scheduled_compose_2site_smoke():
         # #475: pre-existing 2x2 plaquette chi-mismatch on chi-bumped
         # envs is platform-dependent (passes on Linux, fails on macOS)
         # and surfaces in ``_eval_fresh_2site`` after the optimization
-        # loop completes.  Independent of #472 wiring; treat as the
-        # known-limitation pin here.
+        # loop completes.  Independent of #472/#474 wiring; treat as
+        # the known-limitation pin here.
         if "Size of label" not in str(exc):
             raise
+        return  # known limitation — the wiring itself ran without issue
+
+    final_chi = _extract_final_chi(result)
+    assert final_chi > 2, (
+        f"Expected the reactive bump to raise chi above the starting "
+        f"value of 2 on the 2-site path (chi_auto_bump_eps=1e-30 fires "
+        f"on any positive ε_T from #474's 2x2 plaquette tracking), got "
+        f"final_chi={final_chi}.  Either ε_T came out 0.0 (#474 regression) "
+        f"or the reactive trigger is not wired into the 2-site loop "
+        f"(#472 regression)."
+    )
 
 
 def _extract_final_chi(result):


### PR DESCRIPTION
## Summary

Closes #474. The 2x2 plaquette projector now returns a meaningful ε_T (variPEPS §2.8.2 truncation-error) so reactive ``chi_auto_bump`` fires on the 2-site / multisite forward stack with the default recipe — closing the scope caveat the #473 PR added.

## Changes

| File | Change |
|---|---|
| ``_ctm_tensor_projector_2x2.py`` | ``_compute_2x2_projector`` returns ``(P_top, P_bot, eps_T)``. Dense path: ``compute_truncation_error(S_M, k)`` before the SVD slice. Symmetric path: Frobenius identity ``‖S_full‖² = ‖M_prime‖_F²`` (block-sparse SVD truncates, so use ``M_prime.norm()`` minus the kept tail). ``stop_gradient`` applied. |
| ``_ctm_tensor_moves.py`` | ``_compute_plaquette_projector_pair`` propagates ε_T out. |
| ``_ctm_tensor_convergence.py`` | 2x2 branch of ``_ctm_tensor_sweep_multisite`` tracks the running max ε_T across all (direction × cell) projector computations; returns it instead of ``jnp.asarray(0.0)``. |
| ``ipeps_optimize.py`` | Drops the "Scope caveat" comment blocks in ``_update_env_cache_2s`` and its multisite twin now that ε_T is real. |
| ``tests/test_ipeps_chi_schedule_wiring.py`` | Tightens ``test_reactive_plus_scheduled_compose_2site_smoke`` to assert ``final_chi > 2`` (reactive bump fires) with ``chi_auto_bump_eps=1e-30``. |

## Why ``stop_gradient`` on ε_T

ε_T is consumed only by the outer-loop auto-bump (non-AD). The projector's surrounding ``stop_gradient`` block was added to dodge the ``F_ij = 1/(σ_i² − σ_j²)`` backward singularity in ``jnp.linalg.svd``; carrying gradient through ε_T would reintroduce that path.

## Test plan

- [x] All 19 chi-auto-bump / schedule-wiring / integration tests pass on Linux
- [x] Smoke probe: 2-site D=2 chi=2 chi_max=4 with ``chi_auto_bump=True`` ⇒ final chi=4 (bump fires)
- [x] Pre-existing ``test_optimize_gs_ad_auto_bump_raises_chi_under_pressure`` also passes (fixed by parallel PR #476)

## Followups untouched

- #460 (chi as JIT static_argname) — still deferred
- #475 (``_eval_fresh*`` chi-mismatch) — closed by #476 in parallel work, but the smoke test's ValueError swallow stays as belt-and-suspenders

🤖 Generated with [Claude Code](https://claude.com/claude-code)