### PR TITLE
feat(ipeps): surface implicit-AD adjoint diagnostics in verbose step log (#499)

### DIFF
--- a/tests/test_ipeps_ad_adjoint_methods.py
+++ b/tests/test_ipeps_ad_adjoint_methods.py
@@ -92,15 +92,14 @@ def test_fixed_point_arnoldi_rejects_high_rho():
     ``forward_gauge="none"`` at chi=4), the backward must raise
     ``CTMRGGradientError`` instead of looping to ``gmres_maxiter``.
 
-    ``seed=1`` is chosen because it lands on ρ(J^T) ≈ 1.58 on the
-    post-#422-#424 CTM iteration — comfortably above the rejection
-    threshold but not pathological. The original ``seed=7`` fixture
-    drifted to ρ < 1 when the CTM-iteration fixes shipped, so the
-    precheck stopped firing (issue #428). Other rejecting seeds at
-    this config: 1, 3, 8, 12, 15, 19, 21, 22, 25, 26, 27, ...
+    ``seed=42`` is chosen because it lands on ρ(J^T) ≈ 3.20 on the
+    current CTM iteration — comfortably above the rejection threshold
+    (1.0) and not borderline. The previous ``seed=1`` fixture drifted to
+    ρ ≈ 0.54 < 1 after later CTM-iteration fixes shipped, so the precheck
+    stopped firing (issue #469). Other rejecting seeds at this config: 25.
     """
     H = _heisenberg_gate()
-    A = _wrap_as_dense_tensor(_random_peps(seed=1))
+    A = _wrap_as_dense_tensor(_random_peps(seed=42))
 
     def loss(A_):
         return ctm_energy_implicit(


### PR DESCRIPTION
## Summary

Promotes the GMRES adjoint diagnostics from \`logger.debug\` (visible only with \`logging.DEBUG\` enabled) to a user-visible line per L-BFGS step, gated on \`gs_verbose=True\` and \`gs_implicit_ad=True\`. Same observability theme as #490 (\`|g|=\` grad-norm) and #495 (HZ probe counts).

Closes #499.

## What surfaces

\`\`\`
[iPEPS-AD:2site-tensor] step 1/2 GMRES n_iter=4 residual=2.062e-07 \
    converged=True diverged=False ||lam||=3.322e-01 amp=9.649e-01
\`\`\`

* \`n_iter\` — fused fixed-point iterations consumed
* \`residual\` — \`||lam_new - lam_prev||\` at loop exit (**new field**, surfaced through the JIT return tuple)
* \`converged\` / \`diverged\` — fixed-point status flags
* \`||lam||\` / \`amp\` — only present when the per-leaf-norm toggle is on (2-site loop entry flips this on when \`gs_implicit_ad\` + \`gs_verbose\` are both set)

## What changed

| File | Change |
|---|---|
| \`_ctm_energy_ad.py\` | \`_jit_fused_fixed_point_bwd\` returns \`final_diff\`; \`f_bwd\` writes \`residual\` + \`path\` to \`_F3_LAST_DIAGNOSTICS\`. Docstring of \`get_last_implicit_ad_diagnostics\` updated. |
| \`ipeps_optimize.py\` | New \`_log_adjoint_diagnostics\` helper consumes the diagnostics dict and emits one line. The previous inline 2-site emission is replaced with a call to the helper, and the multisite step-log path is wired up too. |
| \`tests/test_ipeps.py\` | Two smoke tests added: \`test_verbose_prints_adjoint_diagnostics\` (implicit-AD line appears), \`test_explicit_ad_omits_adjoint_diagnostics\` (explicit-AD line absent). |

## Verification

- \`tests/test_ipeps.py::TestOptimizeGsAdLogging\`: 4 passed locally.
- \`tests/test_ctm_implicit_warm_start_adjoint.py\`: 6 passed (the F3 return-tuple change in \`_jit_fused_fixed_point_bwd\` is consumed by \`f_bwd\`; the diagnostics dict remains read-back-compatible).
- Smoke runs of the \`optimize_gs_ad\` 2-site implicit-AD path emit the new line cleanly; explicit-AD path emits none.

## Acceptance criteria from #499

- [x] \`adjoint GMRES iters=N residual=R converged=B\` appears for the implicit-AD path.
- [x] No behavior change (purely observability — JIT return-tuple expansion is consumed by \`f_bwd\` directly).
- [x] No new log noise for the explicit-AD path.

## Test plan

- [ ] Required checks pass (\`Tests (Python 3.11)\`, \`Tests (Python 3.12)\`, \`Tests (macOS, Python 3.12)\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)