### PR TITLE
fix(ipeps): preserve canonical bond layout in 2-site SU at D>2 (#563)

### DIFF
--- a/src/tenax/algorithms/ipeps_simple_update.py
+++ b/src/tenax/algorithms/ipeps_simple_update.py
@@ -75,13 +75,19 @@ def _simple_update_2site_horizontal_tensor(
     theta = theta.relabel("phys_B", "sj")
     theta = contract(theta, gate)
 
-    # 5. Truncated SVD
+    # 5. Truncated SVD — preserve the canonical layout of the old horizontal
+    #    bond (A.r) in the new bond. For fermionic SymmetricTensor inputs this
+    #    keeps the per-parity-sector keep COUNTS canonical at D>2 (#558/#559
+    #    in the single-site path; same root cause here per #563). For
+    #    DenseTensor (trivial-charge) inputs base_charges is a no-op.
+    base_charges = np.asarray(A.indices[A.labels().index("r")].charges)
     U, sigma, Vh, s_full = truncated_svd(
         theta,
         left_labels=["u", "d", "l", "si_out"],
         right_labels=["u_B", "d_B", "r_B", "sj_out"],
         new_bond_label="bond_new",
         max_singular_values=max_D,
+        base_charges=base_charges,
     )
 
     # 6. New lambda (normalized)
@@ -177,13 +183,17 @@ def _simple_update_2site_vertical_tensor(
     theta = theta.relabel("phys_B", "sj")
     theta = contract(theta, gate)
 
-    # 5. Truncated SVD
+    # 5. Truncated SVD — preserve the canonical layout of the old vertical
+    #    bond (A.d) in the new bond. See horizontal counterpart above for the
+    #    rationale (#563).
+    base_charges = np.asarray(A.indices[A.labels().index("d")].charges)
     U, sigma, Vh, s_full = truncated_svd(
         theta,
         left_labels=["u", "l", "r", "si_out"],
         right_labels=["d_B", "l_B", "r_B", "sj_out"],
         new_bond_label="bond_new",
         max_singular_values=max_D,
+        base_charges=base_charges,
     )
 
     # 6. New lambda (normalized)

--- a/tests/test_fermionic_ipeps.py
+++ b/tests/test_fermionic_ipeps.py
@@ -337,6 +337,86 @@ class TestFPEPSSimpleUpdate:
         assert jnp.all(jnp.isfinite(A_opt.todense()))
 
 
+class TestFPEPS2SiteSimpleUpdate:
+    """Tests for the 2-site bipartite simple update on FermionParity sites.
+
+    The 2-site SU (``_simple_update_2site_horizontal_tensor`` /
+    ``_simple_update_2site_vertical_tensor``) is polymorphic over the Tensor
+    protocol, so it accepts FermionParity inputs. At D>2 the truncated SVD
+    inside must preserve the canonical ``[i % 2 for i in range(D)]`` bond
+    layout (#563); otherwise the new bond drifts and the next SU step's
+    contractions trip on per-axis charge-order mismatches (same root cause
+    as #558/#559 in the 1-site path).
+    """
+
+    @staticmethod
+    def _make_fermionic_AB(D, key, d=2):
+        sym = FermionParity()
+        virt = np.array([i % 2 for i in range(D)], dtype=np.int32)
+        phys = np.array([0, 1], dtype=np.int32)
+
+        def _indices():
+            return (
+                TensorIndex.from_charges(sym, virt, FlowDirection.OUT, label="u"),
+                TensorIndex.from_charges(sym, virt, FlowDirection.IN, label="d"),
+                TensorIndex.from_charges(sym, virt, FlowDirection.OUT, label="l"),
+                TensorIndex.from_charges(sym, virt, FlowDirection.IN, label="r"),
+                TensorIndex.from_charges(sym, phys, FlowDirection.IN, label="phys"),
+            )
+
+        kA, kB = jax.random.split(key)
+        A = SymmetricTensor.random_normal(_indices(), kA)
+        B = SymmetricTensor.random_normal(_indices(), kB)
+        return A, B
+
+    @pytest.mark.parametrize("D", [3, 4])
+    def test_2site_simple_update_preserves_bond_layout_at_Dgt2(self, D):
+        """20 alternating H/V 2-site SU steps at V=1 must keep the exact
+        canonical position-order ``[i % 2 for i in range(D)]`` on every
+        virtual axis of both A and B (#563).
+
+        The pre-fix code emits new-bond charges in global SV-magnitude
+        order, which (a) can keep different sector counts than canonical
+        and (b) even when counts match, scrambles position-order so
+        downstream ``scale_bond_axis(lam, axis)`` slices the wrong sectors.
+        Exact position-order matching is the discriminating check (sorted
+        counts alone can coincide pre-fix at low step counts).
+        """
+        from tenax.algorithms.ipeps_simple_update import (
+            _simple_update_2site_horizontal_tensor,
+            _simple_update_2site_vertical_tensor,
+        )
+
+        cfg = FPEPSConfig(D=D, t=1.0, V=1.0, dt=0.01)
+        A, B = self._make_fermionic_AB(D=D, key=jax.random.PRNGKey(0))
+        H = spinless_fermion_gate(cfg)
+        trotter = _trotter_gate(H, dt=cfg.dt)
+        lam_h = jnp.ones(D)
+        lam_v = jnp.ones(D)
+        for step in range(20):
+            if step % 2 == 0:
+                A, B, lam_h = _simple_update_2site_horizontal_tensor(
+                    A, B, trotter, lam_h, lam_v, D
+                )
+            else:
+                A, B, lam_v = _simple_update_2site_vertical_tensor(
+                    A, B, trotter, lam_h, lam_v, D
+                )
+
+        canonical = [i % 2 for i in range(D)]
+        for name, T in (("A", A), ("B", B)):
+            for axis_label in ("u", "d", "l", "r"):
+                ax = T.labels().index(axis_label)
+                idx = T.indices[ax]
+                assert idx.dim == D, f"{name}.{axis_label} dim {idx.dim} != D={D}"
+                charges = [int(c) for c in idx.charges]
+                assert charges == canonical, (
+                    f"{name}.{axis_label} position-order {charges} "
+                    f"!= canonical {canonical}"
+                )
+            assert jnp.all(jnp.isfinite(T.todense()))
+
+
 # ------------------------------------------------------------------ #
 # Task 7: fpeps (entry point)                                          #
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary

Issue #563 — at D>2 the 2-site bipartite simple update's truncated SVD picked the top-D singular values in global magnitude order, scrambling the canonical \`[i % 2 for i in range(D)]\` position-order of the new bond. Same root cause as #558/#559 in the 1-site fermionic path (closed by PR #560); the 2-site path was never patched.

## Fix

Extract \`base_charges\` from the OLD bond's \`TensorIndex.charges\` on the input — \`A.r\` for horizontal, \`A.d\` for vertical — and pass to \`truncated_svd\`. This is **symmetry-agnostic**:

- **DenseTensor / trivial-symmetry input**: charges are all-zeros → \`base_charges=[0,…,0]\` is a no-op; behavior unchanged.
- **U(1) / FermionParity / FermionicU1 input**: the SVD's per-sector keep + canonical-position emission (post-#560 + #561 eager path) preserves whatever layout the input had.

No new parameter on the public signature; the input's own bond charges carry the layout intent.

## Verification

### Discriminating regression test

\`tests/test_fermionic_ipeps.py::TestFPEPS2SiteSimpleUpdate::test_2site_simple_update_preserves_bond_layout_at_Dgt2[D]\` — 20 alternating H/V steps at V=1, exact position-order check (sorted counts alone can coincide pre-fix at low step counts).

**Pre-fix:** \`A.d position-order [0, 1, 1] != canonical [0, 1, 0]\` at D=3 step 20 → AssertionError.
**Post-fix:** \`D ∈ {3, 4}\` both PASS.

### Existing tests untouched

\`pytest tests/test_ipeps.py::TestTensor2SiteSimpleUpdate tests/test_fermionic_ipeps.py -m \"not slow\"\` → 40 passed, no regressions.

## Motivation

The 2-site bipartite fPEPS bench (\`examples/bench_tV_2site_mu.py\`, post-#562) found the CDW correctly at V≥2 with D=2 (CDW order ≈ 1, E_with_μ matches analytical pure-CDW PH-symmetric value of -V/site to 4 decimals). To resolve quantum fluctuations on top of the CDW — O(t²/V) per bond — we need D≥3, which this PR unblocks.

## Test plan

- [x] Strict position-order regression test added + verified to fail pre-fix
- [x] Full \`test_ipeps.py::TestTensor2SiteSimpleUpdate\` + \`test_fermionic_ipeps.py\` non-slow: 40 passed
- [ ] CI green on Python 3.11 + 3.12 + macOS

Closes #563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)