### PR TITLE
feat(pess): thread in-CTM chi-bump kwargs into PESS AD loss (#411)

### DIFF
--- a/src/tenax/algorithms/pess_optimize.py
+++ b/src/tenax/algorithms/pess_optimize.py
@@ -131,6 +131,18 @@ def build_pess_loss(
             arnoldi_precheck=False,
             adjoint_method=config.adjoint_method,
             plateau_patience=config.plateau_patience,
+            # In-CTM χ-bump (variPEPS §2.8.2; Issue #492 / #411).  Defaults
+            # in CTMConfig keep the bump off, so existing PESS callers see
+            # no change; downstream ``ctm_energy_implicit`` validates the
+            # combination (chi_max required, step_size > 0, etc.).
+            ctmrg_heuristic_increase_chi=config.ctmrg_heuristic_increase_chi,
+            ctmrg_heuristic_increase_chi_threshold=(
+                config.ctmrg_heuristic_increase_chi_threshold
+            ),
+            ctmrg_heuristic_increase_chi_step_size=(
+                config.ctmrg_heuristic_increase_chi_step_size
+            ),
+            chi_max=config.chi_max,
         )
 
     return loss_fn
@@ -551,6 +563,17 @@ def build_pess_loss_3site_multisite(
             arnoldi_precheck=False,
             adjoint_method=config.adjoint_method,
             plateau_patience=config.plateau_patience,
+            # In-CTM χ-bump (variPEPS §2.8.2; Issue #492 / #411).  Mirror
+            # the 1-site PESS call above so the AD-traced energy and the
+            # warm-start path share the bump policy.
+            ctmrg_heuristic_increase_chi=config.ctmrg_heuristic_increase_chi,
+            ctmrg_heuristic_increase_chi_threshold=(
+                config.ctmrg_heuristic_increase_chi_threshold
+            ),
+            ctmrg_heuristic_increase_chi_step_size=(
+                config.ctmrg_heuristic_increase_chi_step_size
+            ),
+            chi_max=config.chi_max,
         )
 
     return loss_fn

--- a/tests/test_pess_ad.py
+++ b/tests/test_pess_ad.py
@@ -506,6 +506,104 @@ def test_build_pess_loss_3site_multisite_forwards_plateau_patience():
     assert seen.get("plateau_patience") == 7
 
 
+def test_build_pess_loss_3site_multisite_forwards_bump_kwargs():
+    """PESS multisite implicit-AD loss must forward the four
+    ``ctmrg_heuristic_increase_chi*`` / ``chi_max`` kwargs (#411 / #492).
+
+    Mirrors ``test_build_pess_loss_3site_multisite_forwards_plateau_patience``:
+    prior to the fix the PESS loss called ``ctm_energy_implicit`` without
+    the bump kwargs, so PESS gradient evaluations silently no-op'd on the
+    in-CTM bump while ``_update_env_cache`` (warm-start) honored it via
+    ``ctm_converge_kwargs``.  Without this regression coverage the split
+    is invisible.
+    """
+    state = IPESSState.random(D=2, d=3, key=jax.random.PRNGKey(0))
+    bond_gates = kagome_3site_bond_gates(delta=1.0, d=3)
+    config = _dc_replace(
+        _make_test_config(chi=4),
+        chi_max=8,
+        ctmrg_heuristic_increase_chi=True,
+        ctmrg_heuristic_increase_chi_threshold=5e-7,
+        ctmrg_heuristic_increase_chi_step_size=3,
+    )
+
+    seen: dict = {}
+
+    def fake_ctm_energy_implicit(*args, **kwargs):
+        seen.update(kwargs)
+        return jnp.array(0.0)
+
+    loss_fn = build_pess_loss_3site_multisite(bond_gates, config)
+    with _mock_patch(
+        "tenax.algorithms.pess_optimize.ctm_energy_implicit",
+        fake_ctm_energy_implicit,
+    ):
+        loss_fn(state)
+
+    assert seen.get("ctmrg_heuristic_increase_chi") is True
+    assert seen.get("ctmrg_heuristic_increase_chi_threshold") == pytest.approx(5e-7)
+    assert seen.get("ctmrg_heuristic_increase_chi_step_size") == 3
+    assert seen.get("chi_max") == 8
+
+
+def test_build_pess_loss_3site_multisite_bump_defaults_off():
+    """The default PESS config keeps the in-CTM bump off — verify the
+    forwarded kwargs reflect the disabled-by-default contract so this
+    PR doesn't silently flip the default for existing callers."""
+    state = IPESSState.random(D=2, d=3, key=jax.random.PRNGKey(0))
+    bond_gates = kagome_3site_bond_gates(delta=1.0, d=3)
+    config = _make_test_config(chi=4)
+
+    seen: dict = {}
+
+    def fake_ctm_energy_implicit(*args, **kwargs):
+        seen.update(kwargs)
+        return jnp.array(0.0)
+
+    loss_fn = build_pess_loss_3site_multisite(bond_gates, config)
+    with _mock_patch(
+        "tenax.algorithms.pess_optimize.ctm_energy_implicit",
+        fake_ctm_energy_implicit,
+    ):
+        loss_fn(state)
+
+    assert seen.get("ctmrg_heuristic_increase_chi") is False
+    assert seen.get("chi_max") is None
+
+
+def test_build_pess_loss_forwards_bump_kwargs():
+    """Supersite (1-site CG-iPEPS) PESS loss must forward the bump
+    kwargs as well (#411 / #492)."""
+    cg_gates = kagome_xxz_pess_cg_gates(delta=1.0, d=3)
+    config = _dc_replace(
+        _make_test_config(chi=4),
+        chi_max=8,
+        ctmrg_heuristic_increase_chi=True,
+        ctmrg_heuristic_increase_chi_threshold=2e-6,
+        ctmrg_heuristic_increase_chi_step_size=4,
+    )
+
+    state = IPESSState.random(D=2, d=3, key=jax.random.PRNGKey(0))
+
+    seen: dict = {}
+
+    def fake_ctm_energy_implicit(*args, **kwargs):
+        seen.update(kwargs)
+        return jnp.array(0.0)
+
+    loss_fn = build_pess_loss(cg_gates, config)
+    with _mock_patch(
+        "tenax.algorithms.pess_optimize.ctm_energy_implicit",
+        fake_ctm_energy_implicit,
+    ):
+        loss_fn(state)
+
+    assert seen.get("ctmrg_heuristic_increase_chi") is True
+    assert seen.get("ctmrg_heuristic_increase_chi_threshold") == pytest.approx(2e-6)
+    assert seen.get("ctmrg_heuristic_increase_chi_step_size") == 4
+    assert seen.get("chi_max") == 8
+
+
 def test_optimize_pess_3site_multisite_ad_warm_starts_envs():
     """After the first L-BFGS step, `_update_env_cache` populates the cache,
     so the SECOND gradient evaluation receives a non-None env_init.


### PR DESCRIPTION
## Summary

PESS's AD-traced energy paths (``build_pess_loss`` and
``build_pess_loss_3site_multisite``) called ``ctm_energy_implicit``
without the four ``ctmrg_heuristic_increase_chi*`` / ``chi_max``
kwargs, while the warm-start path (``_update_env_cache``) honored
them via ``ctm_converge_kwargs``.  The asymmetry meant the in-CTM
bump was a silent no-op for PESS gradients while the warm-start CTM
grew chi — gradients were evaluated at a smaller chi than the
warm-start env.

This PR threads the four bump kwargs through both PESS loss sites
(supersite 1-site and 3-site multisite).  ``CTMConfig`` defaults
keep the bump off, so existing PESS callers see no change.

Closes #411.  Pairs with #514 (iPEPS implicit-AD bump) and #547
(legacy ``chi_auto_bump`` deprecation).

## Changes

- ``src/tenax/algorithms/pess_optimize.py`` — both
  ``ctm_energy_implicit`` calls (1-site supersite at L114, multisite
  at L531) now pass ``ctmrg_heuristic_increase_chi``,
  ``ctmrg_heuristic_increase_chi_threshold``,
  ``ctmrg_heuristic_increase_chi_step_size``, ``chi_max`` from
  ``CTMConfig``.
- ``tests/test_pess_ad.py`` — three new regression tests
  monkey-patching ``ctm_energy_implicit`` to assert the kwargs land
  (mirrors the existing ``forwards_plateau_patience`` test from PR
  #439).

## Test plan

- [x] ``pre-commit run --files src/tenax/algorithms/pess_optimize.py tests/test_pess_ad.py``
      — ruff + ruff-format pass.
- [x] ``uv run pytest tests/test_pess_ad.py`` — 27 passed (3 new + 24
      pre-existing).
- [ ] CI green on Tests (Python 3.11/3.12, macOS).

## Notes

- The acceptance criterion in #411 also mentions ε_T aggregation
  across multiple absorption coordinates and per-site env padding;
  those are handled inside ``_run_ctm_loop_with_bump`` (PR #514's
  shared loop core) so the kwarg threading here is sufficient for
  the AD path.  The multisite ε_T aggregation lives in
  ``_run_ctm_loop_with_bump`` itself and applies uniformly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)