### PR TITLE
fix(fermionic): remove split-CTM shim fallback now that #557 closed the algebra

### DIFF
--- a/src/tenax/algorithms/_split_ctm_tensor_energy.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_energy.py
@@ -24,24 +24,7 @@ from tenax.algorithms._tensor_utils import fuse_indices
 from tenax.contraction.contractor import contract
 from tenax.core import EPS
 from tenax.core.index import FlowDirection
-from tenax.core.tensor import SymmetricTensor, Tensor
-
-
-def _is_fermionic_site(A: Tensor) -> bool:
-    """Return True iff *A* is a SymmetricTensor with a fermionic symmetry.
-
-    Used by ``compute_energy_split_ctm_tensor*`` to detect when the split-aware
-    energy path would carry a stale ``A.bar()`` Koszul phase that the
-    standard double-layer path's ``fuse_indices`` would otherwise cancel (see
-    issue #392).  In that regime we fall back to the shim path, accepting the
-    standard ``chi²·D⁶`` peak (vs the split-aware ``chi²·D⁴·d`` floor) in
-    exchange for a fermion-correct result.
-    """
-    if not isinstance(A, SymmetricTensor):
-        return False
-    sym = A.indices[0].symmetry if A.indices else None
-    return bool(sym is not None and getattr(sym, "is_fermionic", False))
-
+from tenax.core.tensor import Tensor
 
 # Below this |trace| the unnormalized mixed-env RDM is treated as
 # catastrophically cancelling: dividing by the trace amplifies ~4e-18 rounding
