### PR TITLE
feat(ipeps): three safety nets against 2-site implicit-AD collapse

### DIFF
--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-__all__ = ["ctm_energy_explicit", "ctm_energy_implicit"]
+__all__ = [
+    "ctm_energy_explicit",
+    "ctm_energy_implicit",
+    "get_last_implicit_ad_diagnostics",
+]
 
 import logging
 from functools import partial
@@ -592,6 +596,33 @@ _VJP_CACHE: dict = {}
 # read this to assert the fused fixed-point iteration converged without
 # falling back to eager GMRES. Not part of the public API.
 _F3_LAST_DIAGNOSTICS: dict = {}
+
+
+def get_last_implicit_ad_diagnostics() -> dict:
+    """Snapshot of the most recent implicit-AD adjoint solve diagnostics.
+
+    Populated by the fused fixed-point backward (``adjoint_method="fixed_point"``)
+    after every gradient call.  Keys:
+
+    * ``converged`` -- True if the fixed-point iteration crossed
+      ``gmres_tol`` within ``gmres_maxiter``.
+    * ``diverged`` -- True if the in-loop divergence guard fired
+      (``||lam_{k+1} - lam_k||`` grew past k>5).
+    * ``n_iter`` -- Number of fixed-point iterations consumed.
+    * ``warm_start_invalidated`` -- True if the cached ``prev_lam_leaves``
+      was dropped due to a shape mismatch.
+    * ``lam_norm`` -- ``||lam_final||`` in the env-leaf L2 norm.
+    * ``init_lam_norm`` -- ``||init_lam||`` (warm-start seed or
+      ``dE/dEnv`` on cold start).
+    * ``amplification`` -- ``||lam_final|| / ||init_lam||``.  A large
+      ratio indicates the linear adjoint operator ``(I - J^T)`` is
+      near-singular (e.g. chi-ceiling with degenerate retained SVs in
+      the frozen projectors).
+
+    Returns a shallow copy so the caller cannot mutate internal state.
+    Empty dict if no backward has run yet.
+    """
+    return dict(_F3_LAST_DIAGNOSTICS)
 
 
 def _ctm_energy_implicit_dispatch(
@@ -1237,12 +1268,31 @@ def _make_implicit_vjp_fn(
             _F3_LAST_DIAGNOSTICS["converged"] = bool(jax.device_get(_converged))
             _F3_LAST_DIAGNOSTICS["n_iter"] = int(jax.device_get(_n_iter))
             _F3_LAST_DIAGNOSTICS["warm_start_invalidated"] = invalidated_by_shape
+            # Adjoint-amplification diagnostic: ||lam_final|| vs ||init_lam||.
+            # Large ratios point to (I - J^T) being near-singular (typical at
+            # chi-ceiling with degenerate retained SVs in the frozen projectors).
+            _lam_norm_sq = sum(
+                float(jax.device_get(jnp.sum(jnp.abs(_l) ** 2))) for _l in lam_final
+            )
+            _init_lam_norm_sq = sum(
+                float(jax.device_get(jnp.sum(jnp.abs(_l) ** 2))) for _l in init_lam
+            )
+            _F3_LAST_DIAGNOSTICS["lam_norm"] = _lam_norm_sq**0.5
+            _F3_LAST_DIAGNOSTICS["init_lam_norm"] = _init_lam_norm_sq**0.5
+            _F3_LAST_DIAGNOSTICS["amplification"] = (
+                (_lam_norm_sq / _init_lam_norm_sq) ** 0.5
+                if _init_lam_norm_sq > 0
+                else float("nan")
+            )
             _GMRES_LOGGER.debug(
-                "F3 adjoint: n_iter=%d converged=%s diverged=%s tol=%g",
+                "F3 adjoint: n_iter=%d converged=%s diverged=%s tol=%g "
+                "||lam||=%.3e amp=%.3e",
                 _F3_LAST_DIAGNOSTICS["n_iter"],
                 _F3_LAST_DIAGNOSTICS["converged"],
                 _F3_LAST_DIAGNOSTICS["diverged"],
                 gmres_tol,
+                _F3_LAST_DIAGNOSTICS["lam_norm"],
+                _F3_LAST_DIAGNOSTICS["amplification"],
             )
             if (
                 _F3_LAST_DIAGNOSTICS["diverged"]

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -6,6 +6,7 @@ __all__ = [
     "ctm_energy_explicit",
     "ctm_energy_implicit",
     "get_last_implicit_ad_diagnostics",
+    "set_implicit_ad_norm_diagnostics",
 ]
 
 import logging
@@ -596,6 +597,31 @@ _VJP_CACHE: dict = {}
 # read this to assert the fused fixed-point iteration converged without
 # falling back to eager GMRES. Not part of the public API.
 _F3_LAST_DIAGNOSTICS: dict = {}
+
+# Toggle for the per-leaf ``device_get`` norm extraction in ``f_bwd``.
+# Default False so a production implicit-AD run pays zero extra
+# host-sync cost per backward (codex PR #524 P2).  The 2-site Tensor AD
+# path flips this on at loop entry when both ``gs_implicit_ad`` and
+# ``gs_verbose`` are set, then restores the previous value on exit.
+_F3_DIAG_COMPUTE_NORMS: bool = False
+
+
+def set_implicit_ad_norm_diagnostics(enabled: bool) -> bool:
+    """Enable or disable per-backward ``||lam||`` / ``||init_lam||``
+    extraction in the implicit-AD fused fixed-point backward.
+
+    When disabled (default), ``_F3_LAST_DIAGNOSTICS`` still receives
+    ``converged`` / ``diverged`` / ``n_iter`` (single scalars, one
+    ``device_get`` each), but the per-env-leaf norm reductions are
+    skipped.  Enabling adds one ``device_get`` per env leaf per
+    backward (~ms-scale on GPU at chi~24).
+
+    Returns the previous toggle value so callers can restore it.
+    """
+    global _F3_DIAG_COMPUTE_NORMS
+    prev = _F3_DIAG_COMPUTE_NORMS
+    _F3_DIAG_COMPUTE_NORMS = bool(enabled)
+    return prev
 
 
 def get_last_implicit_ad_diagnostics() -> dict:
@@ -1270,30 +1296,47 @@ def _make_implicit_vjp_fn(
             _F3_LAST_DIAGNOSTICS["warm_start_invalidated"] = invalidated_by_shape
             # Adjoint-amplification diagnostic: ||lam_final|| vs ||init_lam||.
             # Large ratios point to (I - J^T) being near-singular (typical at
-            # chi-ceiling with degenerate retained SVs in the frozen projectors).
-            _lam_norm_sq = sum(
-                float(jax.device_get(jnp.sum(jnp.abs(_l) ** 2))) for _l in lam_final
-            )
-            _init_lam_norm_sq = sum(
-                float(jax.device_get(jnp.sum(jnp.abs(_l) ** 2))) for _l in init_lam
-            )
-            _F3_LAST_DIAGNOSTICS["lam_norm"] = _lam_norm_sq**0.5
-            _F3_LAST_DIAGNOSTICS["init_lam_norm"] = _init_lam_norm_sq**0.5
-            _F3_LAST_DIAGNOSTICS["amplification"] = (
-                (_lam_norm_sq / _init_lam_norm_sq) ** 0.5
-                if _init_lam_norm_sq > 0
-                else float("nan")
-            )
-            _GMRES_LOGGER.debug(
-                "F3 adjoint: n_iter=%d converged=%s diverged=%s tol=%g "
-                "||lam||=%.3e amp=%.3e",
-                _F3_LAST_DIAGNOSTICS["n_iter"],
-                _F3_LAST_DIAGNOSTICS["converged"],
-                _F3_LAST_DIAGNOSTICS["diverged"],
-                gmres_tol,
-                _F3_LAST_DIAGNOSTICS["lam_norm"],
-                _F3_LAST_DIAGNOSTICS["amplification"],
-            )
+            # chi-ceiling with degenerate retained SVs in the frozen
+            # projectors).  Gated on ``_F3_DIAG_COMPUTE_NORMS`` so production
+            # implicit-AD runs pay no per-backward host-sync cost when the
+            # diagnostic isn't consumed (codex PR #524 P2).
+            if _F3_DIAG_COMPUTE_NORMS:
+                _lam_norm_sq = sum(
+                    float(jax.device_get(jnp.sum(jnp.abs(_l) ** 2))) for _l in lam_final
+                )
+                _init_lam_norm_sq = sum(
+                    float(jax.device_get(jnp.sum(jnp.abs(_l) ** 2))) for _l in init_lam
+                )
+                _F3_LAST_DIAGNOSTICS["lam_norm"] = _lam_norm_sq**0.5
+                _F3_LAST_DIAGNOSTICS["init_lam_norm"] = _init_lam_norm_sq**0.5
+                _F3_LAST_DIAGNOSTICS["amplification"] = (
+                    (_lam_norm_sq / _init_lam_norm_sq) ** 0.5
+                    if _init_lam_norm_sq > 0
+                    else float("nan")
+                )
+                _GMRES_LOGGER.debug(
+                    "F3 adjoint: n_iter=%d converged=%s diverged=%s tol=%g "
+                    "||lam||=%.3e amp=%.3e",
+                    _F3_LAST_DIAGNOSTICS["n_iter"],
+                    _F3_LAST_DIAGNOSTICS["converged"],
+                    _F3_LAST_DIAGNOSTICS["diverged"],
+                    gmres_tol,
+                    _F3_LAST_DIAGNOSTICS["lam_norm"],
+                    _F3_LAST_DIAGNOSTICS["amplification"],
+                )
+            else:
+                # Clear stale values so the consumer can detect that
+                # the diagnostic wasn't computed on this backward.
+                _F3_LAST_DIAGNOSTICS.pop("lam_norm", None)
+                _F3_LAST_DIAGNOSTICS.pop("init_lam_norm", None)
+                _F3_LAST_DIAGNOSTICS.pop("amplification", None)
+                _GMRES_LOGGER.debug(
+                    "F3 adjoint: n_iter=%d converged=%s diverged=%s tol=%g",
+                    _F3_LAST_DIAGNOSTICS["n_iter"],
+                    _F3_LAST_DIAGNOSTICS["converged"],
+                    _F3_LAST_DIAGNOSTICS["diverged"],
+                    gmres_tol,
+                )
             if (
                 _F3_LAST_DIAGNOSTICS["diverged"]
                 or not _F3_LAST_DIAGNOSTICS["converged"]

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -421,6 +421,16 @@ class iPEPSConfig:
     # ``converged=False`` line searches.  Honoured on the iPEPS 1-site /
     # 2-site / multisite Tensor AD paths.
     gs_hz_max_iter: int = 40
+    # Chi-ceiling bail-out (variPEPS §2.8.2 mechanism).  When > 0 and the
+    # CTM is at ``ctm.chi_max`` AND the bump indicator (``eps_T`` or
+    # ``norm_smallest_S`` per ``chi_auto_bump_metric``) exceeds
+    # ``chi_auto_bump_eps`` for this many consecutive optimizer steps,
+    # the optimizer exits early and returns ``best_params``.  Counters
+    # reset on a chi bump, a step that brings the indicator below
+    # threshold, or stall recovery.  Default 0 disables the check
+    # (existing behaviour).  Currently honoured only on the 2-site
+    # Tensor AD path.
+    gs_chi_ceiling_bailout: int = 0
     gs_noise_recovery_retries: int = 3  # max retries with noise injection on stall
     gs_stall_recovery_retries: int = 5  # max consecutive resets before giving up (#454)
     gs_noise_amplitude: float = 0.1  # relative noise amplitude for recovery
@@ -561,6 +571,11 @@ class iPEPSConfig:
         if self.gs_hz_max_iter <= 0:
             raise ValueError(
                 f"gs_hz_max_iter must be positive, got {self.gs_hz_max_iter}"
+            )
+        if self.gs_chi_ceiling_bailout < 0:
+            raise ValueError(
+                "gs_chi_ceiling_bailout must be >= 0 (0 disables), "
+                f"got {self.gs_chi_ceiling_bailout}"
             )
         if self.gs_checkpoint_every <= 0:
             raise ValueError(

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -413,6 +413,14 @@ class iPEPSConfig:
     gs_line_search: bool | None = None  # None = auto (True for lbfgs/cg)
     gs_line_search_max_steps: int = 8
     gs_line_search_method: str = "hager_zhang"  # "armijo" or "hager_zhang"
+    # Hager-Zhang line search inner iteration cap (bracket + secant loops in
+    # ``_line_search.hager_zhang_line_search``).  Each iteration triggers
+    # one ``value_and_grad`` call, so on chi-saturated 2-site implicit-AD
+    # one runaway probe at the default 40 burns ~10 minutes.  Lowering to
+    # 15-20 caps the worst case at the cost of accepting more
+    # ``converged=False`` line searches.  Honoured on the iPEPS 1-site /
+    # 2-site / multisite Tensor AD paths.
+    gs_hz_max_iter: int = 40
     gs_noise_recovery_retries: int = 3  # max retries with noise injection on stall
     gs_stall_recovery_retries: int = 5  # max consecutive resets before giving up (#454)
     gs_noise_amplitude: float = 0.1  # relative noise amplitude for recovery
@@ -549,6 +557,10 @@ class iPEPSConfig:
             raise ValueError(
                 "gs_grad_spike_window must be positive, "
                 f"got {self.gs_grad_spike_window}"
+            )
+        if self.gs_hz_max_iter <= 0:
+            raise ValueError(
+                f"gs_hz_max_iter must be positive, got {self.gs_hz_max_iter}"
             )
         if self.gs_checkpoint_every <= 0:
             raise ValueError(

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -398,6 +398,18 @@ class iPEPSConfig:
     gs_verbose: bool = False
     gs_log_interval: int = 10
     gs_max_grad_norm: float = 1.0  # gradient clipping (max global norm)
+    # Reject a step whose new ``||grad||_2`` exceeds
+    # ``gs_grad_spike_ratio * max(median(recent), 1.0)``, where
+    # ``recent`` is the last ``gs_grad_spike_window`` accepted gradient
+    # norms.  A 10x+ jump in gradient magnitude is the cleanest
+    # signature of a non-variational collapse in 2-site implicit-AD
+    # (see project_v9_collapse_findings.md).  On rejection the
+    # optimizer rolls back to ``best_params``, clears L-BFGS history,
+    # and reinits the optimizer state.  ``None`` (default) disables
+    # the guard.  Currently honoured only on the 2-site Tensor AD
+    # path.
+    gs_grad_spike_ratio: float | None = None
+    gs_grad_spike_window: int = 5
     gs_line_search: bool | None = None  # None = auto (True for lbfgs/cg)
     gs_line_search_max_steps: int = 8
     gs_line_search_method: str = "hager_zhang"  # "armijo" or "hager_zhang"
@@ -527,6 +539,16 @@ class iPEPSConfig:
             raise ValueError(
                 f"gs_stall_recovery_retries must be non-negative, "
                 f"got {self.gs_stall_recovery_retries}"
+            )
+        if self.gs_grad_spike_ratio is not None and self.gs_grad_spike_ratio <= 1.0:
+            raise ValueError(
+                "gs_grad_spike_ratio must be > 1.0 (ratio above recent median), "
+                f"got {self.gs_grad_spike_ratio}"
+            )
+        if self.gs_grad_spike_window <= 0:
+            raise ValueError(
+                "gs_grad_spike_window must be positive, "
+                f"got {self.gs_grad_spike_window}"
             )
         if self.gs_checkpoint_every <= 0:
             raise ValueError(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2682,9 +2682,15 @@ def _optimize_gs_ad_tensor_2site(
         # accepted as the new best.
         if (
             config.gs_grad_spike_ratio is not None
-            and len(recent_gnorms_2s) >= 2
+            and len(recent_gnorms_2s) >= 1
             and best_energy < float("inf")
         ):
+            # ``len >= 1`` (was ``>= 2``, codex PR #524 P2): with
+            # ``gs_grad_spike_window == 1`` the buffer is trimmed back to
+            # length 1 each step, so the previous ``>= 2`` guard silently
+            # disabled the spike check for that valid config.  ``len == 1``
+            # is enough: the median is just the prior step's gradient norm,
+            # which is the right baseline for "is this step a >5x jump?".
             spike_floor = max(float(np.median(recent_gnorms_2s)), 1.0)
             if grad_norm_val > config.gs_grad_spike_ratio * spike_floor:
                 params = best_params

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1659,6 +1659,7 @@ def _optimize_gs_ad_tensor(
                     rho=1.5,
                     max_step=2.0 * alpha0,
                     energy_bound=max(2.0, 2.0 * abs(best_energy)),
+                    max_iter=config.gs_hz_max_iter,
                 )
                 if config.gs_verbose:
                     print(
@@ -3026,6 +3027,7 @@ def _optimize_gs_ad_tensor_2site(
                     rho=1.5,
                     max_step=2.0 * alpha0,
                     energy_bound=max(2.0, 2.0 * abs(best_energy)),
+                    max_iter=config.gs_hz_max_iter,
                 )
                 if config.gs_verbose:
                     print(
@@ -3965,6 +3967,7 @@ def _optimize_gs_ad_multisite(
                     rho=1.5,
                     max_step=2.0 * alpha0,
                     energy_bound=max(2.0, 2.0 * abs(best_energy)),
+                    max_iter=config.gs_hz_max_iter,
                 )
                 if config.gs_verbose:
                     print(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2663,6 +2663,14 @@ def _optimize_gs_ad_tensor_2site(
                         prev_precond_grad = None
                     if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
                         opt_state = optimizer.init(params)
+                # Counter-reset contract (codex PR #524 follow-up): the
+                # ``gs_chi_ceiling_bailout`` docstring states the streak
+                # resets on stall recovery.  This branch is the
+                # ``CTMRGGradientError`` recovery path, so clear the
+                # counter before the ``continue`` — otherwise a
+                # recovered CTM-error step would still count toward the
+                # K-consecutive bail-out trigger.
+                chi_ceiling_consecutive_2s = 0
                 continue
             energy_float = float(energy_val)
 

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2727,6 +2727,26 @@ def _optimize_gs_ad_tensor_2site(
                 best_energy,
                 grad_norm=grad_norm_val,
             )
+            # Implicit-AD adjoint diagnostics: surface ||lam||/||init_lam||
+            # amplification so chi-ceiling collapse runs (e.g. v9d/v9h)
+            # have a smoking-gun trace.  Populated by the fused fixed-point
+            # backward; empty dict on the explicit-AD path.
+            if config.gs_implicit_ad:
+                from tenax.algorithms._ctm_energy_ad import (
+                    get_last_implicit_ad_diagnostics,
+                )
+
+                _diag = get_last_implicit_ad_diagnostics()
+                if _diag:
+                    print(
+                        f"[iPEPS-AD:2site-tensor] step {step + 1}/{config.gs_num_steps} "
+                        f"GMRES n_iter={_diag.get('n_iter', '?')} "
+                        f"converged={_diag.get('converged', '?')} "
+                        f"diverged={_diag.get('diverged', '?')} "
+                        f"||lam||={_diag.get('lam_norm', float('nan')):.3e} "
+                        f"amp={_diag.get('amplification', float('nan')):.3e}",
+                        flush=True,
+                    )
             logged = True
 
         prev_energy = energy_float

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2548,7 +2548,9 @@ def _optimize_gs_ad_tensor_2site(
     # Enable per-backward ``||lam||`` extraction in the implicit-AD F3 path
     # only when a consumer is reading them (verbose logging in this loop).
     # Default-off saves one ``jax.device_get`` per env-leaf per gradient
-    # call on production runs (codex PR #524 P2).  Restore on exit.
+    # call on production runs (codex PR #524 P2).  Restore via ``finally``
+    # below so an exception in the loop or in the post-loop fresh-CTM eval
+    # does not leak the diagnostics flag (codex PR #524 follow-up).
     if config.gs_implicit_ad and config.gs_verbose:
         from tenax.algorithms._ctm_energy_ad import (
             set_implicit_ad_norm_diagnostics,
@@ -2556,59 +2558,580 @@ def _optimize_gs_ad_tensor_2site(
 
         _prev_norm_diag = set_implicit_ad_norm_diagnostics(True)
     else:
+        set_implicit_ad_norm_diagnostics = None  # type: ignore[assignment]
         _prev_norm_diag = None
 
-    for step in range(start_step, config.gs_num_steps):
-        # Snapshots for checkpoint "did chi change / new best" detection.
-        # ``best_energy`` only decreases, so a strict < comparison after
-        # the step body identifies a freshly-accepted best.  Both
-        # snapshots are passed to ``_maybe_save_2s_checkpoint`` at every
-        # save call site so the helper can decide what to flush.
-        _best_energy_at_step_start = best_energy
-        _chi_at_step_start = ctm_cfg_2s.chi
-        # Update conv_tol if schedule is active
-        if _conv_tol_schedule_2s is not None:
-            new_tol = _get_scheduled_conv_tol_2s(step, config.gs_num_steps)
-            if new_tol != _current_conv_tol_2s:
-                _current_conv_tol_2s = new_tol
-                ctm_cfg_2s = _replace(ctm_cfg_2s, conv_tol=new_tol)
-        # Update plateau_patience if schedule is active
-        if _patience_schedule_2s is not None:
-            new_patience = _get_scheduled_plateau_patience_2s(step, config.gs_num_steps)
-            if new_patience != _current_patience_2s:
-                _current_patience_2s = new_patience
-                ctm_cfg_2s = _replace(ctm_cfg_2s, plateau_patience=new_patience)
-
-        if config.return_history:
-            _step_t0 = _time.perf_counter()
-        try:
-            energy_val, grads = jax.value_and_grad(loss_fn)(params)
-        except CTMRGGradientError as exc:
-            _logger.warning(
-                "[iPEPS-AD] Arnoldi precheck: rho(J^T) = %.4f >= 1 at step %d — "
-                "skipping, triggering stall recovery",
-                exc.spectral_radius,
-                step,
-            )
-            if config.gs_verbose:
-                print(
-                    f"[iPEPS-AD:2site-tensor] step {step + 1}/{config.gs_num_steps} "
-                    f"rho(J^T)={exc.spectral_radius:.4f} — stall recovery",
-                    flush=True,
+    try:
+        for step in range(start_step, config.gs_num_steps):
+            # Snapshots for checkpoint "did chi change / new best" detection.
+            # ``best_energy`` only decreases, so a strict < comparison after
+            # the step body identifies a freshly-accepted best.  Both
+            # snapshots are passed to ``_maybe_save_2s_checkpoint`` at every
+            # save call site so the helper can decide what to flush.
+            _best_energy_at_step_start = best_energy
+            _chi_at_step_start = ctm_cfg_2s.chi
+            # Update conv_tol if schedule is active
+            if _conv_tol_schedule_2s is not None:
+                new_tol = _get_scheduled_conv_tol_2s(step, config.gs_num_steps)
+                if new_tol != _current_conv_tol_2s:
+                    _current_conv_tol_2s = new_tol
+                    ctm_cfg_2s = _replace(ctm_cfg_2s, conv_tol=new_tol)
+            # Update plateau_patience if schedule is active
+            if _patience_schedule_2s is not None:
+                new_patience = _get_scheduled_plateau_patience_2s(
+                    step, config.gs_num_steps
                 )
-            stall_count += 1
-            if (
-                config.gs_stall_recovery == "noise"
-                and stall_count <= config.gs_noise_recovery_retries
-            ):
-                noise_key = jax.random.PRNGKey(step * 1000 + stall_count)
-                if use_c4v:
-                    noise = config.gs_noise_amplitude * _random_noise(
-                        noise_key, params.shape, params.dtype
+                if new_patience != _current_patience_2s:
+                    _current_patience_2s = new_patience
+                    ctm_cfg_2s = _replace(ctm_cfg_2s, plateau_patience=new_patience)
+
+            if config.return_history:
+                _step_t0 = _time.perf_counter()
+            try:
+                energy_val, grads = jax.value_and_grad(loss_fn)(params)
+            except CTMRGGradientError as exc:
+                _logger.warning(
+                    "[iPEPS-AD] Arnoldi precheck: rho(J^T) = %.4f >= 1 at step %d — "
+                    "skipping, triggering stall recovery",
+                    exc.spectral_radius,
+                    step,
+                )
+                if config.gs_verbose:
+                    print(
+                        f"[iPEPS-AD:2site-tensor] step {step + 1}/{config.gs_num_steps} "
+                        f"rho(J^T)={exc.spectral_radius:.4f} — stall recovery",
+                        flush=True,
                     )
-                    params = params + noise * jnp.linalg.norm(params)
-                    params = params / (jnp.linalg.norm(params) + 1e-10)
+                stall_count += 1
+                if (
+                    config.gs_stall_recovery == "noise"
+                    and stall_count <= config.gs_noise_recovery_retries
+                ):
+                    noise_key = jax.random.PRNGKey(step * 1000 + stall_count)
+                    if use_c4v:
+                        noise = config.gs_noise_amplitude * _random_noise(
+                            noise_key, params.shape, params.dtype
+                        )
+                        params = params + noise * jnp.linalg.norm(params)
+                        params = params / (jnp.linalg.norm(params) + 1e-10)
+                    else:
+                        noisy_params = []
+                        for i, p in enumerate(params):
+                            k = jax.random.fold_in(noise_key, i)
+                            data = p.todense()
+                            noise = config.gs_noise_amplitude * _random_noise(
+                                k, data.shape, data.dtype
+                            )
+                            noisy = data + noise * jnp.linalg.norm(data)
+                            noisy = noisy / (jnp.linalg.norm(noisy) + 1e-10)
+                            noisy_params.append(_wrap_tensor(noisy, p))
+                        params = tuple(noisy_params)
+                    if is_metric_lbfgs:
+                        lbfgs_history.clear()
+                        prev_params_flat = None
+                        prev_grad_flat = None
+                    if is_cg:
+                        cg_direction = None
+                        prev_grad = None
+                        prev_precond_grad = None
+                elif config.gs_stall_recovery == "reset":
+                    # Cap on CTMRGGradientError-driven reset path (#454 follow-up,
+                    # codex review on PR #457).
+                    if stall_count > config.gs_stall_recovery_retries:
+                        n_resets_done = stall_count - 1
+                        if config.gs_verbose:
+                            print(
+                                f"[iPEPS-AD] CTM-error stall budget exhausted after "
+                                f"{n_resets_done} resets, "
+                                f"returning best E={best_energy:.10f}",
+                                flush=True,
+                            )
+                        break
+                    params = best_params
+                    # #518: ``best_env_cache_2s`` may be at a stale χ if a
+                    # reactive/scheduled bump fired after it was last
+                    # snapshotted.  Clear instead of restoring; the next
+                    # CTM call cold-starts at the current ctm_cfg_2s.chi.
+                    _env_cache_2s.clear()
+                    if is_metric_lbfgs:
+                        lbfgs_history.clear()
+                        prev_params_flat = None
+                        prev_grad_flat = None
+                    if is_cg:
+                        cg_direction = None
+                        prev_grad = None
+                        prev_precond_grad = None
+                    if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                        opt_state = optimizer.init(params)
+                continue
+            energy_float = float(energy_val)
+
+            if config.return_history:
+                _step_dt = _time.perf_counter() - _step_t0
+                if _first_step:
+                    _jit_compile_time = float(_step_dt)
+                    _first_step = False
                 else:
+                    _history_step_times.append(float(_step_dt))
+                _history_energies.append(energy_float)
+
+            # Update env cache for warm-starting next step
+            _update_env_cache_2s(params)
+
+            grad_norm_val = _grad_l2_norm(grads)
+
+            # Gradient-spike guard: reject steps whose new ||grad||_2 exceeds
+            # ``gs_grad_spike_ratio * max(median(recent), 1.0)``.  See
+            # project_v9_collapse_findings.md — non-variational drift shows up
+            # as a >10x gradient blowup before the best_energy crosses the QMC
+            # floor.  We check BEFORE updating best so the bad step never gets
+            # accepted as the new best.
+            if (
+                config.gs_grad_spike_ratio is not None
+                and len(recent_gnorms_2s) >= 1
+                and best_energy < float("inf")
+            ):
+                # ``len >= 1`` (was ``>= 2``, codex PR #524 P2): with
+                # ``gs_grad_spike_window == 1`` the buffer is trimmed back to
+                # length 1 each step, so the previous ``>= 2`` guard silently
+                # disabled the spike check for that valid config.  ``len == 1``
+                # is enough: the median is just the prior step's gradient norm,
+                # which is the right baseline for "is this step a >5x jump?".
+                spike_floor = max(float(np.median(recent_gnorms_2s)), 1.0)
+                if grad_norm_val > config.gs_grad_spike_ratio * spike_floor:
+                    params = best_params
+                    _env_cache_2s.clear()
+                    # Clear the rolling buffer too (codex PR #524 P1): if a chi
+                    # bump or stall recovery has shifted the legitimate
+                    # gradient scale upward, the stale median would keep
+                    # tripping the guard on every subsequent step, locking the
+                    # optimizer into perpetual rollback.  Re-seed from the
+                    # rolled-back state instead.
+                    recent_gnorms_2s.clear()
+                    if is_metric_lbfgs:
+                        lbfgs_history.clear()
+                        prev_params_flat = None
+                        prev_grad_flat = None
+                    if is_cg:
+                        cg_direction = None
+                        prev_grad = None
+                        prev_precond_grad = None
+                    if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                        opt_state = optimizer.init(params)
+                    _logger.warning(
+                        "[iPEPS-AD:2site-tensor] step %d/%d gradient spike "
+                        "|g|=%.3e > %.1fx median %.3e — rolling back to best",
+                        step + 1,
+                        config.gs_num_steps,
+                        grad_norm_val,
+                        config.gs_grad_spike_ratio,
+                        spike_floor,
+                    )
+                    if config.gs_verbose:
+                        print(
+                            f"[iPEPS-AD:2site-tensor] step {step + 1}/{config.gs_num_steps} "
+                            f"|g|={grad_norm_val:.3e} spike "
+                            f"(>{config.gs_grad_spike_ratio:.1f}x median {spike_floor:.3e}) "
+                            f"— rollback to best, clear L-BFGS history",
+                            flush=True,
+                        )
+                    continue
+            recent_gnorms_2s.append(grad_norm_val)
+            if len(recent_gnorms_2s) > config.gs_grad_spike_window:
+                recent_gnorms_2s.pop(0)
+
+            if _should_accept_best(
+                current_best=best_energy,
+                candidate=energy_float,
+                floor=config.gs_energy_floor,
+            ):
+                best_energy = energy_float
+                best_params = params
+                best_env_cache_2s = dict(
+                    _env_cache_2s
+                )  # snapshot for warm-start (#317)
+
+            delta_energy = abs(energy_float - prev_energy)
+            logged = False
+            if config.gs_verbose and _should_log_step(
+                step, config.gs_num_steps, log_interval
+            ):
+                _log_ad_step(
+                    "2site-tensor",
+                    step,
+                    config.gs_num_steps,
+                    energy_float,
+                    delta_energy,
+                    best_energy,
+                    grad_norm=grad_norm_val,
+                )
+                # Implicit-AD adjoint diagnostics: surface ||lam||/||init_lam||
+                # amplification so chi-ceiling collapse runs (e.g. v9d/v9h)
+                # have a smoking-gun trace.  Populated by the fused fixed-point
+                # backward; empty dict on the explicit-AD path.
+                if config.gs_implicit_ad:
+                    from tenax.algorithms._ctm_energy_ad import (
+                        get_last_implicit_ad_diagnostics,
+                    )
+
+                    _diag = get_last_implicit_ad_diagnostics()
+                    if _diag:
+                        print(
+                            f"[iPEPS-AD:2site-tensor] step {step + 1}/{config.gs_num_steps} "
+                            f"GMRES n_iter={_diag.get('n_iter', '?')} "
+                            f"converged={_diag.get('converged', '?')} "
+                            f"diverged={_diag.get('diverged', '?')} "
+                            f"||lam||={_diag.get('lam_norm', float('nan')):.3e} "
+                            f"amp={_diag.get('amplification', float('nan')):.3e}",
+                            flush=True,
+                        )
+                logged = True
+
+            prev_energy = energy_float
+            if _converged_outer(config, delta_energy, grad_norm_val):
+                # #455 PR2: at non-final χ stages, treat convergence as a
+                # signal to advance to the next stage rather than exit.
+                # Mirrors the 1-site convergence-block intercept, including
+                # the reactive ε_T bump (#472 codex review on PR #473):
+                # converged-at-too-small-χ runs must apply the requested
+                # auto-bump before exiting so the final env reflects the
+                # bumped χ, and the bump can also unstick a stalled-at-χ_old
+                # landscape via the ``continue`` below.
+                chi_before_bump = ctm_cfg_2s.chi
+                last_eps_t = float(_env_cache_2s.get("max_truncation_error", 0.0))
+                ctm_cfg_2s, _env_cache_2s = _maybe_bump_chi(
+                    ctm_cfg_2s,
+                    _env_cache_2s,
+                    last_eps_t,
+                    base_charges=_bump_base_charges_2s,
+                )
+                if config.gs_chi_schedule_steps is not None:
+                    steps_in_stage = (step + 1) - stage_start_step
+                    _gn_for_bump = (
+                        grad_norm_val
+                        if grad_norm_val is not None
+                        else (
+                            _grad_l2_norm(grads)
+                            if config.gs_conv_criterion != "dE"
+                            else 0.0
+                        )
+                    )
+                    (
+                        ctm_cfg_2s,
+                        _env_cache_2s,
+                        new_stage_idx,
+                        bump_fired,
+                        _,
+                    ) = _advance_chi_stage_if_due(
+                        ctm_cfg_2s,
+                        _env_cache_2s,
+                        chi_schedule=config.gs_chi_schedule_steps,
+                        current_stage_idx=current_stage_idx,
+                        steps_in_stage=steps_in_stage,
+                        config=config,
+                        grad_norm=_gn_for_bump,
+                        delta_energy=delta_energy,
+                        stall_count=stall_count,
+                        base_charges=_bump_base_charges_2s,
+                    )
+                    # Codex review (PR #467): decouple the schedule index
+                    # advance from bump_fired so idempotent advances
+                    # (bump_fired=False AND new_stage_idx>current_stage_idx)
+                    # still continue rather than fall through to break.
+                    stage_advanced = new_stage_idx != current_stage_idx
+                    if stage_advanced:
+                        current_stage_idx = new_stage_idx
+                        stage_start_step = step + 1
+                else:
+                    bump_fired = False
+                    stage_advanced = False
+                if ctm_cfg_2s.chi != chi_before_bump:
+                    # Reactive (#472) or scheduled (#455) bump fired —
+                    # fresh landscape, fresh stall budget.  Gated on the
+                    # χ delta so a reactive-only bump also clears state.
+                    stall_count = 0
+                    if is_metric_lbfgs:
+                        lbfgs_history.clear()
+                        prev_params_flat = None
+                        prev_grad_flat = None
+                    if is_cg:
+                        cg_direction = None
+                        prev_grad = None
+                        prev_precond_grad = None
+                    if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                        opt_state = optimizer.init(params)
+                    if config.gs_verbose:
+                        print(
+                            f"[iPEPS-AD step {step + 1}] converged at "
+                            f"chi={chi_before_bump} → bumping to "
+                            f"chi={ctm_cfg_2s.chi} (#455 PR2 / #472)",
+                            flush=True,
+                        )
+                if bump_fired or stage_advanced:
+                    # Force a checkpoint on stage advance before continuing
+                    # so a crash inside the next stage's first step doesn't
+                    # roll back across the boundary (Codex P2 #497).
+                    _maybe_save_2s_checkpoint(
+                        step,
+                        _chi_at_step_start,
+                        _best_energy_at_step_start,
+                        force_last=True,
+                    )
+                    continue
+                if config.gs_verbose:
+                    if not logged:
+                        _log_ad_step(
+                            "2site-tensor",
+                            step,
+                            config.gs_num_steps,
+                            energy_float,
+                            delta_energy,
+                            best_energy,
+                            grad_norm=grad_norm_val,
+                        )
+                    _log_ad_converged(
+                        "2site-tensor",
+                        step,
+                        delta_energy,
+                        config.gs_conv_tol,
+                        grad_norm=grad_norm_val,
+                        grad_norm_tol=config.gs_grad_norm_tol,
+                        criterion=config.gs_conv_criterion,
+                    )
+                _converged = True
+                break
+
+            # Compute search direction
+            if is_cg:
+                if config.gs_metric_precond and not use_c4v:
+                    from tenax.algorithms._metric_precond import (
+                        precondition_gradient_multisite,
+                    )
+
+                    envs_cached = _env_cache_2s["envs"]
+                    A_g, B_g = grads
+                    envs_m = {(0, 0): envs_cached[(0, 0)], (1, 0): envs_cached[(1, 0)]}
+                    sites_m = {(0, 0): params[0], (1, 0): params[1]}
+                    grads_m = {(0, 0): A_g, (1, 0): B_g}
+                    delta_metric = delta_energy if step > 0 else _tree_dot(grads, grads)
+                    z_dict = precondition_gradient_multisite(
+                        sites_m, envs_m, grads_m, delta_metric, config
+                    )
+                    z = (
+                        _wrap_tensor(z_dict[(0, 0)], A_g),
+                        _wrap_tensor(z_dict[(1, 0)], B_g),
+                    )
+                    neg_z = jax.tree.map(lambda g: -g, z)
+                    if prev_precond_grad is not None and cg_direction is not None:
+                        z_diff = jax.tree.map(lambda a, b: a - b, z, prev_precond_grad)
+                        num = _tree_dot(grads, z_diff)
+                        den = _tree_dot(prev_grad, prev_precond_grad)
+                        beta = max(0.0, num / den) if den > 1e-30 else 0.0
+                        cg_direction = _tree_add(neg_z, _tree_scale(cg_direction, beta))
+                    else:
+                        cg_direction = neg_z
+                    prev_precond_grad = z
+                else:
+                    neg_grad = jax.tree.map(lambda g: -g, grads)
+                    if prev_grad is not None and cg_direction is not None:
+                        beta = _cg_beta_pr(grads, prev_grad)
+                        cg_direction = _tree_add(
+                            neg_grad, _tree_scale(cg_direction, beta)
+                        )
+                    else:
+                        cg_direction = neg_grad
+                prev_grad = grads
+                direction = cg_direction
+            elif is_metric_lbfgs:
+                from tenax.algorithms._metric_precond import lbfgs_two_loop
+
+                if use_c4v:
+                    p_flat = params
+                    g_flat = grads
+                else:
+                    from tenax.algorithms._metric_precond import (
+                        precondition_gradient_multisite,
+                    )
+
+                    A_cur, B_cur = params
+                    A_g, B_g = grads
+                    p_flat = jnp.concatenate(
+                        [
+                            A_cur.todense().reshape(-1),
+                            B_cur.todense().reshape(-1),
+                        ]
+                    )
+                    g_flat = jnp.concatenate(
+                        [
+                            A_g.todense().reshape(-1),
+                            B_g.todense().reshape(-1),
+                        ]
+                    )
+
+                if prev_params_flat is not None:
+                    s = p_flat - prev_params_flat
+                    y = g_flat - prev_grad_flat
+                    sy = float(jnp.real(jnp.vdot(s, y)))
+                    if sy > 1e-10:
+                        rho = 1.0 / sy
+                        lbfgs_history.append((s, y, rho))
+                        if len(lbfgs_history) > 10:
+                            lbfgs_history.pop(0)
+                prev_params_flat = p_flat
+                prev_grad_flat = g_flat
+
+                if use_c4v:
+                    direction_flat = lbfgs_two_loop(g_flat, lbfgs_history, lambda v: v)
+                    direction = -direction_flat
+                else:
+                    envs_cached = _env_cache_2s["envs"]
+                    envs_m = {(0, 0): envs_cached[(0, 0)], (1, 0): envs_cached[(1, 0)]}
+                    sites_m = {(0, 0): A_cur, (1, 0): B_cur}
+                    delta_metric = (
+                        delta_energy
+                        if step > 0
+                        else float(jnp.real(jnp.vdot(g_flat, g_flat)))
+                    )
+                    n_A = A_cur.todense().size
+
+                    def h0_matvec(v):
+                        v_A = v[:n_A]
+                        v_B = v[n_A:]
+                        D_b = A_cur.todense().shape[0]
+                        d_l = A_cur.todense().shape[-1]
+                        grads_v = {
+                            (0, 0): _wrap_tensor(
+                                v_A.reshape(D_b, D_b, D_b, D_b, d_l), A_cur
+                            ),
+                            (1, 0): _wrap_tensor(
+                                v_B.reshape(D_b, D_b, D_b, D_b, d_l), B_cur
+                            ),
+                        }
+                        z_dict = precondition_gradient_multisite(
+                            sites_m, envs_m, grads_v, delta_metric, config
+                        )
+                        return jnp.concatenate(
+                            [
+                                z_dict[(0, 0)].reshape(-1),
+                                z_dict[(1, 0)].reshape(-1),
+                            ]
+                        )
+
+                    direction_flat = lbfgs_two_loop(g_flat, lbfgs_history, h0_matvec)
+                    D_b = A_cur.todense().shape[0]
+                    d_l = A_cur.todense().shape[-1]
+                    dir_A = -direction_flat[:n_A].reshape(D_b, D_b, D_b, D_b, d_l)
+                    dir_B = -direction_flat[n_A:].reshape(D_b, D_b, D_b, D_b, d_l)
+                    direction = (
+                        _wrap_tensor(dir_A, A_cur),
+                        _wrap_tensor(dir_B, B_cur),
+                    )
+            elif optimizer is not None:
+                updates, opt_state = optimizer.update(grads, opt_state, params)
+                direction = updates
+            else:
+                direction = jax.tree.map(lambda g: -g, grads)
+
+            # Issue #328: kill the radial component of the search direction
+            # so the line-search chord stays on-manifold to first order.
+            # ``_normalize_params`` projects the final iterate back to unit
+            # norm, but the intermediate chord ``params + alpha * direction``
+            # drifts off the sphere proportional to ``alpha * <params, dir>``
+            # — for a Euclidean L-BFGS direction this can be large and push
+            # the line search into non-variational CTM regions before
+            # retraction.  Stale curvature pairs accumulated on that chord
+            # then corrupt subsequent L-BFGS steps.
+            if not use_c4v:
+                direction = _tangent_project_unit(direction, params)
+
+            if use_ls:
+                if config.gs_line_search_method == "hager_zhang":
+                    from tenax.algorithms._line_search import hager_zhang_line_search
+
+                    slope = _tree_dot(grads, direction)
+                    if slope >= 0:
+                        direction = jax.tree.map(lambda g: -g, grads)
+                        if not use_c4v:
+                            direction = _tangent_project_unit(direction, params)
+                        slope = _tree_dot(grads, direction)
+                        if is_metric_lbfgs:
+                            lbfgs_history.clear()
+
+                    hz_counter = {"phi": 0, "dphi": 0}
+
+                    def _phi(alpha):
+                        hz_counter["phi"] += 1
+                        trial = _normalize_params(
+                            _tree_add(params, _tree_scale(direction, alpha))
+                        )
+                        return loss_fn_fwd(trial)
+
+                    def _dphi(alpha):
+                        hz_counter["dphi"] += 1
+                        trial = _normalize_params(
+                            _tree_add(params, _tree_scale(direction, alpha))
+                        )
+                        _, g = jax.value_and_grad(loss_fn)(trial)
+                        return _tree_dot(g, direction)
+
+                    dir_norm = math.sqrt(max(_tree_dot(direction, direction), 1e-30))
+                    param_norm = math.sqrt(max(_tree_dot(params, params), 1e-30))
+                    alpha0 = min(1.0, 0.1 * param_norm / dir_norm)
+
+                    alpha, f_alpha, converged = hager_zhang_line_search(
+                        _phi,
+                        _dphi,
+                        energy_float,
+                        slope,
+                        alpha_init=alpha0,
+                        rho=1.5,
+                        max_step=2.0 * alpha0,
+                        energy_bound=max(2.0, 2.0 * abs(best_energy)),
+                        max_iter=config.gs_hz_max_iter,
+                    )
+                    if config.gs_verbose:
+                        print(
+                            f"[iPEPS-AD:2site-tensor] HZ probes phi={hz_counter['phi']} "
+                            f"dphi={hz_counter['dphi']} alpha={alpha:.3e} "
+                            f"converged={converged}",
+                            flush=True,
+                        )
+                    if f_alpha < energy_float:
+                        params = _normalize_params(
+                            _tree_add(params, _tree_scale(direction, alpha))
+                        )
+                        stall_count = 0
+                    else:
+                        stall_count += 1
+                else:
+                    slope_bt = _tree_dot(grads, direction)
+                    if slope_bt >= 0:
+                        direction = jax.tree.map(lambda g: -g, grads)
+                        if not use_c4v:
+                            direction = _tangent_project_unit(direction, params)
+                        if is_metric_lbfgs:
+                            lbfgs_history.clear()
+                    params, new_energy, step_size = _backtracking_line_search(
+                        params,
+                        direction,
+                        grads,
+                        energy_float,
+                        loss_fn_fwd,
+                        max_steps=config.gs_line_search_max_steps,
+                    )
+                    if new_energy < energy_float:
+                        stall_count = 0
+                    else:
+                        stall_count += 1
+
+                # Noise recovery on persistent stall (legacy; see issue #298).
+                # Only used by the non-C4v path; C4v defaults to "reset".
+                if (
+                    config.gs_stall_recovery == "noise"
+                    and stall_count > 0
+                    and stall_count <= config.gs_noise_recovery_retries
+                ):
+                    noise_key = jax.random.PRNGKey(step * 1000 + stall_count)
                     noisy_params = []
                     for i, p in enumerate(params):
                         k = jax.random.fold_in(noise_key, i)
@@ -2620,176 +3143,153 @@ def _optimize_gs_ad_tensor_2site(
                         noisy = noisy / (jnp.linalg.norm(noisy) + 1e-10)
                         noisy_params.append(_wrap_tensor(noisy, p))
                     params = tuple(noisy_params)
-                if is_metric_lbfgs:
-                    lbfgs_history.clear()
-                    prev_params_flat = None
-                    prev_grad_flat = None
-                if is_cg:
-                    cg_direction = None
-                    prev_grad = None
-                    prev_precond_grad = None
-            elif config.gs_stall_recovery == "reset":
-                # Cap on CTMRGGradientError-driven reset path (#454 follow-up,
-                # codex review on PR #457).
-                if stall_count > config.gs_stall_recovery_retries:
-                    n_resets_done = stall_count - 1
                     if config.gs_verbose:
                         print(
-                            f"[iPEPS-AD] CTM-error stall budget exhausted after "
-                            f"{n_resets_done} resets, "
-                            f"returning best E={best_energy:.10f}",
+                            f"[iPEPS-AD] stall #{stall_count}, adding noise", flush=True
+                        )
+                    # Reset optimizer state
+                    if is_cg:
+                        cg_direction = None
+                        prev_grad = None
+                        prev_precond_grad = None
+                    if is_metric_lbfgs:
+                        lbfgs_history.clear()
+                        prev_params_flat = None
+                        prev_grad_flat = None
+                elif config.gs_stall_recovery == "reset" and stall_count > 0:
+                    # Rollback to best on reset (#454). The CTM-error reset path
+                    # above (around L1998-2002) already does this for the
+                    # CTMRGGradientError branch; we extend the same pattern to the
+                    # Wolfe-failure path that was missed. #298's anti-rollback
+                    # evidence was on a pre-trifecta CTM stack (pre-PR #406 2x2
+                    # projector, pre-multisite-CTM rewrite, pre-PR #447 AD
+                    # stop_gradient) and no longer applies.
+                    if stall_count > config.gs_stall_recovery_retries:
+                        # #455 PR2: at non-final χ stages, treat stall-cap
+                        # exhaustion as a signal to advance the χ schedule
+                        # rather than exit with best_energy.  Mirrors the
+                        # 1-site stall-cap intercept (commit 07ffe8e).
+                        if config.gs_chi_schedule_steps is not None:
+                            steps_in_stage = (step + 1) - stage_start_step
+                            _gn_for_bump = (
+                                grad_norm_val
+                                if grad_norm_val is not None
+                                else (
+                                    _grad_l2_norm(grads)
+                                    if config.gs_conv_criterion != "dE"
+                                    else 0.0
+                                )
+                            )
+                            (
+                                ctm_cfg_2s,
+                                _env_cache_2s,
+                                new_stage_idx,
+                                bump_fired,
+                                _,
+                            ) = _advance_chi_stage_if_due(
+                                ctm_cfg_2s,
+                                _env_cache_2s,
+                                chi_schedule=config.gs_chi_schedule_steps,
+                                current_stage_idx=current_stage_idx,
+                                steps_in_stage=steps_in_stage,
+                                config=config,
+                                grad_norm=_gn_for_bump,
+                                delta_energy=delta_energy,
+                                stall_count=stall_count,
+                                base_charges=_bump_base_charges_2s,
+                            )
+                            # Codex review (PR #467): see 1-site stall-cap
+                            # intercept for rationale.  Decouple schedule
+                            # advance from bump_fired; keep reset block
+                            # gated on bump_fired.
+                            stage_advanced = new_stage_idx != current_stage_idx
+                            if stage_advanced:
+                                current_stage_idx = new_stage_idx
+                                stage_start_step = step + 1
+                            if bump_fired:
+                                # Rollback params to best from the previous
+                                # stage; _env_cache_2s stays at the freshly
+                                # padded post-bump state (the budget-path
+                                # invariant — see _apply_chi_bump).
+                                params = best_params
+                                stall_count = 0
+                                if is_metric_lbfgs:
+                                    lbfgs_history.clear()
+                                    prev_params_flat = None
+                                    prev_grad_flat = None
+                                if is_cg:
+                                    cg_direction = None
+                                    prev_grad = None
+                                    prev_precond_grad = None
+                                if (
+                                    optimizer is not None
+                                    and config.gs_optimizer.lower() == "lbfgs"
+                                ):
+                                    opt_state = optimizer.init(params)
+                                if config.gs_verbose:
+                                    print(
+                                        f"[iPEPS-AD step {step + 1}] stall-cap at "
+                                        f"chi={ctm_cfg_2s.chi} → advancing to next "
+                                        f"stage (#455 PR2)",
+                                        flush=True,
+                                    )
+                            if bump_fired or stage_advanced:
+                                # Force a checkpoint on stall-cap stage
+                                # advance before continuing (Codex P2 #497).
+                                _maybe_save_2s_checkpoint(
+                                    step,
+                                    _chi_at_step_start,
+                                    _best_energy_at_step_start,
+                                    force_last=True,
+                                )
+                                continue
+                        n_resets_done = stall_count - 1
+                        if config.gs_verbose:
+                            print(
+                                f"[iPEPS-AD] stall budget exhausted after "
+                                f"{n_resets_done} resets, "
+                                f"returning best E={best_energy:.10f}",
+                                flush=True,
+                            )
+                        break
+                    params = best_params
+                    # #518: ``best_env_cache_2s`` may be at a stale χ if a
+                    # reactive/scheduled bump fired after it was last
+                    # snapshotted.  Clear instead of restoring; the next
+                    # CTM call cold-starts at the current ctm_cfg_2s.chi.
+                    _env_cache_2s.clear()
+                    if is_cg:
+                        cg_direction = None
+                        prev_grad = None
+                        prev_precond_grad = None
+                    if is_metric_lbfgs:
+                        lbfgs_history.clear()
+                        prev_params_flat = None
+                        prev_grad_flat = None
+                    # Optax-backed L-BFGS stores curvature history in opt_state,
+                    # not in lbfgs_history.  Reinitialize it on the rolled-back
+                    # params so the next step really is steepest descent.
+                    if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                        opt_state = optimizer.init(params)
+                    if config.gs_verbose:
+                        print(
+                            f"[iPEPS-AD] stall #{stall_count}, reset L-BFGS history "
+                            f"(rollback to best, retry "
+                            f"{stall_count}/{config.gs_stall_recovery_retries})",
                             flush=True,
                         )
-                    break
-                params = best_params
-                # #518: ``best_env_cache_2s`` may be at a stale χ if a
-                # reactive/scheduled bump fired after it was last
-                # snapshotted.  Clear instead of restoring; the next
-                # CTM call cold-starts at the current ctm_cfg_2s.chi.
-                _env_cache_2s.clear()
-                if is_metric_lbfgs:
-                    lbfgs_history.clear()
-                    prev_params_flat = None
-                    prev_grad_flat = None
-                if is_cg:
-                    cg_direction = None
-                    prev_grad = None
-                    prev_precond_grad = None
-                if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
-                    opt_state = optimizer.init(params)
-            continue
-        energy_float = float(energy_val)
-
-        if config.return_history:
-            _step_dt = _time.perf_counter() - _step_t0
-            if _first_step:
-                _jit_compile_time = float(_step_dt)
-                _first_step = False
             else:
-                _history_step_times.append(float(_step_dt))
-            _history_energies.append(energy_float)
+                params = optax.apply_updates(params, direction)
+                params = _normalize_params(params)
 
-        # Update env cache for warm-starting next step
-        _update_env_cache_2s(params)
-
-        grad_norm_val = _grad_l2_norm(grads)
-
-        # Gradient-spike guard: reject steps whose new ||grad||_2 exceeds
-        # ``gs_grad_spike_ratio * max(median(recent), 1.0)``.  See
-        # project_v9_collapse_findings.md — non-variational drift shows up
-        # as a >10x gradient blowup before the best_energy crosses the QMC
-        # floor.  We check BEFORE updating best so the bad step never gets
-        # accepted as the new best.
-        if (
-            config.gs_grad_spike_ratio is not None
-            and len(recent_gnorms_2s) >= 1
-            and best_energy < float("inf")
-        ):
-            # ``len >= 1`` (was ``>= 2``, codex PR #524 P2): with
-            # ``gs_grad_spike_window == 1`` the buffer is trimmed back to
-            # length 1 each step, so the previous ``>= 2`` guard silently
-            # disabled the spike check for that valid config.  ``len == 1``
-            # is enough: the median is just the prior step's gradient norm,
-            # which is the right baseline for "is this step a >5x jump?".
-            spike_floor = max(float(np.median(recent_gnorms_2s)), 1.0)
-            if grad_norm_val > config.gs_grad_spike_ratio * spike_floor:
-                params = best_params
-                _env_cache_2s.clear()
-                # Clear the rolling buffer too (codex PR #524 P1): if a chi
-                # bump or stall recovery has shifted the legitimate
-                # gradient scale upward, the stale median would keep
-                # tripping the guard on every subsequent step, locking the
-                # optimizer into perpetual rollback.  Re-seed from the
-                # rolled-back state instead.
-                recent_gnorms_2s.clear()
-                if is_metric_lbfgs:
-                    lbfgs_history.clear()
-                    prev_params_flat = None
-                    prev_grad_flat = None
-                if is_cg:
-                    cg_direction = None
-                    prev_grad = None
-                    prev_precond_grad = None
-                if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
-                    opt_state = optimizer.init(params)
-                _logger.warning(
-                    "[iPEPS-AD:2site-tensor] step %d/%d gradient spike "
-                    "|g|=%.3e > %.1fx median %.3e — rolling back to best",
-                    step + 1,
-                    config.gs_num_steps,
-                    grad_norm_val,
-                    config.gs_grad_spike_ratio,
-                    spike_floor,
-                )
-                if config.gs_verbose:
-                    print(
-                        f"[iPEPS-AD:2site-tensor] step {step + 1}/{config.gs_num_steps} "
-                        f"|g|={grad_norm_val:.3e} spike "
-                        f"(>{config.gs_grad_spike_ratio:.1f}x median {spike_floor:.3e}) "
-                        f"— rollback to best, clear L-BFGS history",
-                        flush=True,
-                    )
-                continue
-        recent_gnorms_2s.append(grad_norm_val)
-        if len(recent_gnorms_2s) > config.gs_grad_spike_window:
-            recent_gnorms_2s.pop(0)
-
-        if _should_accept_best(
-            current_best=best_energy,
-            candidate=energy_float,
-            floor=config.gs_energy_floor,
-        ):
-            best_energy = energy_float
-            best_params = params
-            best_env_cache_2s = dict(_env_cache_2s)  # snapshot for warm-start (#317)
-
-        delta_energy = abs(energy_float - prev_energy)
-        logged = False
-        if config.gs_verbose and _should_log_step(
-            step, config.gs_num_steps, log_interval
-        ):
-            _log_ad_step(
-                "2site-tensor",
-                step,
-                config.gs_num_steps,
-                energy_float,
-                delta_energy,
-                best_energy,
-                grad_norm=grad_norm_val,
-            )
-            # Implicit-AD adjoint diagnostics: surface ||lam||/||init_lam||
-            # amplification so chi-ceiling collapse runs (e.g. v9d/v9h)
-            # have a smoking-gun trace.  Populated by the fused fixed-point
-            # backward; empty dict on the explicit-AD path.
-            if config.gs_implicit_ad:
-                from tenax.algorithms._ctm_energy_ad import (
-                    get_last_implicit_ad_diagnostics,
-                )
-
-                _diag = get_last_implicit_ad_diagnostics()
-                if _diag:
-                    print(
-                        f"[iPEPS-AD:2site-tensor] step {step + 1}/{config.gs_num_steps} "
-                        f"GMRES n_iter={_diag.get('n_iter', '?')} "
-                        f"converged={_diag.get('converged', '?')} "
-                        f"diverged={_diag.get('diverged', '?')} "
-                        f"||lam||={_diag.get('lam_norm', float('nan')):.3e} "
-                        f"amp={_diag.get('amplification', float('nan')):.3e}",
-                        flush=True,
-                    )
-            logged = True
-
-        prev_energy = energy_float
-        if _converged_outer(config, delta_energy, grad_norm_val):
-            # #455 PR2: at non-final χ stages, treat convergence as a
-            # signal to advance to the next stage rather than exit.
-            # Mirrors the 1-site convergence-block intercept, including
-            # the reactive ε_T bump (#472 codex review on PR #473):
-            # converged-at-too-small-χ runs must apply the requested
-            # auto-bump before exiting so the final env reflects the
-            # bumped χ, and the bump can also unstick a stalled-at-χ_old
-            # landscape via the ``continue`` below.
-            chi_before_bump = ctm_cfg_2s.chi
+            # Reactive ε_T auto-bump (variPEPS §2.8.2, #472) followed by the
+            # scheduled outer-loop χ bump (#453 / #455).  Compose order
+            # mirrors the 1-site path: reactive first so it can pre-empt the
+            # schedule, scheduled second to advance the stage index even on
+            # idempotent (post-reactive) bumps.  ``chi_before`` is snapshotted
+            # before either fires so the post-bump reset block below catches
+            # either trigger via ``ctm_cfg_2s.chi != chi_before``.
+            chi_before = ctm_cfg_2s.chi
             last_eps_t = float(_env_cache_2s.get("max_truncation_error", 0.0))
             ctm_cfg_2s, _env_cache_2s = _maybe_bump_chi(
                 ctm_cfg_2s,
@@ -2797,6 +3297,12 @@ def _optimize_gs_ad_tensor_2site(
                 last_eps_t,
                 base_charges=_bump_base_charges_2s,
             )
+            # Scheduled outer-loop χ bump (#453 / #455).  No-ops when
+            # ``gs_chi_schedule_steps`` is None.  Fires at the step boundary
+            # so the next iteration's value_and_grad sees the bumped χ — same
+            # invariant as the 1-site path.  Per-stage state
+            # (current_stage_idx, stage_start_step) drives the new helper;
+            # #455 PR2 will add convergence/stall-cap triggers.
             if config.gs_chi_schedule_steps is not None:
                 steps_in_stage = (step + 1) - stage_start_step
                 _gn_for_bump = (
@@ -2808,40 +3314,45 @@ def _optimize_gs_ad_tensor_2site(
                         else 0.0
                     )
                 )
-                (
-                    ctm_cfg_2s,
-                    _env_cache_2s,
-                    new_stage_idx,
-                    bump_fired,
-                    _,
-                ) = _advance_chi_stage_if_due(
-                    ctm_cfg_2s,
-                    _env_cache_2s,
-                    chi_schedule=config.gs_chi_schedule_steps,
-                    current_stage_idx=current_stage_idx,
-                    steps_in_stage=steps_in_stage,
-                    config=config,
-                    grad_norm=_gn_for_bump,
-                    delta_energy=delta_energy,
-                    stall_count=stall_count,
-                    base_charges=_bump_base_charges_2s,
+                ctm_cfg_2s, _env_cache_2s, new_stage_idx, bump_fired, _should_break = (
+                    _advance_chi_stage_if_due(
+                        ctm_cfg_2s,
+                        _env_cache_2s,
+                        chi_schedule=config.gs_chi_schedule_steps,
+                        current_stage_idx=current_stage_idx,
+                        steps_in_stage=steps_in_stage,
+                        config=config,
+                        grad_norm=_gn_for_bump,
+                        delta_energy=delta_energy,
+                        stall_count=stall_count,
+                        base_charges=_bump_base_charges_2s,
+                    )
                 )
-                # Codex review (PR #467): decouple the schedule index
-                # advance from bump_fired so idempotent advances
-                # (bump_fired=False AND new_stage_idx>current_stage_idx)
-                # still continue rather than fall through to break.
                 stage_advanced = new_stage_idx != current_stage_idx
                 if stage_advanced:
+                    if config.gs_verbose:
+                        print(
+                            f"[iPEPS-AD step {step + 1}] schedule advance: "
+                            f"stage {current_stage_idx} → {new_stage_idx}, "
+                            f"chi {chi_before} → {ctm_cfg_2s.chi} (#455)",
+                            flush=True,
+                        )
                     current_stage_idx = new_stage_idx
                     stage_start_step = step + 1
-            else:
-                bump_fired = False
-                stage_advanced = False
-            if ctm_cfg_2s.chi != chi_before_bump:
-                # Reactive (#472) or scheduled (#455) bump fired —
-                # fresh landscape, fresh stall budget.  Gated on the
-                # χ delta so a reactive-only bump also clears state.
+            # Reset block must live OUTSIDE the schedule-only ``if`` so a
+            # reactive-only bump (``chi_auto_bump=True`` with no schedule)
+            # still clears stall_count, CG state, and L-BFGS history at the
+            # new χ.  Gated solely on ``ctm_cfg_2s.chi != chi_before``, which
+            # is set by EITHER reactive (#472) or scheduled (#455) bumps.
+            # (Codex PR #473 review.)
+            if ctm_cfg_2s.chi != chi_before:
+                # χ bump fired: a new landscape begins.  Reset the stall
+                # counter so the next stage gets a fresh retry budget;
+                # also clear L-BFGS curvature history so the first step
+                # at the new χ is plain steepest descent (curvature from
+                # the previous χ landscape isn't valid here).
                 stall_count = 0
+                chi_ceiling_consecutive_2s = 0
                 if is_metric_lbfgs:
                     lbfgs_history.clear()
                     prev_params_flat = None
@@ -2852,622 +3363,128 @@ def _optimize_gs_ad_tensor_2site(
                     prev_precond_grad = None
                 if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
                     opt_state = optimizer.init(params)
-                if config.gs_verbose:
-                    print(
-                        f"[iPEPS-AD step {step + 1}] converged at "
-                        f"chi={chi_before_bump} → bumping to "
-                        f"chi={ctm_cfg_2s.chi} (#455 PR2 / #472)",
-                        flush=True,
-                    )
-            if bump_fired or stage_advanced:
-                # Force a checkpoint on stage advance before continuing
-                # so a crash inside the next stage's first step doesn't
-                # roll back across the boundary (Codex P2 #497).
-                _maybe_save_2s_checkpoint(
-                    step,
-                    _chi_at_step_start,
-                    _best_energy_at_step_start,
-                    force_last=True,
-                )
-                continue
-            if config.gs_verbose:
-                if not logged:
-                    _log_ad_step(
-                        "2site-tensor",
-                        step,
-                        config.gs_num_steps,
-                        energy_float,
-                        delta_energy,
-                        best_energy,
-                        grad_norm=grad_norm_val,
-                    )
-                _log_ad_converged(
-                    "2site-tensor",
-                    step,
-                    delta_energy,
-                    config.gs_conv_tol,
-                    grad_norm=grad_norm_val,
-                    grad_norm_tol=config.gs_grad_norm_tol,
-                    criterion=config.gs_conv_criterion,
-                )
-            _converged = True
-            break
 
-        # Compute search direction
-        if is_cg:
-            if config.gs_metric_precond and not use_c4v:
-                from tenax.algorithms._metric_precond import (
-                    precondition_gradient_multisite,
-                )
-
-                envs_cached = _env_cache_2s["envs"]
-                A_g, B_g = grads
-                envs_m = {(0, 0): envs_cached[(0, 0)], (1, 0): envs_cached[(1, 0)]}
-                sites_m = {(0, 0): params[0], (1, 0): params[1]}
-                grads_m = {(0, 0): A_g, (1, 0): B_g}
-                delta_metric = delta_energy if step > 0 else _tree_dot(grads, grads)
-                z_dict = precondition_gradient_multisite(
-                    sites_m, envs_m, grads_m, delta_metric, config
-                )
-                z = (
-                    _wrap_tensor(z_dict[(0, 0)], A_g),
-                    _wrap_tensor(z_dict[(1, 0)], B_g),
-                )
-                neg_z = jax.tree.map(lambda g: -g, z)
-                if prev_precond_grad is not None and cg_direction is not None:
-                    z_diff = jax.tree.map(lambda a, b: a - b, z, prev_precond_grad)
-                    num = _tree_dot(grads, z_diff)
-                    den = _tree_dot(prev_grad, prev_precond_grad)
-                    beta = max(0.0, num / den) if den > 1e-30 else 0.0
-                    cg_direction = _tree_add(neg_z, _tree_scale(cg_direction, beta))
-                else:
-                    cg_direction = neg_z
-                prev_precond_grad = z
-            else:
-                neg_grad = jax.tree.map(lambda g: -g, grads)
-                if prev_grad is not None and cg_direction is not None:
-                    beta = _cg_beta_pr(grads, prev_grad)
-                    cg_direction = _tree_add(neg_grad, _tree_scale(cg_direction, beta))
-                else:
-                    cg_direction = neg_grad
-            prev_grad = grads
-            direction = cg_direction
-        elif is_metric_lbfgs:
-            from tenax.algorithms._metric_precond import lbfgs_two_loop
-
-            if use_c4v:
-                p_flat = params
-                g_flat = grads
-            else:
-                from tenax.algorithms._metric_precond import (
-                    precondition_gradient_multisite,
-                )
-
-                A_cur, B_cur = params
-                A_g, B_g = grads
-                p_flat = jnp.concatenate(
-                    [
-                        A_cur.todense().reshape(-1),
-                        B_cur.todense().reshape(-1),
-                    ]
-                )
-                g_flat = jnp.concatenate(
-                    [
-                        A_g.todense().reshape(-1),
-                        B_g.todense().reshape(-1),
-                    ]
-                )
-
-            if prev_params_flat is not None:
-                s = p_flat - prev_params_flat
-                y = g_flat - prev_grad_flat
-                sy = float(jnp.real(jnp.vdot(s, y)))
-                if sy > 1e-10:
-                    rho = 1.0 / sy
-                    lbfgs_history.append((s, y, rho))
-                    if len(lbfgs_history) > 10:
-                        lbfgs_history.pop(0)
-            prev_params_flat = p_flat
-            prev_grad_flat = g_flat
-
-            if use_c4v:
-                direction_flat = lbfgs_two_loop(g_flat, lbfgs_history, lambda v: v)
-                direction = -direction_flat
-            else:
-                envs_cached = _env_cache_2s["envs"]
-                envs_m = {(0, 0): envs_cached[(0, 0)], (1, 0): envs_cached[(1, 0)]}
-                sites_m = {(0, 0): A_cur, (1, 0): B_cur}
-                delta_metric = (
-                    delta_energy
-                    if step > 0
-                    else float(jnp.real(jnp.vdot(g_flat, g_flat)))
-                )
-                n_A = A_cur.todense().size
-
-                def h0_matvec(v):
-                    v_A = v[:n_A]
-                    v_B = v[n_A:]
-                    D_b = A_cur.todense().shape[0]
-                    d_l = A_cur.todense().shape[-1]
-                    grads_v = {
-                        (0, 0): _wrap_tensor(
-                            v_A.reshape(D_b, D_b, D_b, D_b, d_l), A_cur
-                        ),
-                        (1, 0): _wrap_tensor(
-                            v_B.reshape(D_b, D_b, D_b, D_b, d_l), B_cur
-                        ),
-                    }
-                    z_dict = precondition_gradient_multisite(
-                        sites_m, envs_m, grads_v, delta_metric, config
-                    )
-                    return jnp.concatenate(
-                        [
-                            z_dict[(0, 0)].reshape(-1),
-                            z_dict[(1, 0)].reshape(-1),
-                        ]
-                    )
-
-                direction_flat = lbfgs_two_loop(g_flat, lbfgs_history, h0_matvec)
-                D_b = A_cur.todense().shape[0]
-                d_l = A_cur.todense().shape[-1]
-                dir_A = -direction_flat[:n_A].reshape(D_b, D_b, D_b, D_b, d_l)
-                dir_B = -direction_flat[n_A:].reshape(D_b, D_b, D_b, D_b, d_l)
-                direction = (
-                    _wrap_tensor(dir_A, A_cur),
-                    _wrap_tensor(dir_B, B_cur),
-                )
-        elif optimizer is not None:
-            updates, opt_state = optimizer.update(grads, opt_state, params)
-            direction = updates
-        else:
-            direction = jax.tree.map(lambda g: -g, grads)
-
-        # Issue #328: kill the radial component of the search direction
-        # so the line-search chord stays on-manifold to first order.
-        # ``_normalize_params`` projects the final iterate back to unit
-        # norm, but the intermediate chord ``params + alpha * direction``
-        # drifts off the sphere proportional to ``alpha * <params, dir>``
-        # — for a Euclidean L-BFGS direction this can be large and push
-        # the line search into non-variational CTM regions before
-        # retraction.  Stale curvature pairs accumulated on that chord
-        # then corrupt subsequent L-BFGS steps.
-        if not use_c4v:
-            direction = _tangent_project_unit(direction, params)
-
-        if use_ls:
-            if config.gs_line_search_method == "hager_zhang":
-                from tenax.algorithms._line_search import hager_zhang_line_search
-
-                slope = _tree_dot(grads, direction)
-                if slope >= 0:
-                    direction = jax.tree.map(lambda g: -g, grads)
-                    if not use_c4v:
-                        direction = _tangent_project_unit(direction, params)
-                    slope = _tree_dot(grads, direction)
-                    if is_metric_lbfgs:
-                        lbfgs_history.clear()
-
-                hz_counter = {"phi": 0, "dphi": 0}
-
-                def _phi(alpha):
-                    hz_counter["phi"] += 1
-                    trial = _normalize_params(
-                        _tree_add(params, _tree_scale(direction, alpha))
-                    )
-                    return loss_fn_fwd(trial)
-
-                def _dphi(alpha):
-                    hz_counter["dphi"] += 1
-                    trial = _normalize_params(
-                        _tree_add(params, _tree_scale(direction, alpha))
-                    )
-                    _, g = jax.value_and_grad(loss_fn)(trial)
-                    return _tree_dot(g, direction)
-
-                dir_norm = math.sqrt(max(_tree_dot(direction, direction), 1e-30))
-                param_norm = math.sqrt(max(_tree_dot(params, params), 1e-30))
-                alpha0 = min(1.0, 0.1 * param_norm / dir_norm)
-
-                alpha, f_alpha, converged = hager_zhang_line_search(
-                    _phi,
-                    _dphi,
-                    energy_float,
-                    slope,
-                    alpha_init=alpha0,
-                    rho=1.5,
-                    max_step=2.0 * alpha0,
-                    energy_bound=max(2.0, 2.0 * abs(best_energy)),
-                    max_iter=config.gs_hz_max_iter,
-                )
-                if config.gs_verbose:
-                    print(
-                        f"[iPEPS-AD:2site-tensor] HZ probes phi={hz_counter['phi']} "
-                        f"dphi={hz_counter['dphi']} alpha={alpha:.3e} "
-                        f"converged={converged}",
-                        flush=True,
-                    )
-                if f_alpha < energy_float:
-                    params = _normalize_params(
-                        _tree_add(params, _tree_scale(direction, alpha))
-                    )
-                    stall_count = 0
-                else:
-                    stall_count += 1
-            else:
-                slope_bt = _tree_dot(grads, direction)
-                if slope_bt >= 0:
-                    direction = jax.tree.map(lambda g: -g, grads)
-                    if not use_c4v:
-                        direction = _tangent_project_unit(direction, params)
-                    if is_metric_lbfgs:
-                        lbfgs_history.clear()
-                params, new_energy, step_size = _backtracking_line_search(
-                    params,
-                    direction,
-                    grads,
-                    energy_float,
-                    loss_fn_fwd,
-                    max_steps=config.gs_line_search_max_steps,
-                )
-                if new_energy < energy_float:
-                    stall_count = 0
-                else:
-                    stall_count += 1
-
-            # Noise recovery on persistent stall (legacy; see issue #298).
-            # Only used by the non-C4v path; C4v defaults to "reset".
+            # variPEPS §2.8.2 chi-ceiling bail-out.  After the post-step bump
+            # has been attempted, if χ is still at chi_max AND the indicator
+            # remains above threshold for K consecutive steps, exit early and
+            # return ``best_params``.  Counter resets on any bump (handled
+            # above), any successful headroom recovery, or stall recovery.
             if (
-                config.gs_stall_recovery == "noise"
-                and stall_count > 0
-                and stall_count <= config.gs_noise_recovery_retries
+                config.gs_chi_ceiling_bailout > 0
+                and ctm_cfg_2s.chi_max is not None
+                and ctm_cfg_2s.chi >= ctm_cfg_2s.chi_max
             ):
-                noise_key = jax.random.PRNGKey(step * 1000 + stall_count)
-                noisy_params = []
-                for i, p in enumerate(params):
-                    k = jax.random.fold_in(noise_key, i)
-                    data = p.todense()
-                    noise = config.gs_noise_amplitude * _random_noise(
-                        k, data.shape, data.dtype
+                _bail_metric = ctm_cfg_2s.chi_auto_bump_metric
+                if _bail_metric == "norm_smallest_S":
+                    _bail_indicator = float(_env_cache_2s.get("max_smallest_S", 0.0))
+                else:
+                    _bail_indicator = float(
+                        _env_cache_2s.get("max_truncation_error", 0.0)
                     )
-                    noisy = data + noise * jnp.linalg.norm(data)
-                    noisy = noisy / (jnp.linalg.norm(noisy) + 1e-10)
-                    noisy_params.append(_wrap_tensor(noisy, p))
-                params = tuple(noisy_params)
-                if config.gs_verbose:
-                    print(f"[iPEPS-AD] stall #{stall_count}, adding noise", flush=True)
-                # Reset optimizer state
-                if is_cg:
-                    cg_direction = None
-                    prev_grad = None
-                    prev_precond_grad = None
-                if is_metric_lbfgs:
-                    lbfgs_history.clear()
-                    prev_params_flat = None
-                    prev_grad_flat = None
-            elif config.gs_stall_recovery == "reset" and stall_count > 0:
-                # Rollback to best on reset (#454). The CTM-error reset path
-                # above (around L1998-2002) already does this for the
-                # CTMRGGradientError branch; we extend the same pattern to the
-                # Wolfe-failure path that was missed. #298's anti-rollback
-                # evidence was on a pre-trifecta CTM stack (pre-PR #406 2x2
-                # projector, pre-multisite-CTM rewrite, pre-PR #447 AD
-                # stop_gradient) and no longer applies.
-                if stall_count > config.gs_stall_recovery_retries:
-                    # #455 PR2: at non-final χ stages, treat stall-cap
-                    # exhaustion as a signal to advance the χ schedule
-                    # rather than exit with best_energy.  Mirrors the
-                    # 1-site stall-cap intercept (commit 07ffe8e).
-                    if config.gs_chi_schedule_steps is not None:
-                        steps_in_stage = (step + 1) - stage_start_step
-                        _gn_for_bump = (
-                            grad_norm_val
-                            if grad_norm_val is not None
-                            else (
-                                _grad_l2_norm(grads)
-                                if config.gs_conv_criterion != "dE"
-                                else 0.0
+                if _bail_indicator > ctm_cfg_2s.chi_auto_bump_eps:
+                    chi_ceiling_consecutive_2s += 1
+                    if chi_ceiling_consecutive_2s >= config.gs_chi_ceiling_bailout:
+                        if config.gs_verbose:
+                            print(
+                                f"[iPEPS-AD:2site-tensor] step {step + 1}/"
+                                f"{config.gs_num_steps} chi-ceiling bail-out: "
+                                f"chi={ctm_cfg_2s.chi} at chi_max, "
+                                f"{_bail_metric}={_bail_indicator:.3e} > "
+                                f"{ctm_cfg_2s.chi_auto_bump_eps:.3e} for "
+                                f"{chi_ceiling_consecutive_2s} consecutive steps "
+                                f"— rolling back to best E={best_energy:.10f}",
+                                flush=True,
                             )
+                        params = best_params
+                        _maybe_save_2s_checkpoint(
+                            step, chi_before, _best_energy_at_step_start
                         )
-                        (
-                            ctm_cfg_2s,
-                            _env_cache_2s,
-                            new_stage_idx,
-                            bump_fired,
-                            _,
-                        ) = _advance_chi_stage_if_due(
-                            ctm_cfg_2s,
-                            _env_cache_2s,
-                            chi_schedule=config.gs_chi_schedule_steps,
-                            current_stage_idx=current_stage_idx,
-                            steps_in_stage=steps_in_stage,
-                            config=config,
-                            grad_norm=_gn_for_bump,
-                            delta_energy=delta_energy,
-                            stall_count=stall_count,
-                            base_charges=_bump_base_charges_2s,
-                        )
-                        # Codex review (PR #467): see 1-site stall-cap
-                        # intercept for rationale.  Decouple schedule
-                        # advance from bump_fired; keep reset block
-                        # gated on bump_fired.
-                        stage_advanced = new_stage_idx != current_stage_idx
-                        if stage_advanced:
-                            current_stage_idx = new_stage_idx
-                            stage_start_step = step + 1
-                        if bump_fired:
-                            # Rollback params to best from the previous
-                            # stage; _env_cache_2s stays at the freshly
-                            # padded post-bump state (the budget-path
-                            # invariant — see _apply_chi_bump).
-                            params = best_params
-                            stall_count = 0
-                            if is_metric_lbfgs:
-                                lbfgs_history.clear()
-                                prev_params_flat = None
-                                prev_grad_flat = None
-                            if is_cg:
-                                cg_direction = None
-                                prev_grad = None
-                                prev_precond_grad = None
-                            if (
-                                optimizer is not None
-                                and config.gs_optimizer.lower() == "lbfgs"
-                            ):
-                                opt_state = optimizer.init(params)
-                            if config.gs_verbose:
-                                print(
-                                    f"[iPEPS-AD step {step + 1}] stall-cap at "
-                                    f"chi={ctm_cfg_2s.chi} → advancing to next "
-                                    f"stage (#455 PR2)",
-                                    flush=True,
-                                )
-                        if bump_fired or stage_advanced:
-                            # Force a checkpoint on stall-cap stage
-                            # advance before continuing (Codex P2 #497).
-                            _maybe_save_2s_checkpoint(
-                                step,
-                                _chi_at_step_start,
-                                _best_energy_at_step_start,
-                                force_last=True,
-                            )
-                            continue
-                    n_resets_done = stall_count - 1
-                    if config.gs_verbose:
-                        print(
-                            f"[iPEPS-AD] stall budget exhausted after "
-                            f"{n_resets_done} resets, "
-                            f"returning best E={best_energy:.10f}",
-                            flush=True,
-                        )
-                    break
-                params = best_params
-                # #518: ``best_env_cache_2s`` may be at a stale χ if a
-                # reactive/scheduled bump fired after it was last
-                # snapshotted.  Clear instead of restoring; the next
-                # CTM call cold-starts at the current ctm_cfg_2s.chi.
-                _env_cache_2s.clear()
-                if is_cg:
-                    cg_direction = None
-                    prev_grad = None
-                    prev_precond_grad = None
-                if is_metric_lbfgs:
-                    lbfgs_history.clear()
-                    prev_params_flat = None
-                    prev_grad_flat = None
-                # Optax-backed L-BFGS stores curvature history in opt_state,
-                # not in lbfgs_history.  Reinitialize it on the rolled-back
-                # params so the next step really is steepest descent.
-                if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
-                    opt_state = optimizer.init(params)
-                if config.gs_verbose:
-                    print(
-                        f"[iPEPS-AD] stall #{stall_count}, reset L-BFGS history "
-                        f"(rollback to best, retry "
-                        f"{stall_count}/{config.gs_stall_recovery_retries})",
-                        flush=True,
-                    )
-        else:
-            params = optax.apply_updates(params, direction)
-            params = _normalize_params(params)
-
-        # Reactive ε_T auto-bump (variPEPS §2.8.2, #472) followed by the
-        # scheduled outer-loop χ bump (#453 / #455).  Compose order
-        # mirrors the 1-site path: reactive first so it can pre-empt the
-        # schedule, scheduled second to advance the stage index even on
-        # idempotent (post-reactive) bumps.  ``chi_before`` is snapshotted
-        # before either fires so the post-bump reset block below catches
-        # either trigger via ``ctm_cfg_2s.chi != chi_before``.
-        chi_before = ctm_cfg_2s.chi
-        last_eps_t = float(_env_cache_2s.get("max_truncation_error", 0.0))
-        ctm_cfg_2s, _env_cache_2s = _maybe_bump_chi(
-            ctm_cfg_2s,
-            _env_cache_2s,
-            last_eps_t,
-            base_charges=_bump_base_charges_2s,
-        )
-        # Scheduled outer-loop χ bump (#453 / #455).  No-ops when
-        # ``gs_chi_schedule_steps`` is None.  Fires at the step boundary
-        # so the next iteration's value_and_grad sees the bumped χ — same
-        # invariant as the 1-site path.  Per-stage state
-        # (current_stage_idx, stage_start_step) drives the new helper;
-        # #455 PR2 will add convergence/stall-cap triggers.
-        if config.gs_chi_schedule_steps is not None:
-            steps_in_stage = (step + 1) - stage_start_step
-            _gn_for_bump = (
-                grad_norm_val
-                if grad_norm_val is not None
-                else (_grad_l2_norm(grads) if config.gs_conv_criterion != "dE" else 0.0)
-            )
-            ctm_cfg_2s, _env_cache_2s, new_stage_idx, bump_fired, _should_break = (
-                _advance_chi_stage_if_due(
-                    ctm_cfg_2s,
-                    _env_cache_2s,
-                    chi_schedule=config.gs_chi_schedule_steps,
-                    current_stage_idx=current_stage_idx,
-                    steps_in_stage=steps_in_stage,
-                    config=config,
-                    grad_norm=_gn_for_bump,
-                    delta_energy=delta_energy,
-                    stall_count=stall_count,
-                    base_charges=_bump_base_charges_2s,
-                )
-            )
-            stage_advanced = new_stage_idx != current_stage_idx
-            if stage_advanced:
-                if config.gs_verbose:
-                    print(
-                        f"[iPEPS-AD step {step + 1}] schedule advance: "
-                        f"stage {current_stage_idx} → {new_stage_idx}, "
-                        f"chi {chi_before} → {ctm_cfg_2s.chi} (#455)",
-                        flush=True,
-                    )
-                current_stage_idx = new_stage_idx
-                stage_start_step = step + 1
-        # Reset block must live OUTSIDE the schedule-only ``if`` so a
-        # reactive-only bump (``chi_auto_bump=True`` with no schedule)
-        # still clears stall_count, CG state, and L-BFGS history at the
-        # new χ.  Gated solely on ``ctm_cfg_2s.chi != chi_before``, which
-        # is set by EITHER reactive (#472) or scheduled (#455) bumps.
-        # (Codex PR #473 review.)
-        if ctm_cfg_2s.chi != chi_before:
-            # χ bump fired: a new landscape begins.  Reset the stall
-            # counter so the next stage gets a fresh retry budget;
-            # also clear L-BFGS curvature history so the first step
-            # at the new χ is plain steepest descent (curvature from
-            # the previous χ landscape isn't valid here).
-            stall_count = 0
-            chi_ceiling_consecutive_2s = 0
-            if is_metric_lbfgs:
-                lbfgs_history.clear()
-                prev_params_flat = None
-                prev_grad_flat = None
-            if is_cg:
-                cg_direction = None
-                prev_grad = None
-                prev_precond_grad = None
-            if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
-                opt_state = optimizer.init(params)
-
-        # variPEPS §2.8.2 chi-ceiling bail-out.  After the post-step bump
-        # has been attempted, if χ is still at chi_max AND the indicator
-        # remains above threshold for K consecutive steps, exit early and
-        # return ``best_params``.  Counter resets on any bump (handled
-        # above), any successful headroom recovery, or stall recovery.
-        if (
-            config.gs_chi_ceiling_bailout > 0
-            and ctm_cfg_2s.chi_max is not None
-            and ctm_cfg_2s.chi >= ctm_cfg_2s.chi_max
-        ):
-            _bail_metric = ctm_cfg_2s.chi_auto_bump_metric
-            if _bail_metric == "norm_smallest_S":
-                _bail_indicator = float(_env_cache_2s.get("max_smallest_S", 0.0))
-            else:
-                _bail_indicator = float(_env_cache_2s.get("max_truncation_error", 0.0))
-            if _bail_indicator > ctm_cfg_2s.chi_auto_bump_eps:
-                chi_ceiling_consecutive_2s += 1
-                if chi_ceiling_consecutive_2s >= config.gs_chi_ceiling_bailout:
-                    if config.gs_verbose:
-                        print(
-                            f"[iPEPS-AD:2site-tensor] step {step + 1}/"
-                            f"{config.gs_num_steps} chi-ceiling bail-out: "
-                            f"chi={ctm_cfg_2s.chi} at chi_max, "
-                            f"{_bail_metric}={_bail_indicator:.3e} > "
-                            f"{ctm_cfg_2s.chi_auto_bump_eps:.3e} for "
-                            f"{chi_ceiling_consecutive_2s} consecutive steps "
-                            f"— rolling back to best E={best_energy:.10f}",
-                            flush=True,
-                        )
-                    params = best_params
-                    _maybe_save_2s_checkpoint(
-                        step, chi_before, _best_energy_at_step_start
-                    )
-                    break
+                        break
+                else:
+                    chi_ceiling_consecutive_2s = 0
             else:
                 chi_ceiling_consecutive_2s = 0
-        else:
-            chi_ceiling_consecutive_2s = 0
 
-        # End-of-step save: cadence-based + new-best detection.
-        _maybe_save_2s_checkpoint(step, chi_before, _best_energy_at_step_start)
+            # End-of-step save: cadence-based + new-best detection.
+            _maybe_save_2s_checkpoint(step, chi_before, _best_energy_at_step_start)
 
-    # Re-evaluate both final params and best_params with fully converged
-    # fresh CTM.  In-loop energies use warm-started CTM that can produce
-    # unphysical values, so we compare fresh evaluations only.
-    # Match in-loop CTM tolerances (#317) by reusing ctm_cfg_2s directly.
+        # Re-evaluate both final params and best_params with fully converged
+        # fresh CTM.  In-loop energies use warm-started CTM that can produce
+        # unphysical values, so we compare fresh evaluations only.
+        # Match in-loop CTM tolerances (#317) by reusing ctm_cfg_2s directly.
 
-    def _eval_fresh_2site(p, env_init=None):
-        """Evaluate energy with fully converged fresh CTM."""
-        if use_c4v:
-            A_t, B_t = _c4v_AB(p)
-        else:
-            A_t, B_t = _normalize_params(p)
-        st = {(0, 0): A_t, (1, 0): B_t}
-        envs, _ = python_loop_ctm_converge(
-            st,
-            CHECKERBOARD_NEIGHBORS,
-            **ctm_converge_kwargs(ctm_cfg_2s, env_init=env_init),
-        )
-        E_ = float(
-            compute_energy_ctm_tensor_2site(
-                A_t, B_t, envs[(0, 0)], envs[(1, 0)], gate, d_phys
+        def _eval_fresh_2site(p, env_init=None):
+            """Evaluate energy with fully converged fresh CTM."""
+            if use_c4v:
+                A_t, B_t = _c4v_AB(p)
+            else:
+                A_t, B_t = _normalize_params(p)
+            st = {(0, 0): A_t, (1, 0): B_t}
+            envs, _ = python_loop_ctm_converge(
+                st,
+                CHECKERBOARD_NEIGHBORS,
+                **ctm_converge_kwargs(ctm_cfg_2s, env_init=env_init),
             )
-        )
-        return A_t, B_t, envs, E_
-
-    A_last, B_last, envs_last, E_last = _eval_fresh_2site(
-        params, _env_cache_2s.get("envs", None)
-    )
-    env_A_last, env_B_last = envs_last[(0, 0)], envs_last[(1, 0)]
-
-    # Pad best_env_cache_2s envs to the current ctm_cfg_2s.chi before use.
-    # Mirrors the same fix on the 1-site path — see comment there.  Fixes #469.
-    # NOTE: if a new _eval_fresh_2site(best_params, best_env_cache_2s["envs"])
-    # call site is added later, it must reapply this padding — there's no
-    # producer-side guarantee that the snapshot is at ctm_cfg_2s.chi.
-    _best_env_init_2s = best_env_cache_2s.get("envs", None)
-    if _best_env_init_2s:
-        _best_env_init_2s = {
-            c: pad_dense_env_chi(
-                _best_env_init_2s[c],
-                ctm_cfg_2s.chi,
-                base_charges=_bump_base_charges_2s,
+            E_ = float(
+                compute_energy_ctm_tensor_2site(
+                    A_t, B_t, envs[(0, 0)], envs[(1, 0)], gate, d_phys
+                )
             )
-            for c in _best_env_init_2s
-        }
+            return A_t, B_t, envs, E_
 
-    if best_params is not params:
-        A_best, B_best, envs_best, E_best_fresh = _eval_fresh_2site(
-            best_params, _best_env_init_2s
+        A_last, B_last, envs_last, E_last = _eval_fresh_2site(
+            params, _env_cache_2s.get("envs", None)
         )
-        env_A_best = envs_best[(0, 0)]
-        env_B_best = envs_best[(1, 0)]
-    else:
-        E_best_fresh = E_last
+        env_A_last, env_B_last = envs_last[(0, 0)], envs_last[(1, 0)]
 
-    # Pick whichever fresh evaluation is lower
-    if E_last <= E_best_fresh:
-        A_final, B_final = A_last, B_last
-        env_A, env_B, E_gs = env_A_last, env_B_last, E_last
-    else:
-        A_final, B_final = A_best, B_best
-        env_A, env_B, E_gs = env_A_best, env_B_best, E_best_fresh
-    if config.gs_verbose:
-        print(f"[iPEPS-AD:2site-tensor] final E={E_gs:.10f}", flush=True)
+        # Pad best_env_cache_2s envs to the current ctm_cfg_2s.chi before use.
+        # Mirrors the same fix on the 1-site path — see comment there.  Fixes #469.
+        # NOTE: if a new _eval_fresh_2site(best_params, best_env_cache_2s["envs"])
+        # call site is added later, it must reapply this padding — there's no
+        # producer-side guarantee that the snapshot is at ctm_cfg_2s.chi.
+        _best_env_init_2s = best_env_cache_2s.get("envs", None)
+        if _best_env_init_2s:
+            _best_env_init_2s = {
+                c: pad_dense_env_chi(
+                    _best_env_init_2s[c],
+                    ctm_cfg_2s.chi,
+                    base_charges=_bump_base_charges_2s,
+                )
+                for c in _best_env_init_2s
+            }
 
-    if config.return_history:
-        history = {
-            "energies": _history_energies,
-            "step_times": _history_step_times,
-            "jit_compile_time": _jit_compile_time,
-            "num_steps": len(_history_energies),
-            "converged": _converged,
-        }
+        if best_params is not params:
+            A_best, B_best, envs_best, E_best_fresh = _eval_fresh_2site(
+                best_params, _best_env_init_2s
+            )
+            env_A_best = envs_best[(0, 0)]
+            env_B_best = envs_best[(1, 0)]
+        else:
+            E_best_fresh = E_last
+
+        # Pick whichever fresh evaluation is lower
+        if E_last <= E_best_fresh:
+            A_final, B_final = A_last, B_last
+            env_A, env_B, E_gs = env_A_last, env_B_last, E_last
+        else:
+            A_final, B_final = A_best, B_best
+            env_A, env_B, E_gs = env_A_best, env_B_best, E_best_fresh
+        if config.gs_verbose:
+            print(f"[iPEPS-AD:2site-tensor] final E={E_gs:.10f}", flush=True)
+
+        if config.return_history:
+            history = {
+                "energies": _history_energies,
+                "step_times": _history_step_times,
+                "jit_compile_time": _jit_compile_time,
+                "num_steps": len(_history_energies),
+                "converged": _converged,
+            }
+            return (A_final, B_final), (env_A, env_B), E_gs, history
+        return (A_final, B_final), (env_A, env_B), E_gs
+    finally:
         if _prev_norm_diag is not None:
             set_implicit_ad_norm_diagnostics(_prev_norm_diag)
-        return (A_final, B_final), (env_A, env_B), E_gs, history
-    if _prev_norm_diag is not None:
-        set_implicit_ad_norm_diagnostics(_prev_norm_diag)
-    return (A_final, B_final), (env_A, env_B), E_gs
 
 
 def _optimize_gs_ad_multisite(

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -3374,7 +3374,13 @@ def _optimize_gs_ad_tensor_2site(
                 and ctm_cfg_2s.chi_max is not None
                 and ctm_cfg_2s.chi >= ctm_cfg_2s.chi_max
             ):
-                _bail_metric = ctm_cfg_2s.chi_auto_bump_metric
+                # ``getattr`` fallback (codex PR #524 follow-up): the
+                # ``chi_auto_bump_metric`` field is added by PR #525.  Until
+                # that lands this PR must still resolve to a working
+                # indicator instead of raising ``AttributeError`` when the
+                # bail-out fires.  Default ``"eps_T"`` matches CTMConfig's
+                # eventual default and the existing 2-site bump cadence.
+                _bail_metric = getattr(ctm_cfg_2s, "chi_auto_bump_metric", "eps_T")
                 if _bail_metric == "norm_smallest_S":
                     _bail_indicator = float(_env_cache_2s.get("max_smallest_S", 0.0))
                 else:

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2290,6 +2290,12 @@ def _optimize_gs_ad_tensor_2site(
     stall_count = 0  # noise recovery: consecutive line search failures
     current_stage_idx = 0
     stage_start_step = 0
+    # Rolling buffer of accepted ``||grad||_2`` for the gradient-spike
+    # guard (config.gs_grad_spike_ratio).  Bad implicit-AD steps land in
+    # a region where the gradient explodes by >10x relative to recent
+    # magnitudes; rejecting those steps prevents the v9-style collapse
+    # below the QMC floor.
+    recent_gnorms_2s: list[float] = []
 
     # Optional trajectory capture (config.return_history).  Always allocated
     # but only populated/returned when the flag is set.
@@ -2648,6 +2654,55 @@ def _optimize_gs_ad_tensor_2site(
         # Update env cache for warm-starting next step
         _update_env_cache_2s(params)
 
+        grad_norm_val = _grad_l2_norm(grads)
+
+        # Gradient-spike guard: reject steps whose new ||grad||_2 exceeds
+        # ``gs_grad_spike_ratio * max(median(recent), 1.0)``.  See
+        # project_v9_collapse_findings.md — non-variational drift shows up
+        # as a >10x gradient blowup before the best_energy crosses the QMC
+        # floor.  We check BEFORE updating best so the bad step never gets
+        # accepted as the new best.
+        if (
+            config.gs_grad_spike_ratio is not None
+            and len(recent_gnorms_2s) >= 2
+            and best_energy < float("inf")
+        ):
+            spike_floor = max(float(np.median(recent_gnorms_2s)), 1.0)
+            if grad_norm_val > config.gs_grad_spike_ratio * spike_floor:
+                params = best_params
+                _env_cache_2s.clear()
+                if is_metric_lbfgs:
+                    lbfgs_history.clear()
+                    prev_params_flat = None
+                    prev_grad_flat = None
+                if is_cg:
+                    cg_direction = None
+                    prev_grad = None
+                    prev_precond_grad = None
+                if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
+                    opt_state = optimizer.init(params)
+                _logger.warning(
+                    "[iPEPS-AD:2site-tensor] step %d/%d gradient spike "
+                    "|g|=%.3e > %.1fx median %.3e — rolling back to best",
+                    step + 1,
+                    config.gs_num_steps,
+                    grad_norm_val,
+                    config.gs_grad_spike_ratio,
+                    spike_floor,
+                )
+                if config.gs_verbose:
+                    print(
+                        f"[iPEPS-AD:2site-tensor] step {step + 1}/{config.gs_num_steps} "
+                        f"|g|={grad_norm_val:.3e} spike "
+                        f"(>{config.gs_grad_spike_ratio:.1f}x median {spike_floor:.3e}) "
+                        f"— rollback to best, clear L-BFGS history",
+                        flush=True,
+                    )
+                continue
+        recent_gnorms_2s.append(grad_norm_val)
+        if len(recent_gnorms_2s) > config.gs_grad_spike_window:
+            recent_gnorms_2s.pop(0)
+
         if _should_accept_best(
             current_best=best_energy,
             candidate=energy_float,
@@ -2658,7 +2713,6 @@ def _optimize_gs_ad_tensor_2site(
             best_env_cache_2s = dict(_env_cache_2s)  # snapshot for warm-start (#317)
 
         delta_energy = abs(energy_float - prev_energy)
-        grad_norm_val = _grad_l2_norm(grads)
         logged = False
         if config.gs_verbose and _should_log_step(
             step, config.gs_num_steps, log_interval

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2297,6 +2297,10 @@ def _optimize_gs_ad_tensor_2site(
     # magnitudes; rejecting those steps prevents the v9-style collapse
     # below the QMC floor.
     recent_gnorms_2s: list[float] = []
+    # Consecutive "at chi_max with indicator above threshold" counter for
+    # the variPEPS §2.8.2 bail-out (config.gs_chi_ceiling_bailout).  Reset
+    # on chi bump or when the indicator dips below threshold.
+    chi_ceiling_consecutive_2s = 0
 
     # Optional trajectory capture (config.return_history).  Always allocated
     # but only populated/returned when the flag is set.
@@ -3306,6 +3310,7 @@ def _optimize_gs_ad_tensor_2site(
             # at the new χ is plain steepest descent (curvature from
             # the previous χ landscape isn't valid here).
             stall_count = 0
+            chi_ceiling_consecutive_2s = 0
             if is_metric_lbfgs:
                 lbfgs_history.clear()
                 prev_params_flat = None
@@ -3316,6 +3321,45 @@ def _optimize_gs_ad_tensor_2site(
                 prev_precond_grad = None
             if optimizer is not None and config.gs_optimizer.lower() == "lbfgs":
                 opt_state = optimizer.init(params)
+
+        # variPEPS §2.8.2 chi-ceiling bail-out.  After the post-step bump
+        # has been attempted, if χ is still at chi_max AND the indicator
+        # remains above threshold for K consecutive steps, exit early and
+        # return ``best_params``.  Counter resets on any bump (handled
+        # above), any successful headroom recovery, or stall recovery.
+        if (
+            config.gs_chi_ceiling_bailout > 0
+            and ctm_cfg_2s.chi_max is not None
+            and ctm_cfg_2s.chi >= ctm_cfg_2s.chi_max
+        ):
+            _bail_metric = ctm_cfg_2s.chi_auto_bump_metric
+            if _bail_metric == "norm_smallest_S":
+                _bail_indicator = float(_env_cache_2s.get("max_smallest_S", 0.0))
+            else:
+                _bail_indicator = float(_env_cache_2s.get("max_truncation_error", 0.0))
+            if _bail_indicator > ctm_cfg_2s.chi_auto_bump_eps:
+                chi_ceiling_consecutive_2s += 1
+                if chi_ceiling_consecutive_2s >= config.gs_chi_ceiling_bailout:
+                    if config.gs_verbose:
+                        print(
+                            f"[iPEPS-AD:2site-tensor] step {step + 1}/"
+                            f"{config.gs_num_steps} chi-ceiling bail-out: "
+                            f"chi={ctm_cfg_2s.chi} at chi_max, "
+                            f"{_bail_metric}={_bail_indicator:.3e} > "
+                            f"{ctm_cfg_2s.chi_auto_bump_eps:.3e} for "
+                            f"{chi_ceiling_consecutive_2s} consecutive steps "
+                            f"— rolling back to best E={best_energy:.10f}",
+                            flush=True,
+                        )
+                    params = best_params
+                    _maybe_save_2s_checkpoint(
+                        step, chi_before, _best_energy_at_step_start
+                    )
+                    break
+            else:
+                chi_ceiling_consecutive_2s = 0
+        else:
+            chi_ceiling_consecutive_2s = 0
 
         # End-of-step save: cadence-based + new-best detection.
         _maybe_save_2s_checkpoint(step, chi_before, _best_energy_at_step_start)

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -2545,6 +2545,19 @@ def _optimize_gs_ad_tensor_2site(
         if is_new_best:
             save_checkpoint(_ckpt_state, config.gs_checkpoint_path, is_best=True)
 
+    # Enable per-backward ``||lam||`` extraction in the implicit-AD F3 path
+    # only when a consumer is reading them (verbose logging in this loop).
+    # Default-off saves one ``jax.device_get`` per env-leaf per gradient
+    # call on production runs (codex PR #524 P2).  Restore on exit.
+    if config.gs_implicit_ad and config.gs_verbose:
+        from tenax.algorithms._ctm_energy_ad import (
+            set_implicit_ad_norm_diagnostics,
+        )
+
+        _prev_norm_diag = set_implicit_ad_norm_diagnostics(True)
+    else:
+        _prev_norm_diag = None
+
     for step in range(start_step, config.gs_num_steps):
         # Snapshots for checkpoint "did chi change / new best" detection.
         # ``best_energy`` only decreases, so a strict < comparison after
@@ -2676,6 +2689,13 @@ def _optimize_gs_ad_tensor_2site(
             if grad_norm_val > config.gs_grad_spike_ratio * spike_floor:
                 params = best_params
                 _env_cache_2s.clear()
+                # Clear the rolling buffer too (codex PR #524 P1): if a chi
+                # bump or stall recovery has shifted the legitimate
+                # gradient scale upward, the stale median would keep
+                # tripping the guard on every subsequent step, locking the
+                # optimizer into perpetual rollback.  Re-seed from the
+                # rolled-back state instead.
+                recent_gnorms_2s.clear()
                 if is_metric_lbfgs:
                     lbfgs_history.clear()
                     prev_params_flat = None
@@ -3436,7 +3456,11 @@ def _optimize_gs_ad_tensor_2site(
             "num_steps": len(_history_energies),
             "converged": _converged,
         }
+        if _prev_norm_diag is not None:
+            set_implicit_ad_norm_diagnostics(_prev_norm_diag)
         return (A_final, B_final), (env_A, env_B), E_gs, history
+    if _prev_norm_diag is not None:
+        set_implicit_ad_norm_diagnostics(_prev_norm_diag)
     return (A_final, B_final), (env_A, env_B), E_gs
 
 

--- a/tests/test_ipeps_config_chi_ceiling_bailout.py
+++ b/tests/test_ipeps_config_chi_ceiling_bailout.py
@@ -1,0 +1,26 @@
+"""gs_chi_ceiling_bailout field tests."""
+
+import pytest
+
+from tenax.algorithms.ipeps_config import iPEPSConfig
+
+
+def test_gs_chi_ceiling_bailout_defaults_to_zero():
+    cfg = iPEPSConfig()
+    assert cfg.gs_chi_ceiling_bailout == 0  # disabled
+
+
+def test_gs_chi_ceiling_bailout_custom():
+    cfg = iPEPSConfig(gs_chi_ceiling_bailout=3)
+    assert cfg.gs_chi_ceiling_bailout == 3
+
+
+def test_gs_chi_ceiling_bailout_negative_rejected():
+    with pytest.raises(ValueError, match="gs_chi_ceiling_bailout"):
+        iPEPSConfig(gs_chi_ceiling_bailout=-1)
+
+
+def test_gs_chi_ceiling_bailout_zero_allowed():
+    # 0 explicitly means disabled, not invalid.
+    cfg = iPEPSConfig(gs_chi_ceiling_bailout=0)
+    assert cfg.gs_chi_ceiling_bailout == 0

--- a/tests/test_ipeps_config_grad_spike.py
+++ b/tests/test_ipeps_config_grad_spike.py
@@ -1,0 +1,29 @@
+"""gs_grad_spike_ratio / gs_grad_spike_window field tests."""
+
+import pytest
+
+from tenax.algorithms.ipeps_config import iPEPSConfig
+
+
+def test_gs_grad_spike_defaults():
+    cfg = iPEPSConfig()
+    assert cfg.gs_grad_spike_ratio is None  # off by default
+    assert cfg.gs_grad_spike_window == 5
+
+
+def test_gs_grad_spike_ratio_custom():
+    cfg = iPEPSConfig(gs_grad_spike_ratio=5.0, gs_grad_spike_window=3)
+    assert cfg.gs_grad_spike_ratio == 5.0
+    assert cfg.gs_grad_spike_window == 3
+
+
+@pytest.mark.parametrize("bad_ratio", [0.0, 1.0, -1.0])
+def test_gs_grad_spike_ratio_must_exceed_one(bad_ratio):
+    with pytest.raises(ValueError, match="gs_grad_spike_ratio"):
+        iPEPSConfig(gs_grad_spike_ratio=bad_ratio)
+
+
+@pytest.mark.parametrize("bad_window", [0, -1])
+def test_gs_grad_spike_window_must_be_positive(bad_window):
+    with pytest.raises(ValueError, match="gs_grad_spike_window"):
+        iPEPSConfig(gs_grad_spike_window=bad_window)

--- a/tests/test_ipeps_config_hz_max_iter.py
+++ b/tests/test_ipeps_config_hz_max_iter.py
@@ -1,0 +1,21 @@
+"""gs_hz_max_iter field tests."""
+
+import pytest
+
+from tenax.algorithms.ipeps_config import iPEPSConfig
+
+
+def test_gs_hz_max_iter_defaults_to_40():
+    cfg = iPEPSConfig()
+    assert cfg.gs_hz_max_iter == 40
+
+
+def test_gs_hz_max_iter_custom():
+    cfg = iPEPSConfig(gs_hz_max_iter=15)
+    assert cfg.gs_hz_max_iter == 15
+
+
+@pytest.mark.parametrize("bad", [0, -1, -40])
+def test_gs_hz_max_iter_must_be_positive(bad):
+    with pytest.raises(ValueError, match="gs_hz_max_iter"):
+        iPEPSConfig(gs_hz_max_iter=bad)


### PR DESCRIPTION
## Summary

Three orthogonal safety mechanisms for the 2-site bipartite implicit-AD path, each addressing a distinct failure mode observed in the v9 series of D=3 spin-½ Heisenberg benchmarks. All knobs default-off / default-no-change so existing runs are bit-identical.

- **`gs_chi_ceiling_bailout` (`int`, default 0)** — variPEPS §2.8.2 mechanism. When CTM is saturated at `chi_max` AND the bump indicator (`eps_T` or `norm_smallest_S` per `chi_auto_bump_metric`) stays above `chi_auto_bump_eps` for K consecutive steps, exit and return `best_params`. Counter resets on a chi bump or when the indicator dips below threshold.
- **`gs_grad_spike_ratio` (`float | None`, default None) + `gs_grad_spike_window` (`int`, default 5)** — Reject any step whose new `||grad||_2` exceeds `ratio * max(median(recent), 1.0)`. On rejection: roll back to `best_params`, clear L-BFGS history, reinit optax state. Targets the |g| 10x+ blowup signature of v9d/v9e/v9h.
- **`gs_hz_max_iter` (`int`, default 40)** — Exposed cap on `_line_search.hager_zhang_line_search`'s bracket + secant loop. Previously hard-coded to 40, where a single runaway probe burns ~10 minutes at chi=24 conv_tol=1e-7. Lowering to 15 caps the worst case.
- **GMRES amplification diagnostic** — `get_last_implicit_ad_diagnostics()` accessor; `_F3_LAST_DIAGNOSTICS["lam_norm" / "init_lam_norm" / "amplification"]` populated each backward. 2-site path emits a per-logged-step line: `GMRES n_iter=N converged=T/F diverged=T/F ||lam||=... amp=...`. Smoking-gun trace for adjoint amplification when `(I - J^T)` is near-singular.

## Background

The 2-site bipartite implicit-AD path at chi-ceiling (`norm_smallest_S` ~1e-6, projectors near rank-deficient) exhibits a reproducible collapse signature: |g| jumps 10x+ within one step, energy crosses the QMC floor, `best_energy` gets spoiled, optimizer drifts. Observed across v9d (chi_max=24), v9e (chi_max=48), v9f (chi_max=24 + Trigger B), v9h (chi_max=24 + `norm_smallest_S`).

The SVD F-matrix was an early suspect but was ruled out — `_gauge_fixed_svd` is dead code on the AD backward path because `_compute_2x2_projector` returns `jax.lax.stop_gradient(P_top, P_bot, eps_T, smallest_S)`. The actual mechanism is most likely the adjoint linear operator `(I - J^T)` becoming ill-conditioned with frozen near-rank-deficient projectors, amplifying GMRES residuals into the gradient. The amplification diagnostic surfaces this directly.

## Test plan

- [x] `tests/test_ipeps_config_grad_spike.py` (7 tests) — defaults, validation, parametrized rejection
- [x] `tests/test_ipeps_config_hz_max_iter.py` (5 tests) — defaults, custom, positive-int validation
- [x] `tests/test_ipeps_config_chi_ceiling_bailout.py` (4 tests) — defaults (0), custom (3), zero-allowed, negative-rejected
- [x] `uv run pytest tests/ -m core -k "ipeps_optimize or chi_bump or stall_recovery" -x` — 14 tests pass (no regressions)
- [ ] End-to-end v9i probe (D=3 χ_max=24 bipartite implicit-AD) confirming chi-ceiling bail-out fires before collapse — in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)