### PR TITLE
feat(ipeps): log HZ probe count per L-BFGS step

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1616,13 +1616,17 @@ def _optimize_gs_ad_tensor(
                     if is_metric_lbfgs:
                         lbfgs_history.clear()
 
+                hz_counter = {"phi": 0, "dphi": 0}
+
                 def _phi(alpha):
+                    hz_counter["phi"] += 1
                     trial = _normalize_params(
                         _tree_add(params, _tree_scale(direction, alpha))
                     )
                     return loss_fn_fwd(trial)
 
                 def _dphi(alpha):
+                    hz_counter["dphi"] += 1
                     trial = _normalize_params(
                         _tree_add(params, _tree_scale(direction, alpha))
                     )
@@ -1643,6 +1647,13 @@ def _optimize_gs_ad_tensor(
                     max_step=2.0 * alpha0,
                     energy_bound=max(2.0, 2.0 * abs(best_energy)),
                 )
+                if config.gs_verbose:
+                    print(
+                        f"[iPEPS-AD:1site-tensor] HZ probes phi={hz_counter['phi']} "
+                        f"dphi={hz_counter['dphi']} alpha={alpha:.3e} "
+                        f"converged={converged}",
+                        flush=True,
+                    )
                 if f_alpha < energy_float:
                     params = _normalize_params(
                         _tree_add(params, _tree_scale(direction, alpha))
@@ -2724,13 +2735,17 @@ def _optimize_gs_ad_tensor_2site(
                     if is_metric_lbfgs:
                         lbfgs_history.clear()
 
+                hz_counter = {"phi": 0, "dphi": 0}
+
                 def _phi(alpha):
+                    hz_counter["phi"] += 1
                     trial = _normalize_params(
                         _tree_add(params, _tree_scale(direction, alpha))
                     )
                     return loss_fn_fwd(trial)
 
                 def _dphi(alpha):
+                    hz_counter["dphi"] += 1
                     trial = _normalize_params(
                         _tree_add(params, _tree_scale(direction, alpha))
                     )
@@ -2751,6 +2766,13 @@ def _optimize_gs_ad_tensor_2site(
                     max_step=2.0 * alpha0,
                     energy_bound=max(2.0, 2.0 * abs(best_energy)),
                 )
+                if config.gs_verbose:
+                    print(
+                        f"[iPEPS-AD:2site-tensor] HZ probes phi={hz_counter['phi']} "
+                        f"dphi={hz_counter['dphi']} alpha={alpha:.3e} "
+                        f"converged={converged}",
+                        flush=True,
+                    )
                 if f_alpha < energy_float:
                     params = _normalize_params(
                         _tree_add(params, _tree_scale(direction, alpha))
@@ -3635,13 +3657,17 @@ def _optimize_gs_ad_multisite(
                     if is_metric_lbfgs:
                         lbfgs_history.clear()
 
+                hz_counter = {"phi": 0, "dphi": 0}
+
                 def _phi(alpha):
+                    hz_counter["phi"] += 1
                     trial = _normalize_params(
                         _tree_add(params, _tree_scale(direction, alpha))
                     )
                     return loss_fn_fwd(trial)
 
                 def _dphi(alpha):
+                    hz_counter["dphi"] += 1
                     trial = _normalize_params(
                         _tree_add(params, _tree_scale(direction, alpha))
                     )
@@ -3662,6 +3688,13 @@ def _optimize_gs_ad_multisite(
                     max_step=2.0 * alpha0,
                     energy_bound=max(2.0, 2.0 * abs(best_energy)),
                 )
+                if config.gs_verbose:
+                    print(
+                        f"[iPEPS-AD:multisite-tensor] HZ probes phi={hz_counter['phi']} "
+                        f"dphi={hz_counter['dphi']} alpha={alpha:.3e} "
+                        f"converged={converged}",
+                        flush=True,
+                    )
                 if f_alpha < energy_float:
                     params = _normalize_params(
                         _tree_add(params, _tree_scale(direction, alpha))


### PR DESCRIPTION
## Summary

Adds per-step observability for the Hager-Zhang line search. Each HZ call now prints

\`\`\`
[iPEPS-AD:<path>] HZ probes phi=N dphi=M alpha=A converged=B
\`\`\`

after the line search completes, gated on \`gs_verbose=True\`. Patched at all three call sites: 1-site, 2-site, and multisite Tensor paths.

## Why

HZ has separate bracket + zoom phases each with \`max_iter=40\` probes, so worst-case probes per step is 80 — each probe a full CTM converge + energy eval. At χ=24 a probe is 30-90s, so when HZ uses many probes a single L-BFGS step can run >1 hour.

Without observability we cannot tell whether per-step wall-clock is dominated by HZ probe count (line search is hard), per-probe CTM cost (χ is large), or HZ failures triggering \`gs_stall_recovery=\"reset\"\`. This patch surfaces it directly.

Mirrors the \`_maybe_bump_chi\` observability pattern from PR #484.

## Side note: HZ max_iter forwarding bug

Separately discovered: \`config.gs_line_search_max_steps\` is only forwarded to \`_backtracking_line_search\`, never to \`hager_zhang_line_search\`. HZ uses its default \`max_iter=40\` regardless of config. Filing as a follow-up issue — the fix decision should be considered against whether to drop HZ default to variPEPS's \`max_iter=20\`.

## Test plan

- [x] Imports OK (1-site, 2-site, multisite functions)
- [x] \`tests/test_line_search.py\` + \`tests/test_ipeps_chi_schedule_wiring.py\` — 11 passed locally
- [ ] CI: \`Tests (Python 3.11)\`, \`Tests (Python 3.12)\`, \`Tests (macOS, Python 3.12)\`
- [ ] Verify in a real v8 run that the new log line shows up at the expected frequency (one per L-BFGS step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)