### PR TITLE
feat(ipeps): checkpoint primitive for AD long-run resume

### DIFF
--- a/src/tenax/algorithms/_checkpoint.py
+++ b/src/tenax/algorithms/_checkpoint.py
@@ -36,6 +36,7 @@ is allowed to differ with a warning.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import pickle
 import subprocess
@@ -44,7 +45,29 @@ from dataclasses import asdict, is_dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+import numpy as np
+
 CHECKPOINT_SCHEMA_VERSION = 1
+
+
+def gate_fingerprint(gate: Any) -> tuple[tuple[int, ...], str, str]:
+    """Stable identifier for a Hamiltonian gate.
+
+    Returns ``(shape, dtype_str, sha256_hex)``.  Used to detect a
+    silent gate swap on resume: the checkpoint records the
+    fingerprint of the gate it was optimized against, and
+    ``_optimize_gs_ad_tensor_2site`` refuses to resume if the live
+    gate hashes to a different value.
+
+    Same shape + same bytes is treated as "same gate" even across
+    JAX-vs-NumPy conversions: both go through ``np.asarray`` first.
+    """
+    arr = np.asarray(gate)
+    return (
+        tuple(arr.shape),
+        str(arr.dtype),
+        hashlib.sha256(arr.tobytes()).hexdigest(),
+    )
 
 
 def _tenax_git_sha() -> str | None:

--- a/src/tenax/algorithms/_checkpoint.py
+++ b/src/tenax/algorithms/_checkpoint.py
@@ -1,0 +1,229 @@
+"""Checkpoint primitives for iPEPS AD long runs.
+
+Serializes optimizer state to disk so a run can be resumed from a
+mid-point after a crash, OOM, or manual interrupt.  The schema is a
+flat dict (no dataclass) so adding new state fields is a forward-
+compatible change: older checkpoints loaded by newer code simply
+return ``None`` for missing keys, and the caller falls back to its
+fresh-init default.
+
+Two files are written per checkpoint path:
+
+* ``ckpt.last.pkl`` — overwritten every K steps and at every
+  chi-schedule stage boundary; this is what ``gs_resume=True``
+  reloads.
+* ``ckpt.best.pkl`` — overwritten only when the current energy beats
+  the prior best-seen value; this is the snapshot the user typically
+  wants to publish.
+
+Writes are atomic: pickle goes to ``<path>.tmp`` first, then
+``os.replace()`` swaps it into place.  A crash mid-write leaves the
+previous good file intact.
+
+Format: pickle (cloudpickle if available, otherwise stdlib pickle).
+Pickle was chosen over HDF5 because the bundle contains dataclasses
+(iPEPSConfig, CTMConfig), variable-length L-BFGS history, and
+Tensor objects with nested structure that HDF5 cannot self-describe
+without a brittle flatten/unflatten layer.  Recovery checkpoints are
+Python-only and ephemeral, so the standard HDF5 selling points
+(cross-language, partial loads, archival) do not apply.
+
+Config-compatibility on resume is enforced by ``validate_config``:
+fields that would silently corrupt the run (``max_bond_dim``,
+``unit_cell``, ``gs_c4v``, hamiltonian shape) raise; everything else
+is allowed to differ with a warning.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import subprocess
+import warnings
+from dataclasses import asdict, is_dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+CHECKPOINT_SCHEMA_VERSION = 1
+
+
+def _tenax_git_sha() -> str | None:
+    """Return the tenax git SHA if discoverable, else ``None``.
+
+    Best-effort identifier so a checkpoint file records which code
+    version produced it.  Failure is non-fatal — the SHA is metadata,
+    not load-bearing.
+    """
+    try:
+        # Run from the tenax package directory so we resolve the
+        # tenax repo's HEAD, not the caller's CWD.
+        import tenax
+
+        pkg_dir = os.path.dirname(os.path.abspath(tenax.__file__))
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=pkg_dir,
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def _config_to_dict(config: Any) -> dict:
+    """Serialise an iPEPSConfig (dataclass tree) to a plain dict.
+
+    Uses ``dataclasses.asdict`` which recurses into nested dataclasses
+    (e.g. ``CTMConfig``) and returns a JSON-pickleable structure.
+    """
+    if is_dataclass(config):
+        return asdict(config)
+    return dict(config)
+
+
+def save_checkpoint(
+    state: dict,
+    path: str,
+    *,
+    is_best: bool = False,
+) -> str:
+    """Atomically write ``state`` to ``path`` as a pickle.
+
+    Adds metadata (schema version, tenax SHA, timestamp) under the
+    keys ``"schema_version"``, ``"tenax_sha"``, ``"timestamp"`` if
+    they are not already present in ``state``.
+
+    Args:
+        state: Plain dict of state to serialise.  Values must be
+            pickleable; JAX arrays are auto-handled by pickle.
+        path: Directory that holds the checkpoint files.  Created if
+            it does not exist.
+        is_best: When ``True``, writes to ``ckpt.best.pkl``; otherwise
+            writes to ``ckpt.last.pkl``.
+
+    Returns:
+        The absolute path of the file that was written.
+    """
+    os.makedirs(path, exist_ok=True)
+    fname = "ckpt.best.pkl" if is_best else "ckpt.last.pkl"
+    final_path = os.path.join(path, fname)
+    tmp_path = final_path + ".tmp"
+
+    bundle = dict(state)
+    bundle.setdefault("schema_version", CHECKPOINT_SCHEMA_VERSION)
+    bundle.setdefault("tenax_sha", _tenax_git_sha())
+    bundle.setdefault(
+        "timestamp",
+        datetime.now(UTC).isoformat(timespec="seconds"),
+    )
+
+    with open(tmp_path, "wb") as f:
+        pickle.dump(bundle, f, protocol=pickle.HIGHEST_PROTOCOL)
+    os.replace(tmp_path, final_path)
+    return final_path
+
+
+def load_checkpoint(path: str, *, prefer_best: bool = False) -> dict | None:
+    """Load a checkpoint from ``path``.
+
+    Args:
+        path: Directory that holds the checkpoint files.
+        prefer_best: When ``True``, loads ``ckpt.best.pkl``; otherwise
+            loads ``ckpt.last.pkl``.
+
+    Returns:
+        The bundled state dict, or ``None`` if no checkpoint file
+        exists at ``path``.
+
+    Raises:
+        ValueError: If the file's ``schema_version`` is newer than
+            ``CHECKPOINT_SCHEMA_VERSION`` (would be loaded under an
+            unknown schema).
+    """
+    fname = "ckpt.best.pkl" if prefer_best else "ckpt.last.pkl"
+    final_path = os.path.join(path, fname)
+    if not os.path.isfile(final_path):
+        return None
+
+    with open(final_path, "rb") as f:
+        bundle = pickle.load(f)
+
+    version = bundle.get("schema_version", 0)
+    if version > CHECKPOINT_SCHEMA_VERSION:
+        raise ValueError(
+            f"Checkpoint at {final_path!r} has schema_version={version}, "
+            f"but this tenax build supports up to "
+            f"{CHECKPOINT_SCHEMA_VERSION}. Update tenax to load this "
+            f"checkpoint."
+        )
+    return bundle
+
+
+_FATAL_CONFIG_FIELDS = (
+    "max_bond_dim",
+    "unit_cell",
+    "gs_c4v",
+    "gs_implicit_ad",
+)
+
+
+def validate_config(saved_config: dict, current_config: Any) -> None:
+    """Verify a fresh ``iPEPSConfig`` is compatible with a saved one.
+
+    Fields whose change would silently corrupt the run
+    (``max_bond_dim``, ``unit_cell``, ``gs_c4v``, ``gs_implicit_ad``)
+    raise ``ValueError`` on mismatch.  All other differences warn but
+    proceed — this lets a user resume with a longer
+    ``gs_num_steps`` or a different log interval without re-running
+    from scratch.
+
+    Args:
+        saved_config: The ``config`` dict that was pickled into the
+            checkpoint (as produced by ``_config_to_dict``).
+        current_config: The fresh ``iPEPSConfig`` instance the caller
+            wants to resume with.
+    """
+    current_dict = _config_to_dict(current_config)
+    fatal_diffs = []
+    soft_diffs = []
+    for k in saved_config.keys() | current_dict.keys():
+        if saved_config.get(k) != current_dict.get(k):
+            if k in _FATAL_CONFIG_FIELDS:
+                fatal_diffs.append(
+                    f"{k}: saved={saved_config.get(k)!r} -> "
+                    f"current={current_dict.get(k)!r}"
+                )
+            else:
+                soft_diffs.append(k)
+
+    if fatal_diffs:
+        raise ValueError(
+            "Cannot resume: checkpoint config differs from current "
+            "config on load-bearing fields:\n  - " + "\n  - ".join(fatal_diffs)
+        )
+
+    if soft_diffs:
+        warnings.warn(
+            "Resuming with config changes on non-fatal fields: "
+            + ", ".join(sorted(soft_diffs))
+            + ". The checkpoint will be loaded; current-config values "
+            "take effect from the next step onward.",
+            stacklevel=2,
+        )
+
+
+def checkpoint_exists(path: str | None, *, prefer_best: bool = False) -> bool:
+    """Return ``True`` iff a checkpoint file exists at ``path``.
+
+    Convenience for the resume guard in ``_optimize_gs_ad_*``.  A
+    ``None`` path returns ``False`` (no checkpoint configured).
+    """
+    if path is None:
+        return False
+    fname = "ckpt.best.pkl" if prefer_best else "ckpt.last.pkl"
+    return os.path.isfile(os.path.join(path, fname))

--- a/src/tenax/algorithms/_checkpoint.py
+++ b/src/tenax/algorithms/_checkpoint.py
@@ -80,6 +80,28 @@ def _config_to_dict(config: Any) -> dict:
 
     Uses ``dataclasses.asdict`` which recurses into nested dataclasses
     (e.g. ``CTMConfig``) and returns a JSON-pickleable structure.
+
+    Known limitations (unreachable in the 2-site-only scope wired in
+    PR #497; relevant to 1-site / multisite follow-ups):
+
+    * ``unit_cell=Lattice(...)`` — ``Lattice.neighbor_map`` is a
+      ``MappingProxyType`` set in ``Lattice.__post_init__``; ``asdict``
+      deepcopies through it and raises
+      ``TypeError: cannot pickle 'mappingproxy' object``.  Fix when the
+      multisite path is wired: convert ``neighbor_map`` to a plain dict
+      before snapshotting (or store a stable Lattice identifier).
+    * ``cg_gates=CGGates(...)`` — ``CGGates`` is a dataclass with
+      ``jnp.ndarray`` fields; ``asdict`` produces nested arrays and
+      ``validate_config`` below then raises
+      ``ValueError: truth value of an array...`` on dict-eq comparison.
+      Fix when the 1-site cg_gates path is wired: special-case
+      ``cg_gates`` with an array-aware (hash or ``np.array_equal``)
+      comparator.
+
+    Both paths are currently blocked by the dispatch guard at
+    ``optimize_gs_ad`` (``ipeps_optimize.py``), which raises
+    ``NotImplementedError`` if ``gs_checkpoint_path`` is set with a
+    non-``"2site"`` ``unit_cell``.  See PR #497 review threads.
     """
     if is_dataclass(config):
         return asdict(config)

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -408,6 +408,18 @@ class iPEPSConfig:
     # Coarse-grained iPEPS: when set, optimize_gs_ad uses compute_energy_cg
     # instead of compute_energy_ctm_tensor.  Only valid with unit_cell="1x1".
     cg_gates: object | None = None
