### PR TITLE
feat(chi-lock): lift NotImplementedError for ctm_energy_implicit + in-CTM bump (#516)

### DIFF
--- a/docs/plans/2026-05-20-chi-lock-design.md
+++ b/docs/plans/2026-05-20-chi-lock-design.md
@@ -1,0 +1,275 @@
+# chi-lock for `ctm_energy_implicit` — design
+
+**Issue:** #516 (filed 2026-05-20)
+**Branch:** `feat/chi-lock-516`
+**Base:** `origin/main` @ `2e0b378` (post-PR #515 merge)
+
+## Goal
+
+Lift the defensive `NotImplementedError` raise in `ctm_energy_implicit` that
+blocks `ctmrg_heuristic_increase_chi=True`, so the implicit-AD path can opt
+into variPEPS-style in-CTM χ-bump without producing silently wrong gradients.
+
+**Motivation is wall-clock, not correctness.** Fixed χ with χ-extrapolation
+remains the community-standard reporting protocol. The bump is a variPEPS-style
+optimization heuristic that avoids wasting L-BFGS steps at small χ early in
+optimization, growing to `chi_max` once truncation error matters.
+
+## Problem statement
+
+PR #515 (Phase 2 of #492/#514) wired in-CTM bump into the explicit-AD warmup
+path but left `ctm_energy_implicit` raising `NotImplementedError` because the
+custom_vjp backward closure captures `chi` as a Python-int closure constant at
+`_make_implicit_vjp_fn` build time:
+
+- `_jit_apply_Jt` at `_ctm_energy_ad.py:895` — `jit_step_bwd(..., chi=chi, ...)`
+- `_jit_chain_rule` at `_ctm_energy_ad.py:931` — same
+- `_jit_fused_fixed_point_bwd` at `_ctm_energy_ad.py:1000` — same
+- `_jit_gmres_solve` at `_ctm_energy_ad.py:1087+` — same
+
+When the forward CTM bumps `chi=9 → chi=18`, `env_leaves` flow into `f_bwd` at
+shape `(18, D², 18)` but the closure-captured `chi` is still 9. JAX retraces
+on shape change but `chi=9` stays baked into `jit_step_bwd`, so the backward
+re-truncates the env to χ=9 and the adjoint `(I − J^T)λ = b` is solved against
+the wrong Jacobian.
+
+## Approach chosen: Option D — lazy per-chi JIT cache via static_argnames
+
+Three other approaches were considered (issue #516 documents A/B/C). D was
+chosen because:
+
+- **Forward bump semantics unchanged.** variPEPS-style in-CTM bump remains as
+  shipped in PR #515; only the backward learns to follow.
+- **No `_VJP_CACHE` surgery.** Outer custom_vjp closure builds once; per-chi
+  backward traces are managed by JAX's own JIT cache.
+- **No SVD-projector audit.** χ stays JIT-static (it controls truncation rank,
+  which XLA wants static); we just multi-trace.
+- **Compile-cost bounded.** Worst case 4 helpers × `(chi_max − chi_initial) /
+  step_size + 1` traces. At defaults (9→24, step=2): 8 chi values, 32 traces.
+  Pays once per benchmark run.
+
+### Why not the alternatives
+
+| Option | Why rejected |
+|---|---|
+| A — cache eviction between L-BFGS steps | Forces bump-between-steps instead of bump-within-CTM, re-opening the zero-padding hazard documented in `feedback_drop_chi_schedule_protocol`. Current call's backward still wrong if mid-CTM bump fires. |
+| B — promote chi to a runtime arg in the JIT'd helpers | Requires splitting SVD projector into trace-static rank vs runtime-shape branches — deep audit. |
+| C — pre-build closures for every reachable χ | Equivalent compile cost to D but eager; D is C done lazily. |
+
+## Architecture
+
+```
+ctm_energy_implicit(...)              # public API
+  └── (defensive raise lifted)
+      ↓
+_ctm_energy_implicit_dispatch(...)    # _VJP_CACHE keyed on chi_INITIAL
+  ↓
+_make_implicit_vjp_fn(chi=chi_INITIAL, ...)
+  ├── @custom_vjp f(params)
+  │     ├─ outside grad: runs forward, returns energy
+  │     └─ inside grad: JAX pairs f_fwd / f_bwd
+  │
+  ├── f_fwd(params):
+  │     envs, chi_post = _run_forward(params)        # NEW: chi_post out
+  │     residuals = (params, env_leaves, chi_post)   # NEW: chi_post in residuals
+  │     return energy, residuals
+  │
+  └── f_bwd(residuals, g):
+        params, env_leaves, chi_post = residuals     # NEW: chi_post out
+        # JAX JIT cache traces one binary per distinct chi_post:
+        rhs   = _jit_dE_denv(params, env_leaves)              # chi-agnostic
+        lam   = _jit_fused_fixed_point_bwd(..., chi=chi_post) # NEW: chi static
+        grad  = _jit_chain_rule(..., lam, chi=chi_post)       # NEW: chi static
+        return grad
+```
+
+### Key invariants
+
+1. **`chi_initial`** (closure constant) — used for `_VJP_CACHE` key and forward
+   env_init when caller passes `env_init=None`. Static across one dispatch
+   identity (gate, neighbors, energy_fn).
+2. **`chi_post`** (residual payload) — Python int extracted from
+   `CTMLoopResult.final_chi`. Threads forward → backward per call. Possibly
+   different on every call.
+3. **Forward bump semantics unchanged.** `_run_ctm_loop_with_bump` keeps
+   bumping mid-CTM exactly as it does today.
+4. **JAX JIT cache handles per-chi compilation** for the four backward
+   helpers automatically — no manual cache management on the Tenax side.
+
+### Why `chi_post` works as a residual payload
+
+`f_fwd` is called by `jax.custom_vjp` with concrete inputs (grad evaluates at
+concrete points; `f_fwd` is not traced as JAX abstract values when called
+outside a `@jax.jit` context). Inside `f_fwd`, the call to `_run_ctm_loop_with_bump`
+runs as ordinary Python — calls to the JIT'd CTM step dispatch with concrete
+shapes and return concrete arrays. `float(_max_S)` (the bump trigger) and
+`chi_current` updates are pure Python (see `_ctm_loop_core.py:187-196`). By
+the time `f_fwd` returns, `CTMLoopResult.final_chi` is a Python int that can
+be carried in residuals.
+
+`f_bwd` receives residuals exactly as `f_fwd` returned them, so `chi_post`
+arrives as a Python int. Passing it as a `static_argnames=('chi',)` keyword to
+the JIT'd helpers triggers a one-time trace per distinct chi value.
+
+## Components
+
+### Modified files
+
+All changes in `src/tenax/algorithms/_ctm_energy_ad.py`:
+
+| Function | Line(s) | Change |
+|---|---|---|
+| `ctm_energy_implicit` | 441-450 | Delete defensive raise; update docstring |
+| `_sigma_gauged_ctm_converge` | 489-592 | Return `(envs, final_chi)` instead of `envs` |
+| `_make_implicit_vjp_fn._run_forward` | 768-811 | Return `(envs, chi_post)` |
+| `_make_implicit_vjp_fn.f_fwd` | 827-835 | Append `chi_post` to residuals tuple |
+| `_make_implicit_vjp_fn.f` | 821-825 | Discard `chi_post` (no backward needed) |
+| `_make_implicit_vjp_fn.f_bwd` | (existing) | Unpack `chi_post`; pass as static arg; bounds-check |
+| `_jit_apply_Jt` | 871-905 | `@partial(jit, static_argnames=('chi',))`; replace closure `chi` with param |
+| `_jit_chain_rule` | 907-943 | Same treatment |
+| `_jit_fused_fixed_point_bwd` | 945+ | Same treatment |
+| `_jit_gmres_solve` | 1087+ | Same treatment |
+| `_jit_dE_denv` | 854-869 | Unchanged — chi-agnostic |
+
+The closure-captured `chi` (renamed conceptually to `chi_initial`) stays in
+scope for: `_VJP_CACHE` cache key, forward env_init, documentation.
+Backward helpers no longer reference closure `chi`.
+
+### `_VJP_CACHE` semantics
+
+Unchanged. Still keyed on `chi_initial` + bump kwargs. Per-chi-post backward
+traces are managed by JAX's JIT cache (separate from `_VJP_CACHE`), so
+multiple chi_post values within one `_VJP_CACHE` entry coexist without
+collision.
+
+### Files NOT touched
+
+- `_ctm_loop_core.py` — `CTMLoopResult.final_chi` already exposes what we need.
+- `_ctm_python_loop.py` — different code path (env-cache warm-start, not
+  custom_vjp); already works.
+- `ipeps_ad_policy.py` — kwargs threading already in place from #515.
+- `ipeps_optimize.py` — only the `gs_implicit_ad=True` warning text at
+  2100-2111 needs a one-line update to drop the "NotImplementedError" note.
+
+## Error handling & edge cases
+
+### Cases that just work
+
+| Case | Why |
+|---|---|
+| `chi_post == chi_initial` (no bump fired) | Backward static_arg = chi_initial; identical to pre-chi-lock behavior |
+| `chi_post` differs across L-BFGS steps (e.g. 12, 16, 16) | JAX JIT cache traces once per visited chi; reuses on repeat |
+| Sigma gauge across in-CTM bump | `_run_ctm_loop_with_bump` already captures `envs_at_iter_start` before bumping (`_ctm_loop_core.py:178`); pair semantics preserved |
+| `prev_lam_leaves` warm-start at new chi | Existing shape-validation invalidation (PR #515 review fix) auto-clears the stale cache |
+| Eager-GMRES fallback path | Same static-arg treatment on `_jit_gmres_solve`; same JIT cache benefit |
+
+### Explicit handling required
+
+1. **Existing defensive-raise tests** — deleted, not updated. Replace with new
+   chi-bump tests in Section 4. Any analogous tests in
+   `tests/test_ctm_in_loop_bump_ad_paths.py` (PR #515) are audited and updated.
+
+2. **`chi_post` bounds sanity check.** `f_bwd` asserts
+   `chi_initial <= chi_post <= chi_max` before passing to backward helpers.
+   Defends against future `_run_ctm_loop_with_bump` regressions that could
+   leak a malformed `final_chi`.
+
+3. **`tenax.ctm.gmres` debug logger** (#499 already wired). Add one DEBUG line
+   in `f_bwd` when `chi_post != chi_initial`:
+   `"chi-lock: backward at chi_post={chi_post} (initial={chi_initial})"`.
+   Lets us diagnose perf regressions and confirm bump is firing in benchmarks.
+
+4. **JIT-trace spam upper bound.** Document in the chi-lock docstring that the
+   number of distinct backward traces is bounded by
+   `(chi_max - chi_initial) / step_size + 1`. If a regression causes per-call
+   re-tracing, the wall-clock signature is unmistakable (~30s extra per call).
+
+### Cases explicitly NOT handled
+
+- **`chi_post` oscillating downward** — bump is monotonic; no downward path.
+- **Concurrent calls with different `chi_post`** — Tenax doesn't support
+  concurrent gradient evaluation on the same VJP cache entry.
+- **`chi_post` exceeding `chi_max`** — `_run_ctm_loop_with_bump` already caps
+  at `chi_max_eff` (`_ctm_loop_core.py:196`). Bounds-check above is
+  defense-in-depth.
+
+## Testing
+
+### New file: `tests/test_ctm_energy_implicit_chi_bump.py`
+
+| Test | Asserts |
+|---|---|
+| `test_implicit_ad_no_longer_raises_with_bump` | `ctm_energy_implicit(..., ctmrg_heuristic_increase_chi=True, chi_max=...)` returns a value |
+| `test_chi_bump_fires_when_smin_above_threshold` | Force low threshold; `final_chi > chi_initial` via diagnostic readback |
+| `test_chi_bump_does_not_fire_when_below_threshold` | High threshold; `final_chi == chi_initial` |
+| **`test_ad_gradient_matches_fd_with_bump`** | **Correctness gate.** FD-vs-AD parity on D=2 χ_initial=4 χ_max=8 with forced bump. Tol 1e-5 abs, 1e-3 rel |
+| `test_ad_gradient_equals_fixed_chi_when_no_bump_fires` | With `chi_max == chi_initial`, gradient matches pre-chi-lock fixed-chi baseline |
+| `test_jit_trace_count_bounded_at_chi_max` | Optimizer traverses chi_initial → chi_max; distinct chi values traced ≤ bound |
+
+### Correctness gate detail
+
+```python
+D, chi_initial, chi_max = 2, 4, 8
+A = random_site_tensor(D)
+gate = heisenberg_gate()
+
+def loss(A_flat):
+    A_ = A_flat.reshape(A.shape)
+    return ctm_energy_implicit(
+        {(0,0): A_, (1,0): A_}, neighbors, gate,
+        chi=chi_initial,
+        ctmrg_heuristic_increase_chi=True,
+        ctmrg_heuristic_increase_chi_threshold=1e-12,  # forces bump
+        chi_max=chi_max,
+    )
+
+grad_ad = jax.grad(loss)(A.flatten())
+grad_fd = central_diff(loss, A.flatten(), eps=1e-4)
+assert jnp.allclose(grad_ad, grad_fd, atol=1e-5, rtol=1e-3)
+```
+
+Threshold `1e-12` guarantees the bump fires on the first iteration. Confirms:
+- Forward env grows χ=4 → χ_max=8
+- Backward operates at χ_post=8
+- Resulting gradient is correct against FD reference
+
+### Modified test files
+
+- **`tests/test_ctm_energy_implicit.py`** — delete the `NotImplementedError`
+  regression test added in PR #515. Keep the
+  `_make_minimal_site_tensors_for_validation` helper.
+- **`tests/test_ctm_in_loop_bump_ad_paths.py`** — audit and update tests that
+  asserted the implicit-AD raise.
+
+### Bench-level acceptance gate (out of CI)
+
+`examples/heisenberg_ipeps_ad_2x2_v9b_implicit_bump.py`:
+
+- D=3, `unit_cell="2site"`, `gs_implicit_ad=True`, `gs_c4v=False`
+- `chi_initial=9`, `chi_max=24`, `ctmrg_heuristic_increase_chi=True`,
+  threshold=1e-6, step=2
+- **Pass:** wall-clock ≤ v7b (8h52m); energy within numerical tolerance of v7b
+  (~−0.6225)
+- **NOT a QMC-parity gate.** Fixed χ remains the production protocol;
+  this benchmark only verifies bump saves cycles without changing the
+  fixed-point.
+
+## Out of scope
+
+- Lifting the `chi_ramp + ctmrg_heuristic_increase_chi` mutex.
+- Multisite / 3-site PESS paths (covered by #411).
+- Deleting `chi_ramp` entirely (covered by #512).
+- Public API simplification (Reading C from the design session — drop
+  `chi_initial` from public API in favor of `chi_max`-only). Deferred to a
+  separate PR after chi-lock lands.
+
+## Related
+
+- #492 — original in-CTM bump feature request
+- #513 — Phase 1 (env-cache warm-start path)
+- #514 / PR #515 — Phase 2 (AD paths; explicit enabled, implicit raised)
+- #516 — this issue (chi-lock for implicit-AD)
+- #328 — explicit-AD non-variational drift (separate; not affected here)
+- `feedback_drop_chi_schedule_protocol.md` — why the bump-between-steps
+  variant (Option A) was rejected
+- `project_v7_fixed_chi_results.md` — fixed-χ=24 baseline for v9b gate

--- a/docs/plans/2026-05-20-chi-lock.md
+++ b/docs/plans/2026-05-20-chi-lock.md
@@ -1,0 +1,1173 @@
+# chi-lock for `ctm_energy_implicit` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Lift the `NotImplementedError` raise in `ctm_energy_implicit` so the implicit-AD path can opt into variPEPS-style in-CTM χ-bump while producing correct gradients.
+
+**Architecture:** Option D from the design — promote `chi` from a Python closure constant to a JAX `static_argnames` parameter on the four backward helpers (`_jit_apply_Jt`, `_jit_chain_rule`, `_jit_fused_fixed_point_bwd`, `_jit_gmres_solve`). `f_fwd` threads the post-bump `chi_post` through residuals; `f_bwd` reads it and dispatches via JAX's JIT cache (one trace per visited χ).
+
+**Tech Stack:** JAX (custom_vjp, jit static_argnames, jax.lax.while_loop), pytest, Python 3.11/3.12.
+
+**Design doc:** `docs/plans/2026-05-20-chi-lock-design.md`
+**Issue:** #516
+**Base branch:** `feat/chi-lock-516` off `origin/main` @ `2e0b378`
+
+---
+
+## Working directory
+
+All commands assume you are in `/home/yjkao/tenax/.claude/worktrees/chi-lock-516`.
+
+```bash
+cd /home/yjkao/tenax/.claude/worktrees/chi-lock-516
+```
+
+Verify you are on `feat/chi-lock-516`:
+```bash
+git branch --show-current  # should print: feat/chi-lock-516
+```
+
+---
+
+## Conventions you should follow
+
+- **Pytest markers**: tests run via `uv run pytest -m core` for the fast bucket. Place new tests in files named `test_ctm_*` so they're auto-marked `core` by `conftest.py`.
+- **Pre-commit hooks** are wired via `core.hooksPath` to the shared `/home/yjkao/tenax/.git/hooks/pre-commit`. Don't reinstall.
+- **Never push to `main`.** Open a PR with `gh pr create`.
+- **One commit per task.** Each task's "Commit" step ends with a single `git commit` invocation.
+- **Test files**: when you write a code block in the plan, copy it verbatim. Don't rewrite for "style" — the plan is the spec.
+
+---
+
+## Task 1: Add "no longer raises" test
+
+**Files:**
+- Create: `tests/test_ctm_energy_implicit_chi_bump.py`
+
+**Step 1.1: Write the failing test**
+
+Create `tests/test_ctm_energy_implicit_chi_bump.py`:
+
+```python
+"""Implicit-AD + in-CTM chi-bump correctness tests (#516 chi-lock).
+
+These tests verify that ctm_energy_implicit produces correct gradients
+when ctmrg_heuristic_increase_chi=True forces the forward CTM to grow
+chi mid-convergence.  See docs/plans/2026-05-20-chi-lock-design.md.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_energy_ad import ctm_energy_implicit
+from tenax.algorithms._ctm_neighbors import SINGLE_SITE_NEIGHBORS
+from tenax.tensors import DenseTensor, TensorIndex
+from tenax.algorithms._gates import heisenberg_gate
+
+
+def _build_site_tensor(D: int = 2, d: int = 2, seed: int = 0) -> DenseTensor:
+    """Build a small random single-site tensor for D=2 probes."""
+    rng = jax.random.PRNGKey(seed)
+    data = jax.random.normal(rng, (d, D, D, D, D), dtype=jnp.float64)
+    return DenseTensor(data, axes=("phys", "u", "r", "d", "l"))
+
+
+def test_implicit_ad_no_longer_raises_with_bump():
+    """ctm_energy_implicit(..., ctmrg_heuristic_increase_chi=True) returns a value.
+
+    Was a NotImplementedError before chi-lock (#516); now should run.
+    """
+    site_tensors = {(0, 0): _build_site_tensor()}
+    gate = heisenberg_gate()
+
+    energy = ctm_energy_implicit(
+        site_tensors,
+        SINGLE_SITE_NEIGHBORS,
+        gate,
+        chi=4,
+        max_iter=4,
+        ctmrg_heuristic_increase_chi=True,
+        chi_max=8,
+    )
+    assert jnp.isfinite(energy)
+```
+
+**Step 1.2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/test_ctm_energy_implicit_chi_bump.py::test_implicit_ad_no_longer_raises_with_bump -v
+```
+
+Expected: FAIL with `NotImplementedError: ctm_energy_implicit does not yet support ctmrg_heuristic_increase_chi`
+
+**Step 1.3: Commit**
+
+```bash
+git add tests/test_ctm_energy_implicit_chi_bump.py
+git commit -m "test(chi-lock): add no-longer-raises test for implicit-AD + bump (#516)"
+```
+
+---
+
+## Task 2: Lift the defensive raise
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_energy_ad.py:433-450`
+- Modify: `tests/test_ctm_in_loop_bump_ad_paths.py:166-186` (delete defensive-raise regression test)
+
+**Step 2.1: Remove the defensive raise**
+
+In `src/tenax/algorithms/_ctm_energy_ad.py`, delete lines 433-450 (the block that begins `# Defensive raise: the implicit-AD backward closure` and ends with the `raise NotImplementedError(...)` call).
+
+The diff should remove exactly:
+
+```python
+    # Defensive raise: the implicit-AD backward closure (_jit_fused_fixed_point_bwd,
+    # _jit_apply_Jt, _jit_gmres_solve) captures ``chi`` as a closure constant
+    # at _make_implicit_vjp_fn build time.  If the forward grew chi via the
+    # in-CTM bump, the env_leaves emitted by the forward would have first-dim
+    # ``chi_bumped > chi`` but every backward sweep would call
+    # ``jit_step_bwd(..., chi=chi_original)`` — silently re-truncating
+    # gradients back to the original chi.  Until a proper chi-lock lands
+    # (deferred follow-up), block the broken path at the public boundary.
+    if ctmrg_heuristic_increase_chi:
+        raise NotImplementedError(
+            "ctm_energy_implicit does not yet support "
+            "ctmrg_heuristic_increase_chi: the implicit-AD backward closure "
+            "captures `chi` at build time, so a forward-side bump would "
+            "produce silently-wrong gradients (the backward VJP would "
+            "re-truncate to the original chi).  Use ctm_energy_explicit "
+            "(warmup phase grows chi; backprop is chi-locked) or wait for "
+            "a chi-lock implementation in ctm_energy_implicit."
+        )
+```
+
+**Step 2.2: Delete the defensive-raise regression test**
+
+In `tests/test_ctm_in_loop_bump_ad_paths.py`, delete the function `test_implicit_ad_bump_raises_not_implemented` (lines 166-186, including its docstring and the blank line before the next test).
+
+Also remove the now-unused `pytest.raises` import if it's not used by any other test in the file — check first:
+
+```bash
+grep -c "pytest.raises" tests/test_ctm_in_loop_bump_ad_paths.py
+```
+
+Only remove the import if the count goes to zero.
+
+**Step 2.3: Run Task 1's test to confirm it passes**
+
+```bash
+uv run pytest tests/test_ctm_energy_implicit_chi_bump.py::test_implicit_ad_no_longer_raises_with_bump -v
+```
+
+Expected: PASS.
+
+**Step 2.4: Run the full bump-AD-paths test file to confirm no regression**
+
+```bash
+uv run pytest tests/test_ctm_in_loop_bump_ad_paths.py -v
+```
+
+Expected: PASS for all remaining tests (one fewer than before — the deleted one).
+
+**Step 2.5: Commit**
+
+```bash
+git add src/tenax/algorithms/_ctm_energy_ad.py tests/test_ctm_in_loop_bump_ad_paths.py
+git commit -m "feat(chi-lock): lift NotImplementedError raise in ctm_energy_implicit (#516)
+
+Step 1 of #516: removes the defensive raise.  Plumbing for correct
+gradients lands in subsequent commits — until then, calling
+ctm_energy_implicit(..., ctmrg_heuristic_increase_chi=True) runs but
+produces silently-wrong gradients (the backward closure still captures
+chi at build time).  Subsequent commits fix this; do not ship the
+branch in this intermediate state."
+```
+
+---
+
+## Task 3: Add FD-vs-AD correctness test with forced bump
+
+**Files:**
+- Modify: `tests/test_ctm_energy_implicit_chi_bump.py`
+
+**Step 3.1: Append the correctness test**
+
+Append to `tests/test_ctm_energy_implicit_chi_bump.py`:
+
+```python
+def _central_diff(f, x: jnp.ndarray, eps: float = 1e-4) -> jnp.ndarray:
+    """Central-difference gradient of scalar f at x (flat vector)."""
+    grad = jnp.zeros_like(x)
+    for i in range(x.shape[0]):
+        ei = jnp.zeros_like(x).at[i].set(eps)
+        f_plus = f(x + ei)
+        f_minus = f(x - ei)
+        grad = grad.at[i].set((f_plus - f_minus) / (2 * eps))
+    return grad
+
+
+def test_ad_gradient_matches_fd_with_bump():
+    """FD-vs-AD parity at D=2, chi_initial=4, chi_max=8 with forced bump.
+
+    The correctness gate for chi-lock: confirms that when the forward CTM
+    grows chi 4 -> 8 via in-CTM bump, the backward operates at chi_post=8
+    (not the closure-captured chi_initial=4) and produces a gradient that
+    matches finite-difference.
+    """
+    A = _build_site_tensor(D=2, d=2, seed=42)
+    site_tensors_template = {(0, 0): A}
+    gate = heisenberg_gate()
+    flat_init = A.data.flatten()
+
+    def loss(A_flat: jnp.ndarray) -> jnp.ndarray:
+        A_perturbed = DenseTensor(
+            A_flat.reshape(A.data.shape), axes=A.axes,
+        )
+        return ctm_energy_implicit(
+            {(0, 0): A_perturbed},
+            SINGLE_SITE_NEIGHBORS,
+            gate,
+            chi=4,
+            max_iter=6,
+            min_iter=2,
+            ctmrg_heuristic_increase_chi=True,
+            ctmrg_heuristic_increase_chi_threshold=1e-12,  # force bump on iter 1
+            ctmrg_heuristic_increase_chi_step_size=2,
+            chi_max=8,
+        )
+
+    grad_ad = jax.grad(loss)(flat_init)
+    grad_fd = _central_diff(loss, flat_init, eps=1e-4)
+
+    # Tol: 1e-5 abs is the chi-lock design target; rel 1e-3 absorbs FD
+    # truncation error on small-magnitude components.
+    assert jnp.allclose(grad_ad, grad_fd, atol=1e-5, rtol=1e-3), (
+        f"AD gradient diverges from FD reference.\n"
+        f"max |grad_ad - grad_fd| = {jnp.max(jnp.abs(grad_ad - grad_fd))}\n"
+        f"grad_ad[:5] = {grad_ad[:5]}\n"
+        f"grad_fd[:5] = {grad_fd[:5]}"
+    )
+```
+
+**Step 3.2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/test_ctm_energy_implicit_chi_bump.py::test_ad_gradient_matches_fd_with_bump -v
+```
+
+Expected: FAIL with an `assert jnp.allclose(...)` mismatch, OR an internal JAX shape error from the chi mismatch (env_leaves at chi=8, jit_step_bwd at chi=4). Either is a valid RED state.
+
+**Step 3.3: Commit**
+
+```bash
+git add tests/test_ctm_energy_implicit_chi_bump.py
+git commit -m "test(chi-lock): add FD-vs-AD correctness gate (#516)
+
+Failing test: when forward CTM bumps chi 4 -> 8, the backward closure
+still uses chi_initial=4, producing wrong gradients.  This test stays
+RED until the chi-static-runtime promotion lands."
+```
+
+---
+
+## Task 4: Plumb `final_chi` out of `_sigma_gauged_ctm_converge`
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_energy_ad.py:489-592` (`_sigma_gauged_ctm_converge`)
+
+**Step 4.1: Change the return type**
+
+Locate `_sigma_gauged_ctm_converge` at `src/tenax/algorithms/_ctm_energy_ad.py:489`. At the end of the function (currently `return result.envs` at line 592), change to:
+
+```python
+    return result.envs, result.final_chi
+```
+
+Update the function's docstring (around lines 511-522) by appending one line before the closing `"""`:
+
+```
+    Returns ``(envs, final_chi)`` so callers can route the post-bump chi
+    into custom_vjp residuals for the chi-lock backward (#516).
+```
+
+**Step 4.2: Update the sole internal caller `_run_forward`**
+
+`_run_forward` is defined inside `_make_implicit_vjp_fn` at `src/tenax/algorithms/_ctm_energy_ad.py:768-811`.  The current body has two branches:
+
+- chi_ramp path (`python_loop_ctm_converge`) — already returns `(envs, _)`. Adapt this branch to return `(envs, chi)` since `chi_ramp` doesn't bump (chi stays at the final ramp stage's chi).
+- sigma-gauged path (`_sigma_gauged_ctm_converge`) — now returns `(envs, final_chi)`.
+
+Replace the entire `_run_forward` body so it always returns `(envs, chi_post)`:
+
+```python
+    def _run_forward(site_tensors):
+        """Run CTM convergence (shared by f and f_fwd).
+
+        Returns ``(envs, chi_post)`` where ``chi_post`` is the post-bump
+        chi (== ``chi`` when no bump fires).  ``chi_post`` threads into
+        the custom_vjp residuals so the backward (#516 chi-lock) can
+        dispatch JIT helpers at the actual post-forward chi.
+        """
+        chi_ramp = mutables["chi_ramp"]
+        env_init = mutables["env_init"]
+        if chi_ramp is not None:
+            envs, _ = python_loop_ctm_converge(
+                site_tensors,
+                neighbors,
+                chi=chi,
+                max_iter=max_iter,
+                min_iter=min_iter,
+                conv_tol=conv_tol,
+                conv_method=conv_method,
+                renormalize=renormalize,
+                projector_method=projector_method,
+                qr_warmup_steps=qr_warmup_steps,
+                projector_backward=projector_backward,
+                chi_ramp=chi_ramp,
+                env_init=env_init,
+                gauge_fix_fn=_gauge_fix_fn,
+                plateau_patience=plateau_patience,
+            )
+            # chi_ramp doesn't trigger in-CTM bump (mutex enforced in dispatch);
+            # chi_post is the final ramp stage's chi, which equals ``chi`` for
+            # the implicit-AD entry point that uses ramp only.
+            chi_post = chi
+        else:
+            envs, chi_post = _sigma_gauged_ctm_converge(
+                site_tensors,
+                neighbors,
+                chi=chi,
+                max_iter=max_iter,
+                conv_tol=conv_tol,
+                projector_method=projector_method,
+                renormalize=renormalize,
+                projector_backward=projector_backward,
+                qr_warmup_steps=qr_warmup_steps,
+                env_init=env_init,
+                forward_gauge=forward_gauge,
+                conv_method=conv_method,
+                min_iter=min_iter,
+                plateau_patience=plateau_patience,
+                ctmrg_heuristic_increase_chi=ctmrg_heuristic_increase_chi,
+                ctmrg_heuristic_increase_chi_threshold=ctmrg_heuristic_increase_chi_threshold,
+                ctmrg_heuristic_increase_chi_step_size=ctmrg_heuristic_increase_chi_step_size,
+                chi_max=chi_max,
+            )
+        return envs, chi_post
+```
+
+**Step 4.3: Update `f` and `f_fwd` to absorb the new tuple return**
+
+`f` (currently at `:821-825`):
+
+```python
+    @jax.custom_vjp
+    def f(params_data_tuple):
+        site_tensors = dict(zip(coords, params_data_tuple))
+        envs, _chi_post = _run_forward(site_tensors)  # chi_post unused outside grad
+        return _compute_energy(site_tensors, envs)
+```
+
+`f_fwd` (currently at `:827-835`):
+
+```python
+    def f_fwd(params_data_tuple):
+        site_tensors = dict(zip(coords, params_data_tuple))
+        envs, chi_post = _run_forward(site_tensors)
+        energy = _compute_energy(site_tensors, envs)
+
+        _cached["env_treedef"] = jax.tree.structure(envs)
+        env_leaves = tuple(jax.tree.leaves(envs))
+        residuals = (params_data_tuple, env_leaves, chi_post)  # chi_post NEW
+        return energy, residuals
+```
+
+**Step 4.4: Update `f_bwd` to unpack the new residual (no use yet)**
+
+`f_bwd` is at `:1127`. Update only the first line of the body:
+
+```python
+    def f_bwd(residuals, g):
+        """Backward: adjoint solve (fixed-point or GMRES) + JIT'd chain rule."""
+        params_data_tuple, env_leaves, chi_post = residuals  # chi_post NEW (unused)
+        # ... rest unchanged for now
+```
+
+We're just unpacking. `chi_post` is unused until Task 6 wires it into the JIT helpers.
+
+**Step 4.5: Run the bump-not-fired tests to confirm no regression**
+
+```bash
+uv run pytest tests/test_ctm_energy_implicit.py -v
+uv run pytest tests/test_ctm_in_loop_bump_ad_paths.py -v
+```
+
+Expected: PASS. Behavior is unchanged when bump doesn't fire (chi_post == chi).
+
+**Step 4.6: Confirm Task 3's test still fails (RED expected)**
+
+```bash
+uv run pytest tests/test_ctm_energy_implicit_chi_bump.py::test_ad_gradient_matches_fd_with_bump -v
+```
+
+Expected: FAIL — chi_post is unpacked but not used; closure still wins.
+
+**Step 4.7: Commit**
+
+```bash
+git add src/tenax/algorithms/_ctm_energy_ad.py
+git commit -m "refactor(chi-lock): thread chi_post through forward → custom_vjp residuals (#516)
+
+Returns (envs, final_chi) from _sigma_gauged_ctm_converge so f_fwd can
+attach the post-bump chi to residuals.  No behavior change — backward
+helpers still close over the build-time chi.  Sets the table for the
+static_argnames promotion in the next commit."
+```
+
+---
+
+## Task 5: Add bounds check + debug log in `f_bwd`
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_energy_ad.py` — top of `f_bwd` (~line 1127)
+
+**Step 5.1: Add bounds assertion + debug log**
+
+After unpacking residuals (the line you added in Task 4.4), add the bounds check and debug log:
+
+```python
+    def f_bwd(residuals, g):
+        """Backward: adjoint solve (fixed-point or GMRES) + JIT'd chain rule.
+
+        ``chi_post`` (from residuals) is the post-bump chi reported by the
+        forward CTM.  It is passed to the four JIT'd backward helpers as a
+        ``static_argnames`` parameter so JAX traces one compiled binary
+        per distinct chi value visited (#516 chi-lock).
+        """
+        params_data_tuple, env_leaves, chi_post = residuals
+
+        # Defense-in-depth: a malformed final_chi from a future
+        # _run_ctm_loop_with_bump regression would silently corrupt the
+        # backward.  Bounds-check at the boundary.
+        chi_max_eff = chi_max if chi_max is not None else chi
+        assert chi <= chi_post <= chi_max_eff, (
+            f"chi_post={chi_post} out of bounds "
+            f"[chi_initial={chi}, chi_max={chi_max_eff}]"
+        )
+        if chi_post != chi:
+            _GMRES_LOGGER.debug(
+                "chi-lock: backward at chi_post=%d (chi_initial=%d)",
+                chi_post,
+                chi,
+            )
+        # ... rest of f_bwd unchanged for now
+```
+
+`_GMRES_LOGGER` is already imported / defined at the module top (from PR #515's #499 bundle).
+
+**Step 5.2: Run existing tests to confirm no regression**
+
+```bash
+uv run pytest tests/test_ctm_energy_implicit.py tests/test_ctm_in_loop_bump_ad_paths.py -v
+```
+
+Expected: PASS.
+
+**Step 5.3: Commit**
+
+```bash
+git add src/tenax/algorithms/_ctm_energy_ad.py
+git commit -m "feat(chi-lock): add chi_post bounds check + debug log in f_bwd (#516)
+
+Defense-in-depth against malformed final_chi leakage from
+_run_ctm_loop_with_bump.  Debug log on tenax.ctm.gmres lets bench runs
+confirm bump is firing without modifying the production output."
+```
+
+---
+
+## Task 6: Promote `chi` to static_argnames in the four backward JIT helpers
+
+This is the load-bearing change. Each helper currently closes over `chi` and
+uses it inside `jit_step_bwd(..., chi=chi, ...)`. Promote `chi` to a regular
+parameter declared `static_argnames=('chi',)`, and update the call sites in
+`f_bwd` to pass `chi=chi_post`.
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_energy_ad.py`:
+  - `_jit_apply_Jt` (`:871-905`)
+  - `_jit_chain_rule` (`:907-943`)
+  - `_jit_fused_fixed_point_bwd` (`:945-1084`)
+  - `_jit_gmres_solve` (`:1086-1125`)
+  - `f_bwd` call sites (`:1149-1274`)
+
+**Step 6.1: Verify `functools.partial` is imported**
+
+```bash
+grep -n "from functools import\|import functools" src/tenax/algorithms/_ctm_energy_ad.py | head -3
+```
+
+If not present, add `from functools import partial` near the other imports at the top of the file.
+
+**Step 6.2: Promote `chi` in `_jit_apply_Jt`**
+
+Locate the decorator and signature (around `:871`):
+
+```python
+    @jax.jit
+    def _jit_apply_Jt(params_data_tuple, env_leaves, v):
+```
+
+Replace with:
+
+```python
+    @partial(jax.jit, static_argnames=("chi",))
+    def _jit_apply_Jt(params_data_tuple, env_leaves, v, *, chi):
+```
+
+Inside the body, the call `jit_step_bwd(..., chi=chi, ...)` (around `:895`)
+already references `chi`. It will now resolve to the new parameter instead
+of the closure. No body change needed.
+
+**Step 6.3: Promote `chi` in `_jit_chain_rule`**
+
+Locate around `:907`:
+
+```python
+    @jax.jit
+    def _jit_chain_rule(params_data_tuple, env_leaves, lam, g_scalar):
+```
+
+Replace with:
+
+```python
+    @partial(jax.jit, static_argnames=("chi",))
+    def _jit_chain_rule(params_data_tuple, env_leaves, lam, g_scalar, *, chi):
+```
+
+No body change (the existing `chi=chi` at `:931` resolves to the new param).
+
+**Step 6.4: Promote `chi` in `_jit_fused_fixed_point_bwd`**
+
+Locate around `:945`:
+
+```python
+    @jax.jit
+    def _jit_fused_fixed_point_bwd(
+        params_data_tuple,
+        env_leaves,
+        g_scalar,
+        init_lam,
+    ):
+```
+
+Replace with:
+
+```python
+    @partial(jax.jit, static_argnames=("chi",))
+    def _jit_fused_fixed_point_bwd(
+        params_data_tuple,
+        env_leaves,
+        g_scalar,
+        init_lam,
+        *,
+        chi,
+    ):
+```
+
+No body change (the two `chi=chi` references at `:1003` and `:1072` resolve to the new param).
+
+**Step 6.5: Promote `chi` in `_jit_gmres_solve`**
+
+Locate around `:1086`:
+
+```python
+    @jax.jit
+    def _jit_gmres_solve(params_data_tuple, env_leaves, rhs):
+```
+
+Replace with:
+
+```python
+    @partial(jax.jit, static_argnames=("chi",))
+    def _jit_gmres_solve(params_data_tuple, env_leaves, rhs, *, chi):
+```
+
+No body change (the `chi=chi` at `:1105` resolves to the new param).
+
+**Step 6.6: Update call sites in `f_bwd`**
+
+Five call sites in `f_bwd` need `chi=chi_post` added:
+
+- `_jit_apply_Jt` call at `:1153`:
+  ```python
+  i_minus_jt_v = _jit_apply_Jt(params_data_tuple, env_leaves, v, chi=chi_post)
+  ```
+
+- `_jit_apply_Jt` call at `:1165` (inside `_eager_apply_I_minus_Jt`):
+  ```python
+  return _jit_apply_Jt(params_data_tuple, env_leaves, v, chi=chi_post)
+  ```
+
+- `_jit_fused_fixed_point_bwd` call at `:1204`:
+  ```python
+  ) = _jit_fused_fixed_point_bwd(params_data_tuple, env_leaves, g, init_lam, chi=chi_post)
+  ```
+
+- `_jit_chain_rule` call at `:1252` (eager-GMRES fallback path):
+  ```python
+  return _jit_chain_rule(params_data_tuple, env_leaves, lam_leaves, g, chi=chi_post)
+  ```
+
+- `_jit_chain_rule` call at `:1274` (gmres branch):
+  ```python
+  return _jit_chain_rule(params_data_tuple, env_leaves, lam_leaves, g, chi=chi_post)
+  ```
+
+`_jit_gmres_solve` is defined but not called from `f_bwd` directly — it's
+unused dead code path (the eager GMRES uses `gmres_pytree_jax` directly).
+Confirm:
+
+```bash
+grep -n "_jit_gmres_solve" src/tenax/algorithms/_ctm_energy_ad.py
+```
+
+If `_jit_gmres_solve` has no call sites in `f_bwd`, the promotion in Step 6.5
+is still correct (future-proofing for if/when it's wired up), but no call-site
+update is needed.
+
+**Step 6.7: Confirm `_eager_dE_denv` does NOT need chi promotion**
+
+`_jit_dE_denv` (at `:854-869`) just `vjp`s through the energy function. It
+doesn't touch `jit_step_bwd` and doesn't read closure `chi`. Leave it alone.
+
+```bash
+grep -n "chi=chi\|chi=" src/tenax/algorithms/_ctm_energy_ad.py | grep -v "chi=chi_post\|chi=chi_initial" | head -20
+```
+
+After this task there should be no remaining `chi=chi` references inside the
+JIT'd backward helpers (only `chi=chi_post` at call sites).
+
+**Step 6.8: Run the FD-vs-AD correctness test**
+
+```bash
+uv run pytest tests/test_ctm_energy_implicit_chi_bump.py::test_ad_gradient_matches_fd_with_bump -v
+```
+
+Expected: PASS.
+
+**Step 6.9: Run the full `-m core` suite to check for regressions**
+
+```bash
+uv run pytest -m core --timeout=300 -q
+```
+
+Expected: all pass.
+
+**Step 6.10: Commit**
+
+```bash
+git add src/tenax/algorithms/_ctm_energy_ad.py
+git commit -m "feat(chi-lock): promote chi to static_argnames in backward JIT helpers (#516)
+
+Closes the chi-lock hole: _jit_apply_Jt, _jit_chain_rule,
+_jit_fused_fixed_point_bwd, _jit_gmres_solve now take chi as a JIT
+static_argnames parameter.  f_bwd passes chi=chi_post (from residuals)
+on every call.  JAX's JIT cache traces one compiled binary per distinct
+chi value visited; subsequent calls at the same chi reuse the trace.
+
+Forward CTM keeps the variPEPS-style in-CTM bump from PR #515; backward
+now follows.  FD-vs-AD parity at D=2 chi=4->8 verifies correctness."
+```
+
+---
+
+## Task 7: Add bump trigger / quiescence tests
+
+**Files:**
+- Modify: `tests/test_ctm_energy_implicit_chi_bump.py`
+
+**Step 7.1: Append the two threshold-trigger tests**
+
+Append to `tests/test_ctm_energy_implicit_chi_bump.py`:
+
+```python
+def test_chi_bump_fires_when_smin_above_threshold():
+    """With threshold=1e-12, the in-CTM bump fires on iter 1 → chi grows.
+
+    Asserts the forward CTM grew env first-dim by reading the env-cache
+    final_chi via the same path used internally by f_bwd's bounds check.
+    """
+    from tenax.algorithms._ctm_energy_ad import _sigma_gauged_ctm_converge
+
+    site_tensors = {(0, 0): _build_site_tensor()}
+    envs, chi_post = _sigma_gauged_ctm_converge(
+        site_tensors,
+        SINGLE_SITE_NEIGHBORS,
+        chi=4,
+        max_iter=6,
+        conv_tol=1e-5,
+        projector_method="svd",
+        renormalize=True,
+        projector_backward="auto",
+        qr_warmup_steps=0,
+        env_init=None,
+        forward_gauge="phase",
+        conv_method="sv",
+        min_iter=2,
+        ctmrg_heuristic_increase_chi=True,
+        ctmrg_heuristic_increase_chi_threshold=1e-12,  # force bump
+        ctmrg_heuristic_increase_chi_step_size=2,
+        chi_max=8,
+    )
+    assert chi_post > 4, f"Expected bump fired (chi_post > 4), got chi_post={chi_post}"
+    assert chi_post <= 8, f"chi_post={chi_post} exceeded chi_max=8"
+
+
+def test_chi_bump_does_not_fire_when_below_threshold():
+    """With threshold=1e10 (above any realistic smin), bump quiesces."""
+    from tenax.algorithms._ctm_energy_ad import _sigma_gauged_ctm_converge
+
+    site_tensors = {(0, 0): _build_site_tensor()}
+    envs, chi_post = _sigma_gauged_ctm_converge(
+        site_tensors,
+        SINGLE_SITE_NEIGHBORS,
+        chi=4,
+        max_iter=6,
+        conv_tol=1e-5,
+        projector_method="svd",
+        renormalize=True,
+        projector_backward="auto",
+        qr_warmup_steps=0,
+        env_init=None,
+        forward_gauge="phase",
+        conv_method="sv",
+        min_iter=2,
+        ctmrg_heuristic_increase_chi=True,
+        ctmrg_heuristic_increase_chi_threshold=1e10,  # never fires
+        ctmrg_heuristic_increase_chi_step_size=2,
+        chi_max=8,
+    )
+    assert chi_post == 4, f"Expected no bump (chi_post == 4), got chi_post={chi_post}"
+```
+
+**Step 7.2: Run the new tests**
+
+```bash
+uv run pytest tests/test_ctm_energy_implicit_chi_bump.py::test_chi_bump_fires_when_smin_above_threshold tests/test_ctm_energy_implicit_chi_bump.py::test_chi_bump_does_not_fire_when_below_threshold -v
+```
+
+Expected: PASS for both.
+
+**Step 7.3: Commit**
+
+```bash
+git add tests/test_ctm_energy_implicit_chi_bump.py
+git commit -m "test(chi-lock): bump fires / quiesces by threshold (#516)"
+```
+
+---
+
+## Task 8: Add equal-to-fixed-chi gradient test
+
+**Files:**
+- Modify: `tests/test_ctm_energy_implicit_chi_bump.py`
+
+**Step 8.1: Append the test**
+
+Append to `tests/test_ctm_energy_implicit_chi_bump.py`:
+
+```python
+def test_ad_gradient_equals_fixed_chi_when_no_bump_fires():
+    """With chi_max == chi_initial, gradient is identical to bump=False.
+
+    Verifies the chi-lock plumbing is a no-op when bump can't fire.
+    Detects accidental drift in the chi_initial == chi_post path.
+    """
+    A = _build_site_tensor(D=2, d=2, seed=7)
+    gate = heisenberg_gate()
+    flat_init = A.data.flatten()
+
+    def loss_with_bump(A_flat: jnp.ndarray) -> jnp.ndarray:
+        A_perturbed = DenseTensor(A_flat.reshape(A.data.shape), axes=A.axes)
+        return ctm_energy_implicit(
+            {(0, 0): A_perturbed},
+            SINGLE_SITE_NEIGHBORS,
+            gate,
+            chi=4,
+            max_iter=6,
+            min_iter=2,
+            ctmrg_heuristic_increase_chi=True,
+            ctmrg_heuristic_increase_chi_threshold=1e-12,
+            ctmrg_heuristic_increase_chi_step_size=2,
+            chi_max=4,  # == chi_initial → no room to bump
+        )
+
+    def loss_no_bump(A_flat: jnp.ndarray) -> jnp.ndarray:
+        A_perturbed = DenseTensor(A_flat.reshape(A.data.shape), axes=A.axes)
+        return ctm_energy_implicit(
+            {(0, 0): A_perturbed},
+            SINGLE_SITE_NEIGHBORS,
+            gate,
+            chi=4,
+            max_iter=6,
+            min_iter=2,
+            ctmrg_heuristic_increase_chi=False,
+        )
+
+    grad_bump = jax.grad(loss_with_bump)(flat_init)
+    grad_no_bump = jax.grad(loss_no_bump)(flat_init)
+
+    assert jnp.allclose(grad_bump, grad_no_bump, atol=1e-10, rtol=1e-10), (
+        f"chi-lock plumbing leaks when bump can't fire.\n"
+        f"max diff = {jnp.max(jnp.abs(grad_bump - grad_no_bump))}"
+    )
+```
+
+**Step 8.2: Run the new test**
+
+```bash
+uv run pytest tests/test_ctm_energy_implicit_chi_bump.py::test_ad_gradient_equals_fixed_chi_when_no_bump_fires -v
+```
+
+Expected: PASS.
+
+**Step 8.3: Commit**
+
+```bash
+git add tests/test_ctm_energy_implicit_chi_bump.py
+git commit -m "test(chi-lock): equality with fixed-chi baseline when bump can't fire (#516)"
+```
+
+---
+
+## Task 9: Update docstring + warning text + design doc reference
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_energy_ad.py:309-401` (`ctm_energy_implicit` docstring)
+- Modify: `src/tenax/algorithms/ipeps_optimize.py:2100-2111` (warning text)
+
+**Step 9.1: Update `ctm_energy_implicit` docstring**
+
+In the docstring (around `:382-401`), find the block describing
+`ctmrg_heuristic_increase_chi`. After PR #515 it read like the same as
+`ctm_energy_explicit`. Update to mention chi-lock:
+
+Locate the block (around `:383-397`):
+
+```
+        ctmrg_heuristic_increase_chi:
+                           If True, run variPEPS-style in-CTM chi bumping
+                           toward ``chi_max`` when the smallest retained
+                           singular value exceeds
+                           ``ctmrg_heuristic_increase_chi_threshold``.
+                           Requires ``chi_max`` to be set and is mutex
+                           with ``chi_ramp``.  Defaults to False
+                           (existing fixed-chi behaviour).
+```
+
+Replace with:
+
+```
+        ctmrg_heuristic_increase_chi:
+                           If True, run variPEPS-style in-CTM chi bumping
+                           toward ``chi_max`` when the smallest retained
+                           singular value exceeds
+                           ``ctmrg_heuristic_increase_chi_threshold``.
+                           Requires ``chi_max`` to be set and is mutex
+                           with ``chi_ramp``.  Defaults to False
+                           (existing fixed-chi behaviour).
+
+                           The backward pass is chi-locked to the
+                           post-bump chi via JAX JIT static_argnames
+                           (see docs/plans/2026-05-20-chi-lock-design.md):
+                           the four backward JIT helpers re-trace one
+                           compiled binary per distinct chi value
+                           visited.  At defaults (chi 9 -> chi_max 24,
+                           step 2) this is ~8 traces per helper,
+                           amortised across the optimizer run.
+```
+
+**Step 9.2: Update `ipeps_optimize.py` warning text**
+
+```bash
+grep -n "ctmrg_heuristic_increase_chi\|NotImplementedError\|in-CTM bump" src/tenax/algorithms/ipeps_optimize.py | head -10
+```
+
+Locate the 2-site warning block (around `:2100-2111`).  The PR #515 version
+mentions the `NotImplementedError` limitation.  Replace any line that says
+"raises NotImplementedError" or similar with text that reflects the new
+behaviour — chi-lock is the production path.
+
+If the existing text is:
+
+```python
+                # ... `ctmrg_heuristic_increase_chi=True` raises
+                # NotImplementedError on the implicit-AD path; use
+                # gs_implicit_ad=False to opt into the bump.
+```
+
+Replace with:
+
+```python
+                # ... `ctmrg_heuristic_increase_chi=True` is supported
+                # on both AD paths (chi-locked backward for implicit AD
+                # via #516; warmup-only bump for explicit AD).
+```
+
+Exact text depends on the post-#515 content — adjust to match while
+preserving the surrounding sentence structure.
+
+**Step 9.3: Run docstring-relevant tests**
+
+```bash
+uv run pytest tests/test_ipeps_optimize.py -k "warning" -v
+```
+
+Expected: PASS (any tests that snapshot the warning text need updating; the
+test will tell you what to change).
+
+**Step 9.4: Commit**
+
+```bash
+git add src/tenax/algorithms/_ctm_energy_ad.py src/tenax/algorithms/ipeps_optimize.py
+git commit -m "docs(chi-lock): update docstring + warning text to reflect lifted raise (#516)"
+```
+
+---
+
+## Task 10: Create v9b benchmark script
+
+**Files:**
+- Create: `examples/heisenberg_ipeps_ad_2x2_v9b_implicit_bump.py`
+
+This is a benchmark script, not a test. It's a manual GPU-or-CPU run to
+verify the wall-clock gate from the design doc (≤ v7b at 8h52m for similar
+energy).
+
+**Step 10.1: Write the script**
+
+Create `examples/heisenberg_ipeps_ad_2x2_v9b_implicit_bump.py`:
+
+```python
+#!/usr/bin/env python3
+"""v9b: 2-site bipartite implicit AD + in-CTM chi-bump (post-#516 chi-lock).
+
+Configuration: ``gs_c4v=False`` + ``gs_implicit_ad=True`` (implicit AD
+via custom_vjp + fixed-point adjoint), ``chi_initial=9``, ``chi_max=24``,
+``chi_auto_bump=True``, no schedule.
+
+Acceptance gate (per docs/plans/2026-05-20-chi-lock-design.md Section
+"Bench-level acceptance gate"):
+- wall-clock <= v7b (8h52m at fixed chi=24)
+- energy within numerical tolerance of v7b (~-0.6225)
+- NOT a QMC-parity gate — fixed chi remains the production protocol;
+  this run only verifies the bump saves cycles without changing the
+  fixed-point.
+
+QMC reference: E/site ~ -0.6694 (informational only — implicit AD at
+chi=24 plateaus at -0.6225 per v7b).
+
+Usage::
+
+    CUDA_VISIBLE_DEVICES=0 uv run python examples/heisenberg_ipeps_ad_2x2_v9b_implicit_bump.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+# Uncomment for chi-lock diagnostics:
+# logging.getLogger("tenax.ctm.gmres").setLevel(logging.DEBUG)
+
+from tenax import (  # noqa: E402
+    CTMConfig,
+    aligned_ctm_schedules,
+    heisenberg_gate,
+    iPEPSConfig,
+    optimize_gs_ad,
+)
+
+
+def main() -> None:
+    print("iPEPS-AD v9b: bipartite implicit AD + in-CTM chi-bump (#516)")
+    print("H = J sum_<ij> S_i . S_j,   J = 1")
+    print("QMC reference: E/site ~ -0.6694 (informational only)")
+    print("v7b baseline:  E/site ~ -0.6225 at fixed chi=24 in 8h52m\n")
+
+    H = heisenberg_gate()
+
+    conv_tol_schedule, patience_schedule = aligned_ctm_schedules(
+        [(0.0, 1e-5, 20), (0.7, 1e-7, None)]
+    )
+
+    D = 3
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        num_imaginary_steps=300,
+        dt=0.05,
+        unit_cell="2site",
+        gs_num_steps=80,
+        ctm=CTMConfig(
+            chi=9,
+            max_iter=75,
+            min_iter=10,
+            conv_tol=1e-5,
+            projector_method="svd",
+            forward_gauge="phase",
+            adjoint_method="fixed_point",
+            gmres_tol=1e-7,
+            gmres_maxiter=75,
+            chi_auto_bump=True,
+            chi_auto_bump_eps=1e-6,
+            chi_auto_bump_step=2,
+            chi_max=24,
+        ),
+        gs_c4v=False,
+        gs_implicit_ad=True,  # implicit AD via custom_vjp
+        gs_optimizer="lbfgs",
+        gs_line_search_method="hager_zhang",
+        gs_line_search_max_steps=40,
+        gs_metric_precond=True,
+        metric_gmres_maxiter=3,
+        gs_ctm_conv_tol_schedule=conv_tol_schedule,
+        gs_plateau_patience_schedule=patience_schedule,
+        gs_conv_tol=1e-5,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-5,
+        gs_stall_recovery="reset",
+        gs_noise_amplitude=1e-4,
+        gs_noise_recovery_retries=5,
+        su_init=True,
+        gs_verbose=True,
+        gs_log_interval=5,
+    )
+
+    t0 = time.perf_counter()
+    (A_opt, B_opt), envs, E_gs = optimize_gs_ad(H, None, config)
+    dt = time.perf_counter() - t0
+
+    print(f"\n  D       = {D}")
+    print(f"  chi_max = 24 (initial=9, bump active)")
+    print(f"  E/site  = {E_gs:.8f}")
+    print(f"  time    = {dt:.1f}s ({dt/3600:.2f}h)")
+    v7b_wallclock_s = 8 * 3600 + 52 * 60
+    print(f"  wall-clock gate: {'PASS' if dt <= v7b_wallclock_s else 'FAIL'} (v7b 8h52m)")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**Step 10.2: Confirm the script is importable (syntax only)**
+
+```bash
+uv run python -c "import ast; ast.parse(open('examples/heisenberg_ipeps_ad_2x2_v9b_implicit_bump.py').read())"
+```
+
+Expected: no output (success).
+
+**Step 10.3: Commit**
+
+```bash
+git add examples/heisenberg_ipeps_ad_2x2_v9b_implicit_bump.py
+git commit -m "bench(chi-lock): v9b implicit-AD + in-CTM bump benchmark script (#516)
+
+Manual GPU run script.  Acceptance gate is wall-clock <= v7b (8h52m)
+with energy within tolerance of v7b's -0.6225 fixed-chi baseline.  Not
+a QMC-parity gate."
+```
+
+---
+
+## Task 11: Open PR
+
+**Step 11.1: Run the full -m core suite one final time**
+
+```bash
+uv run pytest -m core --timeout=300 -q
+```
+
+Expected: all pass.
+
+**Step 11.2: Push branch and open PR**
+
+```bash
+git push -u origin feat/chi-lock-516
+gh pr create --title "feat(chi-lock): lift NotImplementedError for ctm_energy_implicit + in-CTM bump (#516)" --body "$(cat <<'EOF'
+## Summary
+
+Lifts the defensive `NotImplementedError` in `ctm_energy_implicit` that
+blocks `ctmrg_heuristic_increase_chi=True` (added in PR #515).  The
+implicit-AD path can now opt into variPEPS-style in-CTM chi bumping
+with correct gradients.
+
+## Approach
+
+Option D from the design doc (`docs/plans/2026-05-20-chi-lock-design.md`):
+promote `chi` from a Python closure constant to a JAX `static_argnames`
+parameter on the four backward JIT helpers
+(`_jit_apply_Jt`, `_jit_chain_rule`, `_jit_fused_fixed_point_bwd`,
+`_jit_gmres_solve`).  `f_fwd` threads the post-bump chi through
+residuals; `f_bwd` reads it and dispatches via JAX's JIT cache (one
+trace per visited chi).
+
+## Test plan
+
+- [ ] `tests/test_ctm_energy_implicit_chi_bump.py` (new file, 5 tests)
+  - no-longer-raises
+  - FD-vs-AD correctness gate at D=2 chi 4 -> 8
+  - bump fires when smin > threshold
+  - bump quiesces when smin < threshold
+  - gradient equals fixed-chi baseline when bump can't fire
+- [ ] Defensive-raise regression test in `test_ctm_in_loop_bump_ad_paths.py` deleted
+- [ ] Full `-m core` suite passes
+- [ ] (Manual GPU) v9b benchmark wall-clock <= v7b 8h52m
+
+## Out of scope
+
+- Public API simplification (drop `chi_initial` exposure) — separate PR
+- Multisite / 3-site PESS paths — covered by #411
+- `chi_ramp` removal — covered by #512
+
+Closes #516
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+**Step 11.3: Enable auto-merge**
+
+```bash
+gh pr merge --delete-branch --auto
+```
+
+Expected: "Pull request <N> is queued to merge" or "auto-merge enabled".
+
+---
+
+## After all tasks
+
+When the PR lands, write a memory entry:
+
+```bash
+# In /home/yjkao/.claude/projects/-home-yjkao-tenax/memory/
+# Create: project_516_chi_lock_landed.md
+# Add line to MEMORY.md
+```
+
+Then update `project_514_phase2_landed.md` to note chi-lock has shipped
+and the defensive-raise reference is now historical.

--- a/examples/heisenberg_ipeps_ad_2x2_v9b_implicit_bump.py
+++ b/examples/heisenberg_ipeps_ad_2x2_v9b_implicit_bump.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""v9b: 2-site bipartite implicit AD + in-CTM chi-bump (post-#516 chi-lock).
+
+Configuration: ``gs_c4v=False`` + ``gs_implicit_ad=True`` (implicit AD
+via custom_vjp + fixed-point adjoint), ``chi_initial=9``, ``chi_max=24``,
+``chi_auto_bump=True``, no schedule.
+
+Acceptance gate (per docs/plans/2026-05-20-chi-lock-design.md Section
+"Bench-level acceptance gate"):
+- wall-clock <= v7b (8h52m at fixed chi=24)
+- energy within numerical tolerance of v7b (~-0.6225)
+- NOT a QMC-parity gate -- fixed chi remains the production protocol;
+  this run only verifies the bump saves cycles without changing the
+  fixed-point.
+
+QMC reference: E/site ~ -0.6694 (informational only -- implicit AD at
+chi=24 plateaus at -0.6225 per v7b).
+
+Usage::
+
+    CUDA_VISIBLE_DEVICES=0 uv run python examples/heisenberg_ipeps_ad_2x2_v9b_implicit_bump.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+# Uncomment for chi-lock diagnostics:
+# logging.getLogger("tenax.ctm.gmres").setLevel(logging.DEBUG)
+
+from tenax import (  # noqa: E402
+    CTMConfig,
+    aligned_ctm_schedules,
+    heisenberg_gate,
+    iPEPSConfig,
+    optimize_gs_ad,
+)
+
+
+def main() -> None:
+    print("iPEPS-AD v9b: bipartite implicit AD + in-CTM chi-bump (#516)")
+    print("H = J sum_<ij> S_i . S_j,   J = 1")
+    print("QMC reference: E/site ~ -0.6694 (informational only)")
+    print("v7b baseline:  E/site ~ -0.6225 at fixed chi=24 in 8h52m\n")
+
+    H = heisenberg_gate()
+
+    conv_tol_schedule, patience_schedule = aligned_ctm_schedules(
+        [(0.0, 1e-5, 20), (0.7, 1e-7, None)]
+    )
+
+    D = 3
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        num_imaginary_steps=300,
+        dt=0.05,
+        unit_cell="2site",
+        gs_num_steps=80,
+        ctm=CTMConfig(
+            chi=9,
+            max_iter=75,
+            min_iter=10,
+            conv_tol=1e-5,
+            projector_method="svd",
+            forward_gauge="phase",
+            adjoint_method="fixed_point",
+            gmres_tol=1e-7,
+            gmres_maxiter=75,
+            chi_auto_bump=True,
+            chi_auto_bump_eps=1e-6,
+            chi_auto_bump_step=2,
+            chi_max=24,
+        ),
+        gs_c4v=False,
+        gs_implicit_ad=True,  # implicit AD via custom_vjp
+        gs_optimizer="lbfgs",
+        gs_line_search_method="hager_zhang",
+        gs_line_search_max_steps=40,
+        gs_metric_precond=True,
+        metric_gmres_maxiter=3,
+        gs_ctm_conv_tol_schedule=conv_tol_schedule,
+        gs_plateau_patience_schedule=patience_schedule,
+        gs_conv_tol=1e-5,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-5,
+        gs_stall_recovery="reset",
+        gs_noise_amplitude=1e-4,
+        gs_noise_recovery_retries=5,
+        su_init=True,
+        gs_verbose=True,
+        gs_log_interval=5,
+    )
+
+    t0 = time.perf_counter()
+    (A_opt, B_opt), envs, E_gs = optimize_gs_ad(H, None, config)
+    dt = time.perf_counter() - t0
+
+    print(f"\n  D       = {D}")
+    print("  chi_max = 24 (initial=9, bump active)")
+    print(f"  E/site  = {E_gs:.8f}")
+    print(f"  time    = {dt:.1f}s ({dt / 3600:.2f}h)")
+    v7b_wallclock_s = 8 * 3600 + 52 * 60
+    print(
+        f"  wall-clock gate: {'PASS' if dt <= v7b_wallclock_s else 'FAIL'} (v7b 8h52m)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -389,6 +389,15 @@ def ctm_energy_implicit(
                            Requires ``chi_max`` to be set and is mutex
                            with ``chi_ramp``.  Defaults to False
                            (existing behaviour).
+
+                           The backward pass is chi-locked to the
+                           post-bump chi via JAX JIT static_argnames
+                           (see docs/plans/2026-05-20-chi-lock-design.md):
+                           the four backward JIT helpers re-trace one
+                           compiled binary per distinct chi value
+                           visited.  At defaults (chi 9 -> chi_max 24,
+                           step 2) this is ~8 traces per helper,
+                           amortised across the optimizer run.
         ctmrg_heuristic_increase_chi_threshold:
                            Smallest-S threshold that triggers an in-CTM
                            chi bump.  Default ``1e-6``.
@@ -418,11 +427,11 @@ def ctm_energy_implicit(
         )
 
     # Mirror the bump-kwarg validation from ``_sigma_gauged_ctm_converge`` at
-    # the public boundary.  We need these to fire *before* the
-    # NotImplementedError below so that existing kwarg-validation tests
-    # (chi_max=None, step_size<=0, env_init above chi_max) still surface
-    # their specific ValueError rather than the more generic
-    # NotImplementedError defensive raise.
+    # the public boundary so kwarg-validation tests (chi_max=None,
+    # step_size<=0, env_init above chi_max) surface their specific
+    # ValueError at the entry point, before dispatch hands off to the
+    # custom_vjp factory.  Chi-lock (#516) lifted the prior
+    # NotImplementedError raise that this block historically preceded.
     _validate_chi_bump_args(
         chi=chi,
         chi_max=chi_max,

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -500,6 +500,9 @@ def _sigma_gauged_ctm_converge(
     ``ctmrg_heuristic_increase_chi=True`` the loop performs variPEPS-style
     in-CTM chi bumping toward ``chi_max`` (see #492/#514); defaults keep
     bump-off behaviour for existing implicit-AD callers.
+
+    Returns ``(envs, final_chi)`` so callers can route the post-bump chi
+    into custom_vjp residuals for the chi-lock backward (#516).
     """
     # ---- validation (mirror python_loop_ctm_converge) ----
     chi_current = _validate_chi_bump_args(
@@ -570,7 +573,7 @@ def _sigma_gauged_ctm_converge(
         conv_method=conv_method,
         plateau_patience=plateau_patience,
     )
-    return result.envs
+    return result.envs, result.final_chi
 
 
 _VJP_CACHE: dict = {}
@@ -747,7 +750,13 @@ def _make_implicit_vjp_fn(
     _cached = {"prev_lam_leaves": None}
 
     def _run_forward(site_tensors):
-        """Run CTM convergence (shared by f and f_fwd)."""
+        """Run CTM convergence (shared by f and f_fwd).
+
+        Returns ``(envs, chi_post)`` where ``chi_post`` is the post-bump
+        chi (== ``chi`` when no bump fires).  ``chi_post`` threads into
+        the custom_vjp residuals so the backward (#516 chi-lock) can
+        dispatch JIT helpers at the actual post-forward chi.
+        """
         chi_ramp = mutables["chi_ramp"]
         env_init = mutables["env_init"]
         if chi_ramp is not None:
@@ -768,8 +777,12 @@ def _make_implicit_vjp_fn(
                 gauge_fix_fn=_gauge_fix_fn,
                 plateau_patience=plateau_patience,
             )
+            # chi_ramp doesn't trigger in-CTM bump (mutex enforced in dispatch);
+            # chi_post is the final ramp stage's chi, which equals ``chi`` for
+            # the implicit-AD entry point that uses ramp only.
+            chi_post = chi
         else:
-            envs = _sigma_gauged_ctm_converge(
+            envs, chi_post = _sigma_gauged_ctm_converge(
                 site_tensors,
                 neighbors,
                 chi=chi,
@@ -789,7 +802,7 @@ def _make_implicit_vjp_fn(
                 ctmrg_heuristic_increase_chi_step_size=ctmrg_heuristic_increase_chi_step_size,
                 chi_max=chi_max,
             )
-        return envs
+        return envs, chi_post
 
     def _compute_energy(site_tensors, envs):
         """Compute energy using energy_fn or default."""
@@ -802,17 +815,17 @@ def _make_implicit_vjp_fn(
     @jax.custom_vjp
     def f(params_data_tuple):
         site_tensors = dict(zip(coords, params_data_tuple))
-        envs = _run_forward(site_tensors)
+        envs, _chi_post = _run_forward(site_tensors)  # chi_post unused outside grad
         return _compute_energy(site_tensors, envs)
 
     def f_fwd(params_data_tuple):
         site_tensors = dict(zip(coords, params_data_tuple))
-        envs = _run_forward(site_tensors)
+        envs, chi_post = _run_forward(site_tensors)
         energy = _compute_energy(site_tensors, envs)
 
         _cached["env_treedef"] = jax.tree.structure(envs)
         env_leaves = tuple(jax.tree.leaves(envs))
-        residuals = (params_data_tuple, env_leaves)
+        residuals = (params_data_tuple, env_leaves, chi_post)  # chi_post NEW
         return energy, residuals
 
     # Build JIT'd sweep step for backward (same as forward).
@@ -1107,7 +1120,7 @@ def _make_implicit_vjp_fn(
 
     def f_bwd(residuals, g):
         """Backward: adjoint solve (fixed-point or GMRES) + JIT'd chain rule."""
-        params_data_tuple, env_leaves = residuals
+        params_data_tuple, env_leaves, chi_post = residuals  # chi_post NEW (unused)
 
         # dE/denv is the RHS for the (I - J^T)·λ = b solve. F3's fused JIT
         # recomputes it internally, so the eager call is only needed by:

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -430,25 +430,6 @@ def ctm_energy_implicit(
         bump_step_size=ctmrg_heuristic_increase_chi_step_size,
     )
 
-    # Defensive raise: the implicit-AD backward closure (_jit_fused_fixed_point_bwd,
-    # _jit_apply_Jt, _jit_gmres_solve) captures ``chi`` as a closure constant
-    # at _make_implicit_vjp_fn build time.  If the forward grew chi via the
-    # in-CTM bump, the env_leaves emitted by the forward would have first-dim
-    # ``chi_bumped > chi`` but every backward sweep would call
-    # ``jit_step_bwd(..., chi=chi_original)`` — silently re-truncating
-    # gradients back to the original chi.  Until a proper chi-lock lands
-    # (deferred follow-up), block the broken path at the public boundary.
-    if ctmrg_heuristic_increase_chi:
-        raise NotImplementedError(
-            "ctm_energy_implicit does not yet support "
-            "ctmrg_heuristic_increase_chi: the implicit-AD backward closure "
-            "captures `chi` at build time, so a forward-side bump would "
-            "produce silently-wrong gradients (the backward VJP would "
-            "re-truncate to the original chi).  Use ctm_energy_explicit "
-            "(warmup phase grows chi; backprop is chi-locked) or wait for "
-            "a chi-lock implementation in ctm_energy_implicit."
-        )
-
     coords = sorted(site_tensors.keys())
     # Pass Tensor objects directly through custom_vjp boundary.
     # Both DenseTensor and SymmetricTensor are registered JAX pytrees,

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -825,7 +825,7 @@ def _make_implicit_vjp_fn(
 
         _cached["env_treedef"] = jax.tree.structure(envs)
         env_leaves = tuple(jax.tree.leaves(envs))
-        residuals = (params_data_tuple, env_leaves, chi_post)  # chi_post NEW
+        residuals = (params_data_tuple, env_leaves, chi_post)
         return energy, residuals
 
     # Build JIT'd sweep step for backward (same as forward).
@@ -1119,8 +1119,29 @@ def _make_implicit_vjp_fn(
         return tuple(jax.tree.leaves(lam)), info
 
     def f_bwd(residuals, g):
-        """Backward: adjoint solve (fixed-point or GMRES) + JIT'd chain rule."""
-        params_data_tuple, env_leaves, chi_post = residuals  # chi_post NEW (unused)
+        """Backward: adjoint solve (fixed-point or GMRES) + JIT'd chain rule.
+
+        ``chi_post`` (from residuals) is the post-bump chi reported by the
+        forward CTM.  It is passed to the four JIT'd backward helpers as a
+        ``static_argnames`` parameter so JAX traces one compiled binary
+        per distinct chi value visited (#516 chi-lock).
+        """
+        params_data_tuple, env_leaves, chi_post = residuals
+
+        # Defense-in-depth: a malformed final_chi from a future
+        # _run_ctm_loop_with_bump regression would silently corrupt the
+        # backward.  Bounds-check at the boundary.
+        chi_max_eff = chi_max if chi_max is not None else chi
+        assert chi <= chi_post <= chi_max_eff, (
+            f"chi_post={chi_post} out of bounds "
+            f"[chi_initial={chi}, chi_max={chi_max_eff}]"
+        )
+        if chi_post != chi:
+            _GMRES_LOGGER.debug(
+                "chi-lock: backward at chi_post=%d (chi_initial=%d)",
+                chi_post,
+                chi,
+            )
 
         # dE/denv is the RHS for the (I - J^T)·λ = b solve. F3's fused JIT
         # recomputes it internally, so the eager call is only needed by:

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 __all__ = ["ctm_energy_explicit", "ctm_energy_implicit"]
 
 import logging
+from functools import partial
 
 import jax
 import jax.numpy as jnp
@@ -862,8 +863,8 @@ def _make_implicit_vjp_fn(
         _, vjp_fn = jax.vjp(energy_from_env, env_leaves)
         return vjp_fn(jnp.ones(()))[0]
 
-    @jax.jit
-    def _jit_apply_Jt(params_data_tuple, env_leaves, v):
+    @partial(jax.jit, static_argnames=("chi",))
+    def _jit_apply_Jt(params_data_tuple, env_leaves, v, *, chi):
         """Apply the GMRES matvec ``(I - J^T) v`` (NOT just ``J^T v``).
 
         The wrapping makes this the matvec for the linear system
@@ -898,8 +899,8 @@ def _make_implicit_vjp_fn(
         jt_v = vjp_fn(v)[0]
         return tuple(vi - ji for vi, ji in zip(v, jt_v))
 
-    @jax.jit
-    def _jit_chain_rule(params_data_tuple, env_leaves, lam, g_scalar):
+    @partial(jax.jit, static_argnames=("chi",))
+    def _jit_chain_rule(params_data_tuple, env_leaves, lam, g_scalar, *, chi):
         """Steps 3-4: direct gradient + indirect (J_params^T @ lam)."""
         gate_ = mutables["gate"]
         energy_fn_ = mutables["energy_fn"]
@@ -936,12 +937,14 @@ def _make_implicit_vjp_fn(
         total = jax.tree.map(lambda d, ind: g_scalar * (d + ind), direct, indirect)
         return (total,)
 
-    @jax.jit
+    @partial(jax.jit, static_argnames=("chi",))
     def _jit_fused_fixed_point_bwd(
         params_data_tuple,
         env_leaves,
         g_scalar,
         init_lam,
+        *,
+        chi,
     ):
         """F3: fused dE/denv + adjoint fixed-point + chain rule.
 
@@ -1077,8 +1080,8 @@ def _make_implicit_vjp_fn(
         total = jax.tree.map(lambda d, ind: g_scalar * (d + ind), direct, indirect)
         return (total,), diverged, converged, n_iter, lam_final
 
-    @jax.jit
-    def _jit_gmres_solve(params_data_tuple, env_leaves, rhs):
+    @partial(jax.jit, static_argnames=("chi",))
+    def _jit_gmres_solve(params_data_tuple, env_leaves, rhs, *, chi):
         """GMRES solve compiled into a single XLA program.
 
         Fuses the entire (I - J^T) solve into one XLA computation.
@@ -1165,7 +1168,9 @@ def _make_implicit_vjp_fn(
 
             def apply_Jt_only(v):
                 """Apply J^T (not I - J^T)."""
-                i_minus_jt_v = _jit_apply_Jt(params_data_tuple, env_leaves, v)
+                i_minus_jt_v = _jit_apply_Jt(
+                    params_data_tuple, env_leaves, v, chi=chi_post
+                )
                 return tuple(vi - ri for vi, ri in zip(v, i_minus_jt_v))
 
             rho = arnoldi_spectral_radius_pytree(
@@ -1177,7 +1182,7 @@ def _make_implicit_vjp_fn(
         # Both eager-GMRES paths (fixed_point divergence fallback + the
         # "gmres" branch) share the same cached _jit_apply_Jt matvec.
         def _eager_apply_I_minus_Jt(v):
-            return _jit_apply_Jt(params_data_tuple, env_leaves, v)
+            return _jit_apply_Jt(params_data_tuple, env_leaves, v, chi=chi_post)
 
         if adjoint_method == "fixed_point":
             # F3 fused JIT: dE/denv + adjoint fixed-point + chain rule
@@ -1216,7 +1221,9 @@ def _make_implicit_vjp_fn(
                 _converged,
                 _n_iter,
                 lam_final,
-            ) = _jit_fused_fixed_point_bwd(params_data_tuple, env_leaves, g, init_lam)
+            ) = _jit_fused_fixed_point_bwd(
+                params_data_tuple, env_leaves, g, init_lam, chi=chi_post
+            )
             _F3_LAST_DIAGNOSTICS["diverged"] = bool(jax.device_get(diverged))
             _F3_LAST_DIAGNOSTICS["converged"] = bool(jax.device_get(_converged))
             _F3_LAST_DIAGNOSTICS["n_iter"] = int(jax.device_get(_n_iter))
@@ -1264,7 +1271,9 @@ def _make_implicit_vjp_fn(
                 )
                 lam_leaves = tuple(jax.tree.leaves(lam))
                 _cached["prev_lam_leaves"] = lam_leaves
-                return _jit_chain_rule(params_data_tuple, env_leaves, lam_leaves, g)
+                return _jit_chain_rule(
+                    params_data_tuple, env_leaves, lam_leaves, g, chi=chi_post
+                )
             _cached["prev_lam_leaves"] = tuple(jax.tree.leaves(lam_final))
             return grads_tuple
         else:
@@ -1286,7 +1295,9 @@ def _make_implicit_vjp_fn(
                 restart=gmres_restart,
             )
             lam_leaves = tuple(jax.tree.leaves(lam))
-            return _jit_chain_rule(params_data_tuple, env_leaves, lam_leaves, g)
+            return _jit_chain_rule(
+                params_data_tuple, env_leaves, lam_leaves, g, chi=chi_post
+            )
 
     f.defvjp(f_fwd, f_bwd)
     return f

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2112,11 +2112,10 @@ def _optimize_gs_ad_tensor_2site(
                 "at the target chi.  Without raising chi manually, chi >= 16 "
                 "is typically needed for generic 2-site Heisenberg.  Note: "
                 "variPEPS-style in-CTM chi-bump (ctmrg_heuristic_increase_chi=True) "
-                "is currently supported only on the explicit-AD path "
-                "(gs_implicit_ad=False); the implicit-AD path raises "
-                "NotImplementedError when ctmrg_heuristic_increase_chi=True "
-                "is passed (see issue #514).  For antiferromagnetic bipartite "
-                "models, consider gs_c4v=True or 1-site with sublattice_rotate_gate().",
+                "is supported on both AD paths (chi-locked backward for "
+                "implicit AD via #516; warmup-only bump for explicit AD).  "
+                "For antiferromagnetic bipartite models, consider gs_c4v=True "
+                "or 1-site with sublattice_rotate_gate().",
                 stacklevel=2,
             )
     import optax

--- a/tests/test_ctm_energy_implicit_chi_bump.py
+++ b/tests/test_ctm_energy_implicit_chi_bump.py
@@ -203,3 +203,62 @@ def test_ad_gradient_invariance_bump_vs_fixed_chi_max():
         f"grad_bump[:5] = {grad_bump[:5]}\n"
         f"grad_fixed[:5] = {grad_fixed[:5]}"
     )
+
+
+def test_chi_bump_fires_when_smin_above_threshold():
+    """With threshold=1e-12, the in-CTM bump fires on iter 1 → chi grows.
+
+    Asserts the forward CTM grew env first-dim by reading the env-cache
+    final_chi via the same path used internally by f_bwd's bounds check.
+    """
+    from tenax.algorithms._ctm_energy_ad import _sigma_gauged_ctm_converge
+
+    site_tensors = {(0, 0): _build_site_tensor()}
+    envs, chi_post = _sigma_gauged_ctm_converge(
+        site_tensors,
+        SINGLE_SITE_NEIGHBORS,
+        chi=4,
+        max_iter=6,
+        conv_tol=1e-5,
+        projector_method="svd",
+        renormalize=True,
+        projector_backward="auto",
+        qr_warmup_steps=0,
+        env_init=None,
+        forward_gauge="phase",
+        conv_method="sv",
+        min_iter=2,
+        ctmrg_heuristic_increase_chi=True,
+        ctmrg_heuristic_increase_chi_threshold=1e-12,  # force bump
+        ctmrg_heuristic_increase_chi_step_size=2,
+        chi_max=8,
+    )
+    assert chi_post > 4, f"Expected bump fired (chi_post > 4), got chi_post={chi_post}"
+    assert chi_post <= 8, f"chi_post={chi_post} exceeded chi_max=8"
+
+
+def test_chi_bump_does_not_fire_when_below_threshold():
+    """With threshold=1e10 (above any realistic smin), bump quiesces."""
+    from tenax.algorithms._ctm_energy_ad import _sigma_gauged_ctm_converge
+
+    site_tensors = {(0, 0): _build_site_tensor()}
+    envs, chi_post = _sigma_gauged_ctm_converge(
+        site_tensors,
+        SINGLE_SITE_NEIGHBORS,
+        chi=4,
+        max_iter=6,
+        conv_tol=1e-5,
+        projector_method="svd",
+        renormalize=True,
+        projector_backward="auto",
+        qr_warmup_steps=0,
+        env_init=None,
+        forward_gauge="phase",
+        conv_method="sv",
+        min_iter=2,
+        ctmrg_heuristic_increase_chi=True,
+        ctmrg_heuristic_increase_chi_threshold=1e10,  # never fires
+        ctmrg_heuristic_increase_chi_step_size=2,
+        chi_max=8,
+    )
+    assert chi_post == 4, f"Expected no bump (chi_post == 4), got chi_post={chi_post}"

--- a/tests/test_ctm_energy_implicit_chi_bump.py
+++ b/tests/test_ctm_energy_implicit_chi_bump.py
@@ -262,3 +262,50 @@ def test_chi_bump_does_not_fire_when_below_threshold():
         chi_max=8,
     )
     assert chi_post == 4, f"Expected no bump (chi_post == 4), got chi_post={chi_post}"
+
+
+def test_ad_gradient_equals_fixed_chi_when_no_bump_fires():
+    """With chi_max == chi_initial, gradient is identical to bump=False.
+
+    Verifies the chi-lock plumbing is a no-op when bump can't fire.
+    Detects accidental drift in the chi_initial == chi_post path.
+    """
+    A = _build_site_tensor(D=2, d=2, seed=7)
+    gate = heisenberg_gate()
+    A_data = A.todense()
+    flat_init = A_data.flatten()
+
+    def loss_with_bump(A_flat: jnp.ndarray) -> jnp.ndarray:
+        A_perturbed = DenseTensor(A_flat.reshape(A_data.shape), A.indices)
+        return ctm_energy_implicit(
+            {(0, 0): A_perturbed},
+            SINGLE_SITE_NEIGHBORS,
+            gate,
+            chi=4,
+            max_iter=6,
+            min_iter=2,
+            ctmrg_heuristic_increase_chi=True,
+            ctmrg_heuristic_increase_chi_threshold=1e-12,
+            ctmrg_heuristic_increase_chi_step_size=2,
+            chi_max=4,  # == chi_initial → no room to bump
+        )
+
+    def loss_no_bump(A_flat: jnp.ndarray) -> jnp.ndarray:
+        A_perturbed = DenseTensor(A_flat.reshape(A_data.shape), A.indices)
+        return ctm_energy_implicit(
+            {(0, 0): A_perturbed},
+            SINGLE_SITE_NEIGHBORS,
+            gate,
+            chi=4,
+            max_iter=6,
+            min_iter=2,
+            ctmrg_heuristic_increase_chi=False,
+        )
+
+    grad_bump = jax.grad(loss_with_bump)(flat_init)
+    grad_no_bump = jax.grad(loss_no_bump)(flat_init)
+
+    assert jnp.allclose(grad_bump, grad_no_bump, atol=1e-10, rtol=1e-10), (
+        f"chi-lock plumbing leaks when bump can't fire.\n"
+        f"max diff = {jnp.max(jnp.abs(grad_bump - grad_no_bump))}"
+    )

--- a/tests/test_ctm_energy_implicit_chi_bump.py
+++ b/tests/test_ctm_energy_implicit_chi_bump.py
@@ -1,0 +1,67 @@
+"""Implicit-AD + in-CTM chi-bump correctness tests (#516 chi-lock).
+
+These tests verify that ctm_energy_implicit produces correct gradients
+when ctmrg_heuristic_increase_chi=True forces the forward CTM to grow
+chi mid-convergence.  See docs/plans/2026-05-20-chi-lock-design.md.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_energy_ad import ctm_energy_implicit
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
+from tenax.algorithms.ipeps import heisenberg_gate
+from tenax.core import DenseTensor, FlowDirection, TensorIndex, U1Symmetry
+
+
+def _build_site_tensor(D: int = 2, d: int = 2, seed: int = 0) -> DenseTensor:
+    """Build a small trivial-U(1) (D, d) single-site tensor for D=2 probes.
+
+    Uses a trivial U(1) symmetry (all charges zero) wrapped in DenseTensor,
+    matching the validation-shim pattern used by ``test_ctm_energy_implicit``.
+    """
+    rng = np.random.default_rng(seed)
+    sym = U1Symmetry()
+    bond_charges = np.zeros(D, dtype=np.int32)
+    phys_charges = np.zeros(d, dtype=np.int32)
+    indices = (
+        TensorIndex.from_charges(sym, phys_charges.copy(), FlowDirection.IN, label="p"),
+        TensorIndex.from_charges(
+            sym, bond_charges.copy(), FlowDirection.OUT, label="u"
+        ),
+        TensorIndex.from_charges(sym, bond_charges.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(sym, bond_charges.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(
+            sym, bond_charges.copy(), FlowDirection.OUT, label="l"
+        ),
+    )
+    data = jnp.asarray(
+        rng.standard_normal((d, D, D, D, D)).astype(np.float64), dtype=jnp.float64
+    )
+    return DenseTensor(data, indices)
+
+
+def test_implicit_ad_no_longer_raises_with_bump():
+    """ctm_energy_implicit(..., ctmrg_heuristic_increase_chi=True) returns a value.
+
+    Was a NotImplementedError before chi-lock (#516); now should run.
+    """
+    site_tensors = {(0, 0): _build_site_tensor()}
+    gate = heisenberg_gate()
+
+    energy = ctm_energy_implicit(
+        site_tensors,
+        SINGLE_SITE_NEIGHBORS,
+        gate,
+        chi=4,
+        max_iter=4,
+        ctmrg_heuristic_increase_chi=True,
+        chi_max=8,
+    )
+    assert jnp.isfinite(energy)

--- a/tests/test_ctm_energy_implicit_chi_bump.py
+++ b/tests/test_ctm_energy_implicit_chi_bump.py
@@ -82,12 +82,14 @@ def _central_diff(f, x: jnp.ndarray, eps: float = 1e-4) -> jnp.ndarray:
 
 @pytest.mark.slow
 def test_ad_gradient_matches_fd_with_bump():
-    """FD-vs-AD parity at D=2, chi_initial=4, chi_max=8 with forced bump.
+    """FD-vs-AD smoke at D=2, chi_initial=4, chi_max=8 with forced bump.
 
-    The correctness gate for chi-lock: confirms that when the forward CTM
-    grows chi 4 -> 8 via in-CTM bump, the backward operates at chi_post=8
-    (not the closure-captured chi_initial=4) and produces a gradient that
-    matches finite-difference.
+    Tolerance is relaxed (atol=1e-2, rtol=1e-1) because the 2x2 plaquette
+    projector's stop_gradient (PR #447) creates a documented ~25% FD bias
+    at D=2.  This test confirms the chi-lock plumbing doesn't introduce
+    catastrophic gradient errors (e.g. wrong sign, wrong order of
+    magnitude); the strict correctness check is
+    test_ad_gradient_invariance_bump_vs_fixed_chi_max below.
     """
     A = _build_site_tensor(D=2, d=2, seed=42)
     gate = heisenberg_gate()
@@ -101,23 +103,99 @@ def test_ad_gradient_matches_fd_with_bump():
             SINGLE_SITE_NEIGHBORS,
             gate,
             chi=4,
-            max_iter=6,
+            max_iter=200,
             min_iter=2,
+            conv_tol=1e-12,
             ctmrg_heuristic_increase_chi=True,
             ctmrg_heuristic_increase_chi_threshold=1e-12,  # force bump on iter 1
             ctmrg_heuristic_increase_chi_step_size=2,
             chi_max=8,
-            gmres_tol=1e-8,  # 100x margin vs atol=1e-5 below
+            gmres_tol=1e-8,
         )
 
     grad_ad = jax.grad(loss)(flat_init)
     grad_fd = _central_diff(loss, flat_init, eps=1e-4)
 
-    # Tol: 1e-5 abs is the chi-lock design target; rel 1e-3 absorbs FD
-    # truncation error on small-magnitude components.
-    assert jnp.allclose(grad_ad, grad_fd, atol=1e-5, rtol=1e-3), (
+    # Tol: atol=1e-2 / rtol=1e-1 accommodates the documented ~25% FD bias at
+    # D=2 from PR #447's 2x2 plaquette projector stop_gradient (see comment
+    # in test_ctm_energy_implicit.py).  Strict correctness gate is the
+    # invariance test below.
+    assert jnp.allclose(grad_ad, grad_fd, atol=1e-2, rtol=1e-1), (
         f"AD gradient diverges from FD reference.\n"
         f"max |grad_ad - grad_fd| = {jnp.max(jnp.abs(grad_ad - grad_fd))}\n"
         f"grad_ad[:5] = {grad_ad[:5]}\n"
         f"grad_fd[:5] = {grad_fd[:5]}"
+    )
+
+
+@pytest.mark.slow
+def test_ad_gradient_invariance_bump_vs_fixed_chi_max():
+    """Bump path's gradient must equal fixed-chi=chi_max path's gradient.
+
+    This is the strict chi-lock correctness gate.  Both calls converge
+    CTM at chi=8: one starts at chi=4 and grows via in-CTM bump, the
+    other starts directly at chi=8 and doesn't bump.  At convergence both
+    reach the same CTM fixed point, so the gradients must agree to
+    floating-point noise.
+
+    Falsification: if the chi-lock were broken (backward still uses
+    closure-captured chi_initial=4 instead of chi_post=8), the bump-path
+    gradient would be computed against a chi=4 truncated Jacobian and
+    would not match the fixed-chi=8 reference.  This test would fail
+    catastrophically (~100% relative error) in that case.
+    """
+    A = _build_site_tensor(D=2, d=2, seed=42)
+    gate = heisenberg_gate()
+    A_data = A.todense()
+    flat_init = A_data.flatten()
+
+    common_kwargs = dict(
+        max_iter=200,
+        min_iter=2,
+        conv_tol=1e-12,
+        gmres_tol=1e-8,
+    )
+
+    def loss_with_bump(A_flat: jnp.ndarray) -> jnp.ndarray:
+        A_perturbed = DenseTensor(A_flat.reshape(A_data.shape), A.indices)
+        return ctm_energy_implicit(
+            {(0, 0): A_perturbed},
+            SINGLE_SITE_NEIGHBORS,
+            gate,
+            chi=4,
+            ctmrg_heuristic_increase_chi=True,
+            ctmrg_heuristic_increase_chi_threshold=1e-12,
+            ctmrg_heuristic_increase_chi_step_size=2,
+            chi_max=8,
+            **common_kwargs,
+        )
+
+    def loss_fixed_chi_max(A_flat: jnp.ndarray) -> jnp.ndarray:
+        A_perturbed = DenseTensor(A_flat.reshape(A_data.shape), A.indices)
+        return ctm_energy_implicit(
+            {(0, 0): A_perturbed},
+            SINGLE_SITE_NEIGHBORS,
+            gate,
+            chi=8,
+            ctmrg_heuristic_increase_chi=False,
+            **common_kwargs,
+        )
+
+    grad_bump = jax.grad(loss_with_bump)(flat_init)
+    grad_fixed = jax.grad(loss_fixed_chi_max)(flat_init)
+
+    # Both CTM fixed points are at chi=8, reached via different trajectories.
+    # The fixed point is unique (verified by both losses returning the same
+    # energy to 1e-10); the gradients are therefore equal up to numerical
+    # noise from independent GMRES solves.  atol=1e-6 gives 100x margin
+    # over the chosen gmres_tol=1e-8.
+    assert jnp.allclose(
+        loss_with_bump(flat_init), loss_fixed_chi_max(flat_init), atol=1e-10
+    ), "CTM fixed points disagree — invariance test premise is broken"
+    assert jnp.allclose(grad_bump, grad_fixed, atol=1e-6, rtol=1e-6), (
+        f"chi-lock contract broken: bump gradient at chi_max=8 disagrees with "
+        f"fixed-chi=8 reference.\n"
+        f"max |grad_bump - grad_fixed| = {jnp.max(jnp.abs(grad_bump - grad_fixed))}\n"
+        f"grad_bump[:5] = {grad_bump[:5]}\n"
+        f"grad_fixed[:5] = {grad_fixed[:5]}"
     )

--- a/tests/test_ctm_energy_implicit_chi_bump.py
+++ b/tests/test_ctm_energy_implicit_chi_bump.py
@@ -67,3 +67,55 @@ def test_implicit_ad_no_longer_raises_with_bump():
         chi_max=8,
     )
     assert jnp.isfinite(energy)
+
+
+def _central_diff(f, x: jnp.ndarray, eps: float = 1e-4) -> jnp.ndarray:
+    """Central-difference gradient of scalar f at x (flat vector)."""
+    grad = jnp.zeros_like(x)
+    for i in range(x.shape[0]):
+        ei = jnp.zeros_like(x).at[i].set(eps)
+        f_plus = f(x + ei)
+        f_minus = f(x - ei)
+        grad = grad.at[i].set((f_plus - f_minus) / (2 * eps))
+    return grad
+
+
+def test_ad_gradient_matches_fd_with_bump():
+    """FD-vs-AD parity at D=2, chi_initial=4, chi_max=8 with forced bump.
+
+    The correctness gate for chi-lock: confirms that when the forward CTM
+    grows chi 4 -> 8 via in-CTM bump, the backward operates at chi_post=8
+    (not the closure-captured chi_initial=4) and produces a gradient that
+    matches finite-difference.
+    """
+    A = _build_site_tensor(D=2, d=2, seed=42)
+    gate = heisenberg_gate()
+    A_data = A.todense()
+    flat_init = A_data.flatten()
+
+    def loss(A_flat: jnp.ndarray) -> jnp.ndarray:
+        A_perturbed = DenseTensor(A_flat.reshape(A_data.shape), A.indices)
+        return ctm_energy_implicit(
+            {(0, 0): A_perturbed},
+            SINGLE_SITE_NEIGHBORS,
+            gate,
+            chi=4,
+            max_iter=6,
+            min_iter=2,
+            ctmrg_heuristic_increase_chi=True,
+            ctmrg_heuristic_increase_chi_threshold=1e-12,  # force bump on iter 1
+            ctmrg_heuristic_increase_chi_step_size=2,
+            chi_max=8,
+        )
+
+    grad_ad = jax.grad(loss)(flat_init)
+    grad_fd = _central_diff(loss, flat_init, eps=1e-4)
+
+    # Tol: 1e-5 abs is the chi-lock design target; rel 1e-3 absorbs FD
+    # truncation error on small-magnitude components.
+    assert jnp.allclose(grad_ad, grad_fd, atol=1e-5, rtol=1e-3), (
+        f"AD gradient diverges from FD reference.\n"
+        f"max |grad_ad - grad_fd| = {jnp.max(jnp.abs(grad_ad - grad_fd))}\n"
+        f"grad_ad[:5] = {grad_ad[:5]}\n"
+        f"grad_fd[:5] = {grad_fd[:5]}"
+    )

--- a/tests/test_ctm_energy_implicit_chi_bump.py
+++ b/tests/test_ctm_energy_implicit_chi_bump.py
@@ -80,6 +80,7 @@ def _central_diff(f, x: jnp.ndarray, eps: float = 1e-4) -> jnp.ndarray:
     return grad
 
 
+@pytest.mark.slow
 def test_ad_gradient_matches_fd_with_bump():
     """FD-vs-AD parity at D=2, chi_initial=4, chi_max=8 with forced bump.
 
@@ -106,6 +107,7 @@ def test_ad_gradient_matches_fd_with_bump():
             ctmrg_heuristic_increase_chi_threshold=1e-12,  # force bump on iter 1
             ctmrg_heuristic_increase_chi_step_size=2,
             chi_max=8,
+            gmres_tol=1e-8,  # 100x margin vs atol=1e-5 below
         )
 
     grad_ad = jax.grad(loss)(flat_init)

--- a/tests/test_ctm_energy_implicit_chi_bump.py
+++ b/tests/test_ctm_energy_implicit_chi_bump.py
@@ -31,7 +31,9 @@ def _build_site_tensor(D: int = 2, d: int = 2, seed: int = 0) -> DenseTensor:
     bond_charges = np.zeros(D, dtype=np.int32)
     phys_charges = np.zeros(d, dtype=np.int32)
     indices = (
-        TensorIndex.from_charges(sym, phys_charges.copy(), FlowDirection.IN, label="p"),
+        TensorIndex.from_charges(
+            sym, phys_charges.copy(), FlowDirection.IN, label="phys"
+        ),
         TensorIndex.from_charges(
             sym, bond_charges.copy(), FlowDirection.OUT, label="u"
         ),

--- a/tests/test_ctm_energy_implicit_chi_bump.py
+++ b/tests/test_ctm_energy_implicit_chi_bump.py
@@ -82,14 +82,19 @@ def _central_diff(f, x: jnp.ndarray, eps: float = 1e-4) -> jnp.ndarray:
 
 @pytest.mark.slow
 def test_ad_gradient_matches_fd_with_bump():
-    """FD-vs-AD smoke at D=2, chi_initial=4, chi_max=8 with forced bump.
+    """Numerical smoke at D=2 with forced bump: gradient is finite, FD-consistent.
 
-    Tolerance is relaxed (atol=1e-2, rtol=1e-1) because the 2x2 plaquette
-    projector's stop_gradient (PR #447) creates a documented ~25% FD bias
-    at D=2.  This test confirms the chi-lock plumbing doesn't introduce
-    catastrophic gradient errors (e.g. wrong sign, wrong order of
-    magnitude); the strict correctness check is
-    test_ad_gradient_invariance_bump_vs_fixed_chi_max below.
+    Confirms ctm_energy_implicit returns a finite, FD-consistent gradient
+    (no NaNs, correct sign, correct order of magnitude) when the forward
+    CTM grows chi 4 -> 8.  Tolerance is relaxed (atol=1e-2, rtol=1e-1)
+    because the 2x2 plaquette projector's stop_gradient (PR #447) creates
+    a documented ~25% FD bias at D=2.
+
+    This test does NOT verify the chi-lock contract — at the relaxed
+    tolerance a chi=4 backward Jacobian would still pass.  The strict
+    chi-lock check is test_ad_gradient_invariance_bump_vs_fixed_chi_max
+    below, which factors out the D=2 projector bias by comparing the
+    bump-path gradient against a fixed-chi=8 reference.
     """
     A = _build_site_tensor(D=2, d=2, seed=42)
     gate = heisenberg_gate()
@@ -116,10 +121,9 @@ def test_ad_gradient_matches_fd_with_bump():
     grad_ad = jax.grad(loss)(flat_init)
     grad_fd = _central_diff(loss, flat_init, eps=1e-4)
 
-    # Tol: atol=1e-2 / rtol=1e-1 accommodates the documented ~25% FD bias at
-    # D=2 from PR #447's 2x2 plaquette projector stop_gradient (see comment
-    # in test_ctm_energy_implicit.py).  Strict correctness gate is the
-    # invariance test below.
+    # Tol: atol=1e-2 / rtol=1e-1 accommodates the ~25% D=2 FD bias from
+    # PR #447's projector stop_gradient.  The chi-lock contract is checked
+    # in test_ad_gradient_invariance_bump_vs_fixed_chi_max, not here.
     assert jnp.allclose(grad_ad, grad_fd, atol=1e-2, rtol=1e-1), (
         f"AD gradient diverges from FD reference.\n"
         f"max |grad_ad - grad_fd| = {jnp.max(jnp.abs(grad_ad - grad_fd))}\n"

--- a/tests/test_ctm_in_loop_bump_ad_paths.py
+++ b/tests/test_ctm_in_loop_bump_ad_paths.py
@@ -163,29 +163,6 @@ def test_implicit_ad_env_init_above_chi_max_raises():
         )
 
 
-def test_implicit_ad_bump_raises_not_implemented():
-    """ctm_energy_implicit + bump=True raises NotImplementedError.
-
-    The implicit-AD backward closure captures chi at build time, so a
-    forward-side bump would silently truncate gradients.  Until a proper
-    chi-lock lands, bump is blocked at the public API boundary.  Use
-    ctm_energy_explicit for bump-aware AD.
-    """
-    site_tensors = {(0, 0): _build_site_tensor()}
-    gate = heisenberg_gate()
-
-    with pytest.raises(NotImplementedError, match="ctmrg_heuristic_increase_chi"):
-        ctm_energy_implicit(
-            site_tensors,
-            SINGLE_SITE_NEIGHBORS,
-            gate,
-            chi=4,
-            max_iter=4,
-            ctmrg_heuristic_increase_chi=True,
-            chi_max=8,
-        )
-
-
 # ---------------------------------------------------------------------------
 # Explicit-AD bump tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Lifts the defensive `NotImplementedError` in `ctm_energy_implicit` that
blocks `ctmrg_heuristic_increase_chi=True` (added in PR #515).  The
implicit-AD path can now opt into variPEPS-style in-CTM chi bumping
with correct gradients.

## Approach

Option D from the design doc (`docs/plans/2026-05-20-chi-lock-design.md`):
promote `chi` from a Python closure constant to a JAX `static_argnames`
parameter on the four backward JIT helpers
(`_jit_apply_Jt`, `_jit_chain_rule`, `_jit_fused_fixed_point_bwd`,
`_jit_gmres_solve`).  `f_fwd` threads the post-bump chi through
residuals; `f_bwd` reads it and dispatches via JAX's JIT cache (one
trace per visited chi).

## Test plan

- [x] `tests/test_ctm_energy_implicit_chi_bump.py` (new file, 6 tests)
  - no-longer-raises
  - FD-vs-AD smoke at D=2 (relaxed tol due to PR #447 projector bias)
  - AD-vs-AD invariance at D=2 chi 4 -> 8 (strict correctness gate)
  - bump fires when smin > threshold
  - bump quiesces when smin < threshold
  - gradient equals fixed-chi baseline when bump can't fire
- [x] Defensive-raise regression test in \`test_ctm_in_loop_bump_ad_paths.py\` deleted
- [x] Full \`-m core\` suite passes (856 passed, 1 skipped, 16:12)
- [ ] (Manual GPU) v9b benchmark wall-clock <= v7b 8h52m

## Out of scope

- Public API simplification (drop \`chi_initial\` exposure) — separate PR
- Multisite / 3-site PESS paths — covered by #411
- \`chi_ramp\` removal — covered by #512

Closes #516