### PR TITLE
feat(ipeps): chi_auto_bump_metric for variPEPS-literal trigger

### DIFF
--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -160,6 +160,14 @@ class CTMConfig:
     chi_auto_bump: bool = False
     chi_auto_bump_eps: float = 1e-5
     chi_auto_bump_step: int = 2
+    # variPEPS §2.8.2 indicator choice (Tenax extension).  ``"eps_T"``
+    # (default, backward-compatible) reads ``info.max_truncation_error``
+    # (discarded SV tail mass).  ``"norm_smallest_S"`` reads
+    # ``info.max_smallest_S`` (smallest *retained* SV / largest), matching
+    # variPEPS's literal trigger.  The two metrics produce different bump
+    # cadences for the same nominal threshold.  Currently honoured on the
+    # 2-site bipartite path; other paths fall back to ``eps_T``.
+    chi_auto_bump_metric: str = "eps_T"
     chi_max: int | None = None
     # variPEPS-style in-CTM χ-bump (Issue #492).  When enabled,
     # ``python_loop_ctm_converge`` grows ``chi`` *during* CTM convergence
@@ -231,6 +239,11 @@ class CTMConfig:
         if self.chi_auto_bump and self.chi_auto_bump_step <= 0:
             raise ValueError(
                 f"chi_auto_bump_step must be a positive integer, got {self.chi_auto_bump_step}"
+            )
+        if self.chi_auto_bump_metric not in ("eps_T", "norm_smallest_S"):
+            raise ValueError(
+                "chi_auto_bump_metric must be 'eps_T' or 'norm_smallest_S', "
+                f"got {self.chi_auto_bump_metric!r}"
             )
         if self.chi_max is not None and self.chi_max < self.chi:
             raise ValueError(f"chi_max ({self.chi_max}) must be >= chi ({self.chi})")

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -70,15 +70,23 @@ def _maybe_bump_chi(
     env_cache: dict,
     last_eps_t: float,
     *,
+    last_smallest_S: float | None = None,
     base_charges: np.ndarray | None = None,
 ) -> tuple[CTMConfig, dict]:
     """variPEPS §2.8.2 reactive χ_E bump.
 
-    When ``ctm_cfg.chi_auto_bump`` is enabled and the last CTM sweep's
-    ``ε_T`` exceeds ``ctm_cfg.chi_auto_bump_eps``, return a new
-    ``(ctm_cfg, env_cache)`` pair with χ raised by ``chi_auto_bump_step``
-    (capped at ``chi_max`` if set).  The cached env is zero-padded to the
-    new χ.  Otherwise the input pair is returned unchanged.
+    When ``ctm_cfg.chi_auto_bump`` is enabled and the chosen indicator
+    (``last_eps_t`` or ``last_smallest_S`` per
+    ``ctm_cfg.chi_auto_bump_metric``) exceeds ``ctm_cfg.chi_auto_bump_eps``,
+    return a new ``(ctm_cfg, env_cache)`` pair with χ raised by
+    ``chi_auto_bump_step`` (capped at ``chi_max`` if set).  The cached env
+    is zero-padded to the new χ.  Otherwise the input pair is returned
+    unchanged.
+
+    ``last_smallest_S`` is only consulted when
+    ``ctm_cfg.chi_auto_bump_metric == "norm_smallest_S"`` (Tenax extension
+    matching variPEPS's literal trigger).  ``None`` (default) treats the
+    indicator as 0.0, suppressing the bump on that metric.
 
     See ``_apply_chi_bump`` for the in-place mutation contract.
 
@@ -88,30 +96,40 @@ def _maybe_bump_chi(
     """
     if not ctm_cfg.chi_auto_bump:
         return ctm_cfg, env_cache
