### PR TITLE
fix(ipeps): de-silence symmetric/fermionic AD first-step compile (#565)

### DIFF
--- a/docs/guide/algorithms/fpeps.md
+++ b/docs/guide/algorithms/fpeps.md
@@ -61,6 +61,28 @@ print(f"E/site = {energy:.8f}")
   pipeline: simple update + CTM + energy.
 - ``spinless_fermion_gate(t, V, dt=None)`` — build the t-V model gate.
 - ``FPEPSConfig`` — configuration dataclass.
+- ``optimize_fpeps_ad(hamiltonian_gate, A_init, config, fpeps_config=None)`` —
+  AD-based ground-state optimization (1-site). For a 2-site unit cell use
+  ``optimize_gs_ad(gate, (A, B), config)`` with ``config.unit_cell="2site"``.
+
+## Performance: AD compile cost on symmetric tensors
+
+The AD path differentiates through the CTM fixed point. The backward is
+traced and XLA-compiled **once per optimizer run** (then reused across
+steps), but for block-sparse ``SymmetricTensor`` site tensors that single
+trace+compile scales with the **number of charge blocks** — hence with the
+symmetry's sector count and with ``D``/``chi``. This is *not* specific to
+fermions: any charge-conserving iPEPS AD (U(1), Zₙ, FermionParity) is
+affected; fermionic tensors simply always carry non-trivial parity sectors.
+
+Practical consequence: the **first** gradient step can take from seconds (a
+single block) to many minutes (large ``D``/``chi`` with many blocks). With
+``gs_verbose=True`` a one-time notice is printed before step 1 so the wait is
+not mistaken for a hang. Subsequent steps reuse the compiled backward and are
+fast. If the first step seems stuck, it is almost always compiling, not
+deadlocked. The underlying compile-time scaling — and the plan to fix it via
+sweep-level block batching — is tracked in
+[issue #566](https://github.com/tenax-lab/tenax/issues/566).
 
 ## References
 

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1178,6 +1178,27 @@ def _optimize_gs_ad_tensor_reference_c4v(
     return final_A, final_env, float(final_energy)
 
 
+def _log_ad_compile_notice(config) -> None:
+    """Emit a one-time, verbose-gated notice before the first gradient step.
+
+    Step 1 traces and XLA-compiles the CTM backward.  For block-sparse
+    (symmetric / fermionic) site tensors this trace+compile scales with the
+    number of charge blocks and can take minutes at larger ``D``/``chi`` —
+    a *one-time* cost per optimizer run (the implicit-AD backward is cached
+    across steps).  Without this notice the first step looks like a silent
+    hang, which is exactly how issue #565 was reported.  The underlying
+    compile-time scaling is tracked in issue #566.
+    """
+    if config.gs_verbose:
+        print(
+            "[iPEPS-AD] Tracing + compiling the CTM backward for step 1 "
+            "(one-time per run). For block-sparse symmetric/fermionic "
+            "tensors this scales with charge-block count and can take "
+            "minutes at larger D/chi — see issue #566.",
+            flush=True,
+        )
+
+
 def _optimize_gs_ad_tensor(
     hamiltonian_gate: jax.Array,
     A_init: Tensor,
@@ -1527,6 +1548,7 @@ def _optimize_gs_ad_tensor(
                 patience = p
         return patience
 
+    _log_ad_compile_notice(config)
     for step in range(config.gs_num_steps):
         # Update conv_tol if schedule is active
         if _conv_tol_schedule is not None:
@@ -2878,6 +2900,7 @@ def _optimize_gs_ad_tensor_2site(
         _prev_norm_diag = None
 
     try:
+        _log_ad_compile_notice(config)
         for step in range(start_step, config.gs_num_steps):
             # Snapshots for checkpoint "did chi change / new best" detection.
             # ``best_energy`` only decreases, so a strict < comparison after

--- a/tests/test_fpeps_ad.py
+++ b/tests/test_fpeps_ad.py
@@ -11,7 +11,11 @@ from tenax.algorithms.fermionic_ipeps import (
     spinless_fermion_gate,
 )
 from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
-from tenax.algorithms.ipeps_optimize import optimize_fpeps_ad
+from tenax.algorithms.ipeps_optimize import (
+    _log_ad_compile_notice,
+    optimize_fpeps_ad,
+    optimize_gs_ad,
+)
 from tenax.core.tensor import DenseTensor, SymmetricTensor
 
 # ------------------------------------------------------------------ #
@@ -86,6 +90,91 @@ class TestOptimizeFpepsAd:
         H = spinless_fermion_gate(FPEPSConfig())
         with pytest.raises(ValueError, match="fpeps_config is required"):
             optimize_fpeps_ad(H, A_init=None, config=ipeps_config_short)
+
+
+# ------------------------------------------------------------------ #
+# #565: fermionic 2-site AD de-silencing + completion smoke test      #
+# ------------------------------------------------------------------ #
+
+
+class TestFermionic2SiteADRegression:
+    """Regression coverage for #565.
+
+    The 2-site fermionic AD path (``optimize_gs_ad(unit_cell="2site")``
+    on FermionParity input) was reported as a *silent hang*: 30+ min at
+    99% CPU with no output after the implicit-AD warning.  It is not a
+    deadlock — the cost is a one-time trace+compile of the block-sparse
+    CTM backward, which scales with charge-block count (tracked in #566).
+    Two regressions are guarded here:
+
+    1. The first-step compile notice fires (so the wait is never silent).
+    2. The path actually completes with a finite energy and preserves
+       the SymmetricTensor type — the multi-block symmetric AD that CI
+       did not previously exercise (``test_block_sparse_ctm_ad`` uses
+       trivial single-block charges).
+    """
+
+    def test_compile_notice_emitted_when_verbose(self, capsys):
+        """The de-silencing notice prints (with the #566 ref) iff verbose."""
+        verbose_cfg = iPEPSConfig(gs_verbose=True)
+        _log_ad_compile_notice(verbose_cfg)
+        out = capsys.readouterr().out
+        assert "step 1" in out and "#566" in out, out
+
+        quiet_cfg = iPEPSConfig(gs_verbose=False)
+        _log_ad_compile_notice(quiet_cfg)
+        assert capsys.readouterr().out == ""
+
+    @pytest.mark.slow
+    def test_fermionic_2site_ad_completes(self):
+        """One step of 2-site FermionParity AD completes with finite energy.
+
+        Wrapped in a generous wall-clock guard (the compile is the cost,
+        not a deadlock — see #566): a regression to a true hang fails the
+        test loudly instead of stalling the suite indefinitely.
+        """
+        import threading
+
+        fcfg = FPEPSConfig(D=2, t=1.0, V=2.0)
+        gate = spinless_fermion_gate(fcfg)
+        A = _build_initial_fpeps_tensor(fcfg, jax.random.PRNGKey(1))
+        B = _build_initial_fpeps_tensor(fcfg, jax.random.PRNGKey(2))
+        assert isinstance(A, SymmetricTensor)
+
+        config = iPEPSConfig(
+            max_bond_dim=2,
+            unit_cell="2site",
+            su_init=False,
+            gs_implicit_ad=True,
+            gs_num_steps=1,
+            gs_verbose=False,
+            ctm=CTMConfig(chi=4, max_iter=20, conv_tol=1e-4),
+        )
+
+        result: dict = {}
+
+        def _run():
+            try:
+                (A_opt, B_opt), _envs, E = optimize_gs_ad(gate, (A, B), config)
+                result.update(A_opt=A_opt, B_opt=B_opt, E=E)
+            except BaseException as exc:  # noqa: BLE001 - re-raise in main thread
+                result["exc"] = exc
+
+        # XLA compile releases the GIL, so join(timeout) on the main thread
+        # observes a real wall-clock bound.  600s is generous for D=2 chi=4
+        # (~2-4 min) yet well under the >30 min #565 hang.
+        worker = threading.Thread(target=_run, daemon=True)
+        worker.start()
+        worker.join(timeout=600.0)
+
+        assert not worker.is_alive(), (
+            "Fermionic 2-site AD did not complete within 600s — possible "
+            "regression to the #565 hang."
+        )
+        assert "exc" not in result, f"2-site fermionic AD raised: {result['exc']!r}"
+        assert np.isfinite(float(result["E"])), f"Non-finite energy: {result['E']}"
+        assert isinstance(result["A_opt"], SymmetricTensor)
+        assert isinstance(result["B_opt"], SymmetricTensor)
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## What & why

#565 reported the 2-site fermionic AD path as a **silent hang** (30+ min at 99% CPU, no output after the implicit-AD warning). Investigation showed it is **not a deadlock** — the cost is a *one-time* trace+compile of the block-sparse CTM backward.

Crucially, the cost is **general to charge-conserving iPEPS AD** (U(1) / Zₙ / FermionParity), driven by **charge-block count**, not fermion signs. Measured on a 1-site Heisenberg AD, same path/gate, only block count differing:

| tensor | # blocks | `jax.grad` wall |
|---|---|---|
| trivial U(1) charges | 1 | 17s |
| Z₂ bosonic `[0,1]` | 16 | 66s |

The deep fix (sweep-level block batching; ~110× einsum-primitive ceiling measured) is a separate, large effort tracked in **#566**. This PR is the **practical close** for #565.

## Changes

- **De-silence** (`_log_ad_compile_notice`): one-time, `gs_verbose`-gated notice before step 1 in **both** the 1-site and 2-site AD loops, so the first-step compile is never mistaken for a hang.
- **Tests** (`test_fpeps_ad.py`): a `slow` multi-block fermionic 2-site AD **completion smoke test** — the path CI never exercised (`test_block_sparse_ctm_ad` uses *trivial single-block* charges) — guarded by a generous thread-based wall-clock bound so a regression to a true hang fails loudly instead of stalling the suite; plus a fast unit test for the notice.
- **Docs** (`fpeps.md`): performance note on AD compile-cost scaling with block count, linking #566.

## Verification

- New fast notice test + slow 2-site fermionic AD smoke test pass (`277s`, well within the 600s guard).
- `test_block_sparse_ctm_ad` (forward + dense-vs-sparse energy match) and `test_contraction.py` (42) pass.
- Pre-commit (ruff + format) clean.

Closes #565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)