### PR TITLE
fix(ipeps): revert hager_zhang bracket_only_phi default to False (#504 Codex P1)

### DIFF
--- a/src/tenax/algorithms/_line_search.py
+++ b/src/tenax/algorithms/_line_search.py
@@ -24,7 +24,7 @@ def hager_zhang_line_search(
     max_iter: int = 40,
     max_step: float | None = None,
     energy_bound: float | None = None,
-    bracket_only_phi: bool = True,
+    bracket_only_phi: bool = False,
 ) -> tuple[float, float, bool]:
     """Hager-Zhang line search with approximate Wolfe conditions.
 
@@ -43,14 +43,20 @@ def hager_zhang_line_search(
         max_iter: Maximum number of iterations.
         max_step: Maximum allowed step size. If set, alpha is clipped to this.
         energy_bound: Reject trial points where ``|phi(alpha)| > energy_bound``.
-        bracket_only_phi: When True (default), skip ``dphi`` evaluation
-            during the bracket-expansion phase.  Bracket detection then
-            relies solely on the energy-excess criterion ``phi(c) > phi0
-            + eps``; the slope-sign-change shortcut and the Wolfe-OK
+        bracket_only_phi: When True, skip ``dphi`` evaluation during the
+            bracket-expansion phase.  Bracket detection then relies
+            solely on the energy-excess criterion ``phi(c) > phi0 +
+            eps``; the slope-sign-change shortcut and the Wolfe-OK
             early exit are unavailable until the zoom phase.  Saves one
             implicit-AD backward (Neumann/GMRES adjoint + chain rule)
-            per bracket probe.  Set False to restore the original
-            both-phases-use-dphi behavior (issue #504).
+            per bracket probe.  Default is ``False`` (legacy behavior):
+            monotonically-decreasing ``phi`` (e.g. ``exp(-a) - 1``) can
+            satisfy Wolfe at a small ``alpha`` without ever crossing
+            ``phi0 + eps``, so opt-in on this flag is reserved for
+            callers whose probes are expensive enough to justify the
+            extra zoom-phase iterations.  iPEPS HZ call sites pass
+            ``True`` explicitly to capture the implicit-AD backward
+            savings (issue #504).
     """
     # Not a descent direction
     if dphi0 >= 0:

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1842,6 +1842,7 @@ def _optimize_gs_ad_tensor(
                     max_step=2.0 * alpha0,
                     energy_bound=max(2.0, 2.0 * abs(best_energy)),
                     max_iter=config.gs_hz_max_iter,
+                    bracket_only_phi=True,  # #504: skip dphi in bracket
                 )
                 if config.gs_verbose:
                     print(
@@ -3328,6 +3329,7 @@ def _optimize_gs_ad_tensor_2site(
                         max_step=2.0 * alpha0,
                         energy_bound=max(2.0, 2.0 * abs(best_energy)),
                         max_iter=config.gs_hz_max_iter,
+                        bracket_only_phi=True,  # #504: skip dphi in bracket
                     )
                     if config.gs_verbose:
                         print(
@@ -4360,6 +4362,7 @@ def _optimize_gs_ad_multisite(
                     max_step=2.0 * alpha0,
                     energy_bound=max(2.0, 2.0 * abs(best_energy)),
                     max_iter=config.gs_hz_max_iter,
+                    bracket_only_phi=True,  # #504: skip dphi in bracket
                 )
                 if config.gs_verbose:
                     print(

--- a/src/tenax/algorithms/pess_optimize.py
+++ b/src/tenax/algorithms/pess_optimize.py
@@ -266,6 +266,7 @@ def _hager_zhang_line_search_step(
         rho=1.5,
         max_step=2.0 * alpha0,
         energy_bound=max(2.0, 2.0 * abs(energy)),
+        bracket_only_phi=True,  # #504: skip dphi in bracket (implicit-AD path)
     )
     if alpha == 0.0 or f_alpha >= energy:
         return params, energy, 0.0

--- a/tests/test_line_search.py
+++ b/tests/test_line_search.py
@@ -261,3 +261,29 @@ class TestHagerZhangBracketSkipDphi:
         # Wolfe with delta=0.1, sigma=0.9 on (a-2)²+1 — accepted alpha
         # should be close to the minimum at a=2.
         assert abs(alpha - 2.0) < 1.0
+
+    def test_default_converges_on_monotone_decreasing_phi(self):
+        """Codex P1 regression on #539: ``phi(a) = exp(-a) - 1`` is
+        monotonically decreasing, so ``phi(c) > phi0 + eps`` never fires.
+        Under the new ``bracket_only_phi=False`` default the Wolfe-OK
+        shortcut at ``α=1`` runs as before and the line search returns
+        ``converged=True``.  If the default ever flipped back to ``True``,
+        this test would fail (bracket exhausts max_iter)."""
+        import math
+
+        from tenax.algorithms._line_search import hager_zhang_line_search
+
+        def phi(a):
+            return float(math.exp(-a) - 1.0)
+
+        def dphi(a):
+            return float(-math.exp(-a))
+
+        alpha, f_alpha, converged = hager_zhang_line_search(
+            phi, dphi, phi(0.0), dphi(0.0), alpha_init=1.0
+        )
+        assert converged, (
+            "default bracket_only_phi must converge on monotone-decreasing "
+            f"phi; got alpha={alpha} f_alpha={f_alpha}"
+        )
+        assert f_alpha < 0.0


### PR DESCRIPTION
## Summary

Codex P1 review on the merged #539: with \`bracket_only_phi=True\` as the new default, \`phi(a) = exp(-a) - 1\` no longer converges.  The bracket loop never finds an energy-excess (phi monotonically decreasing) so it exhausts \`max_iter\` and returns \`converged=False\` even though Wolfe is satisfied at α=1.

Restore the legacy ``False\` default to keep \`hager_zhang_line_search\` general-purpose.  The three iPEPS HZ call sites (1-site, 2-site, multisite) now pass \`bracket_only_phi=True\` explicitly — that's the only context where the per-probe backward cost (Neumann/GMRES adjoint + chain rule) is expensive enough to justify the extra zoom-phase iterations on cases the heuristic misses.

## Test plan

- [x] New \`test_default_converges_on_monotone_decreasing_phi\` regression on Codex's \`exp(-a) - 1\` case: pin guards against any future default-flip.
- [x] \`uv run pytest tests/test_line_search.py\` — 11 passed.
- [x] \`uv run pytest tests/test_ipeps.py::TestOptimizeGsAd2Site tests/test_ipeps.py::TestOptimizeGsAdLogging\` — 23 passed (iPEPS still gets the perf win via explicit flag pass).
- [x] \`pre-commit run --files <modified>\`

Refs: #504, #539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)