### PR TITLE
fix(ipeps): unblock in-CTM chi-bump on 2-site implicit-AD path (#514)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -33,6 +33,28 @@ _logger = logging.getLogger(__name__)
 Coord = tuple[int, int]
 
 
+def _env_cache_chi(env_cache: dict) -> int | None:
+    """Return the actual chi of the cached env, or ``None`` if unavailable.
+
+    The in-CTM χ-bump (``ctmrg_heuristic_increase_chi=True``, #492/#514)
+    grows chi inside ``python_loop_ctm_converge`` and writes the bumped
+    env to ``env_cache``, but the optimizer's local ``ctm_cfg.chi``
+    stays at the original value — there's no return channel from the
+    AD forward back to the outer dispatcher.  Sites that need the
+    *current* chi (e.g. ``pad_dense_env_chi`` at finalize) read it
+    here from the env's leftmost C1 leg dim rather than trusting
+    ``ctm_cfg.chi``.
+    """
+    envs = env_cache.get("envs")
+    if not envs:
+        return None
+    try:
+        sample = next(iter(envs.values()))
+        return int(sample.C1.indices[0].dim)
+    except (AttributeError, IndexError, StopIteration):
+        return None
+
+
 def _restore_env_cache_after_line_search(env_cache: dict, snapshot: tuple) -> None:
     """Revert ``env_cache["envs"]`` to the pre-line-search snapshot.
 
@@ -2143,9 +2165,14 @@ def _optimize_gs_ad_tensor(
     # guarantee that the snapshot is at ctm_cfg.chi.
     _best_env_init = best_env_cache.get("envs", None)
     if _best_env_init:
+        # Issue #514: ``ctm_cfg.chi`` may be stale if the in-CTM χ-bump fired
+        # during a gradient evaluation.  Pad to the larger of the static
+        # config chi and the env_cache's actual chi so we never try to
+        # shrink a bumped env.
+        _target_chi = max(ctm_cfg.chi, _env_cache_chi(_env_cache) or ctm_cfg.chi)
         _best_env_init = {
             c: pad_dense_env_chi(
-                _best_env_init[c], ctm_cfg.chi, base_charges=_bump_base_charges
+                _best_env_init[c], _target_chi, base_charges=_bump_base_charges
             )
             for c in _best_env_init
         }
@@ -2313,14 +2340,10 @@ def _optimize_gs_ad_tensor_2site(
                 "the optimizer can descend to a non-physical ghost minimum "
                 "(see issue #511).  For chi-ramped runs prefer "
                 "ctmrg_heuristic_increase_chi=True over scheduled chi_ramp "
-                "or end-of-outer-step chi_auto_bump.  Note: the implicit-AD "
-                "path on the 2-site branch currently raises NotImplementedError "
-                "when ctmrg_heuristic_increase_chi=True is passed (issue #514); "
-                "use gs_implicit_ad=False to combine in-CTM bump with 2-site "
-                "explicit AD.  Without raising chi manually, chi >= 16 is "
-                "typically needed for generic 2-site Heisenberg.  For "
-                "antiferromagnetic bipartite models, consider gs_c4v=True or "
-                "1-site with sublattice_rotate_gate().",
+                "or end-of-outer-step chi_auto_bump.  Without raising chi "
+                "manually, chi >= 16 is typically needed for generic 2-site "
+                "Heisenberg.  For antiferromagnetic bipartite models, "
+                "consider gs_c4v=True or 1-site with sublattice_rotate_gate().",
                 stacklevel=2,
             )
     import optax
@@ -3694,10 +3717,16 @@ def _optimize_gs_ad_tensor_2site(
         # producer-side guarantee that the snapshot is at ctm_cfg_2s.chi.
         _best_env_init_2s = best_env_cache_2s.get("envs", None)
         if _best_env_init_2s:
+            # Issue #514: see 1-site finalize.  Pad to the larger of the
+            # static ``ctm_cfg_2s.chi`` and the env_cache's actual chi
+            # so a bumped env is never asked to shrink.
+            _target_chi_2s = max(
+                ctm_cfg_2s.chi, _env_cache_chi(_env_cache_2s) or ctm_cfg_2s.chi
+            )
             _best_env_init_2s = {
                 c: pad_dense_env_chi(
                     _best_env_init_2s[c],
-                    ctm_cfg_2s.chi,
+                    _target_chi_2s,
                     base_charges=_bump_base_charges_2s,
                 )
                 for c in _best_env_init_2s
@@ -4660,10 +4689,13 @@ def _optimize_gs_ad_multisite(
     # guarantee that the snapshot is at ctm_cfg.chi.
     _best_env_init_multi = best_env_cache.get("envs", None)
     if _best_env_init_multi:
+        # Issue #514: see 1-site finalize.  Pad to the larger of the
+        # static ``ctm_cfg.chi`` and the env_cache's actual chi.
+        _target_chi_multi = max(ctm_cfg.chi, _env_cache_chi(_env_cache) or ctm_cfg.chi)
         _best_env_init_multi = {
             c: pad_dense_env_chi(
                 _best_env_init_multi[c],
-                ctm_cfg.chi,
+                _target_chi_multi,
                 base_charges=_bump_base_charges_multi,
             )
             for c in _best_env_init_multi

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -33,19 +33,22 @@ _logger = logging.getLogger(__name__)
 Coord = tuple[int, int]
 
 
-def _env_cache_chi(env_cache: dict) -> int | None:
-    """Return the actual chi of the cached env, or ``None`` if unavailable.
+def _env_dict_chi(envs) -> int | None:
+    """Extract chi from a ``coord -> CTMTensorEnv`` mapping.
 
-    The in-CTM χ-bump (``ctmrg_heuristic_increase_chi=True``, #492/#514)
-    grows chi inside ``python_loop_ctm_converge`` and writes the bumped
-    env to ``env_cache``, but the optimizer's local ``ctm_cfg.chi``
-    stays at the original value — there's no return channel from the
-    AD forward back to the outer dispatcher.  Sites that need the
-    *current* chi (e.g. ``pad_dense_env_chi`` at finalize) read it
-    here from the env's leftmost C1 leg dim rather than trusting
+    Returns ``None`` if the input is falsy or malformed (missing
+    ``C1.indices[0].dim``).  Used by the finalize-pad sites to derive
+    the *actual* chi an env carries — the in-CTM χ-bump
+    (``ctmrg_heuristic_increase_chi=True``, #492/#514) grows chi inside
+    ``python_loop_ctm_converge`` without updating the optimizer's local
     ``ctm_cfg.chi``.
+
+    Accepts the bare env dict (``{coord: CTMTensorEnv}``), not an
+    env_cache wrapper — callers should index ``env_cache["envs"]``
+    themselves so both live cache and snapshot dicts can be queried
+    with the same helper (Codex P2 on PR #542: a cleared live cache
+    must not mask a bumped best-env snapshot).
     """
-    envs = env_cache.get("envs")
     if not envs:
         return None
     try:
@@ -2169,7 +2172,15 @@ def _optimize_gs_ad_tensor(
         # during a gradient evaluation.  Pad to the larger of the static
         # config chi and the env_cache's actual chi so we never try to
         # shrink a bumped env.
-        _target_chi = max(ctm_cfg.chi, _env_cache_chi(_env_cache) or ctm_cfg.chi)
+        # Consult both the live cache *and* the best-env snapshot:
+        # rollback paths may have cleared ``_env_cache`` after the
+        # snapshot was taken, leaving the bumped chi reachable only via
+        # ``_best_env_init`` itself (Codex P2 on PR #542).
+        _target_chi = max(
+            ctm_cfg.chi,
+            _env_dict_chi(_env_cache.get("envs")) or 0,
+            _env_dict_chi(_best_env_init) or 0,
+        )
         _best_env_init = {
             c: pad_dense_env_chi(
                 _best_env_init[c], _target_chi, base_charges=_bump_base_charges
@@ -3720,8 +3731,12 @@ def _optimize_gs_ad_tensor_2site(
             # Issue #514: see 1-site finalize.  Pad to the larger of the
             # static ``ctm_cfg_2s.chi`` and the env_cache's actual chi
             # so a bumped env is never asked to shrink.
+            # See 1-site finalize: consult both live cache and the
+            # best-env snapshot (Codex P2 on PR #542).
             _target_chi_2s = max(
-                ctm_cfg_2s.chi, _env_cache_chi(_env_cache_2s) or ctm_cfg_2s.chi
+                ctm_cfg_2s.chi,
+                _env_dict_chi(_env_cache_2s.get("envs")) or 0,
+                _env_dict_chi(_best_env_init_2s) or 0,
             )
             _best_env_init_2s = {
                 c: pad_dense_env_chi(
@@ -4691,7 +4706,13 @@ def _optimize_gs_ad_multisite(
     if _best_env_init_multi:
         # Issue #514: see 1-site finalize.  Pad to the larger of the
         # static ``ctm_cfg.chi`` and the env_cache's actual chi.
-        _target_chi_multi = max(ctm_cfg.chi, _env_cache_chi(_env_cache) or ctm_cfg.chi)
+        # See 1-site finalize: consult both live cache and the
+        # best-env snapshot (Codex P2 on PR #542).
+        _target_chi_multi = max(
+            ctm_cfg.chi,
+            _env_dict_chi(_env_cache.get("envs")) or 0,
+            _env_dict_chi(_best_env_init_multi) or 0,
+        )
         _best_env_init_multi = {
             c: pad_dense_env_chi(
                 _best_env_init_multi[c],

--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -1892,6 +1892,57 @@ def test_loss_fn_fwd_probe_envs_dont_leak_past_line_search():
     assert broken >= 1, f"no line-search-boundary cache restore observed; got {seen}"
 
 
+def test_2site_implicit_ad_ctmrg_heuristic_increase_chi_grows_env():
+    """Issue #514: in-CTM χ-bump on 2-site implicit-AD path grows env without crash.
+
+    Before this fix, the optimizer's final-pad step called
+    ``pad_dense_env_chi(env_at_chi_bumped, ctm_cfg.chi_initial)`` which
+    raised ``ValueError: chi_new=N must be >= chi_old=M`` because the
+    in-CTM bump grew the env above ``ctm_cfg.chi`` but the static config
+    was never synced.  The finalize site now reads the env's actual chi
+    via ``_env_cache_chi`` so the bumped env is preserved.
+
+    Probe: D=2 χ_init=4 χ_max=8, threshold=1e-12 (forces the bump every
+    iter), 2 steps.  Assert (a) no crash, (b) final env chi > χ_init.
+    """
+    import jax.numpy as jnp
+
+    from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    d = 2
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+    H = jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+    gate = H.reshape(d, d, d, d)
+
+    config = iPEPSConfig(
+        max_bond_dim=2,
+        ctm=CTMConfig(
+            chi=4,
+            max_iter=8,
+            ctmrg_heuristic_increase_chi=True,
+            ctmrg_heuristic_increase_chi_threshold=1e-12,  # force bump every call
+            ctmrg_heuristic_increase_chi_step_size=2,
+            chi_max=8,
+        ),
+        gs_num_steps=2,
+        gs_implicit_ad=True,
+        unit_cell="2site",
+        su_init=True,
+        num_imaginary_steps=10,
+        dt=0.3,
+    )
+    (A_opt, B_opt), (env_A, env_B), E_gs = optimize_gs_ad(gate, None, config)
+    assert math.isfinite(E_gs)
+    final_chi = int(env_A.C1.indices[0].dim)
+    assert final_chi > 4, (
+        f"in-CTM bump must grow env beyond chi_init=4; got final_chi={final_chi}"
+    )
+    assert final_chi <= 8, f"final_chi={final_chi} exceeded chi_max=8"
+
+
 def test_gs_ctm_max_iter_schedule_caps_late_step_ctm():
     """Issue #507: ``gs_ctm_max_iter_schedule`` caps accepted-step CTM iter count.
 


### PR DESCRIPTION
## Summary

Closes (the implicit-AD half of) #514.  The implicit-AD branch already accepts \`ctmrg_heuristic_increase_chi\` and the in-CTM bump fires correctly inside \`ctm_energy_implicit\` — the env_cache holds the post-bump env.  But the optimizer's local \`ctm_cfg.chi\` stays at its original value (no return channel from AD forward back to the dispatcher), so the end-of-loop \`pad_dense_env_chi(best_env, ctm_cfg.chi)\` site tries to pad a bumped env *down* to the static chi and trips \`ValueError: chi_new=N must be >= chi_old=M (shrinking is not supported)\`.

## Fix

- New \`_env_cache_chi(env_cache)\` helper reads the cached env's actual chi from \`sample.C1.indices[0].dim\`.
- All 3 finalize pad sites (1-site, 2-site, multisite) now pad to \`max(ctm_cfg.chi, _env_cache_chi(...) or ctm_cfg.chi)\`.
- 2-site warning text trims the stale "raises NotImplementedError" clause that PR #534 (#511) inherited.

Reproducer (would crash before the fix):

\`\`\`python
config = iPEPSConfig(
    max_bond_dim=2,
    ctm=CTMConfig(
        chi=4, max_iter=10,
        ctmrg_heuristic_increase_chi=True,
        ctmrg_heuristic_increase_chi_threshold=1e-12,
        chi_max=8,
    ),
    gs_num_steps=2, gs_implicit_ad=True, unit_cell="2site",
    su_init=True, num_imaginary_steps=10, dt=0.3,
)
optimize_gs_ad(gate, None, config)
# Before: ValueError: chi_new=4 must be >= chi_old=8 (shrinking is not supported)
# After:  E_gs=-0.629, final env chi=6 (bumped from 4)
\`\`\`

## Test plan

- [x] New \`test_2site_implicit_ad_ctmrg_heuristic_increase_chi_grows_env\`: 2-step D=2 χ=4→8 bipartite implicit-AD with threshold=1e-12 (forces bump every call); asserts no crash + final env chi > 4 and ≤ 8.
- [x] \`uv run pytest tests/test_ipeps.py::TestOptimizeGsAd2Site tests/test_ipeps.py::TestOptimizeGsAdLogging tests/test_ipeps_ad_policy.py tests/test_ctm_energy_implicit_chi_bump.py tests/test_ipeps_chi_bump_rollback_desync.py\` — 38 passed.
- [x] \`pre-commit run --files <modified>\`

## Scope

Explicit-AD warmup bump remains as Phase 2 already landed it.  This PR is the implicit-AD half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)