### PR TITLE
perf(ipeps): add gs_ctm_max_iter_schedule for late-stage CTM cap (#507)

### DIFF
--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -355,6 +355,18 @@ class iPEPSConfig:
                                throughout.  This is an advanced tuning knob
                                for large-chi runs where an initially loose
                                CTM is enough to start moving.
+        gs_ctm_max_iter_schedule:
+                               Optional ramp for ``ctm.max_iter`` across
+                               AD optimization steps (issue #507).  Same
+                               ``(step_fraction, value)`` schema as
+                               ``gs_ctm_conv_tol_schedule``.  Caps the
+                               accepted-step CTM converge — late steps
+                               where the env is barely changing finish
+                               in ~10-15 sweeps instead of the
+                               early-descent budget.  Independent of
+                               ``CTMConfig.probe_max_iter`` (issue #503),
+                               which caps HZ probes.  ``None`` (default)
+                               uses ``ctm.max_iter`` throughout.
         gs_chi_schedule_steps: Outer-loop χ schedule for
                                ``optimize_gs_ad_chi_schedule`` (#453 / #455).
                                List of ``(target_chi, max_steps_in_stage)``
@@ -503,6 +515,19 @@ class iPEPSConfig:
     # Example: [(0.0, 1e-5), (0.5, 1e-6), (0.8, 1e-7)]
     # None = use config.ctm.conv_tol throughout.
     gs_ctm_conv_tol_schedule: list[tuple[float, float]] | None = None
+    # CTM max_iter schedule: list of (step_fraction, max_iter) pairs (#507).
+    # Ramps the accepted-step CTM iteration cap across AD progress so late
+    # steps — where the env is barely changing — bail in 10-15 sweeps
+    # instead of the full early-descent budget (typically 75).  Mirrors
+    # the ``gs_ctm_conv_tol_schedule`` lookup contract (largest threshold
+    # ≤ ``step_idx / gs_num_steps`` wins).  ``None`` (default) uses
+    # ``config.ctm.max_iter`` throughout.  Example late-stage cap:
+    #
+    #     gs_ctm_max_iter_schedule=[(0.0, 75), (0.5, 30), (0.8, 15)]
+    #
+    # Independent of ``CTMConfig.probe_max_iter`` (issue #503): that
+    # caps HZ line-search probes; this caps the accepted-step CTM.
+    gs_ctm_max_iter_schedule: list[tuple[float, int]] | None = None
     # CTM plateau-patience schedule: list of (step_fraction, plateau_patience)
     # pairs.  Ramps the early-bail patience across AD steps so callers can
     # keep a finite stop-loss while the CTM is plateauing (fast, approximate

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1386,6 +1386,11 @@ def _optimize_gs_ad_tensor(
     _conv_tol_schedule = config.gs_ctm_conv_tol_schedule
     _current_conv_tol = ctm_cfg.conv_tol
 
+    # CTM max_iter schedule (issue #507): same lookup contract as the
+    # conv_tol schedule but caps the accepted-step CTM converge budget.
+    _max_iter_schedule = config.gs_ctm_max_iter_schedule
+    _current_max_iter = ctm_cfg.max_iter
+
     # CTM plateau-patience schedule: update ctm_cfg when patience changes.
     # Independent of the conv_tol schedule (intentionally — see
     # iPEPSConfig.gs_plateau_patience_schedule docstring on auto-tuning).
@@ -1419,6 +1424,17 @@ def _optimize_gs_ad_tensor(
                 tol = t
         return tol
 
+    def _get_scheduled_max_iter(step_idx, num_steps):
+        """Look up max_iter from schedule based on step fraction (issue #507)."""
+        if _max_iter_schedule is None:
+            return _current_max_iter
+        frac = step_idx / max(num_steps, 1)
+        mi = _max_iter_schedule[0][1]  # default to first entry
+        for threshold, m in _max_iter_schedule:
+            if frac >= threshold:
+                mi = m
+        return mi
+
     def _get_scheduled_plateau_patience(step_idx, num_steps):
         """Look up plateau_patience from schedule based on step fraction."""
         if _patience_schedule is None:
@@ -1437,6 +1453,12 @@ def _optimize_gs_ad_tensor(
             if new_tol != _current_conv_tol:
                 _current_conv_tol = new_tol
                 ctm_cfg = _replace(ctm_cfg, conv_tol=new_tol)
+        # Update max_iter if schedule is active (#507)
+        if _max_iter_schedule is not None:
+            new_max_iter = _get_scheduled_max_iter(step, config.gs_num_steps)
+            if new_max_iter != _current_max_iter:
+                _current_max_iter = new_max_iter
+                ctm_cfg = _replace(ctm_cfg, max_iter=new_max_iter)
         # Update plateau_patience if schedule is active
         if _patience_schedule is not None:
             new_patience = _get_scheduled_plateau_patience(step, config.gs_num_steps)
@@ -2491,6 +2513,10 @@ def _optimize_gs_ad_tensor_2site(
     _conv_tol_schedule_2s = config.gs_ctm_conv_tol_schedule
     _current_conv_tol_2s = ctm_cfg_2s.conv_tol
 
+    # CTM max_iter schedule (#507): same lookup contract as conv_tol.
+    _max_iter_schedule_2s = config.gs_ctm_max_iter_schedule
+    _current_max_iter_2s = ctm_cfg_2s.max_iter
+
     # CTM plateau-patience schedule (independent of conv_tol — see
     # iPEPSConfig.gs_plateau_patience_schedule docstring).
     _patience_schedule_2s = config.gs_plateau_patience_schedule
@@ -2505,6 +2531,17 @@ def _optimize_gs_ad_tensor_2site(
             if frac >= threshold:
                 tol = t
         return tol
+
+    def _get_scheduled_max_iter_2s(step_idx, num_steps):
+        """Look up max_iter from schedule based on step fraction (issue #507)."""
+        if _max_iter_schedule_2s is None:
+            return _current_max_iter_2s
+        frac = step_idx / max(num_steps, 1)
+        mi = _max_iter_schedule_2s[0][1]
+        for threshold, m in _max_iter_schedule_2s:
+            if frac >= threshold:
+                mi = m
+        return mi
 
     def _get_scheduled_plateau_patience_2s(step_idx, num_steps):
         if _patience_schedule_2s is None:
@@ -2759,6 +2796,12 @@ def _optimize_gs_ad_tensor_2site(
                 if new_tol != _current_conv_tol_2s:
                     _current_conv_tol_2s = new_tol
                     ctm_cfg_2s = _replace(ctm_cfg_2s, conv_tol=new_tol)
+            # Update max_iter if schedule is active (#507)
+            if _max_iter_schedule_2s is not None:
+                new_max_iter = _get_scheduled_max_iter_2s(step, config.gs_num_steps)
+                if new_max_iter != _current_max_iter_2s:
+                    _current_max_iter_2s = new_max_iter
+                    ctm_cfg_2s = _replace(ctm_cfg_2s, max_iter=new_max_iter)
             # Update plateau_patience if schedule is active
             if _patience_schedule_2s is not None:
                 new_patience = _get_scheduled_plateau_patience_2s(
@@ -3871,6 +3914,10 @@ def _optimize_gs_ad_multisite(
     _conv_tol_schedule = config.gs_ctm_conv_tol_schedule
     _current_conv_tol = ctm_cfg.conv_tol
 
+    # CTM max_iter schedule (#507): same lookup contract as conv_tol.
+    _max_iter_schedule = config.gs_ctm_max_iter_schedule
+    _current_max_iter = ctm_cfg.max_iter
+
     # CTM plateau-patience schedule (independent of conv_tol — see
     # iPEPSConfig.gs_plateau_patience_schedule docstring).
     _patience_schedule = config.gs_plateau_patience_schedule
@@ -3885,6 +3932,17 @@ def _optimize_gs_ad_multisite(
             if frac >= threshold:
                 tol = t
         return tol
+
+    def _get_scheduled_max_iter(step_idx, num_steps):
+        """Look up max_iter from schedule based on step fraction (issue #507)."""
+        if _max_iter_schedule is None:
+            return _current_max_iter
+        frac = step_idx / max(num_steps, 1)
+        mi = _max_iter_schedule[0][1]
+        for threshold, m in _max_iter_schedule:
+            if frac >= threshold:
+                mi = m
+        return mi
 
     def _get_scheduled_plateau_patience(step_idx, num_steps):
         if _patience_schedule is None:
@@ -3918,6 +3976,12 @@ def _optimize_gs_ad_multisite(
             if new_tol != _current_conv_tol:
                 _current_conv_tol = new_tol
                 ctm_cfg = _replace(ctm_cfg, conv_tol=new_tol)
+        # Update max_iter if schedule is active (#507)
+        if _max_iter_schedule is not None:
+            new_max_iter = _get_scheduled_max_iter(step, config.gs_num_steps)
+            if new_max_iter != _current_max_iter:
+                _current_max_iter = new_max_iter
+                ctm_cfg = _replace(ctm_cfg, max_iter=new_max_iter)
         # Update plateau_patience if schedule is active
         if _patience_schedule is not None:
             new_patience = _get_scheduled_plateau_patience(step, config.gs_num_steps)

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -1892,6 +1892,113 @@ def test_loss_fn_fwd_probe_envs_dont_leak_past_line_search():
     assert broken >= 1, f"no line-search-boundary cache restore observed; got {seen}"
 
 
+def test_gs_ctm_max_iter_schedule_caps_late_step_ctm():
+    """Issue #507: ``gs_ctm_max_iter_schedule`` caps accepted-step CTM iter count.
+
+    White-box probe: patch ``python_loop_ctm_converge`` to capture the
+    ``max_iter`` argument it receives per call.  Run a 5-step AD with a
+    schedule that drops ``max_iter`` from 75 → 5 at the halfway point.
+    The recorded ``max_iter`` arg must transition from 75 to 5 across
+    the schedule boundary.
+    """
+    from unittest.mock import patch
+
+    import jax.numpy as jnp
+
+    from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    d = 2
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+    H = jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+    gate = H.reshape(d, d, d, d)
+
+    seen_max_iter: list[int] = []
+
+    import tenax.algorithms._ctm_python_loop as ctm_mod
+
+    real_converge = ctm_mod.python_loop_ctm_converge
+
+    def _spy(*args, **kwargs):
+        seen_max_iter.append(int(kwargs.get("max_iter", -1)))
+        return real_converge(*args, **kwargs)
+
+    config = iPEPSConfig(
+        max_bond_dim=2,
+        ctm=CTMConfig(chi=4, max_iter=75),
+        gs_num_steps=5,
+        gs_optimizer="lbfgs",
+        gs_line_search_method="hager_zhang",
+        unit_cell="1x1",
+        su_init=True,
+        num_imaginary_steps=10,
+        dt=0.3,
+        # Cap at 5 from step 2 onward (fraction 0.4): step 0/1 use 75,
+        # step 2/3/4 use 5.  Tight cap so the transition is unambiguous.
+        gs_ctm_max_iter_schedule=[(0.0, 75), (0.4, 5)],
+    )
+    with patch.object(ctm_mod, "python_loop_ctm_converge", side_effect=_spy):
+        optimize_gs_ad(gate, None, config)
+
+    assert 75 in seen_max_iter, (
+        f"early-stage max_iter=75 never observed; got {seen_max_iter}"
+    )
+    assert 5 in seen_max_iter, (
+        f"late-stage max_iter=5 never observed; got {seen_max_iter}"
+    )
+    first_75 = seen_max_iter.index(75)
+    first_5 = seen_max_iter.index(5)
+    assert first_75 < first_5, (
+        f"schedule must apply 75 before 5; got first_75={first_75} "
+        f"first_5={first_5} in {seen_max_iter}"
+    )
+
+
+def test_gs_ctm_max_iter_schedule_default_none_unchanged():
+    """Default ``None`` schedule leaves ``ctm.max_iter`` untouched."""
+    from unittest.mock import patch
+
+    import jax.numpy as jnp
+
+    from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    d = 2
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+    H = jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+    gate = H.reshape(d, d, d, d)
+
+    seen_max_iter: list[int] = []
+
+    import tenax.algorithms._ctm_python_loop as ctm_mod
+
+    real_converge = ctm_mod.python_loop_ctm_converge
+
+    def _spy(*args, **kwargs):
+        seen_max_iter.append(int(kwargs.get("max_iter", -1)))
+        return real_converge(*args, **kwargs)
+
+    config = iPEPSConfig(
+        max_bond_dim=2,
+        ctm=CTMConfig(chi=4, max_iter=12),
+        gs_num_steps=3,
+        unit_cell="1x1",
+        su_init=True,
+        num_imaginary_steps=10,
+        dt=0.3,
+    )
+    with patch.object(ctm_mod, "python_loop_ctm_converge", side_effect=_spy):
+        optimize_gs_ad(gate, None, config)
+
+    assert set(seen_max_iter) == {12}, (
+        f"unscheduled run must always pass max_iter=12; got {set(seen_max_iter)}"
+    )
+
+
 def test_implicit_ad_variational_caveat_warning():
     """Issue #511: chi-bump cliff-edge artifact must be warned about.
 


### PR DESCRIPTION
## Summary

Closes #507.  Adds an optional ``(step_fraction, max_iter)`` ramp that mirrors the existing ``gs_ctm_conv_tol_schedule``.  Late steps where the env is barely changing finish in ~10-15 sweeps instead of the early-descent budget.

- ``iPEPSConfig.gs_ctm_max_iter_schedule: list[tuple[float, int]] | None`` (default ``None``).
- Wired into all 3 dispatchers (1-site, 2-site Tensor, multisite) next to the conv_tol/plateau-patience branches: per-step ``ctm_cfg = _replace(ctm_cfg, max_iter=new)``.

Example:

\`\`\`python
gs_ctm_max_iter_schedule = [
    (0.0, 75),    # full budget for early descent
    (0.5, 30),    # cap at 30 for the middle phase
    (0.8, 15),    # cap at 15 for refinement
]
\`\`\`

## Scope

- Independent of ``CTMConfig.probe_max_iter`` (#503) — that caps HZ probes; this caps the accepted-step CTM converge.
- Composes cleanly with #501 (warm-start adjoint), #502 (φ/dφ env sharing), #503, and #504 (HZ bracket skip-dphi).
- Default ``None`` preserves prior behavior.

## Test plan

- [x] \`uv run pytest tests/test_ipeps.py::test_gs_ctm_max_iter_schedule_caps_late_step_ctm tests/test_ipeps.py::test_gs_ctm_max_iter_schedule_default_none_unchanged\` — 2 passed.  White-box probes patch \`python_loop_ctm_converge\` to record \`max_iter\` per call; the scheduled case observes both 75 and 5 with 75 first; the unscheduled case observes only the static value.
- [x] \`uv run pytest tests/test_ipeps.py::TestOptimizeGsAd2Site tests/test_ipeps.py::TestOptimizeGsAdLogging tests/test_ipeps_ad_policy.py tests/test_ipeps_chi_bump_rollback_desync.py\` — 32 passed (regression).
- [x] \`pre-commit run --files <modified>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)