### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tenax-tn"
-version = "0.5.0"
+version = "0.7.0"
 description = "JAX-based tensor network library with symmetry-aware block-sparse tensors"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/tenax/__init__.py
+++ b/src/tenax/__init__.py
@@ -90,7 +90,7 @@ from tenax.linalg import eigh, qr, rsvd, svd
 from tenax.network.netfile import NetworkBlueprint, from_netfile
 from tenax.network.network import TensorNetwork, build_mps, build_peps
 
-__version__ = "0.5.0"
+__version__ = "0.7.0"
 
 # ---------------------------------------------------------------------------
 # Lazy imports: algorithm modules are loaded on first access


### PR DESCRIPTION
## Summary

The v0.6.0 and v0.7.0 tag releases were both silent no-ops on PyPI because `pyproject.toml` was still at `version = "0.5.0"`. cibuildwheel built `tenax-tn-0.5.0-*.whl`; the publish job's `skip-existing: true` saw 0.5.0 already on PyPI and skipped the upload — workflow finished green, but nothing got published.

This PR bumps:

- `pyproject.toml` → `version = "0.7.0"`
- `src/tenax/__init__.py` → `__version__ = "0.7.0"`

After merge:

1. Delete the existing local + remote \`v0.7.0\` tag (which currently points at the CHANGELOG-only commit \`1fa271b\` and would build 0.5.0 wheels).
2. Re-tag \`v0.7.0\` on the version-bump merge commit.
3. Push the tag → \`publish.yml\` triggers and actually uploads \`tenax-tn-0.7.0\`.

## Follow-up

Track replacing the static `version` field with `hatch-vcs` so the git tag drives the version directly, eliminating the silent skip-existing failure mode.

## Test plan

- [x] CI green on the bump.
- [ ] After tag push: verify `pip install tenax-tn==0.7.0` works from PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)