### PR TITLE
fix(fpeps): preserve canonical bond layout in SU at D>2 (#558)

### DIFF
--- a/src/tenax/algorithms/fermionic_ipeps.py
+++ b/src/tenax/algorithms/fermionic_ipeps.py
@@ -272,13 +272,18 @@ def _fpeps_simple_update_horizontal(
     theta = theta.relabel("phys_B", "sj")
     theta = contract(theta, gate)
 
-    # 5. SVD
+    # 5. SVD (per-sector keep matching canonical [i%2 for i in range(D)] —
+    # see #558: global democratic truncation lets the new bond drift from
+    # the {even: D/2, odd: D/2 (or ±1)} layout, which breaks the next SU
+    # step's contract on the unchanged opposite axis.)
+    virt_charges = np.array([i % 2 for i in range(max_D)], dtype=np.int32)
     U, sigma, Vh, s_full = truncated_svd(
         theta,
         left_labels=["u", "d", "l", "si_out"],
         right_labels=["u_B", "d_B", "r_B", "sj_out"],
         new_bond_label="r_new",
         max_singular_values=max_D,
+        base_charges=virt_charges,
     )
     # U has labels: (u, d, l, si_out, r_new)
 
@@ -350,13 +355,15 @@ def _fpeps_simple_update_vertical(
     theta = theta.relabel("phys_B", "sj")
     theta = contract(theta, gate)
 
-    # 5. SVD
+    # 5. SVD (per-sector keep matching canonical layout — see #558)
+    virt_charges = np.array([i % 2 for i in range(max_D)], dtype=np.int32)
     U, sigma, Vh, s_full = truncated_svd(
         theta,
         left_labels=["u", "l", "r", "si_out"],
         right_labels=["d_B", "l_B", "r_B", "sj_out"],
         new_bond_label="d_new",
         max_singular_values=max_D,
+        base_charges=virt_charges,
     )
     # U has labels: (u, l, r, si_out, d_new)
 

--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -275,8 +275,47 @@ def _truncated_svd_symmetric(
 
     n_keep = max(1, min(n_keep, n_total))
 
-    # Count per-sector keep
-    kept = all_sv_pairs[:n_keep]
+    # Select which singular values to keep.
+    # When ``base_charges`` is supplied with ``max_singular_values``, allocate
+    # keep counts per sector to match the canonical layout, mirroring the
+    # traced-path behavior in ``_truncated_svd_symmetric_traced``. This is the
+    # right policy whenever the caller needs a fixed bond charge structure
+    # (e.g. fPEPS simple update — #558 — where ``A.l`` and ``A.r`` are the
+    # same physical bond and the next step crashes if the SVD lets one drift).
+    # Without ``base_charges`` the historical global "democratic" truncation is
+    # retained — it minimises 2-norm truncation error and is the standard
+    # choice for DMRG.
+    if base_charges is not None and max_singular_values is not None:
+        from tenax.algorithms._ctm_utils import _derive_charges
+
+        target_charges = _derive_charges(base_charges, max_singular_values)
+        target_count: dict[int, int] = {}
+        for tq in target_charges:
+            target_count[int(tq)] = target_count.get(int(tq), 0) + 1
+        available = {q: len(sector_results[q][1]) for q in sector_results}
+        k_per_sector = {q: min(target_count.get(q, 0), available[q]) for q in available}
+        remaining = n_keep - sum(k_per_sector.values())
+        if remaining > 0:
+            for q in sorted(
+                available.keys(),
+                key=lambda qq: (-(available[qq] - k_per_sector.get(qq, 0)), qq),
+            ):
+                if remaining <= 0:
+                    break
+                capacity_left = available[q] - k_per_sector.get(q, 0)
+                take = min(remaining, capacity_left)
+                if take > 0:
+                    k_per_sector[q] = k_per_sector.get(q, 0) + take
+                    remaining -= take
+        kept = []
+        for q, k in k_per_sector.items():
+            if k <= 0:
+                continue
+            sector_pairs = [p for p in all_sv_pairs if p[1] == q]
+            kept.extend(sector_pairs[:k])
+        kept.sort(key=lambda x: -x[0])
+    else:
+        kept = all_sv_pairs[:n_keep]
 
     # Build bond charges and singular values in global descending order
     # so that s_final[k] pairs with U[:,k] and Vh[k,:].

--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -307,13 +307,41 @@ def _truncated_svd_symmetric(
                 if take > 0:
                     k_per_sector[q] = k_per_sector.get(q, 0) + take
                     remaining -= take
+
+        # Emit ``kept`` (and therefore ``bond_charges``/``s_final``) in the
+        # caller's canonical position order, *not* in global SV-magnitude
+        # order. This matters because downstream code (fPEPS SU, traced path
+        # consumers) applies the returned ``sigma``/``lam`` to the opposite
+        # bond axis -- whose ``idx.charges`` is the canonical pattern -- via
+        # ``scale_bond_axis``, which slices the scale vector by position
+        # under ``np.where(idx.charges == q)``.  Mismatched ordering would
+        # multiply the wrong charge sectors and silently corrupt the state
+        # without crashing (PR #560 codex review).
+        #
+        # Pre-build per-sector lists of (value, q, idx_in_sector) sorted
+        # within-sector descending. all_sv_pairs is globally descending, so
+        # filtering by q preserves within-sector descending order.
+        per_sector_pool: dict[int, list[tuple[float, int, int]]] = {}
+        for p in all_sv_pairs:
+            per_sector_pool.setdefault(p[1], []).append(p)
+
         kept = []
-        for q, k in k_per_sector.items():
-            if k <= 0:
-                continue
-            sector_pairs = [p for p in all_sv_pairs if p[1] == q]
-            kept.extend(sector_pairs[:k])
-        kept.sort(key=lambda x: -x[0])
+        used = {q: 0 for q in k_per_sector}
+        # Phase 1: fill in canonical-position order until target_charges is
+        # exhausted *or* a sector runs out of its k_per_sector quota.
+        for tq in target_charges:
+            q = int(tq)
+            if used.get(q, 0) < k_per_sector.get(q, 0):
+                kept.append(per_sector_pool[q][used[q]])
+                used[q] += 1
+        # Phase 2: append any remaining quota for sectors that got more from
+        # greedy fill than target_count requested.  These tail entries don't
+        # have a canonical position in ``base_charges`` -- placing them at
+        # the end preserves sector-grouped contiguity for the overflow.
+        for q in sorted(k_per_sector.keys()):
+            while used[q] < k_per_sector[q]:
+                kept.append(per_sector_pool[q][used[q]])
+                used[q] += 1
     else:
         kept = all_sv_pairs[:n_keep]
 

--- a/tests/test_fermionic_ipeps.py
+++ b/tests/test_fermionic_ipeps.py
@@ -310,6 +310,32 @@ class TestFPEPSSimpleUpdate:
         A_after = A_opt.todense()
         assert not jnp.allclose(A_before, A_after)
 
+    @pytest.mark.parametrize("D", [3, 4])
+    def test_simple_update_preserves_bond_layout_at_Dgt2(self, D):
+        """Regression for #558.
+
+        At D>2 the SU's truncated_svd used global democratic truncation, which
+        let the new `r` bond drift from the canonical {even: D/2, odd: D/2}
+        block layout. On the next step the contract(A_left, B_right) on the
+        unchanged `l` axis vs the new `r` axis triggered an opt_einsum size
+        mismatch. Per-sector keep allocation (via base_charges) preserves the
+        canonical layout and lets SU continue across many steps.
+        """
+        cfg = FPEPSConfig(D=D, t=1.0, V=0.0, dt=0.01)
+        A = _initialize_fpeps(cfg, jax.random.PRNGKey(0))
+        H = spinless_fermion_gate(cfg)
+        A_opt, _, _ = _fpeps_simple_update(A, H, max_D=cfg.D, dt=cfg.dt, steps=5)
+        for axis_label in ("u", "d", "l", "r"):
+            ax = A_opt.labels().index(axis_label)
+            idx = A_opt.indices[ax]
+            assert idx.dim == D, f"axis {axis_label!r} dim {idx.dim} != D={D}"
+            charges = sorted(int(c) for c in idx.charges)
+            expected = sorted([i % 2 for i in range(D)])
+            assert charges == expected, (
+                f"axis {axis_label!r} charges {charges} != canonical {expected}"
+            )
+        assert jnp.all(jnp.isfinite(A_opt.todense()))
+
 
 # ------------------------------------------------------------------ #
 # Task 7: fpeps (entry point)                                          #

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -155,3 +155,97 @@ class TestImportCompat:
 
         assert truncated_svd is linalg_svd
         assert svd_top is linalg_svd
+
+
+# ------------------------------------------------------------------ #
+# base_charges per-sector keep on the eager path (#558)               #
+# ------------------------------------------------------------------ #
+
+
+class TestSvdBaseChargesEagerPath:
+    """Eager-path block-sparse SVD honors base_charges for per-sector keep.
+
+    The eager path historically did global democratic truncation regardless
+    of base_charges (only the traced/AD path consumed it). Callers that
+    depend on a canonical bond layout being preserved across iterations
+    (fpeps SU at D>2 — #558) need per-sector keep matching base_charges.
+    Tests cover both fermionic and bosonic symmetries since the SVD code is
+    shared.
+    """
+
+    def _build_2leg_sym(self, sym, left_charges, right_charges, seed=0):
+        idx_l = TensorIndex.from_charges(sym, left_charges, IN, label="l")
+        idx_r = TensorIndex.from_charges(sym, right_charges, OUT, label="r")
+        return SymmetricTensor.random_normal((idx_l, idx_r), jax.random.PRNGKey(seed))
+
+    def test_eager_base_charges_preserves_canonical_layout_u1(self):
+        """U(1) eager SVD with base_charges keeps {-1:1, 0:1, 1:1} layout."""
+        from tenax.linalg import svd
+
+        sym = U1Symmetry()
+        charges = np.array([-1, 0, 1, -1, 0, 1], dtype=np.int32)
+        T = self._build_2leg_sym(sym, charges, charges, seed=11)
+        # Canonical layout has 2 of each charge; ask for 3 total to force a
+        # choice. Without base_charges, global truncation may keep 3 from one
+        # sector. With base_charges=[-1,0,1], we expect exactly {-1:1,0:1,1:1}.
+        U, s, Vh, _ = svd(
+            T,
+            left_labels=["l"],
+            right_labels=["r"],
+            new_bond_label="bond",
+            max_singular_values=3,
+            base_charges=np.array([-1, 0, 1], dtype=np.int32),
+        )
+        bond_idx = U.indices[U.labels().index("bond")]
+        counts = {int(q): 0 for q in (-1, 0, 1)}
+        for q in bond_idx.charges:
+            counts[int(q)] += 1
+        assert counts == {-1: 1, 0: 1, 1: 1}, (
+            f"bond charges {bond_idx.charges.tolist()} not balanced — "
+            f"got counts {counts}"
+        )
+        assert s.shape == (3,)
+
+    def test_eager_base_charges_preserves_canonical_layout_fermionic(self):
+        """FermionParity eager SVD with base_charges keeps {0:2, 1:2}."""
+        from tenax.core.symmetry import FermionParity
+        from tenax.linalg import svd
+
+        sym = FermionParity()
+        charges = np.array([0, 1, 0, 1, 0, 1, 0, 1], dtype=np.int32)
+        T = self._build_2leg_sym(sym, charges, charges, seed=22)
+        U, s, Vh, _ = svd(
+            T,
+            left_labels=["l"],
+            right_labels=["r"],
+            new_bond_label="bond",
+            max_singular_values=4,
+            base_charges=np.array([0, 1, 0, 1], dtype=np.int32),
+        )
+        bond_idx = U.indices[U.labels().index("bond")]
+        counts = {0: 0, 1: 0}
+        for q in bond_idx.charges:
+            counts[int(q)] += 1
+        assert counts == {0: 2, 1: 2}, (
+            f"fermionic bond charges {bond_idx.charges.tolist()} not balanced — "
+            f"got counts {counts}"
+        )
+        assert s.shape == (4,)
+
+    def test_eager_no_base_charges_keeps_global_truncation(self):
+        """Without base_charges, eager SVD still does global democratic keep."""
+        from tenax.linalg import svd
+
+        sym = U1Symmetry()
+        charges = np.array([-1, 0, 1, -1, 0, 1], dtype=np.int32)
+        T = self._build_2leg_sym(sym, charges, charges, seed=33)
+        U, s, Vh, _ = svd(
+            T,
+            left_labels=["l"],
+            right_labels=["r"],
+            new_bond_label="bond",
+            max_singular_values=3,
+        )
+        # No constraint asserted on bond charge distribution — just that we
+        # got 3 singular values total (global truncation).
+        assert s.shape == (3,)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -249,3 +249,65 @@ class TestSvdBaseChargesEagerPath:
         # No constraint asserted on bond charge distribution — just that we
         # got 3 singular values total (global truncation).
         assert s.shape == (3,)
+
+    def test_eager_base_charges_emits_kept_in_canonical_position_order(self):
+        """bond_charges + s_final follow base_charges position order, not SV magnitude.
+
+        Codex review of PR #560 flagged: emitting kept in global SV-magnitude
+        order silently corrupts downstream ``scale_bond_axis`` calls on the
+        unchanged opposite bond axis (whose ``idx.charges`` is the canonical
+        pattern). The scale vector slice ``scale[np.where(idx.charges == q)]``
+        then picks values that are NOT actually for sector q.
+
+        Test: build a SymmetricTensor whose theta SVD has clearly-ordered
+        singular values per sector (charge=1 sector dominates charge=0 by
+        construction), then verify that after the eager SVD with
+        base_charges, ``s_final[i]`` is the within-sector i-th value for the
+        sector ``base_charges[i]`` — i.e., the lambda vector lines up with
+        canonical positions.
+        """
+        from tenax.core.symmetry import FermionParity
+        from tenax.linalg import svd
+
+        sym = FermionParity()
+        # 4-dim virtual leg with 2 even (charge 0) and 2 odd (charge 1).
+        charges = np.array([0, 1, 0, 1], dtype=np.int32)
+        idx_l = TensorIndex.from_charges(sym, charges, IN, label="l")
+        idx_r = TensorIndex.from_charges(sym, charges, OUT, label="r")
+        # Build a tensor where sector 1 has clearly larger SVs than sector 0,
+        # so global ordering would interleave [1, ..., 0, ...] differently
+        # from canonical [0, 1, 0, 1].
+        T_dense = np.zeros((4, 4), dtype=np.float64)
+        # Sector 0 block (positions [0, 2] x [0, 2]):
+        T_dense[0, 0] = 2.0  # smaller singular values for sector 0
+        T_dense[2, 2] = 1.0
+        # Sector 1 block (positions [1, 3] x [1, 3]):
+        T_dense[1, 1] = 10.0  # larger singular values for sector 1
+        T_dense[3, 3] = 5.0
+        T = SymmetricTensor.from_dense(T_dense, (idx_l, idx_r))
+
+        U, s, Vh, _ = svd(
+            T,
+            left_labels=["l"],
+            right_labels=["r"],
+            new_bond_label="bond",
+            max_singular_values=4,
+            base_charges=np.array([0, 1, 0, 1], dtype=np.int32),
+        )
+        bond_idx = U.indices[U.labels().index("bond")]
+        bond_charges = bond_idx.charges.tolist()
+        s_vals = np.array(s).tolist()
+
+        # Canonical: positions 0, 2 are sector 0; positions 1, 3 are sector 1.
+        # If kept is in canonical order, bond_charges == [0, 1, 0, 1].
+        # If kept is in global SV order, bond_charges would be [1, 1, 0, 0]
+        # (sectors interleaved by SV magnitude).
+        assert bond_charges == [0, 1, 0, 1], (
+            f"bond_charges {bond_charges} not in canonical [0,1,0,1] order — "
+            f"would silently corrupt scale_bond_axis on opposite axis"
+        )
+        # s_final[0] = top SV of sector 0 = 2.0
+        # s_final[1] = top SV of sector 1 = 10.0
+        # s_final[2] = 2nd SV of sector 0 = 1.0
+        # s_final[3] = 2nd SV of sector 1 = 5.0
+        np.testing.assert_allclose(s_vals, [2.0, 10.0, 1.0, 5.0], atol=1e-10)


### PR DESCRIPTION
## Summary

Closes #558. The eager-path block-sparse SVD (`_truncated_svd_symmetric`) did global democratic truncation regardless of `base_charges` — only the traced/AD path consumed it. fPEPS simple update at `D>2` needs the bond charge distribution fixed to the canonical `[i%2 for i in range(D)]` pattern because `A.l` and `A.r` are the same physical bond on a translation-invariant 1-site iPEPS; if the SVD lets `A.r` drift to e.g. `{0:1, 1:3}`, the next step's `contract(A_left, B_right)` crashes with an opt_einsum size mismatch.

## Root cause

After step 0 of horizontal SU at `D=4`:
- A's `r` axis: blocks `{(*, 0, *): dim 1}` and `{(*, 1, *): dim 3}` (drifted from canonical `{0:2, 1:2}`)
- A's `l` axis: unchanged at canonical `{0:2, 1:2}`

Step 1 then does `contract(A_left.r, B_right.l)` on the same physical bond. Block-sparse contractor's per-block opt_einsum call fails:
```
ValueError: Size of label 'g' for operand 1 (3) does not match previous terms (2).
```

## Fix

Two minimal changes (one logic block + two call-site wirings):

1. `src/tenax/linalg.py` — extend the eager `_truncated_svd_symmetric` to honor `base_charges` for per-sector keep allocation. Mirrors the traced path's behavior at `_truncated_svd_symmetric_traced` (lines 510–542): derive a target per-sector keep count, clamp by available SVs per sector, greedy-fill the remaining budget. When `base_charges is None` the historical global democratic truncation is unchanged.

2. `src/tenax/algorithms/fermionic_ipeps.py` — pass `base_charges=virt_charges` (canonical `[i%2 for i in range(D)]`) from both `_fpeps_simple_update_horizontal` and `_fpeps_simple_update_vertical` SVD calls.

## Tests

- `tests/test_fermionic_ipeps.py::TestFPEPSSimpleUpdate::test_simple_update_preserves_bond_layout_at_Dgt2[3,4]` — regression: runs 5 SU steps at `D∈{3,4}`, asserts every virtual axis keeps the canonical `[i%2 for i in range(D)]` charge layout. **Fails on `main`** without the fix.
- `tests/test_linalg.py::TestSvdBaseChargesEagerPath` — 3 new tests covering U(1) per-sector keep, FermionParity per-sector keep, and the no-`base_charges` global-keep path.

End-to-end verification: `D=4` `fpeps()` now runs (was crashing on step 1). Quick smoke (`D=4, χ=12, V=0.5, 20 SU steps`) finishes in 33.8s producing `E ≈ +0.0089`.

## Bosonic-path check

- Bosonic 2-site iPEPS SU uses `DenseTensor` (no charge bookkeeping) → unaffected.
- TRG and DMRG use `truncated_svd` but intentionally let bond charges drift between steps → also unaffected (they don't pass `base_charges`).
- The change is **opt-in**; every existing caller in the codebase sees identical behavior.

## Not addressed here

#559 (D=3 CTM crash in `_ctm_tensor_move_vertical`, label `'d'` size 8 vs 7) is a separate code path and remains open. With this PR, SU at D=3 works but CTM still crashes — independent fix needed.

## Test plan
- [x] `pytest tests/test_fermionic_ipeps.py tests/test_linalg.py` — 46/46 pass.
- [x] `examples/bench_tV_D4.py` smoke at small params — fpeps completes (no crash).
- [ ] Full CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)