+    # Checkpointing for long AD runs (see tenax.algorithms._checkpoint).
+    # When ``gs_checkpoint_path`` is set, the optimizer writes
+    # ``ckpt.last.pkl`` every ``gs_checkpoint_every`` steps and at every
+    # chi-schedule stage boundary, plus a ``ckpt.best.pkl`` snapshot
+    # each time the best-seen energy improves.  ``gs_resume=True``
+    # loads ``ckpt.last.pkl`` at startup, validates config compat, and
+    # resumes from the saved step.  Currently wired for the 2-site
+    # path only (``unit_cell="2site"``); other paths raise
+    # ``NotImplementedError`` if a path is set.
+    gs_checkpoint_path: str | None = None
+    gs_checkpoint_every: int = 10
+    gs_resume: bool = False
 
     def __post_init__(self):
         import warnings
@@ -462,6 +474,12 @@ class iPEPSConfig:
                 f"gs_stall_recovery_retries must be non-negative, "
                 f"got {self.gs_stall_recovery_retries}"
             )
+        if self.gs_checkpoint_every <= 0:
+            raise ValueError(
+                f"gs_checkpoint_every must be positive, got {self.gs_checkpoint_every}"
+            )
+        if self.gs_resume and self.gs_checkpoint_path is None:
+            raise ValueError("gs_resume=True requires gs_checkpoint_path to be set")
         if self.gs_conv_criterion == "dE":
             warnings.warn(
                 "gs_conv_criterion='dE' is deprecated and will be replaced by "

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2119,6 +2119,7 @@ def _optimize_gs_ad_tensor_2site(
     from tenax.algorithms._checkpoint import (
         _config_to_dict,
         checkpoint_exists,
+        gate_fingerprint,
         load_checkpoint,
         save_checkpoint,
         validate_config,
@@ -2364,10 +2365,40 @@ def _optimize_gs_ad_tensor_2site(
     # When gs_resume=True and a checkpoint exists at gs_checkpoint_path,
     # restore optimizer state and pick up at step `saved_step + 1`.
     # All other branches keep the fresh-init values set above.
+    _gate_fp = gate_fingerprint(gate) if config.gs_checkpoint_path is not None else None
     start_step = 0
     if config.gs_resume and checkpoint_exists(config.gs_checkpoint_path):
         bundle = load_checkpoint(config.gs_checkpoint_path)
         validate_config(bundle.get("config", {}), config)
+
+        # Reject silent gate swaps: the checkpoint records the
+        # fingerprint of the hamiltonian it was optimized against, so
+        # resuming with a different gate (same shape but different
+        # bytes — e.g. transverse-field model vs Heisenberg, or J=1
+        # vs J=2) is a fatal config-style mismatch.
+        saved_fp = bundle.get("hamiltonian_fingerprint")
+        if saved_fp is not None and tuple(saved_fp) != _gate_fp:
+            raise ValueError(
+                "Cannot resume: the hamiltonian gate has changed since the "
+                "checkpoint was written.\n"
+                f"  saved fingerprint:   {tuple(saved_fp)!r}\n"
+                f"  current fingerprint: {_gate_fp!r}\n"
+                "If this is intentional, start a fresh run (delete the "
+                "checkpoint or point gs_checkpoint_path elsewhere)."
+            )
+
+        # Optimizer-defining fields (gs_optimizer, gs_metric_precond)
+        # are validated soft, but the saved ``opt_state`` /
+        # L-BFGS curvature pytree are only valid for the optimizer
+        # they came from.  If either changed across resume, restore
+        # the model state (params, envs, energies, schedule) but
+        # discard the optimizer history so the new optimizer starts
+        # from a fresh state.
+        saved_cfg = bundle.get("config", {})
+        _opt_compat = (
+            saved_cfg.get("gs_optimizer") == config.gs_optimizer
+            and saved_cfg.get("gs_metric_precond") == config.gs_metric_precond
+        )
 
         params = bundle["params"]
         best_params = bundle["best_params"]
@@ -2378,14 +2409,28 @@ def _optimize_gs_ad_tensor_2site(
         best_env_cache_2s = dict(bundle.get("best_env_cache", {}))
         stall_count = int(bundle.get("stall_count", 0))
 
-        if optimizer is not None and bundle.get("opt_state") is not None:
-            opt_state = bundle["opt_state"]
-        lbfgs_history = list(bundle.get("lbfgs_history") or [])
-        prev_params_flat = bundle.get("prev_params_flat")
-        prev_grad_flat = bundle.get("prev_grad_flat")
-        cg_direction = bundle.get("cg_direction")
-        prev_grad = bundle.get("prev_grad")
-        prev_precond_grad = bundle.get("prev_precond_grad")
+        if _opt_compat:
+            if optimizer is not None and bundle.get("opt_state") is not None:
+                opt_state = bundle["opt_state"]
+            lbfgs_history = list(bundle.get("lbfgs_history") or [])
+            prev_params_flat = bundle.get("prev_params_flat")
+            prev_grad_flat = bundle.get("prev_grad_flat")
+            cg_direction = bundle.get("cg_direction")
+            prev_grad = bundle.get("prev_grad")
+            prev_precond_grad = bundle.get("prev_precond_grad")
+        else:
+            import warnings as _warnings
+
+            _warnings.warn(
+                "Optimizer-defining config differs from checkpoint "
+                f"(saved: gs_optimizer={saved_cfg.get('gs_optimizer')!r}, "
+                f"gs_metric_precond={saved_cfg.get('gs_metric_precond')!r}; "
+                f"current: gs_optimizer={config.gs_optimizer!r}, "
+                f"gs_metric_precond={config.gs_metric_precond!r}). "
+                "Restoring params/envs/energies but discarding saved "
+                "optimizer history (curvature/momentum will restart fresh).",
+                stacklevel=2,
+            )
 
         current_stage_idx = int(bundle.get("current_stage_idx", 0))
         stage_start_step = int(bundle.get("stage_start_step", 0))
@@ -2411,11 +2456,65 @@ def _optimize_gs_ad_tensor_2site(
                 flush=True,
             )
 
+    # Nested save helper so the three checkpoint-save call sites
+    # (end-of-step, mid-loop convergence-bump intercept, mid-loop
+    # stall-cap stage-advance) stay in sync.  Captures most state by
+    # closure; step-local snapshots (``chi_before``, ``e_prev``) are
+    # passed explicitly so the caller controls the "did chi change /
+    # did we accept a new best this step" detection.
+    def _maybe_save_2s_checkpoint(
+        step: int,
+        chi_before: int,
+        e_prev: float,
+        *,
+        force_last: bool = False,
+    ) -> None:
+        if config.gs_checkpoint_path is None:
+            return
+        chi_changed = ctm_cfg_2s.chi != chi_before
+        is_new_best = best_energy < e_prev
+        should_save_last = (
+            force_last or chi_changed or (step + 1) % config.gs_checkpoint_every == 0
+        )
+        if not (should_save_last or is_new_best):
+            return
+        _ckpt_state = {
+            "step": step,
+            "config": _config_to_dict(config),
+            "hamiltonian_fingerprint": _gate_fp,
+            "params": params,
+            "best_params": best_params,
+            "best_energy": float(best_energy),
+            "prev_energy": float(prev_energy),
+            "env_cache": dict(_env_cache_2s),
+            "best_env_cache": dict(best_env_cache_2s),
+            "opt_state": opt_state,
+            "lbfgs_history": list(lbfgs_history),
+            "prev_params_flat": prev_params_flat,
+            "prev_grad_flat": prev_grad_flat,
+            "cg_direction": cg_direction,
+            "prev_grad": prev_grad,
+            "prev_precond_grad": prev_precond_grad,
+            "stall_count": stall_count,
+            "current_stage_idx": current_stage_idx,
+            "stage_start_step": stage_start_step,
+            "ctm_cfg_chi": ctm_cfg_2s.chi,
+            "current_conv_tol": _current_conv_tol_2s,
+            "current_patience": _current_patience_2s,
+        }
+        if should_save_last:
+            save_checkpoint(_ckpt_state, config.gs_checkpoint_path)
+        if is_new_best:
+            save_checkpoint(_ckpt_state, config.gs_checkpoint_path, is_best=True)
+
     for step in range(start_step, config.gs_num_steps):
-        # Snapshot for end-of-step checkpoint "is_new_best" detection.
+        # Snapshots for checkpoint "did chi change / new best" detection.
         # ``best_energy`` only decreases, so a strict < comparison after
-        # the step body identifies a freshly-accepted best.
+        # the step body identifies a freshly-accepted best.  Both
+        # snapshots are passed to ``_maybe_save_2s_checkpoint`` at every
+        # save call site so the helper can decide what to flush.
         _best_energy_at_step_start = best_energy
+        _chi_at_step_start = ctm_cfg_2s.chi
         # Update conv_tol if schedule is active
         if _conv_tol_schedule_2s is not None:
             new_tol = _get_scheduled_conv_tol_2s(step, config.gs_num_steps)
@@ -2629,6 +2728,15 @@ def _optimize_gs_ad_tensor_2site(
                         flush=True,
                     )
             if bump_fired or stage_advanced:
+                # Force a checkpoint on stage advance before continuing
+                # so a crash inside the next stage's first step doesn't
+                # roll back across the boundary (Codex P2 #497).
+                _maybe_save_2s_checkpoint(
+                    step,
+                    _chi_at_step_start,
+                    _best_energy_at_step_start,
+                    force_last=True,
+                )
                 continue
             if config.gs_verbose:
                 if not logged:
@@ -2980,6 +3088,14 @@ def _optimize_gs_ad_tensor_2site(
                                     flush=True,
                                 )
                         if bump_fired or stage_advanced:
+                            # Force a checkpoint on stall-cap stage
+                            # advance before continuing (Codex P2 #497).
+                            _maybe_save_2s_checkpoint(
+                                step,
+                                _chi_at_step_start,
+                                _best_energy_at_step_start,
+                                force_last=True,
+                            )
                             continue
                     n_resets_done = stall_count - 1
                     if config.gs_verbose:
@@ -3093,46 +3209,8 @@ def _optimize_gs_ad_tensor_2site(
             if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
                 opt_state = optimizer.init(params)
 
-        # ---- Checkpoint save -----------------------------------------
-        # Write ``ckpt.last.pkl`` every K steps and at every chi-bump
-        # boundary; write ``ckpt.best.pkl`` whenever this step accepted
-        # a new best energy.  Both files are atomic (tmp + os.replace).
-        if config.gs_checkpoint_path is not None:
-            _chi_changed_this_step = ctm_cfg_2s.chi != chi_before
-            _should_save_last = (
-                step + 1
-            ) % config.gs_checkpoint_every == 0 or _chi_changed_this_step
-            _is_new_best = best_energy < _best_energy_at_step_start
-            if _should_save_last or _is_new_best:
-                _ckpt_state = {
-                    "step": step,
-                    "config": _config_to_dict(config),
-                    "params": params,
-                    "best_params": best_params,
-                    "best_energy": float(best_energy),
-                    "prev_energy": float(prev_energy),
-                    "env_cache": dict(_env_cache_2s),
-                    "best_env_cache": dict(best_env_cache_2s),
-                    "opt_state": opt_state,
-                    "lbfgs_history": list(lbfgs_history),
-                    "prev_params_flat": prev_params_flat,
-                    "prev_grad_flat": prev_grad_flat,
-                    "cg_direction": cg_direction,
-                    "prev_grad": prev_grad,
-                    "prev_precond_grad": prev_precond_grad,
-                    "stall_count": stall_count,
-                    "current_stage_idx": current_stage_idx,
-                    "stage_start_step": stage_start_step,
-                    "ctm_cfg_chi": ctm_cfg_2s.chi,
-                    "current_conv_tol": _current_conv_tol_2s,
-                    "current_patience": _current_patience_2s,
-                }
-                if _should_save_last:
-                    save_checkpoint(_ckpt_state, config.gs_checkpoint_path)
-                if _is_new_best:
-                    save_checkpoint(
-                        _ckpt_state, config.gs_checkpoint_path, is_best=True
-                    )
+        # End-of-step save: cadence-based + new-best detection.
+        _maybe_save_2s_checkpoint(step, chi_before, _best_energy_at_step_start)
 
     # Re-evaluate both final params and best_params with fully converged
     # fresh CTM.  In-loop energies use warm-started CTM that can produce

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2367,7 +2367,21 @@ def _optimize_gs_ad_tensor_2site(
     # All other branches keep the fresh-init values set above.
     _gate_fp = gate_fingerprint(gate) if config.gs_checkpoint_path is not None else None
     start_step = 0
-    if config.gs_resume and checkpoint_exists(config.gs_checkpoint_path):
+    if config.gs_resume:
+        # Fail fast on a typo'd / deleted / never-written checkpoint
+        # path rather than silently falling through to fresh init —
+        # the user explicitly asked to resume, and a silent fresh
+        # start would discard their intended long-run state and begin
+        # overwriting checkpoints in the wrong place (Codex P2 review
+        # on PR #497).
+        if not checkpoint_exists(config.gs_checkpoint_path):
+            raise FileNotFoundError(
+                f"gs_resume=True but no checkpoint found at "
+                f"{config.gs_checkpoint_path!r} (looked for "
+                f"'ckpt.last.pkl').  Either point gs_checkpoint_path "
+                f"at the directory of a prior run, or set "
+                f"gs_resume=False to start fresh."
+            )
         bundle = load_checkpoint(config.gs_checkpoint_path)
         validate_config(bundle.get("config", {}), config)
 

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -693,6 +693,15 @@ def optimize_gs_ad(
     # See docs/plans/2026-04-13-multisite-c4v-reference-ad-plan.md Task 8.
     config = _resolve_projector_backward(config)
 
+    # Checkpointing is currently wired only for the 2-site path; 1-site
+    # and multisite land in follow-up PRs to feat/ipeps-checkpoint-2site.
+    if config.gs_checkpoint_path is not None and config.unit_cell != "2site":
+        raise NotImplementedError(
+            "iPEPSConfig.gs_checkpoint_path is currently supported only for "
+            "unit_cell='2site'. 1-site and multisite checkpoint wiring land "
+            "in follow-up PRs (see PR #497)."
+        )
+
     if isinstance(config.unit_cell, Lattice):
         return _optimize_gs_ad_multisite(hamiltonian_gate, A_init, config)
 
@@ -2107,6 +2116,13 @@ def _optimize_gs_ad_tensor_2site(
             )
     import optax
 
+    from tenax.algorithms._checkpoint import (
+        _config_to_dict,
+        checkpoint_exists,
+        load_checkpoint,
+        save_checkpoint,
+        validate_config,
+    )
     from tenax.algorithms._ctm_python_loop import python_loop_ctm_converge
     from tenax.algorithms._ctm_tensor import (
         compute_energy_ctm_tensor_2site,
@@ -2344,7 +2360,62 @@ def _optimize_gs_ad_tensor_2site(
                 _build_double_layer_tensor(_A_init)
             )
 
-    for step in range(config.gs_num_steps):
+    # ---- Checkpoint resume ----------------------------------------
+    # When gs_resume=True and a checkpoint exists at gs_checkpoint_path,
+    # restore optimizer state and pick up at step `saved_step + 1`.
+    # All other branches keep the fresh-init values set above.
+    start_step = 0
+    if config.gs_resume and checkpoint_exists(config.gs_checkpoint_path):
+        bundle = load_checkpoint(config.gs_checkpoint_path)
+        validate_config(bundle.get("config", {}), config)
+
+        params = bundle["params"]
+        best_params = bundle["best_params"]
+        best_energy = float(bundle["best_energy"])
+        prev_energy = float(bundle["prev_energy"])
+        _env_cache_2s.clear()
+        _env_cache_2s.update(bundle.get("env_cache", {}))
+        best_env_cache_2s = dict(bundle.get("best_env_cache", {}))
+        stall_count = int(bundle.get("stall_count", 0))
+
+        if optimizer is not None and bundle.get("opt_state") is not None:
+            opt_state = bundle["opt_state"]
+        lbfgs_history = list(bundle.get("lbfgs_history") or [])
+        prev_params_flat = bundle.get("prev_params_flat")
+        prev_grad_flat = bundle.get("prev_grad_flat")
+        cg_direction = bundle.get("cg_direction")
+        prev_grad = bundle.get("prev_grad")
+        prev_precond_grad = bundle.get("prev_precond_grad")
+
+        current_stage_idx = int(bundle.get("current_stage_idx", 0))
+        stage_start_step = int(bundle.get("stage_start_step", 0))
+        saved_chi = bundle.get("ctm_cfg_chi")
+        if saved_chi is not None and int(saved_chi) != ctm_cfg_2s.chi:
+            ctm_cfg_2s = _replace(ctm_cfg_2s, chi=int(saved_chi))
+        saved_conv_tol = bundle.get("current_conv_tol")
+        if saved_conv_tol is not None:
+            _current_conv_tol_2s = float(saved_conv_tol)
+            ctm_cfg_2s = _replace(ctm_cfg_2s, conv_tol=_current_conv_tol_2s)
+        saved_patience = bundle.get("current_patience")
+        if saved_patience is not None:
+            _current_patience_2s = (
+                int(saved_patience) if saved_patience is not None else None
+            )
+            ctm_cfg_2s = _replace(ctm_cfg_2s, plateau_patience=_current_patience_2s)
+
+        start_step = int(bundle["step"]) + 1
+        if config.gs_verbose:
+            print(
+                f"[iPEPS-AD:2site-tensor] resumed from step {start_step} "
+                f"(best E={best_energy:.10f}, chi={ctm_cfg_2s.chi})",
+                flush=True,
+            )
+
+    for step in range(start_step, config.gs_num_steps):
+        # Snapshot for end-of-step checkpoint "is_new_best" detection.
+        # ``best_energy`` only decreases, so a strict < comparison after
+        # the step body identifies a freshly-accepted best.
+        _best_energy_at_step_start = best_energy
         # Update conv_tol if schedule is active
         if _conv_tol_schedule_2s is not None:
             new_tol = _get_scheduled_conv_tol_2s(step, config.gs_num_steps)
@@ -3021,6 +3092,47 @@ def _optimize_gs_ad_tensor_2site(
                 prev_precond_grad = None
             if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
                 opt_state = optimizer.init(params)
+
+        # ---- Checkpoint save -----------------------------------------
+        # Write ``ckpt.last.pkl`` every K steps and at every chi-bump
+        # boundary; write ``ckpt.best.pkl`` whenever this step accepted
+        # a new best energy.  Both files are atomic (tmp + os.replace).
+        if config.gs_checkpoint_path is not None:
+            _chi_changed_this_step = ctm_cfg_2s.chi != chi_before
+            _should_save_last = (
+                step + 1
+            ) % config.gs_checkpoint_every == 0 or _chi_changed_this_step
+            _is_new_best = best_energy < _best_energy_at_step_start
+            if _should_save_last or _is_new_best:
+                _ckpt_state = {
+                    "step": step,
+                    "config": _config_to_dict(config),
+                    "params": params,
+                    "best_params": best_params,
+                    "best_energy": float(best_energy),
+                    "prev_energy": float(prev_energy),
+                    "env_cache": dict(_env_cache_2s),
+                    "best_env_cache": dict(best_env_cache_2s),
+                    "opt_state": opt_state,
+                    "lbfgs_history": list(lbfgs_history),
+                    "prev_params_flat": prev_params_flat,
+                    "prev_grad_flat": prev_grad_flat,
+                    "cg_direction": cg_direction,
+                    "prev_grad": prev_grad,
+                    "prev_precond_grad": prev_precond_grad,
+                    "stall_count": stall_count,
+                    "current_stage_idx": current_stage_idx,
+                    "stage_start_step": stage_start_step,
+                    "ctm_cfg_chi": ctm_cfg_2s.chi,
+                    "current_conv_tol": _current_conv_tol_2s,
+                    "current_patience": _current_patience_2s,
+                }
+                if _should_save_last:
+                    save_checkpoint(_ckpt_state, config.gs_checkpoint_path)
+                if _is_new_best:
+                    save_checkpoint(
+                        _ckpt_state, config.gs_checkpoint_path, is_best=True
+                    )
 
     # Re-evaluate both final params and best_params with fully converged
     # fresh CTM.  In-loop energies use warm-started CTM that can produce

--- a/tests/test_ipeps_checkpoint.py
+++ b/tests/test_ipeps_checkpoint.py
@@ -18,6 +18,7 @@ import pytest
 from tenax.algorithms._checkpoint import (
     CHECKPOINT_SCHEMA_VERSION,
     checkpoint_exists,
+    gate_fingerprint,
     load_checkpoint,
     save_checkpoint,
     validate_config,
@@ -158,6 +159,25 @@ def test_validate_config_soft_mismatch_warns():
         warnings.simplefilter("always")
         validate_config(saved, current)
     assert any("gs_num_steps" in str(w.message) for w in caught)
+
+
+@pytest.mark.core
+def test_gate_fingerprint_round_trip_and_changes_with_bytes():
+    """Same bytes → same fingerprint; different bytes → different.
+
+    Also verifies that ``jnp.array`` and ``np.array`` with identical
+    values produce the same fingerprint (both go through
+    ``np.asarray``).
+    """
+    g1 = jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    g2 = jnp.array([[1.0, 0.0], [0.0, -1.0]])  # same bytes
+    g3 = jnp.array([[1.0, 0.0], [0.0, 1.0]])  # different bytes (sign flip)
+    fp1, fp2, fp3 = (gate_fingerprint(g) for g in (g1, g2, g3))
+    assert fp1 == fp2
+    assert fp1 != fp3
+    # Cross-typesystem stability: jnp ↔ np.
+    fp1_np = gate_fingerprint(np.asarray(g1))
+    assert fp1 == fp1_np
 
 
 @pytest.mark.core

--- a/tests/test_ipeps_checkpoint.py
+++ b/tests/test_ipeps_checkpoint.py
@@ -1,0 +1,181 @@
+"""Tests for the checkpoint primitive (``_checkpoint.py``).
+
+Covers round-trip, atomic-write semantics, schema versioning, and
+config-compatibility validation.  Resume-integration tests for the
+2-site AD path live separately to keep this file unit-scoped.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import warnings
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tenax.algorithms._checkpoint import (
+    CHECKPOINT_SCHEMA_VERSION,
+    checkpoint_exists,
+    load_checkpoint,
+    save_checkpoint,
+    validate_config,
+)
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+
+
+@pytest.mark.core
+def test_save_load_round_trip(tmp_path):
+    state = {
+        "step": 7,
+        "best_energy": -0.5,
+        "params": jnp.array([1.0, 2.0, 3.0]),
+        "history": [jnp.array([1.0]), jnp.array([2.0, 3.0])],
+        "config": {"max_bond_dim": 2, "ctm": {"chi": 4}},
+    }
+    written = save_checkpoint(state, str(tmp_path))
+    assert os.path.isfile(written)
+    assert os.path.basename(written) == "ckpt.last.pkl"
+
+    loaded = load_checkpoint(str(tmp_path))
+    assert loaded is not None
+    assert loaded["step"] == 7
+    assert loaded["best_energy"] == -0.5
+    np.testing.assert_array_equal(loaded["params"], np.array([1.0, 2.0, 3.0]))
+    assert loaded["schema_version"] == CHECKPOINT_SCHEMA_VERSION
+    assert "timestamp" in loaded
+
+
+@pytest.mark.core
+def test_load_missing_file_returns_none(tmp_path):
+    assert load_checkpoint(str(tmp_path)) is None
+    assert load_checkpoint(str(tmp_path), prefer_best=True) is None
+
+
+@pytest.mark.core
+def test_checkpoint_exists(tmp_path):
+    assert not checkpoint_exists(str(tmp_path))
+    assert not checkpoint_exists(None)
+    save_checkpoint({"step": 0}, str(tmp_path))
+    assert checkpoint_exists(str(tmp_path))
+    assert not checkpoint_exists(str(tmp_path), prefer_best=True)
+
+
+@pytest.mark.core
+def test_best_and_last_are_independent(tmp_path):
+    save_checkpoint({"step": 1, "energy": -0.1}, str(tmp_path))
+    save_checkpoint({"step": 1, "energy": -0.5}, str(tmp_path), is_best=True)
+    save_checkpoint({"step": 2, "energy": -0.3}, str(tmp_path))
+
+    last = load_checkpoint(str(tmp_path))
+    best = load_checkpoint(str(tmp_path), prefer_best=True)
+    assert last["step"] == 2 and last["energy"] == -0.3
+    assert best["step"] == 1 and best["energy"] == -0.5
+
+
+@pytest.mark.core
+def test_atomic_write_no_partial_file_on_crash(tmp_path, monkeypatch):
+    """A crash mid-write must leave any prior good file intact.
+
+    Forces ``pickle.dump`` to raise after the tmp file is created but
+    before ``os.replace`` runs; the prior good ``ckpt.last.pkl`` must
+    still be readable and the tmp file must not exist as the final
+    file.
+    """
+    save_checkpoint({"step": 1, "marker": "good"}, str(tmp_path))
+
+    real_dump = pickle.dump
+    call_count = {"n": 0}
+
+    def _failing_dump(obj, fp, *args, **kwargs):
+        call_count["n"] += 1
+        # Write a few bytes so the tmp file exists & is non-empty
+        fp.write(b"partial")
+        raise RuntimeError("simulated crash mid-dump")
+
+    monkeypatch.setattr(pickle, "dump", _failing_dump)
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        save_checkpoint({"step": 2, "marker": "bad"}, str(tmp_path))
+    monkeypatch.setattr(pickle, "dump", real_dump)
+
+    # Final file untouched, .tmp left over (caller can clean up).
+    loaded = load_checkpoint(str(tmp_path))
+    assert loaded["step"] == 1 and loaded["marker"] == "good"
+    assert call_count["n"] == 1
+
+
+@pytest.mark.core
+def test_load_rejects_newer_schema(tmp_path):
+    """A checkpoint with schema_version > current must raise."""
+    bogus = {
+        "schema_version": CHECKPOINT_SCHEMA_VERSION + 99,
+        "step": 0,
+    }
+    final_path = os.path.join(str(tmp_path), "ckpt.last.pkl")
+    with open(final_path, "wb") as f:
+        pickle.dump(bogus, f)
+
+    with pytest.raises(ValueError, match="schema_version"):
+        load_checkpoint(str(tmp_path))
+
+
+@pytest.mark.core
+def test_validate_config_fatal_mismatch_raises():
+    saved = {
+        "max_bond_dim": 2,
+        "unit_cell": "2site",
+        "gs_c4v": True,
+        "gs_implicit_ad": True,
+    }
+    current = iPEPSConfig(
+        max_bond_dim=3,  # changed - fatal
+        unit_cell="2site",
+        gs_c4v=True,
+        gs_implicit_ad=True,
+    )
+    with pytest.raises(ValueError, match="max_bond_dim"):
+        validate_config(saved, current)
+
+
+@pytest.mark.core
+def test_validate_config_soft_mismatch_warns():
+    current = iPEPSConfig(
+        max_bond_dim=2,
+        unit_cell="2site",
+        gs_c4v=True,
+        gs_implicit_ad=True,
+        gs_num_steps=50,  # different from saved (soft)
+    )
+    saved = {
+        "max_bond_dim": 2,
+        "unit_cell": "2site",
+        "gs_c4v": True,
+        "gs_implicit_ad": True,
+        "gs_num_steps": 20,
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        validate_config(saved, current)
+    assert any("gs_num_steps" in str(w.message) for w in caught)
+
+
+@pytest.mark.core
+def test_validate_config_compatible_no_warning():
+    cfg = iPEPSConfig(
+        max_bond_dim=2,
+        unit_cell="2site",
+        gs_c4v=True,
+        gs_implicit_ad=True,
+        ctm=CTMConfig(chi=4),
+    )
+    saved = {**cfg.__dict__}
+    # asdict recurses through nested dataclasses; for the round-trip
+    # comparison validate_config uses asdict on the live one, so make
+    # the saved snapshot match that shape.
+    from tenax.algorithms._checkpoint import _config_to_dict
+
+    saved = _config_to_dict(cfg)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        validate_config(saved, cfg)  # no warning expected

--- a/tests/test_ipeps_checkpoint_resume.py
+++ b/tests/test_ipeps_checkpoint_resume.py
@@ -125,6 +125,103 @@ def test_resume_no_op_when_already_completed(tmp_path):
     assert abs(E_b - E_a) < 1e-3, f"E_a={E_a!r}, E_b={E_b!r}"
 
 
+@pytest.mark.algorithm
+def test_resume_rejects_different_hamiltonian_gate(tmp_path):
+    """A silent gate swap on resume must be a fatal error.
+
+    Phase A writes a checkpoint optimized against Heisenberg; phase B
+    tries to resume against a different (Ising-like) gate with the
+    same shape.  ``_optimize_gs_ad_tensor_2site`` must raise rather
+    than continue with weights tuned for the wrong Hamiltonian.
+    (Codex P2 review on PR #497.)
+    """
+    heisenberg = _heisenberg_gate()
+    ckpt_path = str(tmp_path / "ckpt")
+
+    cfg_a = _base_cfg(ckpt_path, gs_num_steps=2, gs_resume=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        optimize_gs_ad(heisenberg, None, cfg_a)
+
+    # Same shape, different bytes: transverse-field Ising-like (Sx⊗Sx
+    # only).  Same (d,d,d,d) layout, completely different physics.
+    sx = 0.5 * jnp.array([[0.0, 1.0], [1.0, 0.0]])
+    ising = jnp.einsum("ij,kl->ikjl", sx, sx).real
+    assert ising.shape == heisenberg.shape
+
+    cfg_b = _base_cfg(ckpt_path, gs_num_steps=4, gs_resume=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with pytest.raises(ValueError, match="hamiltonian gate has changed"):
+            optimize_gs_ad(ising, None, cfg_b)
+
+
+@pytest.mark.algorithm
+def test_resume_discards_optimizer_state_on_optimizer_change(tmp_path):
+    """Changing ``gs_optimizer`` across resume warns and starts the
+    new optimizer's history fresh, rather than installing a saved
+    L-BFGS state into Adam (or vice versa) — which would crash on the
+    next ``optimizer.update``.  (Codex P2 review on PR #497.)
+
+    Tests the L-BFGS → Adam transition: a saved Adam ``opt_state``
+    cannot be a valid metric-L-BFGS state, so we must discard it on
+    resume.  The optimizer must complete the resumed step without
+    raising.
+    """
+    gate = _heisenberg_gate()
+    ckpt_path = str(tmp_path / "ckpt")
+
+    # Phase A: write checkpoint with optax-lbfgs (gs_metric_precond=False)
+    cfg_a = iPEPSConfig(
+        unit_cell="2site",
+        max_bond_dim=2,
+        ctm=CTMConfig(chi=4),
+        gs_num_steps=2,
+        gs_checkpoint_path=ckpt_path,
+        gs_checkpoint_every=1,
+        gs_optimizer="lbfgs",
+        gs_metric_precond=False,  # optax-backed LBFGS, opt_state populated
+        gs_c4v=True,
+        su_init=False,
+        gs_conv_criterion="grad_norm",
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        optimize_gs_ad(gate, None, cfg_a)
+
+    saved = load_checkpoint(ckpt_path)
+    assert saved is not None
+    assert saved["opt_state"] is not None, "phase A should have written opt_state"
+
+    # Phase B: resume with metric-LBFGS — different optimizer state layout.
+    cfg_b = iPEPSConfig(
+        unit_cell="2site",
+        max_bond_dim=2,
+        ctm=CTMConfig(chi=4),
+        gs_num_steps=4,
+        gs_checkpoint_path=ckpt_path,
+        gs_checkpoint_every=1,
+        gs_resume=True,
+        gs_optimizer="lbfgs",
+        gs_metric_precond=True,  # changed — opt_state becomes None
+        gs_c4v=True,
+        su_init=False,
+        gs_conv_criterion="grad_norm",
+    )
+
+    # Must warn (about discarded optimizer history) but not raise.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        optimize_gs_ad(gate, None, cfg_b)
+    discard_warnings = [
+        w for w in caught if "discarding saved optimizer history" in str(w.message)
+    ]
+    assert discard_warnings, (
+        "expected a warning about discarded optimizer history; "
+        f"got: {[str(w.message) for w in caught]}"
+    )
+
+
 @pytest.mark.core
 def test_checkpoint_path_rejects_non_2site_paths():
     """1-site and multisite paths must raise NotImplementedError when a

--- a/tests/test_ipeps_checkpoint_resume.py
+++ b/tests/test_ipeps_checkpoint_resume.py
@@ -1,0 +1,144 @@
+"""End-to-end resume tests for the 2-site iPEPS AD checkpoint hook.
+
+Runs the optimizer, persists a mid-point, then loads the checkpoint
+back via ``gs_resume=True`` and checks that the run continues from
+the saved step with the saved best-seen energy intact.
+
+Marked ``algorithm`` (not ``core``) because it exercises a real
+optimizer step at ``D=2 / chi=4``, which costs a few seconds per
+step.  Unit-scoped primitive tests live in
+``test_ipeps_checkpoint.py``.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import jax.numpy as jnp
+import pytest
+
+from tenax.algorithms._checkpoint import (
+    checkpoint_exists,
+    load_checkpoint,
+)
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+
+def _heisenberg_gate():
+    sx = 0.5 * jnp.array([[0.0, 1.0], [1.0, 0.0]])
+    sy = 0.5 * jnp.array([[0.0, -1j], [1j, 0.0]])
+    sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    return (
+        jnp.einsum("ij,kl->ikjl", sx, sx)
+        + jnp.einsum("ij,kl->ikjl", sy, sy)
+        + jnp.einsum("ij,kl->ikjl", sz, sz)
+    ).real
+
+
+def _base_cfg(ckpt_path, *, gs_num_steps, gs_resume):
+    return iPEPSConfig(
+        unit_cell="2site",
+        max_bond_dim=2,
+        ctm=CTMConfig(chi=4),
+        gs_num_steps=gs_num_steps,
+        gs_checkpoint_path=ckpt_path,
+        gs_checkpoint_every=1,
+        gs_resume=gs_resume,
+        gs_c4v=True,
+        su_init=False,
+        gs_conv_criterion="grad_norm",
+    )
+
+
+@pytest.mark.algorithm
+def test_resume_2site_continues_from_saved_step(tmp_path):
+    """End-to-end: run 2 steps, then resume to 4 steps total.
+
+    Verifies:
+      * ckpt.last.pkl is written and records the last completed step
+      * a resume run with the same ``gs_checkpoint_path`` advances the
+        step counter rather than restarting at 0
+      * the final energy from the resumed run is no worse than the
+        first run (monotone within tolerance)
+    """
+    gate = _heisenberg_gate()
+    ckpt_path = str(tmp_path / "ckpt")
+
+    cfg_phase_a = _base_cfg(ckpt_path, gs_num_steps=2, gs_resume=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result_a = optimize_gs_ad(gate, None, cfg_phase_a)
+    _, _, E_a = result_a[:3]
+
+    assert checkpoint_exists(ckpt_path), "phase A did not write a checkpoint"
+    bundle = load_checkpoint(ckpt_path)
+    assert bundle is not None
+    assert bundle["step"] == 1, (
+        f"ckpt.last should record the last completed step (1); got {bundle['step']!r}"
+    )
+
+    cfg_phase_b = _base_cfg(ckpt_path, gs_num_steps=4, gs_resume=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result_b = optimize_gs_ad(gate, None, cfg_phase_b)
+    _, _, E_b = result_b[:3]
+
+    bundle_b = load_checkpoint(ckpt_path)
+    assert bundle_b["step"] == 3, (
+        f"resumed run should advance ckpt.last.step to 3; got {bundle_b['step']!r}"
+    )
+
+    # Optimizer is monotone in best-seen energy across resume; allow a
+    # tiny tolerance for pickle round-trip float drift.
+    assert E_b <= E_a + 1e-6, f"resumed run regressed: E_a={E_a!r}, E_b={E_b!r}"
+
+
+@pytest.mark.algorithm
+def test_resume_no_op_when_already_completed(tmp_path):
+    """Resume from a fully-completed run does nothing (loop range empty).
+
+    After running ``gs_num_steps=2``, ``ckpt.last`` has ``step=1``.
+    Resume with ``gs_num_steps=2`` again gives ``start_step=2`` and
+    ``range(2, 2)`` runs zero iterations — the finalize block still
+    fires so a valid result is returned.
+    """
+    gate = _heisenberg_gate()
+    ckpt_path = str(tmp_path / "ckpt")
+
+    cfg = _base_cfg(ckpt_path, gs_num_steps=2, gs_resume=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result_a = optimize_gs_ad(gate, None, cfg)
+    _, _, E_a = result_a[:3]
+
+    cfg_resume = _base_cfg(ckpt_path, gs_num_steps=2, gs_resume=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result_b = optimize_gs_ad(gate, None, cfg_resume)
+    _, _, E_b = result_b[:3]
+
+    # No optimizer steps ran on the second call, so the final
+    # re-evaluation simply re-uses the saved best/last params; the
+    # returned energy should match the first run within fresh-CTM
+    # convergence drift.
+    assert abs(E_b - E_a) < 1e-3, f"E_a={E_a!r}, E_b={E_b!r}"
+
+
+@pytest.mark.core
+def test_checkpoint_path_rejects_non_2site_paths():
+    """1-site and multisite paths must raise NotImplementedError when a
+    checkpoint path is requested (only 2-site is wired in this PR)."""
+    gate = _heisenberg_gate()
+    cfg_1site = iPEPSConfig(
+        unit_cell="1x1",
+        max_bond_dim=2,
+        ctm=CTMConfig(chi=4),
+        gs_num_steps=1,
+        gs_checkpoint_path="/tmp/should_not_be_used",
+        gs_c4v=True,
+        su_init=False,
+        gs_conv_criterion="grad_norm",
+    )
+    with pytest.raises(NotImplementedError, match="2site"):
+        optimize_gs_ad(gate, None, cfg_1site)

--- a/tests/test_ipeps_checkpoint_resume.py
+++ b/tests/test_ipeps_checkpoint_resume.py
@@ -223,6 +223,22 @@ def test_resume_discards_optimizer_state_on_optimizer_change(tmp_path):
 
 
 @pytest.mark.core
+def test_resume_with_missing_checkpoint_raises(tmp_path):
+    """``gs_resume=True`` with no checkpoint file must raise fast.
+
+    Silent fresh-init on a typo'd / deleted / never-written
+    checkpoint path would discard the user's intended long-run state
+    and start overwriting the wrong directory.  (Codex P2 review on
+    PR #497.)
+    """
+    gate = _heisenberg_gate()
+    missing_path = str(tmp_path / "does_not_exist")
+    cfg = _base_cfg(missing_path, gs_num_steps=2, gs_resume=True)
+    with pytest.raises(FileNotFoundError, match="no checkpoint found"):
+        optimize_gs_ad(gate, None, cfg)
+
+
+@pytest.mark.core
 def test_checkpoint_path_rejects_non_2site_paths():
     """1-site and multisite paths must raise NotImplementedError when a
     checkpoint path is requested (only 2-site is wired in this PR)."""


### PR DESCRIPTION
## Summary

Adds a checkpoint primitive so long iPEPS AD runs can be resumed from a mid-point after a crash, OOM, or manual interrupt.

This first commit lands the primitive in isolation with full unit-test coverage; subsequent commits on this branch will wire it into the 2-site optimizer path. 1-site reference C4v and multisite paths are deferred to follow-up PRs once the schema is validated in production.

### Design choices (discussed in chat)

| Question | Choice |
|---|---|
| Format | Pickle (HDF5 evaluated and rejected — recovery files are Python-only and ephemeral, the HDF5 selling points don't apply) |
| Include CTM envs? | Yes — warm-start saves cold-CTM cost on resume |
| Cadence | Every K steps + chi-stage boundaries |
| File policy | `ckpt.last.pkl` (overwritten each write) + `ckpt.best.pkl` (overwritten only when energy improves) |
| Atomic writes | `<path>.tmp` then `os.replace()` |
| Config-mismatch on resume | Fatal on `max_bond_dim` / `unit_cell` / `gs_c4v` / `gs_implicit_ad`; warn-and-use for everything else |

### What this commit lands

- `src/tenax/algorithms/_checkpoint.py` — `save_checkpoint`, `load_checkpoint`, `checkpoint_exists`, `validate_config`, `_config_to_dict`. Schema-versioned dicts; future fields are forward-compatible (older bundles loaded by newer code return `None` for missing keys).
- `tests/test_ipeps_checkpoint.py` — 9 core tests: round-trip, missing file, `prefer_best=False/True` isolation, atomic-write-on-crash, schema-version rejection, config fatal/soft validation.

## Test plan

- [x] `uv run pytest tests/test_ipeps_checkpoint.py -v` → 9 passed
- [ ] Wire into 2-site optimizer (`_optimize_gs_ad_tensor_2site`) — separate commit on this branch
- [ ] Resume integration test: 20-step run, kill at step 10, resume, verify final energies match within tolerance
- [ ] Update `iPEPSConfig` with `gs_checkpoint_path`, `gs_checkpoint_every`, `gs_resume` fields
- [ ] README + `__all__` exports for any newly-public API

## Follow-ups (not in this PR)

- 1-site reference C4v wiring
- Multisite wiring
- README example + Sphinx docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)