@@ -1122,12 +1105,6 @@ def compute_energy_split_ctm_tensor(
     ``(T_ket, T_bra, A, A.bar())``, without merging ket/bra to the
     standard double-layer env. Bounded peak intermediate ~chi^2 * D^4.
 
-    For fermionic sites the split-aware path used to carry a stale
-    ``bar_super`` Koszul phase that ``fuse_indices`` couldn't cancel (#392).
-    Post-#555 (removal of the contractor's auto-Koszul + bar_super phase),
-    that convention mismatch should no longer exist; #392's shim fallback
-    remains in place until #392 is re-validated against the new convention.
-
     Args:
         A:                iPEPS site tensor with labels ``(u, d, l, r, phys)``.
         env:              Converged SplitCTMTensorEnv.
@@ -1137,13 +1114,6 @@ def compute_energy_split_ctm_tensor(
     Returns:
         Scalar energy per site.
     """
-    if _is_fermionic_site(A):
-        from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
-
-        return compute_energy_ctm_tensor(
-            A, _split_env_to_tensor_standard(env), hamiltonian_gate, d
-        )
-
     if d is None:
         phys_idx = [i for i in A.indices if i.label == "phys"]
         d = phys_idx[0].dim if phys_idx else A.indices[-1].dim
@@ -1170,9 +1140,6 @@ def compute_energy_split_ctm_tensor_2site(
 ) -> jax.Array:
     """Compute energy per site for a 2-site checkerboard iPEPS, split-aware.
 
-    Falls back to the shim path for fermionic sites (issue #392) — see
-    :func:`compute_energy_split_ctm_tensor` for details.
-
     Args:
         A:                Site tensor for sublattice A.
         B:                Site tensor for sublattice B.
@@ -1184,18 +1151,6 @@ def compute_energy_split_ctm_tensor_2site(
     Returns:
         Scalar energy per site.
     """
-    if _is_fermionic_site(A) or _is_fermionic_site(B):
-        from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor_2site
-
-        return compute_energy_ctm_tensor_2site(
-            A,
-            B,
-            _split_env_to_tensor_standard(env_A),
-            _split_env_to_tensor_standard(env_B),
-            hamiltonian_gate,
-            d,
-        )
-
     if d is None:
         phys_idx = [i for i in A.indices if i.label == "phys"]
         d = phys_idx[0].dim if phys_idx else A.indices[-1].dim
@@ -1230,9 +1185,6 @@ def compute_energy_split_ctm_tensor_multisite(
 
     Each bond is counted once. Energy is normalized by the number of sites.
 
-    Falls back to the shim path when any site is fermionic (issue #392) — see
-    :func:`compute_energy_split_ctm_tensor` for details.
-
     Args:
         site_tensors: ``{coord: Tensor}`` mapping coordinates to iPEPS site tensors.
         envs:         ``{coord: SplitCTMTensorEnv}`` converged split environments per site.
@@ -1244,18 +1196,6 @@ def compute_energy_split_ctm_tensor_multisite(
     Returns:
         Scalar energy per site.
     """
-    if any(_is_fermionic_site(site) for site in site_tensors.values()):
-        from tenax.algorithms._ctm_tensor_energy import (
-            compute_energy_ctm_tensor_multisite,
-        )
-
-        std_envs = {
-            coord: _split_env_to_tensor_standard(env) for coord, env in envs.items()
-        }
-        return compute_energy_ctm_tensor_multisite(
-            site_tensors, std_envs, neighbors, gate, d
-        )
-
     # Infer physical dimension
     if d is None:
         first_A = next(iter(site_tensors.values()))

--- a/tests/test_split_ctm_tensor.py
+++ b/tests/test_split_ctm_tensor.py
@@ -791,26 +791,25 @@ class TestSplitRDMs:
 
 @pytest.mark.slow
 class TestSplitRDMsFermionic:
-    """Parity vs shim with FermionParity site tensors (Tier 2).
+    """Native split-aware energy matches shim on FermionParity sites (#392).
 
-    Bosonic parity tests don't exercise ``A.bar_super()``'s Koszul-twist /
-    flow-flip handling.  The split-aware path's per-leg ``A.bar_super()``
-    absorption carries a stale Koszul phase that ``_build_double_layer_open_tensor``'s
-    raw ``fuse_indices`` would otherwise cancel; until the convention mismatch
-    in the split-aware RDM functions is resolved (issue #392),
-    ``compute_energy_split_ctm_tensor`` falls back to the shim path
-    automatically when the site is fermionic.  This parity test verifies
-    that the fall-back is wired up correctly: split-CTM-on-fermionic must
-    return the shim's energy to machine precision.
+    Pre-#555 the split-aware path absorbed an extra Koszul phase via
+    ``A.bar_super()`` that ``_build_double_layer_open_tensor``'s raw
+    ``fuse_indices`` (used by the standard path) couldn't cancel; the
+    energies disagreed once the bra was non-trivial.  PR #557 removed both
+    the contractor's auto-Koszul and ``bar_super()`` (only ``A.bar()``
+    remains), eliminating the convention mismatch.  The fermionic shim
+    fallback that ``compute_energy_split_ctm_tensor`` used to apply is now
+    gone, so this parity test exercises the native ``chi²·D⁴`` split-aware
+    contraction directly.
 
     Note on chi choice: with ``FermionParity`` virtual charges (alternating
     0/1), ``ctm_split_tensor`` converges cleanly at every chi after the
     fix for issue #391 (canonical SVD-bond charges shared between ket and
-    bra).  Pre-fix this test only exercised chi=6 and chi=12 because
-    intermediate chi values crashed in the projector path.
+    bra).
     """
 
-    @pytest.mark.parametrize("D, chi", [(2, 6), (3, 12)])
+    @pytest.mark.parametrize("D, chi", [(2, 6), (2, 8), (3, 12)])
     def test_fermionic_energy_matches_shim(self, D, chi, heisenberg_gate):
         from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
         from tenax.algorithms._split_ctm_tensor_energy import (


### PR DESCRIPTION
## Summary

Issue #392 reported that the χ²·D⁴ split-aware fermionic energy path (`compute_energy_split_ctm_tensor*`) disagreed with the standard χ²·D⁶ shim once the bra was non-trivial. PR #394 routed fermionic input through the shim to keep the parity test green, accepting the χ²·D⁶ memory cost.

PR #557 removed the two sources of the spurious sign:
- The contractor's auto-Koszul (mis-applied to planar networks; #555 root cause)
- `A.bar_super()` (extra per-block phase that `fuse_indices` couldn't cancel)

This PR re-validates the split-aware path against the shim with both fixes in place, and removes the fallback now that they agree.

## Verification

Probed `compute_energy_split_ctm_tensor` natively (bypassing `_is_fermionic_site`) vs the shim on the same `make_random_fermionic_site(D, d=2, seed=70)` tensor used by `TestSplitRDMsFermionic`:

| (D, χ) | E_split (native) | E_shim | \|diff\| |
|---|---|---|---|
| (2, 6)  | -0.0591871172 | -0.0591871172 | < 1e-10 |
| (2, 8)  | -0.0591871172 | -0.0591871172 | < 1e-10 |
| (3, 12) | +0.0512894545 | +0.0512894545 | < 1e-10 |

All three pass `atol=1e-10`. The (D=2, χ=8) case is new vs the original parity test — added as a third parametrise so the regression net covers an intermediate χ that pre-#391 used to crash in the projector path.

## Changes

- Drop `_is_fermionic_site` helper and the three call-site guards in `compute_energy_split_ctm_tensor`, `_2site`, `_multisite`.
- Remove the now-unused `SymmetricTensor` import.
- Rewrite `TestSplitRDMsFermionic` docstring to reflect that it now exercises the native split-aware path directly.
- Add `(D=2, χ=8)` to the parametrise.

## Test plan

- [x] `pytest tests/test_split_ctm_tensor.py::TestSplitRDMsFermionic -xvs --no-cov` → 3 passed in 308s on Python 3.11 CPU
- [ ] CI tests pass (Python 3.11 + 3.12 + macOS)

Closes #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)