### PR TITLE
docs(ipeps): annotate _normalize_stall_recovery 2-site default as pre-#494 (#521)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -325,6 +325,14 @@ def _normalize_stall_recovery(config, *, unit_cell: str):
     SU-init plateau (gradient norms ~1e-10 trip ``gs_conv_tol`` before the first
     real step).  The 2-site path's larger parameter space interacts
     pathologically with non-variational CTM regions under noise; see issue #298.
+
+    **Caveat (pre-#494)**: the "noise pathological on 2-site" verdict
+    behind the ``"reset"`` default was reached before PR #494 fixed a
+    4-bond undercount in the 2-site bipartite energy (2026-05-17).  The
+    claim has not been revalidated on the corrected energy landscape;
+    see issue #520 for the re-test and #522 for the default-rationale
+    review.  Until then the ``"reset"`` 2-site default carries an
+    asterisk.
     """
     from dataclasses import replace
 


### PR DESCRIPTION
## Summary

- Adds a caveat paragraph to ``_normalize_stall_recovery`` explaining
  that the 2-site ``"reset"`` default was set before PR #494 fixed a
  4-bond undercount in the 2-site bipartite energy (2026-05-17).
- Cross-references issue #520 (empirical re-test) and #522 (default
  rationale review).

Closes #521.  No behavioral change.

## Test plan

- [x] ``pre-commit run --files src/tenax/algorithms/ipeps_optimize.py``
      (ruff + ruff-format pass).
- [x] ``python -c "from tenax.algorithms.ipeps_optimize import _normalize_stall_recovery"``
      — docstring still loads.
- [ ] CI green on Tests (Python 3.11/3.12, macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)