### PR TITLE
perf(tensor): vectorize fuse scatter / split gather loops (#569)

### DIFF
--- a/src/tenax/algorithms/_tensor_utils.py
+++ b/src/tenax/algorithms/_tensor_utils.py
@@ -362,18 +362,20 @@ def _fuse_indices_symmetric(
             full_shape[a] = fused_dim[q_f]
             new_blocks[new_key] = jnp.zeros(full_shape, dtype=block.dtype)
 
-        # Scatter sub-block elements to correct positions in fused block
+        # Scatter every sub-block slice along axis a in ONE vectorized op:
+        #   existing[..., offsets[k], ...] = block_flat[..., k, ...]  for all k.
+        # The offsets are distinct (each local index maps to a unique target),
+        # so there are no scatter collisions; and different (qa, qb) pairs own
+        # disjoint offset ranges within the fused block, so successive `.set()`
+        # calls accumulate correctly without clobbering. This replaces a
+        # per-element Python loop (one `.at[].set()` primitive per element —
+        # hundreds at large bond dim, which bloats the jaxpr/XLA compile) with
+        # a single scatter primitive (#569, Milestone A). Numerically identical
+        # to the loop (same data movement) and differentiable (scatter VJP).
         existing = new_blocks[new_key]
-        sub_size = block_flat.shape[a]
-        for local_idx in range(sub_size):
-            target = int(offsets[local_idx])
-            # Extract slice along axis a at local_idx
-            slc_src = [slice(None)] * len(new_shape)
-            slc_src[a] = local_idx
-            slc_dst = [slice(None)] * len(new_shape)
-            slc_dst[a] = target
-            existing = existing.at[tuple(slc_dst)].set(block_flat[tuple(slc_src)])
-        new_blocks[new_key] = existing
+        dst = [slice(None)] * len(new_shape)
+        dst[a] = jnp.asarray(offsets)
+        new_blocks[new_key] = existing.at[tuple(dst)].set(block_flat)
 
     obj = object.__new__(SymmetricTensor)
     obj._indices = new_indices
@@ -523,21 +525,15 @@ def _split_index_symmetric(T: SymmetricTensor, axis: int) -> SymmetricTensor:
             ma = len(positions_a[qa])
             mb = len(positions_b[qb])
 
-            # Gather elements from fused block at scatter offsets
-            sub_size = ma * mb
-            # Build new block by gathering from fused axis
-            gathered_slices = []
-            for local_idx in range(sub_size):
-                target = int(offsets[local_idx])
-                slc = [slice(None)] * ndim
-                slc[axis] = target
-                gathered_slices.append(block[tuple(slc)])
-
-            if not gathered_slices:
-                continue
-
-            # Stack along fused axis, then reshape to (ma, mb)
-            sub_block = jnp.stack(gathered_slices, axis=axis)
+            # Gather every sub-block slice along the fused axis in ONE
+            # vectorized op: sub[..., k, ...] = block[..., offsets[k], ...].
+            # A single advanced-index gather (the gathered dim stays at `axis`
+            # since it is the only advanced index) replaces a per-element
+            # Python gather + jnp.stack (#569). Numerically identical and
+            # differentiable (gather VJP = scatter-add).
+            src = [slice(None)] * ndim
+            src[axis] = jnp.asarray(offsets)
+            sub_block = block[tuple(src)]
             shape = list(sub_block.shape)
             new_shape = shape[:axis] + [ma, mb] + shape[axis + 1 :]
             sub_block = sub_block.reshape(new_shape)

--- a/tests/test_tensor_utils.py
+++ b/tests/test_tensor_utils.py
@@ -513,3 +513,90 @@ class TestDoubleLayerTensor:
             rtol=1e-5,
             err_msg="Symmetric double_layer_tensor doesn't match dense",
         )
+
+
+# ------------------------------------------------------------------ #
+# Vectorized fuse/split scatter-gather (#569, Milestone A)             #
+# ------------------------------------------------------------------ #
+
+
+class TestFuseSplitVectorized:
+    """The vectorized scatter (fuse) / gather (split) must be exactly
+    equivalent to the per-element loops they replaced — including under AD
+    and jit, and for fermionic tensors (the scatter/gather move data only,
+    so Koszul signs in the block values are carried through untouched)."""
+
+    def _u1_3leg(self, seed=0):
+        sym = U1Symmetry()
+        ch = np.array([-1, 0, 1], dtype=np.int32)
+        ch2 = np.array([0, 1], dtype=np.int32)
+        idx_a = TensorIndex.from_charges(sym, ch, FlowDirection.IN, label="a")
+        idx_b = TensorIndex.from_charges(sym, ch2, FlowDirection.IN, label="b")
+        idx_c = TensorIndex.from_charges(sym, ch, FlowDirection.OUT, label="c")
+        return SymmetricTensor.random_normal(
+            (idx_a, idx_b, idx_c), jax.random.PRNGKey(seed), dtype=jnp.float64
+        )
+
+    def test_fermionic_fuse_split_roundtrip(self):
+        from tenax.core.symmetry import FermionParity
+
+        sym = FermionParity()
+        ch = np.array([0, 0, 1, 1], dtype=np.int32)
+        idx_a = TensorIndex.from_charges(sym, ch, FlowDirection.IN, label="a")
+        idx_b = TensorIndex.from_charges(sym, ch, FlowDirection.IN, label="b")
+        idx_c = TensorIndex.from_charges(sym, ch, FlowDirection.OUT, label="c")
+        T = SymmetricTensor.random_normal(
+            (idx_a, idx_b, idx_c), jax.random.PRNGKey(1), dtype=jnp.float64
+        )
+        fused = fuse_indices(T, 0, 1, "ab", FlowDirection.IN)
+        recovered = split_index(fused, 0)
+        np.testing.assert_allclose(
+            recovered.todense(), T.todense(), rtol=1e-12, atol=1e-14
+        )
+
+    def test_fuse_split_jit_bit_identical(self):
+        # The vectorized scatter/gather must give the SAME result under jit as
+        # eager (data movement is a pure scatter/gather primitive).
+        T = self._u1_3leg(seed=2)
+        fused_eager = fuse_indices(T, 0, 1, "ab", FlowDirection.IN)
+        split_eager = split_index(fused_eager, 0)
+
+        fused_jit = jax.jit(lambda t: fuse_indices(t, 0, 1, "ab", FlowDirection.IN))(T)
+        split_jit = jax.jit(lambda t: split_index(t, 0))(fused_jit)
+        np.testing.assert_array_equal(
+            np.asarray(fused_jit.todense()), np.asarray(fused_eager.todense())
+        )
+        np.testing.assert_array_equal(
+            np.asarray(split_jit.todense()), np.asarray(split_eager.todense())
+        )
+
+    def test_fuse_split_ad_roundtrip(self):
+        # Differentiating through fuse->split (an identity on data) must give a
+        # gradient equal to differentiating the same scalar of the input —
+        # i.e. the scatter then gather compose to the identity VJP. Compares
+        # analytic grad to central finite difference on the flat buffer.
+        T = self._u1_3leg(seed=3)
+
+        leaves, treedef = jax.tree_util.tree_flatten(T)
+        x0 = leaves[0]
+
+        def loss(x):
+            Tx = jax.tree_util.tree_unflatten(treedef, [x])
+            fused = fuse_indices(Tx, 0, 1, "ab", FlowDirection.IN)
+            split = split_index(fused, 0)
+            # weighted sum so the gradient is a fixed nonconstant tensor
+            return jnp.sum(split.todense() ** 2)
+
+        g = jax.grad(loss)(x0)
+        x0n = np.asarray(x0)
+        eps = 1e-6
+        fd = np.zeros_like(x0n)
+        for i in range(x0n.shape[0]):
+            xp = x0n.copy()
+            xp[i] += eps
+            xm = x0n.copy()
+            xm[i] -= eps
+            fd[i] = (float(loss(jnp.asarray(xp))) - float(loss(jnp.asarray(xm)))) / (
+                2 * eps
+            )
+        np.testing.assert_allclose(np.asarray(g), fd, rtol=1e-5, atol=1e-7)


### PR DESCRIPTION
## Summary

**Milestone A, increment 2** of the #566 sequencing. Block-sparse `fuse` and `split` each reassembled blocks with a **per-element Python loop** over a sub-block axis:

- fuse: one `existing.at[..., target, ...].set(slice)` per element
- split: one `block[..., target, ...]` gather + `jnp.stack`

At large bond dimension this emits hundreds of scatter/gather primitives per block, bloating the jaxpr and XLA compile — a direct contributor to the #566 symmetric-AD compile wall.

## Change

Each loop becomes a **single vectorized primitive** over the already-precomputed static offset array:

- **fuse**: `existing.at[(..., offsets, ...)].set(block_flat)` — one scatter. Offsets are distinct (no collisions) and disjoint across `(qa, qb)` pairs, so multi-block accumulation into a shared fused block is preserved.
- **split**: `block[(..., offsets, ...)]` — one advanced-index gather (the gathered axis stays in place as the sole advanced index), then reshape.

## Why no gate

This is **numerically identical** to the loops (pure data movement; no gauge or sign logic touched — fermionic Koszul signs live in the block *values* and are carried straight through) and fully differentiable (scatter/gather VJPs). Unlike the SVD/contraction batching (#571/#572) there is **no small-D vmap tradeoff** — one scatter kernel strictly beats N `.at[].set()` calls — so it is the **unconditional default**, no `TENAX_BATCH_BLOCKSPARSE` gate.

## Verification

- Existing dense-vs-symmetric `fuse`/`split` equivalence + roundtrip tests pass (`test_tensor_utils` 31; `test_split_ctm_tensor` green — the heavy consumer).
- New tests: a **fermionic** fuse/split roundtrip (sign preservation), **jit bit-identity**, and **finite-difference AD parity** through fuse→split.

## Milestone A status (#569)

- ✅ batched SVD/QR/eigh (#572, merged)
- ✅ fuse/split vectorization (this PR)
- ⬜ transpose group-by-shape vmap (low value; optional)
- ⬜ GPU/TPU benchmark — the gate for flipping `TENAX_BATCH_BLOCKSPARSE` on by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)