### PR TITLE
build: pin upper bounds on build-system.requires (fix twine Metadata-Version 2.5 failure)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs", "hatch-cython>=0.5", "cython>=3.0", "numpy>=1.26", "scipy>=1.11"]
+# hatchling capped <1.30: 1.30.0 (2026-06-01, since yanked) emitted
+# Metadata-Version 2.5, which `twine check` (the Build distribution CI step)
+# rejects as "not a valid metadata version". Lift the cap once twine/packaging
+# support 2.5.
+requires = ["hatchling>=1.27,<1.30", "hatch-vcs", "hatch-cython>=0.5", "cython>=3.0", "numpy>=1.26", "scipy>=1.11"]
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,21 @@
 [build-system]
-# hatchling capped <1.30: 1.30.0 (2026-06-01, since yanked) emitted
-# Metadata-Version 2.5, which `twine check` (the Build distribution CI step)
-# rejects as "not a valid metadata version". Lift the cap once twine/packaging
-# support 2.5.
-requires = ["hatchling>=1.27,<1.30", "hatch-vcs", "hatch-cython>=0.5", "cython>=3.0", "numpy>=1.26", "scipy>=1.11"]
+# Upper bounds guard the build against breaking releases of unpinned build
+# tooling (build-system.requires is not captured by uv.lock, so `uv build`
+# otherwise resolves the latest at build time). Caps are at the next major,
+# except:
+#   * hatchling <1.30 -- 1.30.0 (2026-06-01, since yanked) emitted
+#     Metadata-Version 2.5, which `twine check` (the Build distribution CI
+#     step) rejects as "not a valid metadata version"; lift once
+#     twine/packaging support 2.5.
+#   * hatch-vcs / hatch-cython are pre-1.0, so their cap is the next major (1.0).
+requires = [
+    "hatchling>=1.27,<1.30",
+    "hatch-vcs>=0.4,<1.0",
+    "hatch-cython>=0.5,<1.0",
+    "cython>=3.0,<4.0",
+    "numpy>=1.26,<3.0",
+    "scipy>=1.11,<2.0",
+]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
## Problem

The **Build distribution** CI step (`ci.yml` → `uv run twine check dist/*`) failed on PR #576 with:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

**hatchling 1.30.0** (released 2026-06-01, since **yanked**) emits `Metadata-Version: 2.5`, which the installed `twine`/`packaging` don't recognize yet. `build-system.requires` was unconstrained and **is not captured by `uv.lock`**, so `uv build` resolved 1.30.0 while it was briefly the latest. (`main` went green once 1.30.0 was yanked and builds fell back to 1.29.0 → `2.4`.)

## Fix

Pin upper bounds on **all** of `build-system.requires` so a breaking build-tooling release can't hit CI again. Caps are at the next major, except hatchling which is held below the known-bad 1.30 line:

| dep | bound |
|---|---|
| hatchling | `>=1.27,<1.30` (1.30.0 emits the unsupported Metadata-Version 2.5) |
| hatch-vcs | `>=0.4,<1.0` (pre-1.0) |
| hatch-cython | `>=0.5,<1.0` (pre-1.0) |
| cython | `>=3.0,<4.0` |
| numpy | `>=1.26,<3.0` |
| scipy | `>=1.11,<2.0` |

Lift the hatchling cap once `twine`/`packaging` support Metadata-Version 2.5.

## Verification (local)

`uv build` resolves within the bounds (hatchling 1.29.0 → `Metadata-Version: 2.4`); `uv run twine check dist/*` **PASSED** on both wheel and sdist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)