### PR TITLE
fix(ipeps): count all 4 NN bonds in 2-site bipartite energy (#493)

### DIFF
--- a/src/tenax/algorithms/_ctm_tensor_energy.py
+++ b/src/tenax/algorithms/_ctm_tensor_energy.py
@@ -693,6 +693,12 @@ def compute_energy_ctm_tensor_2site(
 ) -> jax.Array:
     """Compute energy per site for a 2-site checkerboard iPEPS.
 
+    For the ``[[0,1],[1,0]]`` checkerboard tiling, the unit cell has 4
+    NN bonds: 2 A-B and 2 B-A.  Sums all four (swapped (A,B) → (B,A) for
+    the B-starting bonds) and divides by the 2 unique tensors per site.
+    Issue #493: counting only A-B bonds drove unphysical drift on
+    \\\`gs_c4v=False\\\` bipartite when A↔B symmetry was broken.
+
     Uses native Tensor contractions for the RDM computation, avoiding
     densification of the chi-dimensional environment.
 
@@ -716,11 +722,18 @@ def compute_energy_ctm_tensor_2site(
     else:
         H = hamiltonian_gate.reshape(d, d, d, d)
 
-    rdm_h = _rdm2x1_tensor_2site(A, B, env_A, env_B)
-    rdm_v = _rdm1x2_tensor_2site(A, B, env_A, env_B)
-    E_h = jnp.einsum("ijkl,ijkl->", rdm_h, H)
-    E_v = jnp.einsum("ijkl,ijkl->", rdm_v, H)
-    return (E_h + E_v).real
+    rdm_h_AB = _rdm2x1_tensor_2site(A, B, env_A, env_B)
+    rdm_h_BA = _rdm2x1_tensor_2site(B, A, env_B, env_A)
+    rdm_v_AB = _rdm1x2_tensor_2site(A, B, env_A, env_B)
+    rdm_v_BA = _rdm1x2_tensor_2site(B, A, env_B, env_A)
+    E = (
+        jnp.einsum("ijkl,ijkl->", rdm_h_AB, H)
+        + jnp.einsum("ijkl,ijkl->", rdm_h_BA, H)
+        + jnp.einsum("ijkl,ijkl->", rdm_v_AB, H)
+        + jnp.einsum("ijkl,ijkl->", rdm_v_BA, H)
+    )
+    # 4 bonds (2 A-B + 2 B-A) / 2 unique sites per unit cell.
+    return 0.5 * E.real
 
 
 def compute_energy_ctm_tensor_multisite(

--- a/src/tenax/algorithms/_split_ctm_tensor_energy.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_energy.py
@@ -956,11 +956,18 @@ def compute_energy_split_ctm_tensor_2site(
     else:
         H = hamiltonian_gate.reshape(d, d, d, d)
 
-    rdm_h = _rdm2x1_split_tensor_2site(A, B, env_A, env_B)
-    rdm_v = _rdm1x2_split_tensor_2site(A, B, env_A, env_B)
-    E_h = jnp.einsum("ijkl,ijkl->", rdm_h, H)
-    E_v = jnp.einsum("ijkl,ijkl->", rdm_v, H)
-    return (E_h + E_v).real
+    rdm_h_AB = _rdm2x1_split_tensor_2site(A, B, env_A, env_B)
+    rdm_h_BA = _rdm2x1_split_tensor_2site(B, A, env_B, env_A)
+    rdm_v_AB = _rdm1x2_split_tensor_2site(A, B, env_A, env_B)
+    rdm_v_BA = _rdm1x2_split_tensor_2site(B, A, env_B, env_A)
+    E = (
+        jnp.einsum("ijkl,ijkl->", rdm_h_AB, H)
+        + jnp.einsum("ijkl,ijkl->", rdm_h_BA, H)
+        + jnp.einsum("ijkl,ijkl->", rdm_v_AB, H)
+        + jnp.einsum("ijkl,ijkl->", rdm_v_BA, H)
+    )
+    # 4 NN bonds (2 A-B + 2 B-A) per [[0,1],[1,0]] unit cell / 2 unique sites.
+    return 0.5 * E.real
 
 
 def compute_energy_split_ctm_tensor_multisite(

--- a/tests/test_ctm_tensor.py
+++ b/tests/test_ctm_tensor.py
@@ -427,6 +427,43 @@ class TestTwoSiteCTM:
         for field in env_B:
             assert jnp.all(jnp.isfinite(field.todense()))
 
+    @pytest.mark.core
+    def test_2site_energy_invariant_under_AB_swap(
+        self, small_peps_pair_dense, heisenberg_gate
+    ):
+        """Issue #493: bipartite per-site energy must be symmetric under A↔B.
+
+        For a 2-site bipartite ansatz with the ``[[0,1],[1,0]]`` checkerboard
+        tiling, the unit cell has 4 NN bonds (2 A-B + 2 B-A).  The per-site
+        energy is invariant under swapping which sublattice is labelled A:
+        ``E(A, B, env_A, env_B) == E(B, A, env_B, env_A)``.
+
+        With random asymmetric (A, B), the old single-orientation formula
+        (only A-B bonds) violates this invariance; the fixed formula
+        (4-bond average) restores it.
+        """
+        A, B = small_peps_pair_dense  # seeds 42, 123 — deliberately asymmetric
+        chi = 6
+
+        env_A, env_B = ctm_tensor_2site(
+            A, B, chi=chi, max_iter=40, conv_tol=1e-8, recipe="1x1"
+        )
+        env_A_swap, env_B_swap = ctm_tensor_2site(
+            B, A, chi=chi, max_iter=40, conv_tol=1e-8, recipe="1x1"
+        )
+
+        E_AB = float(
+            compute_energy_ctm_tensor_2site(A, B, env_A, env_B, heisenberg_gate, d=2)
+        )
+        E_BA = float(
+            compute_energy_ctm_tensor_2site(
+                B, A, env_A_swap, env_B_swap, heisenberg_gate, d=2
+            )
+        )
+
+        # The energy must be the same up to CTM convergence noise.
+        np.testing.assert_allclose(E_AB, E_BA, atol=1e-6)
+
     def test_2site_symmetric_energy_matches_dense(
         self, small_peps_pair_symmetric, heisenberg_gate
     ):


### PR DESCRIPTION
## Summary

- For ``[[0,1],[1,0]]`` checkerboard, per-site energy must average all 4 NN bonds (2 A-B + 2 B-A). The 2-site fast paths were summing only A-B bonds and dividing by 1, biasing the loss whenever A↔B symmetry was broken.
- Fixed in both ``compute_energy_ctm_tensor_2site`` and ``compute_energy_split_ctm_tensor_2site`` by including the swapped-role RDMs and dividing by 2 (== ``len_unique_tensors``), matching variPEPS's ``iter_all_rows(only_unique=True)`` bipartite estimator.
- New invariance test ``test_2site_energy_invariant_under_AB_swap`` would have caught the bug: it asserts ``E(A,B,env_A,env_B) == E(B,A,env_B,env_A)`` for deliberately asymmetric seeds.

Closes #493.

## Why this matters

Without this fix, ``gs_c4v=False`` bipartite optimizations drift to E/site ≈ −0.91 (implicit AD) and ≈ −1.24 (explicit AD) on D=3 χ=16 — well below the spin-½ Heisenberg QMC floor (−0.6694). The optimizer was exploiting a bias the estimator could not see.

The multisite path (``compute_energy_ctm_tensor_multisite``) already iterates over all unique sites with right+bottom dedup and was unaffected; only the 2-site fast paths had the bug.

## Test plan

- [x] ``tests/test_ctm_tensor.py`` (31 passed locally, incl. new ``test_2site_energy_invariant_under_AB_swap`` + existing ``test_2site_symmetric_energy_matches_dense``)
- [x] ``tests/test_split_ctm_tensor.py`` (regression caught and fixed: ``test_compute_energy_split_2site_matches_shim`` passes)
- [x] ``tests/test_complex128_ad.py`` + full ``test_split_ctm_tensor.py`` (44 passed locally)
- [ ] CI: ``Tests (Python 3.11)``, ``Tests (Python 3.12)``, ``Tests (macOS, Python 3.12)``
- [ ] Follow-up: rerun #328 probe (v7c) on the fixed branch to confirm bipartite explicit AD now converges above QMC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)