### PR TITLE
perf(ipeps): skip dphi during HZ bracket phase (#504)

### DIFF
--- a/src/tenax/algorithms/_line_search.py
+++ b/src/tenax/algorithms/_line_search.py
@@ -24,6 +24,7 @@ def hager_zhang_line_search(
     max_iter: int = 40,
     max_step: float | None = None,
     energy_bound: float | None = None,
+    bracket_only_phi: bool = True,
 ) -> tuple[float, float, bool]:
     """Hager-Zhang line search with approximate Wolfe conditions.
 
@@ -42,10 +43,14 @@ def hager_zhang_line_search(
         max_iter: Maximum number of iterations.
         max_step: Maximum allowed step size. If set, alpha is clipped to this.
         energy_bound: Reject trial points where ``|phi(alpha)| > energy_bound``.
-
-    Returns:
-        (alpha, phi_alpha, converged) where converged is True if Wolfe
-        conditions are satisfied.
+        bracket_only_phi: When True (default), skip ``dphi`` evaluation
+            during the bracket-expansion phase.  Bracket detection then
+            relies solely on the energy-excess criterion ``phi(c) > phi0
+            + eps``; the slope-sign-change shortcut and the Wolfe-OK
+            early exit are unavailable until the zoom phase.  Saves one
+            implicit-AD backward (Neumann/GMRES adjoint + chain rule)
+            per bracket probe.  Set False to restore the original
+            both-phases-use-dphi behavior (issue #504).
     """
     # Not a descent direction
     if dphi0 >= 0:
@@ -178,18 +183,27 @@ def hager_zhang_line_search(
             b, fb, db = c, fc, 0.0
             break
 
-        dc = _safe_dphi(c)
+        # Issue #504: phi-only bracket skips the per-probe dphi call.
+        # Bracket detection then relies solely on the energy-excess
+        # branch (``fc > phi0 + eps``) below; the slope-sign-change
+        # shortcut and the Wolfe-OK early exit are unavailable until
+        # the zoom phase.  ``d_prev`` is propagated as NaN so the zoom
+        # secant degrades gracefully (``da if finite else 0.0``).
+        if bracket_only_phi:
+            dc = float("nan")
+        else:
+            dc = _safe_dphi(c)
 
-        # Check Wolfe at this point
-        if _wolfe_ok(c, fc, dc):
-            return c, fc, True
+            # Check Wolfe at this point
+            if _wolfe_ok(c, fc, dc):
+                return c, fc, True
 
-        if dc >= 0:
-            # Found bracket: slope changed sign
-            # The bracket is [c_prev, c] but we need dphi(a) < 0
-            a, fa, da = c_prev, f_prev, d_prev
-            b, fb, db = c, fc, dc
-            break
+            if dc >= 0:
+                # Found bracket: slope changed sign
+                # The bracket is [c_prev, c] but we need dphi(a) < 0
+                a, fa, da = c_prev, f_prev, d_prev
+                b, fb, db = c, fc, dc
+                break
 
         if fc > phi0 + eps:
             # phi too high — bracket using bisection from [0, c]

--- a/tests/test_line_search.py
+++ b/tests/test_line_search.py
@@ -145,3 +145,119 @@ class TestLineSearchSafety:
         )
         assert converged
         assert f_alpha < phi(0.0)
+
+
+class TestHagerZhangBracketSkipDphi:
+    """Issue #504: ``bracket_only_phi`` defers dphi to the zoom phase."""
+
+    def _quadratic(self, *, minimum: float = 3.0):
+        """Convex quadratic with min at ``minimum``.  Returns (phi, dphi)
+        plus call-count dicts for each so tests can introspect them."""
+        phi_n = {"n": 0}
+        dphi_n = {"n": 0}
+
+        def phi(a):
+            phi_n["n"] += 1
+            return float((a - minimum) ** 2)
+
+        def dphi(a):
+            dphi_n["n"] += 1
+            return float(2.0 * (a - minimum))
+
+        return phi, dphi, phi_n, dphi_n
+
+    def test_bracket_only_phi_skips_dphi_during_expansion(self):
+        """In a pure bracket-expansion scenario, flag=True calls 0 dphi.
+
+        ``phi(α) = -α`` is monotonically decreasing, so the bracket loop
+        never finds an energy-excess; ``dphi(α) = -1`` is constant and
+        Wolfe never fires.  The bracket phase fills the entire
+        ``max_iter`` budget — flag-off calls dphi once per probe;
+        flag-on calls dphi zero times in this regime.
+        """
+        from tenax.algorithms._line_search import hager_zhang_line_search
+
+        def make_probes():
+            n = {"phi": 0, "dphi": 0}
+
+            def phi(a):
+                n["phi"] += 1
+                return float(-a)
+
+            def dphi(_a):
+                n["dphi"] += 1
+                return -1.0
+
+            return phi, dphi, n
+
+        phi, dphi, n_off = make_probes()
+        phi0_off, dphi0_off = phi(0.0), dphi(0.0)
+        n_off["phi"] = 0
+        n_off["dphi"] = 0
+        hager_zhang_line_search(
+            phi,
+            dphi,
+            phi0_off,
+            dphi0_off,
+            alpha_init=1.0,
+            max_step=1e6,
+            max_iter=8,
+            bracket_only_phi=False,
+        )
+        dphi_off = n_off["dphi"]
+
+        phi, dphi, n_on = make_probes()
+        phi0_on, dphi0_on = phi(0.0), dphi(0.0)
+        n_on["phi"] = 0
+        n_on["dphi"] = 0
+        hager_zhang_line_search(
+            phi,
+            dphi,
+            phi0_on,
+            dphi0_on,
+            alpha_init=1.0,
+            max_step=1e6,
+            max_iter=8,
+            bracket_only_phi=True,
+        )
+        dphi_on = n_on["dphi"]
+
+        # Flag-off must call dphi at least once per bracket probe.
+        assert dphi_off >= 4, (
+            f"flag-off must call dphi every probe in this regime; got {dphi_off}"
+        )
+        # Flag-on must call dphi zero times during the entire run because
+        # the bracket loop never finds an excess and there is no zoom.
+        assert dphi_on == 0, f"flag-on must skip dphi in bracket phase; got {dphi_on}"
+        # Phi-only mode also runs the same probe count overall (bracket
+        # expansion doesn't depend on dphi).
+        assert n_on["phi"] >= 4, (
+            f"flag-on should still run multiple phi probes; got {n_on['phi']}"
+        )
+
+    def test_bracket_only_phi_off_matches_legacy_behavior(self):
+        """``bracket_only_phi=False`` must yield identical alpha/f to the
+        pre-issue #504 implementation.  Smooth quadratic where the
+        slope-sign-change shortcut at ``dc >= 0`` would have fired."""
+        from tenax.algorithms._line_search import hager_zhang_line_search
+
+        def phi(a):
+            return float((a - 2.0) ** 2 + 1.0)
+
+        def dphi(a):
+            return float(2 * (a - 2.0))
+
+        # alpha_init=1.5 puts the first probe near the minimum; with
+        # dphi available, Wolfe-OK or dc>=0 detection should fire fast.
+        alpha, f_alpha, converged = hager_zhang_line_search(
+            phi,
+            dphi,
+            phi(0.0),
+            dphi(0.0),
+            alpha_init=1.5,
+            bracket_only_phi=False,
+        )
+        assert converged
+        # Wolfe with delta=0.1, sigma=0.9 on (a-2)²+1 — accepted alpha
+        # should be close to the minimum at a=2.
+        assert abs(alpha - 2.0) < 1.0


### PR DESCRIPTION
## Summary

Closes #504.  The Hager-Zhang bracket-expansion loop currently calls \`_safe_dphi(c)\` at every trial point to support two early exits (Wolfe-OK satisfaction and slope-sign-change detection).  Both are cheap for analytical phi/dphi; for iPEPS implicit AD each \`dphi\` call costs one full backward (Neumann/GMRES adjoint + chain rule) — 20-75s at χ=24.

New flag: \`bracket_only_phi: bool = True\` on \`hager_zhang_line_search\`.

- When **True** (new default): bracket loop skips \`_safe_dphi(c)\`; bracket detection uses only the existing energy-excess branch \`fc > phi0 + eps\` (which triggers bisection from \`[0, c]\` with \`da = dphi0\`).  Zoom phase still uses \`dphi\` — secant steps structurally need it.
- When **False**: restores the previous both-phases-use-dphi behavior.

Stacks cleanly with #501 (warm-start adjoint), #502 (φ/dφ env sharing in zoom), and #503 (probe CTM cap).

## Test plan

- [x] \`uv run pytest tests/test_line_search.py\` — 10 passed (8 existing + 2 new):
  - \`test_bracket_only_phi_skips_dphi_during_expansion\` — pure-bracket scenario, flag-off makes ≥ 4 dphi calls, flag-on makes 0.
  - \`test_bracket_only_phi_off_matches_legacy_behavior\` — opt-out still converges Wolfe on a smooth quadratic.
- [x] \`uv run pytest tests/test_ipeps.py::TestOptimizeGsAd2Site tests/test_ipeps.py::TestOptimizeGsAdLogging tests/test_ipeps_ad_policy.py tests/test_line_search.py\` — 41 passed.
- [x] \`pre-commit run --files <modified>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)