### PR TITLE
perf(ipeps): cap CTM iter for HZ line-search probes (#503)

### DIFF
--- a/src/tenax/algorithms/ipeps_ad_policy.py
+++ b/src/tenax/algorithms/ipeps_ad_policy.py
@@ -95,6 +95,7 @@ def ctm_converge_kwargs(
     ctm_cfg: CTMConfig,
     *,
     env_init=None,
+    for_probe: bool = False,
 ) -> dict:
     """Return the policy kwargs forwarded to ``python_loop_ctm_converge``.
 
@@ -103,12 +104,27 @@ def ctm_converge_kwargs(
     historical issue where some warm-start paths silently fell back to
     ``conv_method="sv"`` while the implicit-AD energy used
     ``conv_method="elementwise"`` (#351).
+
+    Set ``for_probe=True`` from forward-only line-search probes
+    (``loss_fn_fwd``).  When ``ctm_cfg.probe_max_iter`` /
+    ``ctm_cfg.probe_conv_tol`` are also set, those override the
+    accepted-step ``max_iter`` / ``conv_tol`` so HZ φ probes bail in
+    ~10-15 sweeps instead of 30-60 (issue #503).  Either probe override
+    may be ``None`` independently — the un-overridden field keeps the
+    accepted-step value.
     """
+    _max_iter = ctm_cfg.max_iter
+    _conv_tol = ctm_cfg.conv_tol
+    if for_probe:
+        if ctm_cfg.probe_max_iter is not None:
+            _max_iter = ctm_cfg.probe_max_iter
+        if ctm_cfg.probe_conv_tol is not None:
+            _conv_tol = ctm_cfg.probe_conv_tol
     return {
         "chi": ctm_cfg.chi,
-        "max_iter": ctm_cfg.max_iter,
+        "max_iter": _max_iter,
         "min_iter": ctm_cfg.min_iter,
-        "conv_tol": ctm_cfg.conv_tol,
+        "conv_tol": _conv_tol,
         "conv_method": ctm_cfg.ctm_conv_method,
         "renormalize": ctm_cfg.renormalize,
         "projector_method": ctm_cfg.projector_method,

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -72,15 +72,6 @@ class CTMConfig:
     chi_ramp: list[tuple[int, int | None]] | None = None
     max_iter: int = 100
     conv_tol: float = 1e-8
-    # Issue #503: line-search φ probes don't need a fully converged env.
-    # When set, these override ``max_iter`` / ``conv_tol`` only on the
-    # forward-only ``loss_fn_fwd`` path used by ``hager_zhang_line_search``
-    # and ``_backtracking_line_search``.  variPEPS caps probe sweeps at
-    # 10-15 to bound the worst-case HZ probe cost.  ``None`` (default)
-    # preserves prior behavior — probes use the same ``max_iter`` /
-    # ``conv_tol`` as the accepted-step CTM converge.
-    probe_max_iter: int | None = None
-    probe_conv_tol: float | None = None
     renormalize: bool = True
     projector_method: str = "svd"  # "svd" (Fishman, default), "eigh", or "qr"
     min_iter: int = 10  # minimum CTM sweeps before checking convergence
@@ -214,6 +205,27 @@ class CTMConfig:
     # (or when the CTM actually converges) for strict variational
     # gradients.
     plateau_patience: int | None = 20
+    # Issue #503: line-search φ probes don't need a fully converged env.
+    # When set, these override ``max_iter`` / ``conv_tol`` only on the
+    # forward-only ``loss_fn_fwd`` path used by ``hager_zhang_line_search``
+    # and ``_backtracking_line_search``.  variPEPS caps probe sweeps at
+    # 10-15 to bound the worst-case HZ probe cost.  ``None`` (default)
+    # preserves prior behavior — probes use the same ``max_iter`` /
+    # ``conv_tol`` as the accepted-step CTM converge.
+    #
+    # **Bias note:** an aggressively-capped probe can produce an
+    # under-converged energy estimate at the trial α.  The optimizer's
+    # ``best_energy`` and ``best_params`` are still maintained from the
+    # full-CTM ``loss_fn`` (the value returned by ``jax.value_and_grad``
+    # on the next iteration), so probe bias never corrupts the rolling
+    # best.  But the per-step accept gate ``_is_real_decrease(f_alpha,
+    # energy_float)`` uses the probe-capped ``f_alpha`` — keep
+    # ``probe_max_iter >= max_iter // 2`` (or set ``probe_conv_tol`` no
+    # looser than ~10 × ``conv_tol``) to keep the bias below the noise
+    # floor.  Appended at the end of the dataclass to preserve positional
+    # CTMConfig ABI.
+    probe_max_iter: int | None = None
+    probe_conv_tol: float | None = None
 
     def __post_init__(self):
         valid_modes = {None, "c4v_reference"}

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -72,6 +72,15 @@ class CTMConfig:
     chi_ramp: list[tuple[int, int | None]] | None = None
     max_iter: int = 100
     conv_tol: float = 1e-8
+    # Issue #503: line-search φ probes don't need a fully converged env.
+    # When set, these override ``max_iter`` / ``conv_tol`` only on the
+    # forward-only ``loss_fn_fwd`` path used by ``hager_zhang_line_search``
+    # and ``_backtracking_line_search``.  variPEPS caps probe sweeps at
+    # 10-15 to bound the worst-case HZ probe cost.  ``None`` (default)
+    # preserves prior behavior — probes use the same ``max_iter`` /
+    # ``conv_tol`` as the accepted-step CTM converge.
+    probe_max_iter: int | None = None
+    probe_conv_tol: float | None = None
     renormalize: bool = True
     projector_method: str = "svd"  # "svd" (Fishman, default), "eigh", or "qr"
     min_iter: int = 10  # minimum CTM sweeps before checking convergence

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1277,7 +1277,11 @@ def _optimize_gs_ad_tensor(
         envs, _ = python_loop_ctm_converge(
             site_tensors,
             SINGLE_SITE_NEIGHBORS,
-            **ctm_converge_kwargs(ctm_cfg, env_init=_env_cache.get("envs", None)),
+            **ctm_converge_kwargs(
+                ctm_cfg,
+                env_init=_env_cache.get("envs", None),
+                for_probe=True,
+            ),
         )
         if _use_cg:
             return float(compute_energy_cg(A_norm, envs[(0, 0)], cg_gates, _cg_d_eff))
@@ -2438,7 +2442,11 @@ def _optimize_gs_ad_tensor_2site(
         envs, _ = python_loop_ctm_converge(
             site_tensors,
             CHECKERBOARD_NEIGHBORS,
-            **ctm_converge_kwargs(ctm_cfg_2s, env_init=_env_cache_2s.get("envs", None)),
+            **ctm_converge_kwargs(
+                ctm_cfg_2s,
+                env_init=_env_cache_2s.get("envs", None),
+                for_probe=True,
+            ),
         )
         return float(
             compute_energy_ctm_tensor_2site(
@@ -3722,7 +3730,11 @@ def _optimize_gs_ad_multisite(
         envs, _ = python_loop_ctm_converge(
             site_tensors,
             neighbors,
-            **ctm_converge_kwargs(ctm_cfg, env_init=_env_cache.get("envs", None)),
+            **ctm_converge_kwargs(
+                ctm_cfg,
+                env_init=_env_cache.get("envs", None),
+                for_probe=True,
+            ),
         )
         return float(
             compute_energy_ctm_tensor_multisite(

--- a/tests/test_ipeps_ad_policy.py
+++ b/tests/test_ipeps_ad_policy.py
@@ -142,6 +142,50 @@ def test_ctm_converge_kwargs_propagates_min_iter_and_conv_method():
     assert kw["env_init"] is None
 
 
+def test_ctm_converge_kwargs_probe_overrides():
+    """Issue #503: ``for_probe=True`` swaps in ``probe_max_iter`` / ``probe_conv_tol``.
+
+    The override is opt-in via two independent CTMConfig fields, so a
+    caller can cap iterations without loosening conv_tol (or vice
+    versa).  Default behavior (both fields ``None``) is preserved.
+    """
+    cfg = CTMConfig(
+        chi=12,
+        max_iter=100,
+        conv_tol=1e-8,
+        probe_max_iter=15,
+        probe_conv_tol=1e-4,
+    )
+
+    # for_probe=False: accepted-step values, overrides ignored.
+    kw = ctm_converge_kwargs(cfg, env_init=None, for_probe=False)
+    assert kw["max_iter"] == 100
+    assert kw["conv_tol"] == 1e-8
+
+    # for_probe=True with overrides set: probe values applied.
+    kw = ctm_converge_kwargs(cfg, env_init=None, for_probe=True)
+    assert kw["max_iter"] == 15
+    assert kw["conv_tol"] == 1e-4
+
+    # for_probe=True but no overrides configured: accepted-step values.
+    cfg_default = CTMConfig(chi=12, max_iter=100, conv_tol=1e-8)
+    kw = ctm_converge_kwargs(cfg_default, env_init=None, for_probe=True)
+    assert kw["max_iter"] == 100
+    assert kw["conv_tol"] == 1e-8
+
+    # Independent fields: ``probe_max_iter`` only.
+    cfg_iter_only = CTMConfig(chi=12, max_iter=100, conv_tol=1e-8, probe_max_iter=15)
+    kw = ctm_converge_kwargs(cfg_iter_only, env_init=None, for_probe=True)
+    assert kw["max_iter"] == 15
+    assert kw["conv_tol"] == 1e-8
+
+    # ``probe_conv_tol`` only.
+    cfg_tol_only = CTMConfig(chi=12, max_iter=100, conv_tol=1e-8, probe_conv_tol=1e-4)
+    kw = ctm_converge_kwargs(cfg_tol_only, env_init=None, for_probe=True)
+    assert kw["max_iter"] == 100
+    assert kw["conv_tol"] == 1e-4
+
+
 def test_make_ctm_energy_fn_resolves_ctm_cfg_at_call_time():
     """``conv_tol`` schedule rebindings must reach the AD loss closure.
 


### PR DESCRIPTION
## Summary

Closes #503.  Adds two opt-in CTMConfig fields so HZ φ probes can bail in 10-15 sweeps instead of the accepted-step 30-60.  Default (\`None\`) preserves prior behavior.

- \`CTMConfig.probe_max_iter: int | None\` — caps probe \`max_iter\`.
- \`CTMConfig.probe_conv_tol: float | None\` — loosens probe \`conv_tol\`.
- \`ctm_converge_kwargs(cfg, *, env_init, for_probe=False)\` — flag to apply the overrides.
- Three \`loss_fn_fwd\` definitions (1-site, 2-site, multisite) now pass \`for_probe=True\`.

## Scope decision

Only \`loss_fn_fwd\` (forward-only φ probes) gets the cap.  \`_dphi\` uses the full \`loss_fn\` with implicit-AD backward — capping its CTM converge would bias the Wolfe curvature check.  Separate follow-up #504 covers the \"skip \`_dphi\` during bracket\" optimisation in the same HZ-cost cluster.

## Test plan

- [x] \`uv run pytest tests/test_ipeps_ad_policy.py\` — 19 passed (includes new \`test_ctm_converge_kwargs_probe_overrides\` covering: \`for_probe=False\` ignores overrides, both overrides set, no overrides configured, \`probe_max_iter\`-only, \`probe_conv_tol\`-only).
- [x] \`uv run pytest tests/test_ipeps.py::TestOptimizeGsAd2Site tests/test_ipeps.py::TestOptimizeGsAdLogging tests/test_ipeps.py::TestOptimizeGsAdOptimizers\` — 14 passed (full regression on the AD optimizer paths).
- [x] \`pre-commit run --files <modified>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)