### PR TITLE
docs(ipeps): document implicit-AD variational guarantee precondition (#511)

### DIFF
--- a/docs/ipeps-code-paths.md
+++ b/docs/ipeps-code-paths.md
@@ -344,7 +344,22 @@ between L-BFGS steps and zero-pads the cached environment as a warm start.
 Disabled by default (opt-in). Mutually exclusive with `chi_ramp`.
 
 The bump fires *between* optimizer steps — the implicit-AD GMRES linearisation
-sees a fixed χ within each gradient evaluation, so AD correctness is unaffected.
+sees a fixed χ within each gradient evaluation, so AD correctness within a
+single backward solve is unaffected.
+
+> **Variational caveat (issue #511).** Implicit AD's variational guarantee
+> requires the CTM env to be a *converged* fixed point at the current χ.
+> End-of-outer-step `chi_auto_bump` (and scheduled `chi_ramp`) zero-pads
+> env rows for newly-active χ indices: the first few gradient evaluations
+> after a bump see a non-fixed-point env, during which the optimizer can
+> descend to a non-physical "ghost minimum" below the true variational
+> floor (v8b D=3 bipartite: E_best = −0.844 vs QMC ≈ −0.669).  For
+> χ-grown runs **prefer `ctmrg_heuristic_increase_chi=True`** (in-CTM
+> bump, see #492/#514), which grows χ *during* CTM convergence and
+> never returns a partial env to the optimizer.  The end-of-outer-step
+> `chi_auto_bump` path is retained for explicit-AD runs and for
+> backwards-compatibility; see also memory note
+> `feedback_drop_chi_schedule_protocol.md`.
 
 ```python
 from tenax import iPEPSConfig, CTMConfig, optimize_gs_ad

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -232,6 +232,50 @@ def _resolve_projector_backward(config: iPEPSConfig) -> iPEPSConfig:
     return resolve_projector_backward(config, logger=_logger)
 
 
+def _warn_implicit_ad_variational_caveat(config: iPEPSConfig, *, path: str) -> None:
+    """Emit a warning when implicit AD's variational guarantee is at risk.
+
+    Implicit AD through the CTM fixed point is variational *only* when the
+    env passed to the gradient evaluation is a converged fixed point at the
+    current chi.  Scheduled ``chi_ramp`` advances and end-of-outer-step
+    ``chi_auto_bump`` events zero-pad newly-active env rows, which violate
+    that precondition until CTM repopulates them.  See issue #511.
+
+    Args:
+        config: The iPEPSConfig being dispatched.
+        path: Short label for the call site (used in the warning text).
+    """
+    if not config.gs_implicit_ad:
+        return
+    ctm_cfg = config.ctm
+    in_ctm_bump = getattr(ctm_cfg, "ctmrg_heuristic_increase_chi", False)
+    if in_ctm_bump:
+        return
+    chi_ramped = getattr(ctm_cfg, "chi_ramp", None) is not None
+    end_of_step_bump = getattr(ctm_cfg, "chi_auto_bump", False)
+    if not (chi_ramped or end_of_step_bump):
+        return
+    import warnings
+
+    trigger = []
+    if chi_ramped:
+        trigger.append("scheduled chi_ramp")
+    if end_of_step_bump:
+        trigger.append("end-of-outer-step chi_auto_bump")
+    warnings.warn(
+        f"{path} AD with gs_implicit_ad=True is variational **only when "
+        "the CTM environment is a converged fixed point at the current "
+        f"chi**.  The current config enables {' and '.join(trigger)}, "
+        "which zero-pads env rows for newly-active chi indices; several "
+        "gradient evaluations may be required before CTM repopulates them, "
+        "during which the optimizer can descend to a non-physical ghost "
+        "minimum (see issue #511).  Prefer ctmrg_heuristic_increase_chi=True "
+        "(in-CTM bump, #492/#514) to grow chi during CTM convergence and "
+        "preserve the variational guarantee across stages.",
+        stacklevel=3,
+    )
+
+
 def _normalize_stall_recovery(config, *, unit_cell: str):
     """Auto-default ``gs_stall_recovery`` based on unit cell when unset.
 
@@ -816,6 +860,7 @@ def _optimize_gs_ad_tensor_reference_c4v(
             "return_history is currently only supported for unit_cell='1x1' "
             "(non-C4v-reference) and unit_cell='2site'."
         )
+    _warn_implicit_ad_variational_caveat(config, path="1-site dense C4v reference")
     import optax
 
     from tenax.algorithms._ctm_tensor import compute_energy_ctm_tensor
@@ -1007,6 +1052,7 @@ def _optimize_gs_ad_tensor(
             init_fn output) here so the user's starting state is honored.
     """
     config = _normalize_stall_recovery(config, unit_cell="1x1")
+    _warn_implicit_ad_variational_caveat(config, path="1-site Tensor-protocol")
     import optax
 
     from tenax.algorithms._ctm_python_loop import python_loop_ctm_converge
@@ -2143,15 +2189,26 @@ def _optimize_gs_ad_tensor_2site(
         else:
             warnings.warn(
                 "2-site AD with gs_c4v=False uses the implicit-AD path. "
-                "This is variational when the CTM environment is converged "
-                "at the target chi.  Without raising chi manually, chi >= 16 "
-                "is typically needed for generic 2-site Heisenberg.  Note: "
-                "variPEPS-style in-CTM chi-bump (ctmrg_heuristic_increase_chi=True) "
-                "is currently supported only on the explicit-AD path "
-                "(gs_implicit_ad=False); the implicit-AD path raises "
-                "NotImplementedError when ctmrg_heuristic_increase_chi=True "
-                "is passed (see issue #514).  For antiferromagnetic bipartite "
-                "models, consider gs_c4v=True or 1-site with sublattice_rotate_gate().",
+                "This is variational **only when the CTM environment is a "
+                "converged fixed point at the current chi**.  This condition "
+                "is automatically satisfied for fixed chi (no ramp, no bump) "
+                "and for runs using ctmrg_heuristic_increase_chi=True (in-CTM "
+                "bump, #492/#514).  It is NOT satisfied immediately after a "
+                "scheduled chi_ramp stage advance or an end-of-outer-step "
+                "chi_auto_bump event, where env rows for newly-active chi "
+                "indices are zero-initialized; several gradient evaluations "
+                "may be required before CTM repopulates them, during which "
+                "the optimizer can descend to a non-physical ghost minimum "
+                "(see issue #511).  For chi-ramped runs prefer "
+                "ctmrg_heuristic_increase_chi=True over scheduled chi_ramp "
+                "or end-of-outer-step chi_auto_bump.  Note: the implicit-AD "
+                "path on the 2-site branch currently raises NotImplementedError "
+                "when ctmrg_heuristic_increase_chi=True is passed (issue #514); "
+                "use gs_implicit_ad=False to combine in-CTM bump with 2-site "
+                "explicit AD.  Without raising chi manually, chi >= 16 is "
+                "typically needed for generic 2-site Heisenberg.  For "
+                "antiferromagnetic bipartite models, consider gs_c4v=True or "
+                "1-site with sublattice_rotate_gate().",
                 stacklevel=2,
             )
     import optax
@@ -3548,6 +3605,7 @@ def _optimize_gs_ad_multisite(
     keyed by site name (e.g. ``"u"``, ``"v"``, ``"w"``).
     """
     config = _normalize_stall_recovery(config, unit_cell="multisite")
+    _warn_implicit_ad_variational_caveat(config, path="Multisite Lattice")
     if config.return_history:
         raise NotImplementedError(
             "return_history is currently only supported for unit_cell='1x1' "

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -1638,6 +1638,76 @@ def test_stall_recovery_auto_defaults():
     assert cfg_user.gs_stall_recovery == "noise", "explicit user setting must win"
 
 
+def test_implicit_ad_variational_caveat_warning():
+    """Issue #511: chi-bump cliff-edge artifact must be warned about.
+
+    The helper fires only when implicit AD is enabled AND a non-in-CTM
+    chi-policy (scheduled chi_ramp or end-of-outer-step chi_auto_bump)
+    is configured.  Fixed-chi runs and ``ctmrg_heuristic_increase_chi``
+    (in-CTM bump, #492/#514) preserve the variational guarantee and must
+    stay silent.
+    """
+    import warnings as _w
+
+    from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+    from tenax.algorithms.ipeps_optimize import (
+        _warn_implicit_ad_variational_caveat,
+    )
+
+    # Fixed chi, implicit AD: silent.
+    cfg = iPEPSConfig(gs_implicit_ad=True, ctm=CTMConfig(chi=10))
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        _warn_implicit_ad_variational_caveat(cfg, path="probe")
+    assert caught == [], "fixed-chi implicit AD must not warn"
+
+    # Explicit AD with chi_auto_bump: silent (warning is implicit-AD-only).
+    cfg = iPEPSConfig(
+        gs_implicit_ad=False,
+        ctm=CTMConfig(chi=10, chi_auto_bump=True, chi_max=20),
+    )
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        _warn_implicit_ad_variational_caveat(cfg, path="probe")
+    assert caught == [], "explicit AD path must not warn from this helper"
+
+    # Implicit AD + chi_auto_bump: must warn and cite #511.
+    cfg = iPEPSConfig(
+        gs_implicit_ad=True,
+        ctm=CTMConfig(chi=10, chi_auto_bump=True, chi_max=20),
+    )
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        _warn_implicit_ad_variational_caveat(cfg, path="probe")
+    assert len(caught) == 1, "chi_auto_bump + implicit AD must warn"
+    msg = str(caught[0].message)
+    assert "#511" in msg and "ghost minimum" in msg
+
+    # Implicit AD + chi_ramp: must warn.
+    cfg = iPEPSConfig(
+        gs_implicit_ad=True,
+        ctm=CTMConfig(chi=8, chi_ramp=[(8, 10), (12, 10), (16, None)]),
+    )
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        _warn_implicit_ad_variational_caveat(cfg, path="probe")
+    assert len(caught) == 1, "chi_ramp + implicit AD must warn"
+    assert "chi_ramp" in str(caught[0].message)
+
+    # Implicit AD + in-CTM bump (preferred): silent.
+    cfg = iPEPSConfig(
+        gs_implicit_ad=True,
+        ctm=CTMConfig(chi=10, ctmrg_heuristic_increase_chi=True, chi_max=20),
+    )
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        _warn_implicit_ad_variational_caveat(cfg, path="probe")
+    assert caught == [], (
+        "ctmrg_heuristic_increase_chi=True preserves the variational "
+        "guarantee and must not warn"
+    )
+
+
 def test_should_accept_best_respects_energy_floor():
     """Issue #298: gs_energy_floor rejects non-variational best-state candidates."""
     from tenax.algorithms.ipeps_optimize import _should_accept_best


### PR DESCRIPTION
## Summary

- Adds a warning at every implicit-AD dispatch point (1-site Tensor-protocol, 1-site dense C4v reference, multisite Lattice, and the existing 2-site branch) that implicit AD is variational only when the CTM env is a converged fixed point at the current χ.
- New helper `_warn_implicit_ad_variational_caveat(config, path=...)` fires only when `gs_implicit_ad=True` and a non-in-CTM χ-policy (`chi_ramp` or end-of-outer-step `chi_auto_bump`) is active — fixed-χ runs and `ctmrg_heuristic_increase_chi=True` (in-CTM bump, #492/#514) stay silent.
- Updates the auto-χ_E bump section in `docs/ipeps-code-paths.md` to point users at the in-CTM bump as the χ-grown path that preserves variationality.

## Why

The 2-site warning at `ipeps_optimize.py:2046` previously presented implicit AD as unconditionally variational once χ ≥ 16. In practice the variational property is conditional on the env being a converged fixed point. End-of-outer-step `chi_auto_bump` and scheduled `chi_ramp` zero-pad new env rows, and the first few gradient evaluations after a bump see a non-fixed-point env. Bench evidence (v8b D=3 bipartite, 2026-05-19): E_best=-0.844, 0.175 *below* QMC, after a χ=9 → 12 stage advance. This is documented in memory `feedback_drop_chi_schedule_protocol.md` and was the trigger for #511.

## Test plan

- [x] `uv run pytest tests/test_ipeps.py::test_implicit_ad_variational_caveat_warning` — new unit test exercises the 4 silent/loud combinations (fixed χ, explicit AD + bump, implicit AD + chi_auto_bump, implicit AD + chi_ramp, implicit AD + in-CTM bump).
- [x] `uv run pytest tests/test_ipeps_chi_bump_rollback_desync.py tests/test_ipeps_stall_recovery_cap.py` — existing UserWarning-filtering tests still pass (no breakage from the broader warning text).
- [x] `pre-commit run --files docs/ipeps-code-paths.md src/tenax/algorithms/ipeps_optimize.py tests/test_ipeps.py`

Closes #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)