### PR TITLE
perf(ipeps): TBPTT truncation for explicit-AD CTM backward (#506)

### DIFF
--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -57,6 +57,7 @@ def ctm_energy_explicit(
     chi: int = 20,
     warmup_steps: int = 3,
     backprop_steps: int = 20,
+    backward_steps: int | None = None,
     projector_method: str = "svd",
     renormalize: bool = True,
     projector_backward: str = "auto",
@@ -82,7 +83,27 @@ def ctm_energy_explicit(
     The backprop phase uses the final post-warmup chi as a Python int so
     JAX traces the checkpointed sweep once and reuses across all backprop
     iterations — bump cannot fire during backprop.
+
+    When ``backward_steps=K`` is set (TBPTT; #506), only the last ``K`` of
+    the ``backprop_steps`` sweeps are differentiated; the leading
+    ``backprop_steps - K`` sweeps run under ``jax.lax.stop_gradient`` so
+    JAX skips their backward.  CTM converges geometrically, so the early
+    backward contribution is bounded by ``ρ^K × (full contribution)`` —
+    negligible for ρ≲0.5 and K≳10.  ``None`` (default) preserves the
+    full backward.
     """
+    if backward_steps is not None:
+        if backward_steps < 1:
+            raise ValueError(
+                "backward_steps must be >= 1 (or None to disable TBPTT), "
+                f"got {backward_steps}"
+            )
+        if backward_steps > backprop_steps:
+            raise ValueError(
+                f"backward_steps ({backward_steps}) cannot exceed "
+                f"backprop_steps ({backprop_steps}); set to None to "
+                "backprop through all sweeps."
+            )
     # ---- validation (mirror ctm_energy_implicit / _sigma_gauged_ctm_converge) ----
     chi_current = _validate_chi_bump_args(
         chi=chi,
@@ -140,7 +161,13 @@ def ctm_energy_explicit(
         )
         return envs_out
 
-    for _ in range(backprop_steps):
+    # TBPTT split (#506): leading ``truncated`` sweeps stop-gradient, last
+    # ``backward_steps`` sweeps remain differentiated.  When backward_steps
+    # is None we backprop through everything (preserves pre-#506 contract).
+    truncated = 0 if backward_steps is None else max(0, backprop_steps - backward_steps)
+    for _ in range(truncated):
+        envs = jax.lax.stop_gradient(_step_envs_only(site_tensors, envs))
+    for _ in range(backprop_steps - truncated):
         envs = jax.checkpoint(_step_envs_only)(site_tensors, envs)
 
     if energy_fn is not None:

--- a/src/tenax/algorithms/ipeps_ad_policy.py
+++ b/src/tenax/algorithms/ipeps_ad_policy.py
@@ -154,6 +154,7 @@ def make_ctm_energy_fn(
     use_explicit: bool,
     explicit_warmup: int,
     explicit_steps: int,
+    explicit_backward_steps: int | None = None,
     energy_fn=None,
 ):
     """Build a ``site_tensors → energy`` closure used by every iPEPS AD dispatcher.
@@ -181,6 +182,12 @@ def make_ctm_energy_fn(
         use_explicit:     True for the explicit-AD path, False for implicit.
         explicit_warmup:  Number of forward-only warmup CTM sweeps (explicit).
         explicit_steps:   Number of backprop-tracked CTM sweeps (explicit).
+        explicit_backward_steps:
+                          TBPTT cutoff (#506): when set, only the last K
+                          of ``explicit_steps`` sweeps are differentiated;
+                          the leading ``explicit_steps - K`` sweeps run
+                          under ``jax.lax.stop_gradient``.  ``None``
+                          (default) preserves full backward.
         energy_fn:        Optional energy callback for non-default
                           (e.g. coarse-grain) energy evaluation.
     """
@@ -207,6 +214,7 @@ def make_ctm_energy_fn(
                 chi=ctm_cfg.chi,
                 warmup_steps=explicit_warmup,
                 backprop_steps=explicit_steps,
+                backward_steps=explicit_backward_steps,
                 projector_method=ctm_cfg.projector_method,
                 renormalize=ctm_cfg.renormalize,
                 projector_backward=ctm_cfg.projector_backward,

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -505,6 +505,15 @@ class iPEPSConfig:
     gs_explicit_ad: bool | None = None
     gs_explicit_ad_steps: int = 20  # CTM steps for explicit AD backprop phase
     gs_explicit_ad_warmup: int = 3  # warmup CTM steps (no gradient tracking)
+    # TBPTT cutoff (#506): when set, only the last K of ``gs_explicit_ad_steps``
+    # sweeps are differentiated; the leading ``gs_explicit_ad_steps - K`` sweeps
+    # use ``jax.lax.stop_gradient`` so JAX skips their backward.  CTM converges
+    # geometrically, so the early-iteration backward contribution is bounded by
+    # ``ρ^K × (full contribution)`` — negligible for ρ≲0.5 and K≳10.  ``None``
+    # (default) keeps the full backward; an int 1..gs_explicit_ad_steps enables
+    # truncation.  Composes with the existing per-step ``jax.checkpoint`` wrap
+    # in ``ctm_energy_explicit`` to combine memory and compute savings.
+    gs_explicit_ad_backward_steps: int | None = None
     su_init: bool = True  # initialize via simple update before AD
     gs_c4v: bool = False  # enforce C4v symmetry on site tensor during AD
     gs_projector_method: str | None = (
@@ -631,6 +640,20 @@ class iPEPSConfig:
             raise ValueError(
                 f"gs_hz_max_iter must be positive, got {self.gs_hz_max_iter}"
             )
+        if self.gs_explicit_ad_backward_steps is not None:
+            if self.gs_explicit_ad_backward_steps < 1:
+                raise ValueError(
+                    "gs_explicit_ad_backward_steps must be >= 1 (or None to "
+                    "disable truncation), "
+                    f"got {self.gs_explicit_ad_backward_steps}"
+                )
+            if self.gs_explicit_ad_backward_steps > self.gs_explicit_ad_steps:
+                raise ValueError(
+                    "gs_explicit_ad_backward_steps "
+                    f"({self.gs_explicit_ad_backward_steps}) cannot exceed "
+                    f"gs_explicit_ad_steps ({self.gs_explicit_ad_steps}); "
+                    "set to None to backprop through all sweeps."
+                )
         if self.gs_chi_ceiling_bailout < 0:
             raise ValueError(
                 "gs_chi_ceiling_bailout must be >= 0 (0 disables), "

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1191,6 +1191,7 @@ def _optimize_gs_ad_tensor(
     use_explicit = not config.gs_implicit_ad
     explicit_steps = config.gs_explicit_ad_steps
     explicit_warmup = config.gs_explicit_ad_warmup
+    explicit_backward_steps = config.gs_explicit_ad_backward_steps
 
     def _params_to_A_norm(params):
         """Convert raw optimizer params to a normalized DenseTensor."""
@@ -1225,6 +1226,7 @@ def _optimize_gs_ad_tensor(
         use_explicit=use_explicit,
         explicit_warmup=explicit_warmup,
         explicit_steps=explicit_steps,
+        explicit_backward_steps=explicit_backward_steps,
         energy_fn=_energy_fn_kw,
     )
 
@@ -2362,6 +2364,7 @@ def _optimize_gs_ad_tensor_2site(
     use_explicit = not config.gs_implicit_ad
     explicit_steps = config.gs_explicit_ad_steps
     explicit_warmup = config.gs_explicit_ad_warmup
+    explicit_backward_steps = config.gs_explicit_ad_backward_steps
 
     # Env warm-start cache — replaces flat env_leaves threading.
     _env_cache_2s: dict[str, dict] = {}
@@ -2427,6 +2430,7 @@ def _optimize_gs_ad_tensor_2site(
         use_explicit=use_explicit,
         explicit_warmup=explicit_warmup,
         explicit_steps=explicit_steps,
+        explicit_backward_steps=explicit_backward_steps,
         energy_fn=_energy_fn_2site,
     )
 
@@ -3813,6 +3817,7 @@ def _optimize_gs_ad_multisite(
     use_explicit = not config.gs_implicit_ad
     explicit_steps = config.gs_explicit_ad_steps
     explicit_warmup = config.gs_explicit_ad_warmup
+    explicit_backward_steps = config.gs_explicit_ad_backward_steps
 
     # Env warm-start cache
     _env_cache: dict[str, dict] = {}
@@ -3834,6 +3839,7 @@ def _optimize_gs_ad_multisite(
         use_explicit=use_explicit,
         explicit_warmup=explicit_warmup,
         explicit_steps=explicit_steps,
+        explicit_backward_steps=explicit_backward_steps,
         energy_fn=_energy_fn,
     )
 

--- a/tests/test_ctm_explicit_tbptt.py
+++ b/tests/test_ctm_explicit_tbptt.py
@@ -1,0 +1,140 @@
+"""TBPTT truncation for explicit-AD CTM backward (#506).
+
+Covers:
+
+* default ``backward_steps=None`` produces a finite gradient (the pre-#506
+  contract is unchanged).
+* ``backward_steps == backprop_steps`` matches the ``None`` baseline
+  numerically — verifies the ``truncated = 0`` short-circuit is a true
+  no-op.
+* ``backward_steps < backprop_steps`` still produces a finite gradient
+  with a bounded relative deviation from full backward on a contractive
+  CTM (geometric-decay assumption #506 relies on).
+* validation: ``backward_steps`` outside ``[1, backprop_steps]`` raises
+  ``ValueError`` at the ``ctm_energy_explicit`` boundary and in
+  ``iPEPSConfig.__post_init__``.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tenax.algorithms._ctm_energy_ad import ctm_energy_explicit
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
+from tenax.algorithms.ipeps import heisenberg_gate
+from tenax.algorithms.ipeps_config import iPEPSConfig
+from tenax.core import DenseTensor, FlowDirection, TensorIndex, U1Symmetry
+
+pytestmark = pytest.mark.core
+
+
+def _trivial_site(D: int = 2, d: int = 2, seed: int = 0) -> DenseTensor:
+    """Trivial-U(1) ``(D, D, D, D, d)`` DenseTensor for fast CTM smoke tests."""
+    rng = np.random.default_rng(seed)
+    sym = U1Symmetry()
+    bond_charges = np.zeros(D, dtype=np.int32)
+    phys_charges = np.zeros(d, dtype=np.int32)
+    indices = (
+        TensorIndex.from_charges(
+            sym, bond_charges.copy(), FlowDirection.OUT, label="u"
+        ),
+        TensorIndex.from_charges(sym, bond_charges.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(
+            sym, bond_charges.copy(), FlowDirection.OUT, label="l"
+        ),
+        TensorIndex.from_charges(sym, bond_charges.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(
+            sym, phys_charges.copy(), FlowDirection.IN, label="phys"
+        ),
+    )
+    data = rng.standard_normal((D, D, D, D, d)).astype(np.float64)
+    return DenseTensor(data, indices)
+
+
+def _grad_energy(A: DenseTensor, *, backward_steps, backprop_steps: int = 8):
+    """Run ``ctm_energy_explicit`` once and return (energy, |grad|)."""
+    gate = heisenberg_gate()
+
+    def _loss(data):
+        site = DenseTensor(data, A.indices)
+        return ctm_energy_explicit(
+            {(0, 0): site},
+            SINGLE_SITE_NEIGHBORS,
+            gate,
+            chi=4,
+            warmup_steps=2,
+            backprop_steps=backprop_steps,
+            backward_steps=backward_steps,
+        )
+
+    e, g = jax.value_and_grad(_loss)(jnp.asarray(A.todense()))
+    return float(e), float(jnp.linalg.norm(g))
+
+
+def test_default_none_runs_and_returns_finite_gradient():
+    A = _trivial_site()
+    e, gnorm = _grad_energy(A, backward_steps=None)
+    assert np.isfinite(e) and np.isfinite(gnorm)
+    assert gnorm > 0.0
+
+
+def test_k_equals_backprop_steps_matches_full_backward():
+    """``backward_steps == backprop_steps`` is the ``truncated=0`` path and
+    must match the ``None`` baseline to floating-point precision."""
+    A = _trivial_site()
+    e_none, g_none = _grad_energy(A, backward_steps=None, backprop_steps=8)
+    e_full, g_full = _grad_energy(A, backward_steps=8, backprop_steps=8)
+    assert e_none == pytest.approx(e_full, rel=0.0, abs=1e-14)
+    assert g_none == pytest.approx(g_full, rel=1e-12, abs=1e-14)
+
+
+def test_truncated_backward_produces_finite_gradient():
+    """K=4 on N=8 still produces a finite gradient; the value differs from
+    full backward because the leading 4 sweeps are stop-gradient'd, but
+    the optimizer-visible norm should be O(1) of the full gradient (the
+    early-iter contribution is not the entire gradient)."""
+    A = _trivial_site()
+    e_full, g_full = _grad_energy(A, backward_steps=None, backprop_steps=8)
+    e_trunc, g_trunc = _grad_energy(A, backward_steps=4, backprop_steps=8)
+    assert np.isfinite(e_trunc) and np.isfinite(g_trunc)
+    # Energy is identical — only the gradient changes under TBPTT.
+    assert e_trunc == pytest.approx(e_full, rel=0.0, abs=1e-14)
+    # Gradient norm should remain in the same order of magnitude.  Full
+    # backward at chi=4 D=2 lands at gnorm ~1; we tolerate an order of
+    # magnitude either side as a smoke bound (the issue's ρ^K bound is
+    # tightest at converged ρ<1, but a fixed-iter 8-sweep CTM is not
+    # converged, so the K=4 vs N=8 ratio is just a smoke proxy).
+    assert 0.1 * g_full < g_trunc < 10.0 * g_full
+
+
+def test_backward_steps_zero_raises():
+    A = _trivial_site()
+    with pytest.raises(ValueError, match="backward_steps must be >= 1"):
+        _grad_energy(A, backward_steps=0, backprop_steps=8)
+
+
+def test_backward_steps_above_backprop_steps_raises():
+    A = _trivial_site()
+    with pytest.raises(ValueError, match="cannot exceed"):
+        _grad_energy(A, backward_steps=9, backprop_steps=8)
+
+
+def test_ipeps_config_rejects_invalid_backward_steps():
+    with pytest.raises(ValueError, match="must be >= 1"):
+        iPEPSConfig(max_bond_dim=2, gs_explicit_ad_backward_steps=0)
+    with pytest.raises(ValueError, match="cannot exceed"):
+        iPEPSConfig(
+            max_bond_dim=2,
+            gs_explicit_ad_steps=5,
+            gs_explicit_ad_backward_steps=10,
+        )
+
+
+def test_ipeps_config_accepts_valid_backward_steps_and_default_none():
+    c_default = iPEPSConfig(max_bond_dim=2)
+    assert c_default.gs_explicit_ad_backward_steps is None
+    c_set = iPEPSConfig(max_bond_dim=2, gs_explicit_ad_backward_steps=10)
+    assert c_set.gs_explicit_ad_backward_steps == 10


### PR DESCRIPTION
## Summary

- Adds ``backward_steps: int | None`` to ``ctm_energy_explicit``: when
  set to ``K``, the leading ``backprop_steps - K`` sweeps run under
  ``jax.lax.stop_gradient`` so JAX skips their backward; the last ``K``
  sweeps remain ``jax.checkpoint``-wrapped exactly as before.  ``None``
  (default) preserves the pre-#506 contract.
- Exposes the cutoff at the config level as
  ``iPEPSConfig.gs_explicit_ad_backward_steps`` with validation
  rejecting values outside ``[1, gs_explicit_ad_steps]``.
- Threaded through ``make_ctm_energy_fn`` to the 1-site, 2-site, and
  multisite dispatchers.
- 7 new tests in ``tests/test_ctm_explicit_tbptt.py`` cover the
  default behaviour, full-K = full-backward numeric parity, finite
  truncated-gradient smoke check, and boundary validation in both
  ``ctm_energy_explicit`` and ``iPEPSConfig``.

Closes #506.

## Why this matters

CTM converges geometrically, so the early-iter backward contribution
is bounded by ``ρ^K × (full contribution)``.  At ``ρ=0.5, K=10`` the
bias floor is ~0.1% — well below the optimizer's epsilon.  YASTN uses
TBPTT by default for the same reason.

Composes with the existing per-step ``jax.checkpoint`` wrap that
PR #340 already shipped (effectively the "aggressive" variant of
#505): together, backward memory is bounded by ``K × env_size`` and
backward compute by ``K × ctm_step`` instead of ``N × env_size`` and
``N × ctm_step``.

> Note on #505: while implementing #506 I discovered the explicit-AD
> path *already* wraps every backprop step in ``jax.checkpoint``
> (``src/tenax/algorithms/_ctm_energy_ad.py:144``, present since PR
> #340).  That is the more aggressive of the two variants from #505's
> trade-off table.  #505 can be closed or rescoped to switch from the
> aggressive (O(1) memory, ~3× backward) to the √N variant (O(√N)
> memory, ~1.5–2× backward).

## Test plan

- [x] ``pre-commit run`` — ruff + ruff-format pass on all 5 touched files.
- [x] ``uv run pytest tests/test_ctm_explicit_tbptt.py`` — 7 passed.
- [x] ``uv run pytest tests/test_ctm_in_loop_bump_ad_paths.py tests/test_ipeps_ad_history.py``
      — 11 passed (no regression on adjacent explicit-AD entry points).
- [ ] CI green on Tests (Python 3.11/3.12, macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)