### PR TITLE
feat(ipeps): gs_line_search_method='auto' picks Armijo at low chi, HZ at high (#509)

### DIFF
--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -458,7 +458,21 @@ class iPEPSConfig:
     gs_grad_spike_window: int = 5
     gs_line_search: bool | None = None  # None = auto (True for lbfgs/cg)
     gs_line_search_max_steps: int = 8
-    gs_line_search_method: str = "hager_zhang"  # "armijo" or "hager_zhang"
+    # Line search method: "armijo", "hager_zhang", or "auto".  "auto" (#509)
+    # picks Armijo backtracking when ``ctm.chi < gs_line_search_hz_chi_threshold``
+    # and Hager-Zhang otherwise.  Rationale: iPEPS-AD's gradient at small chi
+    # carries CTM truncation noise of order ε_T that frequently exceeds HZ's
+    # strong-Wolfe curvature tolerance (σ ≈ 0.9), so HZ wastes
+    # ``value_and_grad`` calls hunting an unachievable Wolfe point and falls
+    # back to a poor α.  Armijo only checks sufficient decrease, dodging the
+    # noise entirely at ~5-10× lower per-probe cost.  Resolved once at
+    # optimizer entry from ``ctm.chi``, not adaptively rebound mid-run.
+    gs_line_search_method: str = "hager_zhang"  # "armijo", "hager_zhang", "auto"
+    # χ threshold under which "auto" picks Armijo; at or above, HZ.
+    # variPEPS notes the 2-site bipartite implicit-AD path is variational only
+    # at χ ≥ 16 (warning at ``ipeps_optimize.py``); below that the gradient is
+    # too noisy for strong Wolfe.  16 mirrors that threshold.
+    gs_line_search_hz_chi_threshold: int = 16
     # Hager-Zhang line search inner iteration cap (bracket + secant loops in
     # ``_line_search.hager_zhang_line_search``).  Each iteration triggers
     # one ``value_and_grad`` call, so on chi-saturated 2-site implicit-AD
@@ -639,6 +653,17 @@ class iPEPSConfig:
         if self.gs_hz_max_iter <= 0:
             raise ValueError(
                 f"gs_hz_max_iter must be positive, got {self.gs_hz_max_iter}"
+            )
+        valid_line_search_methods = {"armijo", "hager_zhang", "auto"}
+        if self.gs_line_search_method not in valid_line_search_methods:
+            raise ValueError(
+                f"gs_line_search_method must be one of {valid_line_search_methods}, "
+                f"got {self.gs_line_search_method!r}"
+            )
+        if self.gs_line_search_hz_chi_threshold <= 0:
+            raise ValueError(
+                "gs_line_search_hz_chi_threshold must be positive, "
+                f"got {self.gs_line_search_hz_chi_threshold}"
             )
         if self.gs_explicit_ad_backward_steps is not None:
             if self.gs_explicit_ad_backward_steps < 1:

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -472,6 +472,32 @@ def _use_line_search(config: iPEPSConfig) -> bool:
     return config.gs_optimizer.lower() in ("lbfgs", "cg")
 
 
+def _resolve_line_search_method(config: iPEPSConfig, ctm_cfg: CTMConfig) -> str:
+    """Return the concrete line-search method ("armijo" or "hager_zhang").
+
+    Honours ``config.gs_line_search_method``:
+
+    * ``"armijo"`` / ``"hager_zhang"`` — returned as-is.
+    * ``"auto"`` (#509) — picks Armijo backtracking when
+      ``ctm_cfg.chi < config.gs_line_search_hz_chi_threshold`` and
+      Hager-Zhang otherwise.  Rationale: iPEPS-AD's gradient at small chi
+      carries CTM truncation noise of order ε_T that frequently exceeds
+      HZ's strong-Wolfe curvature tolerance (σ ≈ 0.9); Armijo only checks
+      sufficient decrease and dodges this entirely at ~5-10× lower
+      per-probe cost.
+
+    Resolved once at optimizer entry from the *initial* ``ctm_cfg.chi``,
+    not rebound mid-run.  Users wanting stage-specific behaviour can wrap
+    ``optimize_gs_ad`` calls per chi stage with an explicit method.
+    """
+    method = config.gs_line_search_method
+    if method == "auto":
+        if ctm_cfg.chi < config.gs_line_search_hz_chi_threshold:
+            return "armijo"
+        return "hager_zhang"
+    return method
+
+
 def _tree_dot(a, b) -> float:
     """Compute real dot product between two pytrees of arrays.
 
@@ -1836,7 +1862,7 @@ def _optimize_gs_ad_tensor(
             # Snapshot for env-cache restore after the line search; see
             # ``_restore_env_cache_after_line_search`` (#502 Codex P1).
             _ls_env_snap = ("envs" in _env_cache, _env_cache.get("envs"))
-            if config.gs_line_search_method == "hager_zhang":
+            if _resolve_line_search_method(config, ctm_cfg) == "hager_zhang":
                 from tenax.algorithms._line_search import hager_zhang_line_search
 
                 slope = _tree_dot(grads, direction)
@@ -3332,7 +3358,7 @@ def _optimize_gs_ad_tensor_2site(
                     "envs" in _env_cache_2s,
                     _env_cache_2s.get("envs"),
                 )
-                if config.gs_line_search_method == "hager_zhang":
+                if _resolve_line_search_method(config, ctm_cfg_2s) == "hager_zhang":
                     from tenax.algorithms._line_search import hager_zhang_line_search
 
                     slope = _tree_dot(grads, direction)
@@ -4378,7 +4404,7 @@ def _optimize_gs_ad_multisite(
             # Snapshot for env-cache restore after the line search; see
             # ``_restore_env_cache_after_line_search`` (#502 Codex P1).
             _ls_env_snap = ("envs" in _env_cache, _env_cache.get("envs"))
-            if config.gs_line_search_method == "hager_zhang":
+            if _resolve_line_search_method(config, ctm_cfg) == "hager_zhang":
                 from tenax.algorithms._line_search import hager_zhang_line_search
 
                 slope = _tree_dot(grads, direction)

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -486,9 +486,15 @@ def _resolve_line_search_method(config: iPEPSConfig, ctm_cfg: CTMConfig) -> str:
       sufficient decrease and dodges this entirely at ~5-10× lower
       per-probe cost.
 
-    Resolved once at optimizer entry from the *initial* ``ctm_cfg.chi``,
-    not rebound mid-run.  Users wanting stage-specific behaviour can wrap
-    ``optimize_gs_ad`` calls per chi stage with an explicit method.
+    Each iPEPS optimizer (1-site / 2-site / multisite) calls this helper
+    exactly once after ``ctm_cfg`` is built and caches the result in
+    ``line_search_method``; the dispatch sites inside the optimizer loop
+    consult the cached value, not this function.  That keeps the method
+    stable when ``ctm_cfg.chi`` shifts mid-run under legacy ``chi_ramp``
+    or ``chi_auto_bump`` paths (both deprecated by #512, but still
+    functional — without caching, an "auto" run could silently flip
+    Armijo↔HZ after a bump).  Users wanting stage-specific behaviour
+    should wrap ``optimize_gs_ad`` per chi stage with an explicit method.
     """
     method = config.gs_line_search_method
     if method == "auto":
@@ -1384,6 +1390,12 @@ def _optimize_gs_ad_tensor(
     optimizer = None if is_metric_lbfgs else _build_optimizer(config)
     opt_state = optimizer.init(params) if optimizer is not None else None
     use_ls = _use_line_search(config)
+    # Resolve ``gs_line_search_method`` once per dispatch (#509 / codex P2 on
+    # #549).  ``ctm_cfg.chi`` can shift mid-run under legacy ``chi_ramp`` /
+    # ``chi_auto_bump`` paths (deprecated by #512 but still functional), so
+    # re-resolving inside the line-search step would silently flip Armijo↔HZ
+    # after a bump.  Cache the initial-chi decision and keep it stable.
+    line_search_method = _resolve_line_search_method(config, ctm_cfg)
     is_cg = config.gs_optimizer.lower() == "cg"
 
     best_energy = float("inf")
@@ -1862,7 +1874,7 @@ def _optimize_gs_ad_tensor(
             # Snapshot for env-cache restore after the line search; see
             # ``_restore_env_cache_after_line_search`` (#502 Codex P1).
             _ls_env_snap = ("envs" in _env_cache, _env_cache.get("envs"))
-            if _resolve_line_search_method(config, ctm_cfg) == "hager_zhang":
+            if line_search_method == "hager_zhang":
                 from tenax.algorithms._line_search import hager_zhang_line_search
 
                 slope = _tree_dot(grads, direction)
@@ -2547,6 +2559,9 @@ def _optimize_gs_ad_tensor_2site(
     optimizer = None if is_metric_lbfgs else _build_optimizer(config)
     opt_state = optimizer.init(params) if optimizer is not None else None
     use_ls = _use_line_search(config)
+    # Resolve ``gs_line_search_method`` once per dispatch (#509 / codex P2 on
+    # #549) — see comment in the 1-site path.  2-site uses ``ctm_cfg_2s``.
+    line_search_method = _resolve_line_search_method(config, ctm_cfg_2s)
     is_cg = config.gs_optimizer.lower() == "cg"
 
     best_energy = float("inf")
@@ -3358,7 +3373,7 @@ def _optimize_gs_ad_tensor_2site(
                     "envs" in _env_cache_2s,
                     _env_cache_2s.get("envs"),
                 )
-                if _resolve_line_search_method(config, ctm_cfg_2s) == "hager_zhang":
+                if line_search_method == "hager_zhang":
                     from tenax.algorithms._line_search import hager_zhang_line_search
 
                     slope = _tree_dot(grads, direction)
@@ -3979,6 +3994,9 @@ def _optimize_gs_ad_multisite(
     optimizer = None if is_metric_lbfgs else _build_optimizer(config)
     opt_state = optimizer.init(params) if optimizer is not None else None
     use_ls = _use_line_search(config)
+    # Resolve ``gs_line_search_method`` once per dispatch (#509 / codex P2 on
+    # #549) — see comment in the 1-site path.
+    line_search_method = _resolve_line_search_method(config, ctm_cfg)
     is_cg = config.gs_optimizer.lower() == "cg"
 
     best_energy = float("inf")
@@ -4404,7 +4422,7 @@ def _optimize_gs_ad_multisite(
             # Snapshot for env-cache restore after the line search; see
             # ``_restore_env_cache_after_line_search`` (#502 Codex P1).
             _ls_env_snap = ("envs" in _env_cache, _env_cache.get("envs"))
-            if _resolve_line_search_method(config, ctm_cfg) == "hager_zhang":
+            if line_search_method == "hager_zhang":
                 from tenax.algorithms._line_search import hager_zhang_line_search
 
                 slope = _tree_dot(grads, direction)

--- a/tests/test_line_search_auto.py
+++ b/tests/test_line_search_auto.py
@@ -85,3 +85,59 @@ def test_default_method_is_hager_zhang_for_back_compat():
     # ctm.chi value should not matter for the explicit-default branch.
     assert _resolve_line_search_method(config, CTMConfig(chi=4)) == "hager_zhang"
     assert _resolve_line_search_method(config, CTMConfig(chi=32)) == "hager_zhang"
+
+
+def test_resolver_called_once_per_optimizer_dispatch():
+    """Codex P2 on #549: ``_resolve_line_search_method`` must be called
+    exactly once per ``optimize_gs_ad`` dispatch, not per line-search
+    step.  Without caching, ``ctm_cfg.chi`` shifting mid-run under
+    legacy ``chi_ramp`` / ``chi_auto_bump`` paths would silently flip
+    the resolved method between Armijo and HZ — violating the
+    documented "resolved once per dispatch" contract.
+
+    This test patches the resolver, runs a short ``optimize_gs_ad``
+    (1-site, default path), and asserts a single call.  The same
+    invariant applies to the 2-site and multisite dispatchers by
+    construction (all three optimizers now bind the resolver result
+    to ``line_search_method`` before the optimizer loop).
+    """
+    import jax.numpy as jnp
+
+    import tenax.algorithms.ipeps_optimize as opt_mod
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    # Heisenberg gate (small, fast).
+    Sz = jnp.array([[0.5, 0.0], [0.0, -0.5]])
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+    gate = (jnp.kron(Sz, Sz) + 0.5 * (jnp.kron(Sp, Sm) + jnp.kron(Sm, Sp))).reshape(
+        2, 2, 2, 2
+    )
+
+    config = iPEPSConfig(
+        max_bond_dim=2,
+        ctm=CTMConfig(chi=4),
+        gs_num_steps=2,  # enough to traverse multiple line-search calls
+        gs_line_search_method="auto",
+        gs_implicit_ad=True,
+        gs_optimizer="lbfgs",
+    )
+
+    real_resolver = opt_mod._resolve_line_search_method
+    calls: list[tuple] = []
+
+    def counting_resolver(cfg, ctm_cfg):
+        calls.append((id(cfg), id(ctm_cfg)))
+        return real_resolver(cfg, ctm_cfg)
+
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr(opt_mod, "_resolve_line_search_method", counting_resolver)
+    try:
+        optimize_gs_ad(gate, None, config)
+    finally:
+        monkey.undo()
+
+    # Exactly one call per dispatch, regardless of gs_num_steps / line-search retries.
+    assert len(calls) == 1, (
+        f"expected resolver called once per dispatch, got {len(calls)} calls"
+    )

--- a/tests/test_line_search_auto.py
+++ b/tests/test_line_search_auto.py
@@ -1,0 +1,87 @@
+"""Per-χ-stage ``gs_line_search_method='auto'`` resolver (#509).
+
+iPEPS-AD's gradient at small χ carries CTM truncation noise of order ε_T
+that frequently exceeds Hager-Zhang's strong-Wolfe curvature tolerance
+(σ ≈ 0.9), so HZ wastes ``value_and_grad`` calls hunting an unachievable
+Wolfe point and falls back to a poor α anyway.  Armijo only checks
+sufficient decrease and dodges the noise entirely at ~5-10× lower per-
+probe cost — but at large χ (≥ 16 for the 2-site bipartite path) HZ's
+strong-Wolfe pairing helps L-BFGS converge superlinearly.
+
+``gs_line_search_method='auto'`` picks Armijo when ``ctm.chi`` is below
+``gs_line_search_hz_chi_threshold`` and HZ otherwise; explicit
+``'armijo'`` / ``'hager_zhang'`` choices pass through unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+from tenax.algorithms.ipeps_optimize import _resolve_line_search_method
+
+pytestmark = pytest.mark.core
+
+
+def test_explicit_hager_zhang_passes_through():
+    config = iPEPSConfig(max_bond_dim=2, gs_line_search_method="hager_zhang")
+    assert _resolve_line_search_method(config, CTMConfig(chi=8)) == "hager_zhang"
+    assert _resolve_line_search_method(config, CTMConfig(chi=64)) == "hager_zhang"
+
+
+def test_explicit_armijo_passes_through():
+    config = iPEPSConfig(max_bond_dim=2, gs_line_search_method="armijo")
+    assert _resolve_line_search_method(config, CTMConfig(chi=8)) == "armijo"
+    assert _resolve_line_search_method(config, CTMConfig(chi=64)) == "armijo"
+
+
+def test_auto_picks_armijo_below_default_threshold():
+    """Default threshold is 16; chi < 16 → Armijo."""
+    config = iPEPSConfig(max_bond_dim=2, gs_line_search_method="auto")
+    assert _resolve_line_search_method(config, CTMConfig(chi=8)) == "armijo"
+    assert _resolve_line_search_method(config, CTMConfig(chi=15)) == "armijo"
+
+
+def test_auto_picks_hager_zhang_at_or_above_default_threshold():
+    """Default threshold is 16; chi >= 16 → HZ."""
+    config = iPEPSConfig(max_bond_dim=2, gs_line_search_method="auto")
+    assert _resolve_line_search_method(config, CTMConfig(chi=16)) == "hager_zhang"
+    assert _resolve_line_search_method(config, CTMConfig(chi=24)) == "hager_zhang"
+
+
+def test_auto_honors_custom_threshold():
+    config = iPEPSConfig(
+        max_bond_dim=2,
+        gs_line_search_method="auto",
+        gs_line_search_hz_chi_threshold=24,
+    )
+    assert _resolve_line_search_method(config, CTMConfig(chi=16)) == "armijo"
+    assert _resolve_line_search_method(config, CTMConfig(chi=23)) == "armijo"
+    assert _resolve_line_search_method(config, CTMConfig(chi=24)) == "hager_zhang"
+    assert _resolve_line_search_method(config, CTMConfig(chi=64)) == "hager_zhang"
+
+
+def test_invalid_method_rejected_in_config():
+    with pytest.raises(ValueError, match="gs_line_search_method must be one of"):
+        iPEPSConfig(max_bond_dim=2, gs_line_search_method="bogus")
+
+
+def test_invalid_threshold_rejected_in_config():
+    with pytest.raises(
+        ValueError, match="gs_line_search_hz_chi_threshold must be positive"
+    ):
+        iPEPSConfig(max_bond_dim=2, gs_line_search_hz_chi_threshold=0)
+    with pytest.raises(
+        ValueError, match="gs_line_search_hz_chi_threshold must be positive"
+    ):
+        iPEPSConfig(max_bond_dim=2, gs_line_search_hz_chi_threshold=-4)
+
+
+def test_default_method_is_hager_zhang_for_back_compat():
+    """The pre-#509 default was ``hager_zhang`` and stays unchanged so
+    existing callers see no behavior change.  Auto is opt-in."""
+    config = iPEPSConfig(max_bond_dim=2)
+    assert config.gs_line_search_method == "hager_zhang"
+    # ctm.chi value should not matter for the explicit-default branch.
+    assert _resolve_line_search_method(config, CTMConfig(chi=4)) == "hager_zhang"
+    assert _resolve_line_search_method(config, CTMConfig(chi=32)) == "hager_zhang"


### PR DESCRIPTION
## Summary

iPEPS-AD's gradient at small χ carries CTM truncation noise of order
ε_T that frequently exceeds Hager-Zhang's strong-Wolfe curvature
tolerance (σ ≈ 0.9), so HZ wastes ``value_and_grad`` calls hunting an
unachievable Wolfe point and falls back to a poor α anyway.  Armijo
backtracking only checks sufficient decrease, dodging the noise at
~5-10× lower per-probe cost (no ∂φ → no adjoint solve).  The v8b
evidence in #509 documents the failure mode at χ=9 (~5h wasted on
HZ probes that all returned ``converged=False``).

This PR adds ``gs_line_search_method='auto'``:

- Resolves to ``"armijo"`` when ``ctm_cfg.chi <
  gs_line_search_hz_chi_threshold`` (default 16, mirrors variPEPS's
  2-site bipartite variational floor).
- Resolves to ``"hager_zhang"`` otherwise.
- Resolved once per dispatch via ``_resolve_line_search_method``, not
  rebound mid-run — users wanting stage-aware behaviour can wrap
  ``optimize_gs_ad`` per stage with explicit methods.

Default stays ``"hager_zhang"`` so existing callers see no change.

Closes #509.

## Changes

- ``src/tenax/algorithms/ipeps_config.py`` — extend
  ``gs_line_search_method`` literal to ``{"armijo", "hager_zhang",
  "auto"}``; add ``gs_line_search_hz_chi_threshold: int = 16``;
  validation in ``__post_init__``.
- ``src/tenax/algorithms/ipeps_optimize.py`` — add
  ``_resolve_line_search_method(config, ctm_cfg)``; update the three
  HZ dispatch sites (1-site at L1865, 2-site at L3361 using
  ``ctm_cfg_2s``, multisite at L4407) to consult the resolver.
- ``tests/test_line_search_auto.py`` — 8 regression tests covering
  the resolver across explicit / auto / threshold-boundary / invalid
  inputs and the back-compat default.

## Test plan

- [x] ``pre-commit run`` — ruff + ruff-format pass.
- [x] ``uv run pytest tests/test_line_search_auto.py`` — 8 passed.
- [x] ``uv run pytest tests/test_line_search.py tests/test_ipeps_stall_recovery_cap.py``
      — 13 passed.  Existing HZ / Armijo / stall-cap coverage untouched.
- [ ] CI green on Tests (Python 3.11/3.12, macOS).

## Notes

- ``gs_hz_max_iter`` (the related #496) already shipped and bounds the
  worst-case cost when HZ does fail; ``"auto"`` reduces how often the
  worst case is hit at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)