### PR TITLE
fix(contractor): multi-input contract() silently returns 0 on disjoint inputs (#553)

### DIFF
--- a/src/tenax/contraction/contractor.py
+++ b/src/tenax/contraction/contractor.py
@@ -436,49 +436,94 @@ def _contract_symmetric(
         inversion_pairs = _contraction_inversion_pairs(input_subs, output_part)
 
     # For each tensor, build an index:
-    #   contracted_charge_sig -> list of (block_key, block_array)
-    # where contracted_charge_sig = tuple of charges on contracted legs
-    # in a canonical order (sorted contracted chars).
+    #   partial_sig -> list of (block_key, block_array)
+    # where partial_sig is the tuple of this tensor's contracted-leg charges
+    # in *canonical order*, restricted to the contracted chars the tensor
+    # carries.  Per-tensor partial sigs allow correct multi-input contraction
+    # even when some pair of inputs shares no contracted labels (issue #553);
+    # the previous full-sig intersection silently dropped to zero whenever
+    # two tensors' sig tuples had different lengths.
     contracted_chars_sorted = sorted(contracted_chars)
+    char_to_canonical_pos = {c: i for i, c in enumerate(contracted_chars_sorted)}
 
-    tensor_indices_by_sig: list[dict[tuple[int, ...], list[tuple[BlockKey, Any]]]] = []
-    for tensor_i, (tensor, subs) in enumerate(zip(tensors, input_subs)):
-        # Find which positions in this tensor's subscript are contracted
-        contracted_positions = [
-            pos for pos, c in enumerate(subs) if c in contracted_chars
-        ]
-        # Map contracted char -> position in contracted_chars_sorted
-        char_to_contracted_pos = {c: i for i, c in enumerate(contracted_chars_sorted)}
-        # For this tensor, map each contracted char to its position in subs
-        contracted_char_positions = [
-            (char_to_contracted_pos[subs[pos]], pos) for pos in contracted_positions
-        ]
-        # Sort by canonical contracted char order
-        contracted_char_positions.sort(key=lambda x: x[0])
+    tensor_partial_indices: list[
+        tuple[list[tuple[int, int]], dict[tuple[int, ...], list[tuple[BlockKey, Any]]]]
+    ] = []
+    for tensor, subs in zip(tensors, input_subs):
+        # For each canonical contracted char that this tensor carries, record
+        # ``(canonical_pos, position_in_subs)`` so we can extract the partial
+        # sig from a block key.  Sorted by canonical order so partial sigs
+        # are comparable across tensors that share the same labels.
+        covered: list[tuple[int, int]] = sorted(
+            (char_to_canonical_pos[c], pos)
+            for pos, c in enumerate(subs)
+            if c in contracted_chars
+        )
 
-        sig_index: dict[tuple[int, ...], list[tuple[BlockKey, Any]]] = {}
+        partial_sig_index: dict[tuple[int, ...], list[tuple[BlockKey, Any]]] = {}
         for key, array in tensor.blocks.items():
-            # Extract charges at contracted leg positions, ordered canonically
-            sig = tuple(int(key[pos]) for _, pos in contracted_char_positions)
-            sig_index.setdefault(sig, []).append((key, array))
-        tensor_indices_by_sig.append(sig_index)
+            partial_sig = tuple(int(key[pos]) for _, pos in covered)
+            partial_sig_index.setdefault(partial_sig, []).append((key, array))
+        tensor_partial_indices.append((covered, partial_sig_index))
 
-    # Find contracted-charge signatures shared across all tensors
-    if tensor_indices_by_sig:
-        common_sigs = set(tensor_indices_by_sig[0].keys())
-        for idx_map in tensor_indices_by_sig[1:]:
+    # Fast path: if every tensor carries every contracted char, partial sigs
+    # equal full sigs and we can iterate via direct set intersection (cheaper
+    # than the cartesian product for the common case where the contraction
+    # graph is "complete").
+    all_complete = all(
+        len(covered) == len(contracted_chars_sorted)
+        for covered, _ in tensor_partial_indices
+    )
+    if all_complete and tensor_partial_indices:
+        common_sigs: set[tuple[int, ...]] = set(tensor_partial_indices[0][1].keys())
+        for _, idx_map in tensor_partial_indices[1:]:
             common_sigs &= set(idx_map.keys())
+        sig_iter = iter(common_sigs)
     else:
-        common_sigs = set()
+        # General path: iterate over the cartesian product of allowed charges
+        # at each canonical position, then look up each tensor's partial sig.
+        # For each canonical contracted position, intersect (over tensors
+        # carrying that label) the set of charges they have on that leg.
+        # Tensors that don't carry the label contribute no constraint (their
+        # blocks tensor-product over it).
+        allowed_per_pos: list[set[int]] = []
+        for pos_idx in range(len(contracted_chars_sorted)):
+            constraint: set[int] | None = None
+            for covered, partial_sig_index in tensor_partial_indices:
+                local_pos = None
+                for ci, (canonical_pos, _tensor_pos) in enumerate(covered):
+                    if canonical_pos == pos_idx:
+                        local_pos = ci
+                        break
+                if local_pos is None:
+                    continue
+                charges_here = {sig[local_pos] for sig in partial_sig_index}
+                constraint = (
+                    charges_here if constraint is None else constraint & charges_here
+                )
+            allowed_per_pos.append(constraint if constraint is not None else {0})
+        sig_iter = itertools.product(*[sorted(s) for s in allowed_per_pos])
 
     # Cache for within-block contraction expressions
     block_expr_cache: dict[tuple[tuple[int, ...], ...], Any] = {}
 
     output_blocks: dict[BlockKey, Any] = {}
 
-    for sig in common_sigs:
-        # Get matching blocks for each tensor
-        matching_lists = [idx_map[sig] for idx_map in tensor_indices_by_sig]
+    for full_sig in sig_iter:
+        # For each tensor, extract its partial sig from full_sig and look up
+        # matching blocks. Missing partial sigs (no blocks for that
+        # assignment) terminate this iteration early.
+        matching_lists: list[list[tuple[BlockKey, Any]]] = []
+        skip = False
+        for covered, partial_sig_index in tensor_partial_indices:
+            partial_sig = tuple(full_sig[canonical_pos] for canonical_pos, _ in covered)
+            matching = partial_sig_index.get(partial_sig)
+            if not matching:
+                skip = True
+                break
+            matching_lists.append(matching)
+        if skip:
+            continue
 
         # Iterate over the product of matching blocks only
         for combo in itertools.product(*matching_lists):

--- a/tests/test_contraction.py
+++ b/tests/test_contraction.py
@@ -374,6 +374,101 @@ class TestContractSymmetric:
             net = sum(int(idx.flow) * int(q) for idx, q in zip(result.indices, key))
             assert net == u1.identity(), f"Block {key} violates conservation"
 
+    def test_multi_input_with_disjoint_contracted_legs(self, u1, rng):
+        """Regression for #553: contract(A, B, C) where A and B share no
+        labels but both share separately with C must agree with pairwise
+        contraction.
+
+        Topology::
+
+            A = (a,)        B = (b,)        C = (a, b)
+
+        Before the fix the multi-input ``_contract_symmetric`` path
+        intersected per-tensor contracted-leg signatures of mismatched
+        lengths (A's 1-tuples vs C's 2-tuples) and silently produced
+        an all-zero output.  Pairwise execution gives the correct
+        scalar.  See GitHub issue tenax-lab/tenax#553 for details.
+        """
+        sym = u1
+        charges = np.zeros(2, dtype=np.int32)
+        A = SymmetricTensor.random_normal(
+            (TensorIndex.from_charges(sym, charges, FlowDirection.IN, label="a"),),
+            rng,
+        )
+        B = SymmetricTensor.random_normal(
+            (TensorIndex.from_charges(sym, charges, FlowDirection.IN, label="b"),),
+            jax.random.split(rng)[0],
+        )
+        C = SymmetricTensor.random_normal(
+            (
+                TensorIndex.from_charges(sym, charges, FlowDirection.OUT, label="a"),
+                TensorIndex.from_charges(sym, charges, FlowDirection.OUT, label="b"),
+            ),
+            jax.random.split(rng)[1],
+        )
+
+        r3 = float(contract(A, B, C).todense())
+        r_pair_ab = float(contract(contract(A, B), C).todense())
+        r_pair_ac = float(contract(contract(A, C), B).todense())
+
+        # All three orderings should agree (and the pre-fix bug returned 0.0).
+        np.testing.assert_allclose(r3, r_pair_ab, atol=1e-12)
+        np.testing.assert_allclose(r3, r_pair_ac, atol=1e-12)
+        # Cross-check against numpy einsum (no symmetry tracking — for U(1)
+        # trivial charges this gives the same answer).
+        ref = float(
+            np.einsum(
+                "a,b,ab->",
+                np.array(A.todense()),
+                np.array(B.todense()),
+                np.array(C.todense()),
+            )
+        )
+        np.testing.assert_allclose(r3, ref, atol=1e-12)
+
+    def test_multi_input_dmrg_style_three_input(self, u1, rng):
+        """Regression for #553: structurally similar to in-tree call sites
+        like ``contract(s_left_dag, corner, s_right)`` and
+        ``contract(C0, L0, C1, L1, C2, L2, T_r, ...)`` where some pairs
+        of inputs do not share labels directly.
+
+        Topology::
+
+            X = (l, m, p)
+            Y = (m, n)
+            Z = (n, l)
+
+        Each pair shares one label; full contraction → scalar of (p,).
+        """
+        sym = u1
+        charges = np.zeros(2, dtype=np.int32)
+        X = SymmetricTensor.random_normal(
+            (
+                TensorIndex.from_charges(sym, charges, FlowDirection.IN, label="l"),
+                TensorIndex.from_charges(sym, charges, FlowDirection.IN, label="m"),
+                TensorIndex.from_charges(sym, charges, FlowDirection.IN, label="p"),
+            ),
+            rng,
+        )
+        Y = SymmetricTensor.random_normal(
+            (
+                TensorIndex.from_charges(sym, charges, FlowDirection.OUT, label="m"),
+                TensorIndex.from_charges(sym, charges, FlowDirection.IN, label="n"),
+            ),
+            jax.random.split(rng)[0],
+        )
+        Z = SymmetricTensor.random_normal(
+            (
+                TensorIndex.from_charges(sym, charges, FlowDirection.OUT, label="n"),
+                TensorIndex.from_charges(sym, charges, FlowDirection.OUT, label="l"),
+            ),
+            jax.random.split(rng)[1],
+        )
+
+        r3 = np.array(contract(X, Y, Z).todense())
+        r_pair = np.array(contract(contract(X, Y), Z).todense())
+        np.testing.assert_allclose(r3, r_pair, atol=1e-12)
+
 
 # ------------------------------------------------------------------ #
 # Truncated SVD                                                        #


### PR DESCRIPTION
## Summary

- Fixes #553: `contract(*tensors)` on `SymmetricTensor` silently returned a zero tensor when three or more inputs had a non-complete contraction graph (some pair of inputs shares no contracted labels — e.g. `A=(a), B=(b), C=(a,b)`).
- Affected every symmetry group (U(1), Z_n, FermionParity) and any 3+-input `contract()` call where the per-input contracted-label sets differed.

## Why this was a silent-correctness hazard

`_contract_symmetric` paired blocks across inputs by intersecting per-tensor "contracted-charge signatures" computed in a single canonical order over the *global* contracted-label set. When a tensor carried only a subset of those labels, its signature tuple was shorter than the others', and the intersection collapsed to `{}` — producing an all-zero output with no warning.

In-tree call sites with this topology (e.g. `contract(s_left_dag, corner, s_right)` in DMRG, `contract(C0, L0, C1, L1, C2, L2, T_r, ...)` in multi-corner CTM, gate-insertion patterns used by the fermionic ED reference scaffolding for #392) were at risk of silent zero results.

## Fix

Index each tensor by its own *partial* signature (charges on the contracted labels the tensor actually carries, in canonical order):

- **Fast path** preserved: when every tensor carries every contracted label (the "complete" graph case), partial sigs equal full sigs and the set intersection works as before — no performance cost.
- **General path**: iterate the cartesian product of allowed per-position charges, intersecting (over tensors that carry each label) the set of charges they actually have on that leg. For each candidate full-sig assignment, look up each tensor's matching blocks via its partial sig.

This keeps the original O(common-sig-count × per-block-pairings) cost when the graph is complete, and only pays the cartesian-product cost in the rare non-complete case.

## Test plan

Two regression tests added to `TestContractSymmetric`:

- [x] `test_multi_input_with_disjoint_contracted_legs` — the minimal repro `A=(a), B=(b), C=(a,b)` from the issue body. Asserts 3-input result matches pairwise across all orderings and matches a dense `np.einsum` reference.
- [x] `test_multi_input_dmrg_style_three_input` — triangular `X=(l,m,p), Y=(m,n), Z=(n,l)` topology mirroring in-tree DMRG/CTM call sites where each pair shares one label.
- [x] `JAX_PLATFORMS=cpu uv run pytest tests/test_contraction.py --no-cov` — all 42 contraction tests pass (40 pre-existing + 2 new).
- [x] Externally verified all original repros from the issue body across U(1)/Z2/FermionParity on shapes 2+1+1, 3+1+2, 3+2+1, 4+2+2 — 3-input and pairwise now agree to 1e-12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)