### PR TITLE
feat(ipeps): observability for reactive chi_auto_bump (eps_T trace + bump events)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -88,13 +88,32 @@ def _maybe_bump_chi(
     """
     if not ctm_cfg.chi_auto_bump:
         return ctm_cfg, env_cache
+    _logger.debug(
+        "_maybe_bump_chi: chi=%d eps_T=%.3e threshold=%.3e",
+        ctm_cfg.chi,
+        last_eps_t,
+        ctm_cfg.chi_auto_bump_eps,
+    )
     if last_eps_t <= ctm_cfg.chi_auto_bump_eps:
         return ctm_cfg, env_cache
     chi_new = ctm_cfg.chi + ctm_cfg.chi_auto_bump_step
     if ctm_cfg.chi_max is not None:
         chi_new = min(chi_new, ctm_cfg.chi_max)
     if chi_new <= ctm_cfg.chi:
+        _logger.info(
+            "_maybe_bump_chi: at chi_max=%d ceiling; eps_T=%.3e exceeded threshold %.3e but no headroom",
+            ctm_cfg.chi,
+            last_eps_t,
+            ctm_cfg.chi_auto_bump_eps,
+        )
         return ctm_cfg, env_cache  # at ceiling
+    _logger.info(
+        "_maybe_bump_chi: reactive bump chi %d -> %d (eps_T=%.3e > threshold=%.3e)",
+        ctm_cfg.chi,
+        chi_new,
+        last_eps_t,
+        ctm_cfg.chi_auto_bump_eps,
+    )
     return _apply_chi_bump(ctm_cfg, env_cache, chi_new, base_charges=base_charges)
 
 

--- a/tests/test_apply_chi_bump.py
+++ b/tests/test_apply_chi_bump.py
@@ -7,6 +7,8 @@ bump (variPEPS §2.8.2) and the upcoming scheduled-bump for outer-loop
 
 from __future__ import annotations
 
+import logging
+
 import jax
 import numpy as np
 import pytest
@@ -93,3 +95,77 @@ def test_apply_chi_bump_no_op_when_envs_missing():
     assert new_cfg.chi == 8
     assert new_cache is cache
     assert "envs" not in new_cache
+
+
+@pytest.mark.core
+def test_maybe_bump_chi_logs_reactive_fire(caplog):
+    """Reactive bump emits an INFO-level log with the chi transition and ε_T values."""
+    cfg = CTMConfig(
+        chi=4, chi_auto_bump=True, chi_auto_bump_eps=1e-5, chi_auto_bump_step=2
+    )
+    cache = _make_dense_env_cache(4)
+
+    with caplog.at_level(logging.INFO, logger=_opt.__name__):
+        new_cfg, _ = _opt._maybe_bump_chi(cfg, cache, last_eps_t=1e-3)
+
+    assert new_cfg.chi == 6
+    fire_records = [r for r in caplog.records if "reactive bump" in r.message]
+    assert len(fire_records) == 1
+    assert fire_records[0].levelno == logging.INFO
+    msg = fire_records[0].getMessage()
+    assert "4 -> 6" in msg
+    assert "1.000e-03" in msg
+
+
+@pytest.mark.core
+def test_maybe_bump_chi_logs_per_step_eps_at_debug(caplog):
+    """Every call (regardless of bump) emits a DEBUG-level ε_T trace."""
+    cfg = CTMConfig(
+        chi=4, chi_auto_bump=True, chi_auto_bump_eps=1e-5, chi_auto_bump_step=2
+    )
+    cache = _make_dense_env_cache(4)
+
+    with caplog.at_level(logging.DEBUG, logger=_opt.__name__):
+        _opt._maybe_bump_chi(cfg, cache, last_eps_t=1e-8)  # below threshold
+
+    trace_records = [r for r in caplog.records if "_maybe_bump_chi: chi=" in r.message]
+    assert len(trace_records) == 1
+    assert trace_records[0].levelno == logging.DEBUG
+    msg = trace_records[0].getMessage()
+    assert "chi=4" in msg
+    assert "1.000e-08" in msg
+    assert "1.000e-05" in msg
+
+
+@pytest.mark.core
+def test_maybe_bump_chi_logs_ceiling_hit(caplog):
+    """When chi is already at chi_max but ε_T exceeded the threshold, log INFO."""
+    cfg = CTMConfig(
+        chi=8,
+        chi_max=8,
+        chi_auto_bump=True,
+        chi_auto_bump_eps=1e-5,
+        chi_auto_bump_step=2,
+    )
+    cache = _make_dense_env_cache(8)
+
+    with caplog.at_level(logging.INFO, logger=_opt.__name__):
+        new_cfg, _ = _opt._maybe_bump_chi(cfg, cache, last_eps_t=1e-3)
+
+    assert new_cfg.chi == 8  # no bump
+    ceiling_records = [r for r in caplog.records if "ceiling" in r.message]
+    assert len(ceiling_records) == 1
+    assert ceiling_records[0].levelno == logging.INFO
+
+
+@pytest.mark.core
+def test_maybe_bump_chi_silent_when_disabled(caplog):
+    """When chi_auto_bump is False, no log lines fire at all."""
+    cfg = CTMConfig(chi=4, chi_auto_bump=False)
+    cache = _make_dense_env_cache(4)
+
+    with caplog.at_level(logging.DEBUG, logger=_opt.__name__):
+        _opt._maybe_bump_chi(cfg, cache, last_eps_t=1e-3)
+
+    bump_records = [r for r in caplog.records if "_maybe_bump_chi" in r.message]
+    assert len(bump_records) == 0


### PR DESCRIPTION
## Summary

Adds INFO/DEBUG log lines to \`_maybe_bump_chi\` so the upcoming v6 \`chi_schedule\` + \`chi_auto_bump\` compose benchmark has post-run observability — without this, reactive bumps are silent.

## Motivation

PR #471 added verbose stdout logs for **scheduled** stage advances (\`[iPEPS-AD step N] schedule advance: …\`), but \`_maybe_bump_chi\` itself was silent on three states that matter for tuning \`chi_auto_bump_eps\`:

| State | Before | After |
|---|---|---|
| Per-step \`eps_T\` value | invisible | DEBUG: \`_maybe_bump_chi: chi=4 eps_T=1.234e-06 threshold=1.000e-05\` |
| Reactive bump fires | invisible | INFO: \`_maybe_bump_chi: reactive bump chi 4 -> 6 (eps_T=1.234e-04 > threshold=1.000e-05)\` |
| At \`chi_max\` ceiling but ε_T over threshold | invisible | INFO: \`_maybe_bump_chi: at chi_max=24 ceiling; eps_T=… exceeded threshold … but no headroom\` |

For v6 (post-#481), the variPEPS default \`chi_auto_bump_eps=1e-5\` may not be calibrated to Tenax's 2x2 ε_T magnitudes. Without per-step ε_T trace, a single 8h+ run can't distinguish "reactive fired but didn't help" from "reactive never fired because threshold too tight" from "reactive fired but hit ceiling immediately". This PR makes all three legible.

## Tests

\`tests/test_apply_chi_bump.py\` (+4 tests, caplog-based):
- \`test_maybe_bump_chi_logs_reactive_fire\` — INFO log on actual bump (chi 4→6, eps_T=1e-3 > 1e-5).
- \`test_maybe_bump_chi_logs_per_step_eps_at_debug\` — DEBUG trace on every call regardless of bump.
- \`test_maybe_bump_chi_logs_ceiling_hit\` — INFO when chi already at chi_max.
- \`test_maybe_bump_chi_silent_when_disabled\` — no log spam when \`chi_auto_bump=False\`.

All 7 tests in the file pass locally (\`uv run pytest tests/test_apply_chi_bump.py\`).

## Compose with #481

Lands independently. After both this and #481 merge, the v6 compose benchmark gets:
- Real \`eps_T\` from the 2x2 plaquette path (#474 / #481).
- Per-step \`eps_T\` trace + bump-event INFO logs (this PR).

→ enables data-driven \`chi_auto_bump_eps\` tuning from one run instead of speculative.

## Notes

- DEBUG-level for per-step trace keeps default-config benchmarks quiet; users opt in with \`logging.basicConfig(level=logging.DEBUG)\`.
- Silent when \`chi_auto_bump=False\` so non-auto-bump runs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)