+    metric = ctm_cfg.chi_auto_bump_metric
+    if metric == "norm_smallest_S":
+        indicator = float(last_smallest_S) if last_smallest_S is not None else 0.0
+        label = "norm_smallest_S"
+    else:
+        indicator = last_eps_t
+        label = "eps_T"
     _logger.debug(
-        "_maybe_bump_chi: chi=%d eps_T=%.3e threshold=%.3e",
+        "_maybe_bump_chi: chi=%d %s=%.3e threshold=%.3e",
         ctm_cfg.chi,
-        last_eps_t,
+        label,
+        indicator,
         ctm_cfg.chi_auto_bump_eps,
     )
-    if last_eps_t <= ctm_cfg.chi_auto_bump_eps:
+    if indicator <= ctm_cfg.chi_auto_bump_eps:
         return ctm_cfg, env_cache
     chi_new = ctm_cfg.chi + ctm_cfg.chi_auto_bump_step
     if ctm_cfg.chi_max is not None:
         chi_new = min(chi_new, ctm_cfg.chi_max)
     if chi_new <= ctm_cfg.chi:
         _logger.info(
-            "_maybe_bump_chi: at chi_max=%d ceiling; eps_T=%.3e exceeded threshold %.3e but no headroom",
+            "_maybe_bump_chi: at chi_max=%d ceiling; %s=%.3e exceeded threshold %.3e but no headroom",
             ctm_cfg.chi,
-            last_eps_t,
+            label,
+            indicator,
             ctm_cfg.chi_auto_bump_eps,
         )
         return ctm_cfg, env_cache  # at ceiling
     _logger.info(
-        "_maybe_bump_chi: reactive bump chi %d -> %d (eps_T=%.3e > threshold=%.3e)",
+        "_maybe_bump_chi: reactive bump chi %d -> %d (%s=%.3e > threshold=%.3e)",
         ctm_cfg.chi,
         chi_new,
-        last_eps_t,
+        label,
+        indicator,
         ctm_cfg.chi_auto_bump_eps,
     )
     return _apply_chi_bump(ctm_cfg, env_cache, chi_new, base_charges=base_charges)
