### PR TITLE
feat(ipeps): extend return_history to multisite optimizer (#458)

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -3811,11 +3811,6 @@ def _optimize_gs_ad_multisite(
     """
     config = _normalize_stall_recovery(config, unit_cell="multisite")
     _warn_implicit_ad_variational_caveat(config, path="Multisite Lattice")
-    if config.return_history:
-        raise NotImplementedError(
-            "return_history is currently only supported for unit_cell='1x1' "
-            "(non-C4v-reference) and unit_cell='2site'."
-        )
 
     from tenax.algorithms._ctm_python_loop import python_loop_ctm_converge
     from tenax.algorithms._ctm_tensor_energy import (
@@ -3983,6 +3978,15 @@ def _optimize_gs_ad_multisite(
     _patience_schedule = config.gs_plateau_patience_schedule
     _current_patience = ctm_cfg.plateau_patience
 
+    # Optional trajectory capture (config.return_history).  Always allocated
+    # so the post-loop return doesn't have to special-case the disabled path;
+    # values are only populated under ``if config.return_history`` (#458).
+    _history_energies: list[float] = []
+    _history_step_times: list[float] = []
+    _jit_compile_time: float = 0.0
+    _first_step = True
+    _converged = False
+
     def _get_scheduled_conv_tol(step_idx, num_steps):
         if _conv_tol_schedule is None:
             return _current_conv_tol
@@ -4049,6 +4053,8 @@ def _optimize_gs_ad_multisite(
                 _current_patience = new_patience
                 ctm_cfg = _replace(ctm_cfg, plateau_patience=new_patience)
 
+        if config.return_history:
+            _step_t0 = _time.perf_counter()
         try:
             energy_val, grads = jax.value_and_grad(loss_fn)(params)
         except CTMRGGradientError as exc:
@@ -4120,6 +4126,15 @@ def _optimize_gs_ad_multisite(
                     prev_precond_grad = None
             continue
         energy_float = float(energy_val)
+
+        if config.return_history:
+            _step_dt = _time.perf_counter() - _step_t0
+            if _first_step:
+                _jit_compile_time = float(_step_dt)
+                _first_step = False
+            else:
+                _history_step_times.append(float(_step_dt))
+            _history_energies.append(energy_float)
 
         # Update env cache for warm-starting next step
         _update_env_cache(params)
@@ -4265,6 +4280,7 @@ def _optimize_gs_ad_multisite(
                     grad_norm_tol=config.gs_grad_norm_tol,
                     criterion=config.gs_conv_criterion,
                 )
+            _converged = True
             break
 
         # ── Search direction ─────────────────────────────────────────────
@@ -4758,6 +4774,16 @@ def _optimize_gs_ad_multisite(
     # Map coord keys back to site names
     out_tensors = {coord_to_name[c]: out_sites[c] for c in coords}
     out_envs_named = {coord_to_name[c]: out_envs[c] for c in coords}
+
+    if config.return_history:
+        history = {
+            "energies": _history_energies,
+            "step_times": _history_step_times,
+            "jit_compile_time": _jit_compile_time,
+            "num_steps": len(_history_energies),
+            "converged": _converged,
+        }
+        return out_tensors, out_envs_named, E_gs, history
     return out_tensors, out_envs_named, E_gs
 
 

--- a/tests/test_ipeps_ad_history.py
+++ b/tests/test_ipeps_ad_history.py
@@ -78,3 +78,66 @@ def test_optimize_gs_ad_default_no_history():
     # 1-site path: (A, env, E_gs) — last element is a JAX scalar, NOT a dict.
     assert not isinstance(out[-1], dict)
     assert len(out) == 3
+
+
+def _fast_multisite_config(*, return_history: bool, num_steps: int = 3) -> iPEPSConfig:
+    """Minimal-cost multisite (Lattice) config; mirrors _fast_config for the
+    1-site path.  Used to validate the #458 return_history extension to
+    ``_optimize_gs_ad_multisite``."""
+    from tenax.core.lattice import checkerboard
+
+    return iPEPSConfig(
+        max_bond_dim=2,
+        unit_cell=checkerboard(),
+        ctm=CTMConfig(chi=4, max_iter=5),
+        gs_num_steps=num_steps,
+        gs_learning_rate=1e-2,
+        gs_implicit_ad=False,
+        gs_explicit_ad_steps=2,
+        gs_explicit_ad_warmup=1,
+        gs_optimizer="adam",
+        return_history=return_history,
+    )
+
+
+@pytest.mark.algorithm
+def test_optimize_gs_ad_returns_history_multisite():
+    """The multisite dispatcher (#458 follow-up) now surfaces the same
+    history dict as the 1-site and 2-site paths.
+
+    Pre-#458 this raised ``NotImplementedError`` before any optimization
+    work.  The 4-tuple return shape and dict keys must match the 1-site
+    contract so downstream consumers (benchmark harnesses, finite-χ
+    scaling tooling) can treat the three paths interchangeably.
+    """
+    gate = _heisenberg_gate()
+    out = optimize_gs_ad(gate, None, _fast_multisite_config(return_history=True))
+
+    # Multisite default: (sites_dict, envs_dict, E_gs) → with flag adds history
+    assert len(out) == 4
+    assert isinstance(out[-1], dict)
+    history = out[-1]
+    for key in ("energies", "step_times", "jit_compile_time", "num_steps", "converged"):
+        assert key in history, f"history missing {key!r}"
+
+    assert len(history["energies"]) == history["num_steps"]
+    assert len(history["step_times"]) == max(history["num_steps"] - 1, 0)
+    assert history["num_steps"] >= 1
+
+    assert all(isinstance(e, float) for e in history["energies"])
+    assert all(isinstance(t, float) for t in history["step_times"])
+    assert isinstance(history["jit_compile_time"], float)
+    assert isinstance(history["converged"], bool)
+    assert isinstance(history["num_steps"], int)
+
+
+@pytest.mark.algorithm
+def test_optimize_gs_ad_default_no_history_multisite():
+    """Default multisite return shape stays a 3-tuple when the flag is off."""
+    gate = _heisenberg_gate()
+    out = optimize_gs_ad(
+        gate, None, _fast_multisite_config(return_history=False, num_steps=2)
+    )
+    # Multisite: (sites_dict, envs_dict, E_gs).
+    assert len(out) == 3
+    assert not isinstance(out[-1], dict)


### PR DESCRIPTION
## Summary

Pre-#458 ``_optimize_gs_ad_multisite`` raised ``NotImplementedError``
whenever ``config.return_history`` was set, while the 1-site and 2-site
paths already returned a per-step history dict.  This blocked the
planned finite-χ scaling tooling on the multisite path.

This PR mirrors the 1-site / 2-site pattern in the multisite optimizer
so all three paths surface the same history contract:

\`\`\`python
{
    "energies": list[float],
    "step_times": list[float],
    "jit_compile_time": float,
    "num_steps": int,
    "converged": bool,
}
\`\`\`

Return shape with ``return_history=True`` becomes
``(sites_dict, envs_dict, E_gs, history)``; default 3-tuple unchanged.

Closes #458 sub-piece 1.  Sub-pieces 2 (``ChiStageRecord`` dataclass)
and 3 (``return_stages=True`` on ``optimize_gs_ad_chi_schedule``)
remain as follow-up but now unblock on this PR — they need the
per-step ``energies`` / ``step_times`` lists from this dict to
reconstruct ``ChiStageRecord`` entries at schedule boundaries.

## Changes

- Drop ``NotImplementedError`` gate at top of multisite dispatcher.
- Allocate history accumulators alongside other init.
- Capture ``_step_t0`` / ``_step_dt`` around the multisite
  ``value_and_grad`` call.
- Append per-step energy + step time after a successful gradient
  evaluation (skipped on stall-recovery ``continue`` paths, matching
  1-site / 2-site).
- Flip ``_converged = True`` before breaking on convergence.
- Surface the history dict in the final return.

## Test plan

- [x] ``pre-commit run`` — ruff + ruff-format pass.
- [x] ``uv run pytest tests/test_ipeps_ad_history.py`` — 4 passed
      (2 pre-existing 1-site tests + 2 new multisite tests).
- [x] Smoke-tested end-to-end on D=2, χ=4, 2 steps with
      ``checkerboard()`` lattice.
- [ ] CI green on Tests (Python 3.11/3.12, macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)