### PR TITLE
perf(ipeps): expose implicit-AD warm-start invalidation API (#501)

### DIFF
--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -593,6 +593,39 @@ def _sigma_gauged_ctm_converge(
 
 _VJP_CACHE: dict = {}
 
+
+def invalidate_implicit_ad_warm_start() -> int:
+    """Clear cached Neumann warm-start seeds across the implicit-AD VJP cache.
+
+    The implicit-AD backward (``adjoint_method="fixed_point"`` and the
+    eager-GMRES fallback) caches the final adjoint vector ``λ`` and feeds
+    it back as the initial guess for the next gradient evaluation, which
+    converges in ~3-10 iterations instead of ~20-40 in smooth basins
+    (issue #501).  After events that decouple consecutive iterates --
+    stall recovery rolling ``params`` back to ``best_params``, a scheduled
+    χ-stage advance, or a reactive ``chi_auto_bump`` -- the cached ``λ``
+    is no longer a good seed and the optimizer should drop it.
+
+    Shape mismatches between ``prev_lam`` and the current ``env_leaves``
+    are already auto-invalidated inside ``f_bwd``; this hook covers the
+    parameter-jump case where shapes still line up but the iterate has
+    moved far enough that the cached seed costs more than it saves.
+
+    Returns
+    -------
+    int
+        Number of cache entries whose seed was cleared (one per distinct
+        static-config key currently held in ``_VJP_CACHE``).
+    """
+    n = 0
+    for _f, mutables in _VJP_CACHE.values():
+        cb = mutables.get("_invalidate_warm_start")
+        if cb is not None:
+            cb()
+            n += 1
+    return n
+
+
 # F3 diagnostic: written by f_bwd after each fused-JIT call. Tests can
 # read this to assert the fused fixed-point iteration converged without
 # falling back to eager GMRES. Not part of the public API.
@@ -815,6 +848,21 @@ def _make_implicit_vjp_fn(
     # Neumann iteration converges in fewer iterations (#501).  Cleared on
     # divergence/non-convergence so the next call gets a fresh start.
     _cached = {"prev_lam_leaves": None}
+
+    def _invalidate_warm_start() -> None:
+        """Drop the cached ``prev_lam_leaves`` warm-start seed.
+
+        Called by ``invalidate_implicit_ad_warm_start`` when the optimizer
+        triggers a stall reset (params roll back to ``best_params``), a
+        scheduled chi advance, or a reactive ``chi_auto_bump``.  Without
+        this hook the next backward would seed the Neumann iteration from
+        a λ computed at a now-stale parameter point; correctness is still
+        preserved by the in-loop divergence guard, but convergence costs
+        extra iterations (see issue #501).
+        """
+        _cached["prev_lam_leaves"] = None
+
+    mutables["_invalidate_warm_start"] = _invalidate_warm_start
 
     def _run_forward(site_tensors):
         """Run CTM convergence (shared by f and f_fwd).
@@ -1381,22 +1429,41 @@ def _make_implicit_vjp_fn(
         else:
             # adjoint_method == "gmres": eager Krylov via JAX's built-in
             # solver.  Retained as an opt-out for divergent edge cases.
+            # Warm-start from the cached ``prev_lam_leaves`` when shape-
+            # compatible (issue #501); fall back to ``rhs`` as the cold
+            # x0 otherwise.  The shape check matches the fixed-point
+            # branch above.
             rhs = _eager_dE_denv()
+            prev_lam = _cached.get("prev_lam_leaves")
+            if prev_lam is not None and (
+                len(prev_lam) != len(env_leaves)
+                or any(a.shape != b.shape for a, b in zip(prev_lam, env_leaves))
+            ):
+                _cached["prev_lam_leaves"] = None
+                prev_lam = None
+            if prev_lam is not None:
+                # Unflatten back into the same pytree structure as rhs.
+                rhs_treedef = jax.tree.structure(rhs)
+                x0 = jax.tree.unflatten(rhs_treedef, prev_lam)
+            else:
+                x0 = rhs
             _GMRES_LOGGER.debug(
-                "Eager GMRES: maxiter=%d tol=%g restart=%d",
+                "Eager GMRES: maxiter=%d tol=%g restart=%d warm=%s",
                 gmres_maxiter,
                 gmres_tol,
                 gmres_restart,
+                prev_lam is not None,
             )
             lam, _info = gmres_pytree_jax(
                 _eager_apply_I_minus_Jt,
                 rhs,
-                rhs,
+                x0,
                 tol=gmres_tol,
                 maxiter=gmres_maxiter,
                 restart=gmres_restart,
             )
             lam_leaves = tuple(jax.tree.leaves(lam))
+            _cached["prev_lam_leaves"] = lam_leaves
             return _jit_chain_rule(
                 params_data_tuple, env_leaves, lam_leaves, g, chi=chi_post
             )

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -15,6 +15,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from tenax.algorithms._ctm_energy_ad import invalidate_implicit_ad_warm_start
 from tenax.algorithms._ctm_env_pad import pad_dense_env_chi
 from tenax.algorithms.ipeps_ad_policy import (
     build_ad_ctm_config,
@@ -30,6 +31,20 @@ from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
 _logger = logging.getLogger(__name__)
 
 Coord = tuple[int, int]
+
+
+def _drop_env_cache_for_reset(env_cache: dict) -> None:
+    """Clear the env warm-start cache AND the implicit-AD λ warm-start seed.
+
+    Called from stall-recovery rollbacks (``params = best_params`` paths)
+    and checkpoint restore.  After these events the env that the next CTM
+    sweep produces decouples from whatever the implicit-AD backward
+    cached, so the Neumann seed in ``_VJP_CACHE`` is no longer a good
+    initial guess (issue #501).  Bump-driven env shape changes are
+    handled by ``_apply_chi_bump`` directly.
+    """
+    env_cache.clear()
+    invalidate_implicit_ad_warm_start()
 
 
 def _apply_chi_bump(
@@ -62,6 +77,12 @@ def _apply_chi_bump(
             )
             for c in env_cache["envs"]
         }
+    # Issue #501: env shape just changed, so the cached Neumann warm-start
+    # λ lives in the wrong vector space.  The shape-mismatch guard inside
+    # ``f_bwd`` already drops it on the next call, but doing so here is
+    # cheap and defensive (covers symmetric-tensor padding paths whose
+    # leaf shape may not change even though the logical χ did).
+    invalidate_implicit_ad_warm_start()
     return new_cfg, env_cache
 
 
@@ -1377,7 +1398,7 @@ def _optimize_gs_ad_tensor(
                 # reactive/scheduled bump fired after it was last
                 # snapshotted.  Clear instead of restoring; the next
                 # CTM call cold-starts at the current ctm_cfg.chi.
-                _env_cache.clear()
+                _drop_env_cache_for_reset(_env_cache)
                 if is_metric_lbfgs:
                     lbfgs_history.clear()
                     prev_A_flat = None
@@ -1851,7 +1872,7 @@ def _optimize_gs_ad_tensor(
                 # reactive/scheduled bump fired after it was last
                 # snapshotted.  Clear instead of restoring; the next
                 # CTM call cold-starts at the current ctm_cfg.chi.
-                _env_cache.clear()
+                _drop_env_cache_for_reset(_env_cache)
                 if is_cg:
                     cg_direction = None
                     prev_grad = None
@@ -2472,7 +2493,7 @@ def _optimize_gs_ad_tensor_2site(
         best_params = bundle["best_params"]
         best_energy = float(bundle["best_energy"])
         prev_energy = float(bundle["prev_energy"])
-        _env_cache_2s.clear()
+        _drop_env_cache_for_reset(_env_cache_2s)
         _env_cache_2s.update(bundle.get("env_cache", {}))
         best_env_cache_2s = dict(bundle.get("best_env_cache", {}))
         stall_count = int(bundle.get("stall_count", 0))
@@ -2682,7 +2703,7 @@ def _optimize_gs_ad_tensor_2site(
                     # reactive/scheduled bump fired after it was last
                     # snapshotted.  Clear instead of restoring; the next
                     # CTM call cold-starts at the current ctm_cfg_2s.chi.
-                    _env_cache_2s.clear()
+                    _drop_env_cache_for_reset(_env_cache_2s)
                     if is_metric_lbfgs:
                         lbfgs_history.clear()
                         prev_params_flat = None
@@ -2738,7 +2759,7 @@ def _optimize_gs_ad_tensor_2site(
                 spike_floor = max(float(np.median(recent_gnorms_2s)), 1.0)
                 if grad_norm_val > config.gs_grad_spike_ratio * spike_floor:
                     params = best_params
-                    _env_cache_2s.clear()
+                    _drop_env_cache_for_reset(_env_cache_2s)
                     # Clear the rolling buffer too (codex PR #524 P1): if a chi
                     # bump or stall recovery has shifted the legitimate
                     # gradient scale upward, the stale median would keep
@@ -3295,7 +3316,7 @@ def _optimize_gs_ad_tensor_2site(
                     # reactive/scheduled bump fired after it was last
                     # snapshotted.  Clear instead of restoring; the next
                     # CTM call cold-starts at the current ctm_cfg_2s.chi.
-                    _env_cache_2s.clear()
+                    _drop_env_cache_for_reset(_env_cache_2s)
                     if is_cg:
                         cg_direction = None
                         prev_grad = None
@@ -3791,7 +3812,7 @@ def _optimize_gs_ad_multisite(
                 # reactive/scheduled bump fired after it was last
                 # snapshotted.  Clear instead of restoring; the next
                 # CTM call cold-starts at the current ctm_cfg.chi.
-                _env_cache.clear()
+                _drop_env_cache_for_reset(_env_cache)
                 if is_metric_lbfgs:
                     lbfgs_history.clear()
                     prev_params_flat = None
@@ -4254,7 +4275,7 @@ def _optimize_gs_ad_multisite(
                 # reactive/scheduled bump fired after it was last
                 # snapshotted.  Clear instead of restoring; the next
                 # CTM call cold-starts at the current ctm_cfg.chi.
-                _env_cache.clear()
+                _drop_env_cache_for_reset(_env_cache)
                 if is_cg:
                     cg_direction = None
                     prev_grad = None

--- a/tests/test_ctm_implicit_warm_start_adjoint.py
+++ b/tests/test_ctm_implicit_warm_start_adjoint.py
@@ -269,6 +269,63 @@ def test_adjoint_warm_start_invalidated_on_shape_mismatch():
     )
 
 
+def test_invalidate_implicit_ad_warm_start_clears_seed():
+    """Public invalidation API drops the cached prev_lam_leaves seed (#501).
+
+    After a stall-recovery rollback (``params = best_params``) the cached
+    λ is no longer a good warm-start seed.  The optimizer side calls
+    ``invalidate_implicit_ad_warm_start`` to drop it without depending on
+    the shape-mismatch heuristic.
+    """
+    from tenax.algorithms._ctm_energy_ad import (
+        _VJP_CACHE,
+        invalidate_implicit_ad_warm_start,
+    )
+
+    _VJP_CACHE.clear()
+    # Empty cache: invalidation is a no-op and reports 0 entries cleared.
+    assert invalidate_implicit_ad_warm_start() == 0
+
+    params = _make_su_tensor(D=2, d=2)
+    loss = _make_loss_fn()
+
+    # Populate cache and confirm the seed is cached.
+    jax.grad(loss)(params)
+    assert len(_VJP_CACHE) == 1
+    f_cached, mutables = next(iter(_VJP_CACHE.values()))
+    assert "_invalidate_warm_start" in mutables, (
+        "make_implicit_vjp_fn must register the warm-start invalidator in mutables"
+    )
+    cached_dict = None
+    for cell in f_cached.bwd.__closure__:
+        try:
+            v = cell.cell_contents
+        except ValueError:
+            continue
+        if isinstance(v, dict) and "prev_lam_leaves" in v:
+            cached_dict = v
+            break
+    assert cached_dict is not None
+    assert cached_dict["prev_lam_leaves"] is not None, (
+        "warm-up call must seed prev_lam_leaves"
+    )
+
+    # Invalidate via the public API and confirm the cell was cleared.
+    n_cleared = invalidate_implicit_ad_warm_start()
+    assert n_cleared == 1, f"expected 1 cache entry cleared, got {n_cleared}"
+    assert cached_dict["prev_lam_leaves"] is None, (
+        "invalidate_implicit_ad_warm_start must clear prev_lam_leaves"
+    )
+
+    # Next grad call cold-starts (init_lam = dE_denv), produces a valid
+    # gradient, and re-populates the seed for subsequent calls.
+    g = jax.grad(loss)(params)
+    assert np.all(np.isfinite(np.asarray(g)))
+    assert cached_dict["prev_lam_leaves"] is not None, (
+        "post-invalidation cold-start should refill prev_lam_leaves"
+    )
+
+
 def test_gmres_logger_emits_at_eager_fallback(caplog):
     """When F3 diverges (gmres_maxiter=1 forces it), eager-GMRES log fires too.
 


### PR DESCRIPTION
## Summary

Closes #501.  The fixed-point implicit-AD backward already caches the previous step's adjoint `λ` and uses it as the Neumann initial guess — this PR finishes the remaining acceptance items.

- **New public API `invalidate_implicit_ad_warm_start()`** on `_ctm_energy_ad`.  Walks `_VJP_CACHE` and clears every cached `prev_lam_leaves` seed.  Each implicit-AD closure registers a per-instance invalidator via `mutables["_invalidate_warm_start"]`.
- **Optimizer wiring.** New helper `_drop_env_cache_for_reset(env_cache)` bundles `env_cache.clear()` with `invalidate_implicit_ad_warm_start()`.  All eight stall-rollback / checkpoint-restore sites (1-site + 2-site Tensor + multisite) go through it.
- **Chi-bump path.** `_apply_chi_bump` (used by both reactive `chi_auto_bump` and scheduled `_advance_chi_stage_if_due`) invalidates defensively; shape-mismatch guard handles the common case but symmetric-tensor paths where leaf shape stays the same across logical χ changes still benefit.
- **Eager-GMRES branch** (`adjoint_method=\"gmres\"` opt-out) now warm-starts from cached `prev_lam_leaves` when shape-compatible and caches `lam_leaves` afterward — matches the fixed-point lifecycle.

## Why

Stall reset rolls `params` back to `best_params` and clears the env cache, but the cached `λ` from the failed iterate is at a different parameter point.  The shape-mismatch guard inside `f_bwd` doesn't catch this (shapes match), so the stale seed costs extra Neumann iterations until the loop settles.  Correctness was already preserved via the divergence guard; this PR closes the perf gap.

## Test plan

- [x] `uv run pytest tests/test_ctm_implicit_warm_start_adjoint.py` — 7 passed (includes new `test_invalidate_implicit_ad_warm_start_clears_seed`, plus the existing warm-start unchanged-grad / iter-reduction / divergence-invalidation / shape-mismatch coverage).
- [x] `uv run pytest tests/test_ipeps.py::test_stall_recovery_auto_defaults tests/test_ipeps.py::test_stall_reset_reinits_optax_lbfgs_state tests/test_ipeps_chi_bump_rollback_desync.py tests/test_ipeps_stall_recovery_cap.py` — 5 passed (optimizer reset-path regressions).
- [x] `pre-commit run --files src/tenax/algorithms/_ctm_energy_ad.py src/tenax/algorithms/ipeps_optimize.py tests/test_ctm_implicit_warm_start_adjoint.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)