@@ -2266,6 +2284,10 @@ def _optimize_gs_ad_tensor_2site(
         # returns a real ε_T (previously a 0.0 placeholder), so reactive
         # bumps fire on the 2-site forward stack with the default recipe.
         _env_cache_2s["max_truncation_error"] = float(info.max_truncation_error)
+        # Also capture ``info.max_smallest_S`` (smallest retained SV /
+        # largest, per projector SVD) so ``chi_auto_bump_metric =
+        # "norm_smallest_S"`` can match variPEPS's literal trigger.
+        _env_cache_2s["max_smallest_S"] = float(info.max_smallest_S)
 
     params = c4v_coeffs if use_c4v else (A, B)
     is_metric_lbfgs = (
@@ -2686,10 +2708,12 @@ def _optimize_gs_ad_tensor_2site(
             # landscape via the ``continue`` below.
             chi_before_bump = ctm_cfg_2s.chi
             last_eps_t = float(_env_cache_2s.get("max_truncation_error", 0.0))
+            last_smallest_S = float(_env_cache_2s.get("max_smallest_S", 0.0))
             ctm_cfg_2s, _env_cache_2s = _maybe_bump_chi(
                 ctm_cfg_2s,
                 _env_cache_2s,
                 last_eps_t,
+                last_smallest_S=last_smallest_S,
                 base_charges=_bump_base_charges_2s,
             )
             if config.gs_chi_schedule_steps is not None:
@@ -3173,10 +3197,12 @@ def _optimize_gs_ad_tensor_2site(
         # either trigger via ``ctm_cfg_2s.chi != chi_before``.
         chi_before = ctm_cfg_2s.chi
         last_eps_t = float(_env_cache_2s.get("max_truncation_error", 0.0))
+        last_smallest_S = float(_env_cache_2s.get("max_smallest_S", 0.0))
         ctm_cfg_2s, _env_cache_2s = _maybe_bump_chi(
             ctm_cfg_2s,
             _env_cache_2s,
             last_eps_t,
+            last_smallest_S=last_smallest_S,
             base_charges=_bump_base_charges_2s,
         )
         # Scheduled outer-loop χ bump (#453 / #455).  No-ops when

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -85,8 +85,11 @@ def _maybe_bump_chi(
 
     ``last_smallest_S`` is only consulted when
     ``ctm_cfg.chi_auto_bump_metric == "norm_smallest_S"`` (Tenax extension
-    matching variPEPS's literal trigger).  ``None`` (default) treats the
-    indicator as 0.0, suppressing the bump on that metric.
+    matching variPEPS's literal trigger).  When the metric is selected
+    but the caller has not plumbed the indicator (``last_smallest_S is
+    None``), the bump silently falls back to the ``last_eps_t`` (default
+    ``eps_T``) signal so non-2-site paths still grow χ reactively.  This
+    matches the ``CTMConfig.chi_auto_bump_metric`` docstring contract.
 
     See ``_apply_chi_bump`` for the in-place mutation contract.
 
@@ -97,10 +100,15 @@ def _maybe_bump_chi(
     if not ctm_cfg.chi_auto_bump:
         return ctm_cfg, env_cache
     metric = ctm_cfg.chi_auto_bump_metric
-    if metric == "norm_smallest_S":
-        indicator = float(last_smallest_S) if last_smallest_S is not None else 0.0
+    if metric == "norm_smallest_S" and last_smallest_S is not None:
+        # variPEPS-literal trigger when the caller supplies the indicator.
+        indicator = float(last_smallest_S)
         label = "norm_smallest_S"
     else:
+        # Default ``eps_T`` path and fallback for callers (non-2-site paths)
+        # that have not been plumbed for ``norm_smallest_S`` yet — see the
+        # ``CTMConfig.chi_auto_bump_metric`` doc.  Mapping a missing
+        # indicator to 0.0 would suppress all bumps on unsupported paths.
         indicator = last_eps_t
         label = "eps_T"
     _logger.debug(


### PR DESCRIPTION
## Summary

- Adds `CTMConfig.chi_auto_bump_metric` (default `"eps_T"`, backward compatible) with a second option `"norm_smallest_S"` matching variPEPS's literal §2.8.2 indicator (`s[chi-1] / s[0]`).
- 2-site bipartite implicit-AD path consults the configured indicator: `_maybe_bump_chi` dispatches on `metric`, the forward stack now caches `info.max_smallest_S` alongside `max_truncation_error`, and the two call sites pass the new `last_smallest_S` kwarg through.
- The two metrics produce different chi-cascade cadences at the same nominal threshold (see test plan).

## Relationship to PR #524

PR #524's chi-ceiling bail-out (`9431d70` / `e6f8a33`) reads `ctm_cfg_2s.chi_auto_bump_metric` directly, but does not add the field. This PR adds the field, so:

- If this PR merges first → #524 rebases cleanly.
- If #524 merges first → the bail-out path raises `AttributeError` until this PR lands. Recommended merge order: this PR before #524, or rebase #524 onto this branch.

## Empirical motivation

D=3 spin-½ Heisenberg, 2-site bipartite, implicit-AD, chi_max=24:

| Run | Metric | Threshold | E_best | Final E | vs QMC (-0.6694) |
|---|---|---:|---:|---:|---|
| v9i | `eps_T` | 1e-6 | -0.6690 | -0.6710 | ≈ QMC |
| v9j | `eps_T` | 1e-5 | -0.6927 | -0.7025 | below (silent collapse) |
| v9k | `norm_smallest_S` | 1e-6 | -0.6162 | -0.6160 | +0.053 above |

`norm_smallest_S` triggers the chi cascade earlier than `eps_T` at the same nominal threshold — the variPEPS-literal trigger needs more headroom (chi_max ≥ 48) to fully converge on this problem.

## Test plan

- [x] Pre-commit hooks (ruff + ruff-format) pass on changed files.
- [x] `CTMConfig.__post_init__` validation rejects values other than `"eps_T"` / `"norm_smallest_S"`.
- [x] Default `"eps_T"` preserves existing `_maybe_bump_chi` behaviour (regression-tested by the existing config suite).
- [ ] PR #524 to be rebased once this lands so its bail-out reference resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)