### PR TITLE
fix(benchmarks): pair symmetric MPO with symmetric MPS in DMRG bench

### DIFF
--- a/benchmarks/bench_dmrg.py
+++ b/benchmarks/bench_dmrg.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 
-from tenax import DMRGConfig, build_mpo_heisenberg, build_random_mps, dmrg
+from tenax import (
+    DMRGConfig,
+    build_mpo_heisenberg,
+    build_random_symmetric_mps,
+    dmrg,
+)
 
 _SIZES = {
     "small": {"L": 20, "chi": 32, "sweeps": 5, "init_bond_dim": 8},
@@ -20,7 +25,11 @@ def get_benchmarks(dtype=jnp.float64) -> list[dict]:
         def _make_fns(p=p, dtype=dtype):
             def setup():
                 mpo = build_mpo_heisenberg(p["L"], dtype=dtype)
-                mps = build_random_mps(p["L"], bond_dim=p["init_bond_dim"], dtype=dtype)
+                # build_mpo_heisenberg returns a symmetric (U(1)) MPO, so the
+                # initial MPS must also be symmetric — dmrg() rejects mixed types.
+                mps = build_random_symmetric_mps(
+                    p["L"], bond_dim=p["init_bond_dim"], dtype=dtype
+                )
                 config = DMRGConfig(
                     max_bond_dim=p["chi"],
                     num_sweeps=p["sweeps"],


### PR DESCRIPTION
## Problem

`bench_dmrg.py` failed on all three sizes (`small`/`medium`/`large`) with:

```
TypeError: dmrg() requires uniform tensor types: all DenseTensor or all
SymmetricTensor. Got mixed types — convert explicitly.
```

`build_mpo_heisenberg` returns a U(1)-symmetric (`SymmetricTensor`) MPO, but
the benchmark initialised the state with `build_random_mps`, which produces a
dense MPS. `dmrg()` rejects mixed tensor types.

## Fix

Use `build_random_symmetric_mps` so the initial MPS shares the
`SymmetricTensor` backend with the MPO. Same call signature (`L`, `bond_dim`,
`dtype`).

## Verification

DMRG benchmark run on a GTX 1080 Ti (CUDA backend, float64) — all three sizes
now pass:

| Size   | Mean (s) | E_final    | Status |
|--------|----------|------------|--------|
| small  | 320.95   | -8.682473  | OK     |
| medium | 987.13   | -17.541473 | OK     |
| large  | 1693.86  | -35.265237 | OK     |

🤖 Generated with [Claude Code](https://claude.com/claude-code)