### PR TITLE
Block-sparse contraction backend seam (#200 Phase A) + stacked-block foundation (#566)

### DIFF
--- a/docs/superpowers/handoffs/2026-06-06-cutensornet-phase-b-a100-handoff.md
+++ b/docs/superpowers/handoffs/2026-06-06-cutensornet-phase-b-a100-handoff.md
@@ -1,0 +1,158 @@
+# cuTensorNet backend (Phase B) — A100/CUDA handoff (#200)
+
+**Date:** 2026-06-06
+**Depends on:** PR #586 (Phase A seam — branch `docs/symmetric-ctm-ad-stacked-design-566`).
+**Goal:** a GPU `CuTensorNetBackend` that does the **forward** block-sparse contraction as a
+single op, slotting into the existing seam. The plan, dispatch, and the **hand-written VJP are
+already done and proven on CPU (float64 + complex128)** — Phase B is the forward kernel + the
+A100 measurement.
+
+You do NOT need #586 merged — branch Phase B off `docs/symmetric-ctm-ad-stacked-design-566`
+(you get the whole seam). Wait only for #586's CI to go green before building on it.
+
+---
+
+## 0. What's already done (do not rebuild)
+
+| Piece | Where | Status |
+|---|---|---|
+| Static plan | `blocksparse_plan.py` `build_block_contract_plan` → `BlockContractPlan` | done; no tensor data |
+| Pure-JAX reference backend | `blocksparse_backend.py` `StackedJaxBackend` | done; your value oracle |
+| Backend protocol + dispatch | `blocksparse_backend.py` `BlockSparseContractBackend`, `select_backend`, `_select_cutensornet` (stub → returns None) | done; plug in here |
+| Hand-written VJP | `blocksparse_vjp.py` `backward_contraction(subscripts, fwd_operands, out_cotangent_stack, plan, wrt)` | **done; reuse verbatim** (real+complex128, fp 1e-12) |
+| Opaque-backend template | `blocksparse_backend.py` `MockFFIBackend._execute_opaque` (lines ~154-196) | **copy this custom_vjp pattern** |
+| Accuracy spine | `tests/stacked/_harness.py` (bit / bounded-fp / gauge-invariant) | use for validation |
+| Profiler | `examples/profile_ctm_ad_wall_566.py` | use for the A100 measurement |
+
+---
+
+## 1. Prereqs on the A100 box
+
+- CUDA + cuQuantum / cuTensorNet (`cuquantum-python` or the `nvidia-cuquantum-cu12` wheels).
+- JAX with the matching CUDA build; Tenax forces `jax_enable_x64=True` on import.
+- `git fetch && git checkout -b feat/cutensornet-backend-200 origin/docs/symmetric-ctm-ad-stacked-design-566`
+- Sanity: `JAX_PLATFORMS=cuda uv run python -c "import jax; print(jax.devices())"` shows the GPU.
+
+---
+
+## 2. The contract the backend must honour
+
+`BlockSparseContractBackend` (`blocksparse_backend.py:36`):
+
+```python
+def available(self) -> bool          # CUDA present + cuTensorNet importable
+def supports(self, tensors, plan) -> bool   # dtype/shape it can run (else dispatch falls back)
+def execute(self, operand_stacks, plan) -> Any   # -> canonical stacked output array
+```
+
+- `operand_stacks`: per forward operand, its stacked block array `(n_blocks, *block_shape)`
+  (from `tensor.stacked_blocks()`; for even-D single-shape-group there's exactly one group/operand).
+- **Output contract:** return the canonical-ordered stacked output array of shape
+  `(len(plan.out_block_keys), *plan.out_block_shapes[0])`, rows in **`plan.out_block_keys` order**.
+  The contractor's assembly and `backward_contraction` both assume this canonical row order.
+
+`BlockContractPlan` (`blocksparse_plan.py:63`) gives the kernel everything static:
+`out_indices`, `out_block_keys`, `out_block_shapes`, `out_block_offsets`, `total_size`,
+`batched_subscripts`, and `groups: tuple[PlanGroup]` where each `PlanGroup` has
+`operand_rows` (which stacked rows of each operand feed the batched contraction),
+`segment_ids` + `num_segments` (output accumulation), and `canonical_perm`.
+
+---
+
+## 3. The ONE anticipated seam change: per-operand metadata on the plan
+
+`execute(operand_stacks, plan)` does **not** carry the per-operand block metadata
+(`indices`, `block_keys`, `block_shapes`, `block_offsets`) that the **backward** needs to rebuild
+operands for `backward_contraction`. `MockFFIBackend` worked around this by capturing it at
+construction (`operand_meta`, `blocksparse_backend.py:123`). For a real backend, make it clean:
+
+- **Recommended (a):** add per-operand metadata to `BlockContractPlan`
+  (`operand_indices`, `operand_block_keys`, `operand_block_shapes`, `operand_block_offsets` —
+  tuples parallel to the inputs). `build_block_contract_plan` already has the tensors, so this is
+  a small additive edit; both `CuTensorNetBackend` and `StackedJaxBackend` then read it from the
+  plan, and `backward_contraction` can take the plan instead of separately-passed `fwd_operands`.
+- Alternative (b): widen the protocol to `execute(tensors, operand_stacks, plan)`.
+
+Do (a). This is the single API edit Phase B drives back into the seam — make it on the Phase B
+branch, keep `tests/stacked/` green, and it folds back cleanly.
+
+---
+
+## 4. Build order (de-risk the novel/GPU-specific parts first)
+
+**P-B0 — cuTensorNet FFI smoke (highest unknown).** Can you call cuTensorNet from JAX as a
+`custom_call`/FFI at all on this stack? Do a trivial *dense* pairwise contraction, forward only,
+GPU. This answers the riskiest question (FFI plumbing + library availability) before touching the
+seam. Mine `src/tenax/contraction/cutensor_blocksparse.py` (`contract_blocksparse`, `is_available`)
+for the cuTensorNet **calling pattern** — but note it is the **legacy, NON-seam-conformant** path
+(`TENAX_USE_CUTENSOR_BLOCKSPARSE`, eager, full-tensor `custom_vjp`, non-fermionic); **do not reuse
+it as the backend**, only as an API reference.
+
+**P-B1 — forward block-sparse kernel.** For the even-D double-layer plan (build it from
+`tests/stacked` ferm_D2/D4), feed `operand_stacks` + `plan` to cuTensorNet and produce the
+canonical stacked output. Two viable shapes: (a) cuTensorNet does the grouped block-sparse
+contraction natively; (b) you drive the per-`PlanGroup` batched contraction via its API and
+`segment_sum`-accumulate (mirror `stacked_execute`). Either way the **output must be the canonical
+stacked array**. **Validate VALUE** against `StackedJaxBackend().execute(operand_stacks, plan)` at
+fp tier (`assert_tiered(..., tier="fp")`, 1e-12), real + complex128.
+
+**P-B2 — wrap in `jax.custom_vjp` + reuse `backward_contraction`.** Copy
+`MockFFIBackend._execute_opaque` (`blocksparse_backend.py:154-196`) verbatim in structure: forward
+= your cuTensorNet `execute`; `opaque_fwd` residual = operand stacks only (no forward intermediates
+→ autodiff can't leak); `opaque_bwd` = `backward_contraction(subscripts, fwd_operands,
+out_cotangent_stack, plan, wrt)` for each operand. Register the backend in `_select_cutensornet`
+(`blocksparse_backend.py:266`), guarded by `available()`.
+
+**P-B3 — validate against the spine.** Swap `MockFFIBackend` → `CuTensorNetBackend` in the
+`tests/stacked/test_vjp_seam.py` pattern: assert `value` and `jax.grad` match per-block AND
+`StackedJaxBackend`, **real and complex128**, ferm_D2/D4, fp tier. Run the whole
+`tests/stacked/` on GPU. (Note: GPU `segment_sum` reduction order can drift ~5e-7 — that lives in
+the bounded-fp tier, not bit-identical; the energy/grad assertions should still hold at 1e-12 in
+f64. Never compare raw SVD factors — N/A here, contraction only.)
+
+**P-B4 — THE MEASUREMENT (the point of #200).**
+```bash
+# baseline (per-block) vs cuTensorNet, fermionic, A100, x64, implicit/fixed_point
+TENAX_BLOCKSPARSE_BACKEND=perblock    uv run python examples/profile_ctm_ad_wall_566.py \
+  --D 2 3 4 --sym fermionic --depth 8 --reps 3 --json profile_perblock.json
+TENAX_BLOCKSPARSE_BACKEND=cutensornet uv run python examples/profile_ctm_ad_wall_566.py \
+  --D 2 3 4 --sym fermionic --depth 8 --reps 3 --json profile_cutensornet.json
+```
+Report `vg_cmp` (compile) + warm-step for both. Reference baselines (A100, per-block):
+compile D2/3/4 ≈ 206 / 2111 / 2379 s; warm step ≈ 4.5 / 5.5 / 9.5 s. **Targets:** compile collapses
+toward dense (~40-60 s, χ/D-flat) — the original ≥10×-at-D4 framing now applies to the kernel; warm
+step approaches dense (~0.5-2.3 s) — the #195/#200 tiny-kernel fix.
+
+---
+
+## 5. Scope notes / gotchas
+
+- **Default OFF.** cuTensorNet is selected ONLY via `TENAX_BLOCKSPARSE_BACKEND=cutensornet` (and
+  `available()`); never auto-selected, so the default path stays byte-identical.
+- **Odd-D / ragged is cuTensorNet's real advantage** (native ragged blocks) over the pure-JAX
+  stacked path — BUT `build_block_contract_plan` currently returns `None` for multi-shape-group
+  (odd-D, U(1)), so those fall back to per-block today. Exercising odd-D needs a ragged-plan
+  extension (a follow-up). For the first measurement, **even-D D2/D4 suffices to prove the lever**;
+  odd-D D3 is where cuTensorNet should later beat both paths.
+- **complex128:** `backward_contraction` applies **no conjugation** and is proven correct for
+  complex (the VJP of a bilinear contraction transposes the unconjugated surviving operand;
+  conjugation enters only via non-holomorphic leaf ops, outside the seam). cuTensorNet iPEPS/CTM
+  runs complex128 — validate it.
+- **Canonical order:** if cuTensorNet does its own accumulation, the returned rows MUST be in
+  `plan.out_block_keys` order (assembly + backward assume it).
+- **Energies:** compare only at **full CTM convergence** (P1d lesson — early-iteration SVD-projector
+  gauge freedom makes raw env data differ under 1e-16 perturbations while the gauge-invariant energy
+  converges identically).
+
+---
+
+## 6. Success criteria (the #200 gate)
+
+1. **Correctness:** `CuTensorNetBackend` value + grad == per-block within fp 1e-12, real AND
+   complex128, ferm_D2/D4 (the `test_vjp_seam` pattern on GPU).
+2. **Compile:** fermionic `vg_cmp` at D=4 collapses toward dense (from ~2379 s — order-of-magnitude
+   reduction).
+3. **Runtime:** warm step approaches dense (#195 tiny-kernel launches eliminated).
+
+If 1 holds but 2/3 disappoint, that's a real finding about cuTensorNet block-sparse overhead on this
+problem size — bring the numbers back before scaling to Pallas/TPU.

--- a/docs/superpowers/handoffs/2026-06-06-cutensornet-phase-b-a100-handoff.md
+++ b/docs/superpowers/handoffs/2026-06-06-cutensornet-phase-b-a100-handoff.md
@@ -80,28 +80,59 @@ branch, keep `tests/stacked/` green, and it folds back cleanly.
 
 ## 4. Build order (de-risk the novel/GPU-specific parts first)
 
-**P-B0 — cuTensorNet FFI smoke (highest unknown).** Can you call cuTensorNet from JAX as a
-`custom_call`/FFI at all on this stack? Do a trivial *dense* pairwise contraction, forward only,
-GPU. This answers the riskiest question (FFI plumbing + library availability) before touching the
-seam. Mine `src/tenax/contraction/cutensor_blocksparse.py` (`contract_blocksparse`, `is_available`)
-for the cuTensorNet **calling pattern** — but note it is the **legacy, NON-seam-conformant** path
-(`TENAX_USE_CUTENSOR_BLOCKSPARSE`, eager, full-tensor `custom_vjp`, non-fermionic); **do not reuse
-it as the backend**, only as an API reference.
+**P-B0 — JAX↔GPU contraction bridge smoke. ✅ DONE (A100, commit `df1b92f` on branch
+`feat/cutensornet-backend-200`; `examples/probe_200_cutensornet_smoke.py`).** A dense `ij,jk->ik`
+routed through cupy's cuTENSOR inside one `jax.pure_callback` returns a JAX array under jit as
+**exactly 1 opaque op in the jaxpr**, f64 bit-exact, c128 8.88e-16. Plumbing notes: `pure_callback`
+needs `JAX_PLATFORMS=cuda,cpu` (cuda alone has no CPU device to stage host inputs) + `JAX_ENABLE_X64=1`;
+cuQuantum installed transiently (`cuquantum-cu13` + `nvmath-python` + `cupy-cuda13x`), **not yet in
+`pyproject`**. (`src/tenax/contraction/cutensor_blocksparse.py` remains a NON-seam-conformant API
+reference only — do not reuse as the backend.)
 
-**P-B1 — forward block-sparse kernel.** For the even-D double-layer plan (build it from
-`tests/stacked` ferm_D2/D4), feed `operand_stacks` + `plan` to cuTensorNet and produce the
-canonical stacked output. Two viable shapes: (a) cuTensorNet does the grouped block-sparse
-contraction natively; (b) you drive the per-`PlanGroup` batched contraction via its API and
-`segment_sum`-accumulate (mirror `stacked_execute`). Either way the **output must be the canonical
-stacked array**. **Validate VALUE** against `StackedJaxBackend().execute(operand_stacks, plan)` at
-fp tier (`assert_tiered(..., tier="fp")`, 1e-12), real + complex128.
+### Decision surfaced by P-B0: `pure_callback` vs `jax.ffi` (read before P-B1)
+P-B0 used the **callback** bridge (cheapest faithful route). It splits the two #200 goals:
+- **Compile (#566): callback likely WINS** — 1 op/contraction, so the per-block structural graph
+  (incl. the fixed-point backward) collapses. Host round-trip does not affect compile-graph size.
+- **Runtime (#195): callback likely LOSES (maybe badly)** — `pure_callback` does a
+  device→host→device round-trip *per contraction*, and a CTM sweep is ~60–97 contractions ×
+  many iterations. That is the opposite of the tiny-kernel fix. The on-device win needs
+  **`jax.ffi.ffi_call`** (a C++/CUDA handler calling cuTensorNet on the device buffers, no transfer).
+
+**Strategy:** use `pure_callback` as the **correctness + compile-win scaffold** through P-B1→P-B3;
+let the **P-B4 warm-step measurement be the go/no-go for building the `jax.ffi` on-device handler**
+(almost certainly needed for runtime — but measure it, don't assume). Keep the backend's `execute`
+backend-shaped so swapping callback→FFI later is internal to `CuTensorNetBackend.execute`.
+
+**P-B1 — forward block-sparse kernel (still callback).** Build a `CuTensorNetBackend.execute(
+operand_stacks, plan)` that produces the **canonical stacked output array** (rows in
+`plan.out_block_keys` order). Generalize P-B0's callback from dense `ij,jk->ik` to the block-sparse
+forward: for each `PlanGroup`, gather the operand rows (`group.operand_rows`), run the batched
+group contraction via cuTENSOR inside ONE `pure_callback` (or one per group — fewer is better),
+and accumulate by `segment_ids`/`num_segments` then reorder by `canonical_perm` — i.e. the same
+shape as `stacked_execute` (`blocksparse_plan.py`), but the einsum runs on the GPU kernel. The plan
+is now self-contained (commit `34347b2`): everything you need is on it — `subscripts`,
+`batched_subscripts`, `groups`, `out_block_*`, and `operand_*` metadata.
+Validate, even-D `ferm_D2`/`ferm_D4`, real + complex128:
+1. **VALUE** == `StackedJaxBackend().execute(operand_stacks, plan)` at fp tier
+   (`tests/stacked/_harness.py::assert_tiered(..., tier="fp")`, 1e-12) — `StackedJaxBackend` is the
+   correctness oracle, identical block structure.
+2. **OP-COUNT** (the compile-collapse premise, on a REAL block-sparse contraction not just dense):
+   `len(jax.make_jaxpr(lambda s: backend.execute(s, plan))(operand_stacks).jaxpr.eqns)` should be
+   O(#groups) callback ops — NOT O(#blocks) structural ops. Confirm it's a handful, independent of
+   block count. This is the direct evidence the kernel route fixes #566.
+Forward + value/op-count only here; VJP is P-B2.
 
 **P-B2 — wrap in `jax.custom_vjp` + reuse `backward_contraction`.** Copy
-`MockFFIBackend._execute_opaque` (`blocksparse_backend.py:154-196`) verbatim in structure: forward
-= your cuTensorNet `execute`; `opaque_fwd` residual = operand stacks only (no forward intermediates
-→ autodiff can't leak); `opaque_bwd` = `backward_contraction(subscripts, fwd_operands,
-out_cotangent_stack, plan, wrt)` for each operand. Register the backend in `_select_cutensornet`
-(`blocksparse_backend.py:266`), guarded by `available()`.
+`MockFFIBackend._execute_opaque` verbatim in structure (`blocksparse_backend.py`): forward = your
+cuTensorNet `execute`; `opaque_fwd` residual = operand stacks only (no forward intermediates →
+autodiff can't leak); `opaque_bwd` = `backward_contraction(operand_stacks_res, out_cotangent_stack,
+plan, wrt)` for each operand. **NB (post-`34347b2`):** the signature is now plan-sourced —
+`backward_contraction(operand_stacks, out_cotangent_stack, plan, wrt)`, NO `subscripts`/`fwd_operands`
+args (it reads `plan.subscripts` + `plan.operand_*` and rebuilds operands itself). So the backend
+needs nothing but `(operand_stacks, plan)` — the protocol gap is already closed. The backward is
+itself a contraction, so under the **callback** route it becomes another `pure_callback` (the
+transposed contraction on GPU); under **FFI** it's another `ffi_call`. Register in
+`_select_cutensornet`, guarded by `available()` (cupy/cuQuantum import check).
 
 **P-B3 — validate against the spine.** Swap `MockFFIBackend` → `CuTensorNetBackend` in the
 `tests/stacked/test_vjp_seam.py` pattern: assert `value` and `jax.grad` match per-block AND

--- a/docs/superpowers/handoffs/2026-06-06-cutensornet-phase-b-a100-handoff.md
+++ b/docs/superpowers/handoffs/2026-06-06-cutensornet-phase-b-a100-handoff.md
@@ -118,10 +118,28 @@ TENAX_BLOCKSPARSE_BACKEND=perblock    uv run python examples/profile_ctm_ad_wall
 TENAX_BLOCKSPARSE_BACKEND=cutensornet uv run python examples/profile_ctm_ad_wall_566.py \
   --D 2 3 4 --sym fermionic --depth 8 --reps 3 --json profile_cutensornet.json
 ```
-Report `vg_cmp` (compile) + warm-step for both. Reference baselines (A100, per-block):
-compile D2/3/4 ≈ 206 / 2111 / 2379 s; warm step ≈ 4.5 / 5.5 / 9.5 s. **Targets:** compile collapses
-toward dense (~40-60 s, χ/D-flat) — the original ≥10×-at-D4 framing now applies to the kernel; warm
-step approaches dense (~0.5-2.3 s) — the #195/#200 tiny-kernel fix.
+Run **all three** backends at the **same χ** (use the profiler default χ-factor 3, matching the
+A100 stacked-vs-per-block run §C, so the numbers are apples-to-apples — do NOT override `--chi-factor`):
+
+```bash
+for be in perblock stacked cutensornet; do
+  TENAX_BLOCKSPARSE_BACKEND=$be uv run python examples/profile_ctm_ad_wall_566.py \
+    --D 2 4 --sym fermionic --depth 8 --reps 3 --json profile_$be.json
+done
+```
+
+Report `bwd_cmp` + `vg_cmp` (compile) **and** warm-step for all three. Measured A100 baselines to
+beat (fermionic, **χ = 3·D**, from §C of `profile_566_a100_summary.md`):
+
+| D=4, χ=12 | per-block | **stacked** (current best) | dense floor (χ=16) |
+|---|---|---|---|
+| `bwd_cmp` | 880 s | **546 s** | ~13 s |
+| `vg_cmp`  | 1418 s | **1061 s** | ~39 s |
+
+(Per-block at the higher χ=4·D is worse still: D=4 `vg_cmp` ≈ 2379 s, §A.) Warm-step baseline not yet
+measured for stacked/per-block — capture it in this same run. **Targets:** `bwd_cmp` collapses from
+the **546 s stacked baseline toward the ~13 s dense floor** (that ~42× residual is the remaining
+order-of-magnitude #200 must deliver); warm step approaches dense (#195/#200 tiny-kernel fix).
 
 ---
 
@@ -150,9 +168,14 @@ step approaches dense (~0.5-2.3 s) — the #195/#200 tiny-kernel fix.
 
 1. **Correctness:** `CuTensorNetBackend` value + grad == per-block within fp 1e-12, real AND
    complex128, ferm_D2/D4 (the `test_vjp_seam` pattern on GPU).
-2. **Compile:** fermionic `vg_cmp` at D=4 collapses toward dense (from ~2379 s — order-of-magnitude
-   reduction).
-3. **Runtime:** warm step approaches dense (#195 tiny-kernel launches eliminated).
+2. **Compile (the bar to beat):** fermionic `bwd_cmp` at D=4, χ=12 drops from the **stacked
+   baseline 546 s toward the ~13 s dense floor** (per-block is 880 s; stacked already banked −38%).
+   The remaining ~42× from stacked→dense is the order-of-magnitude #200 must deliver; beating only
+   the 546 s stacked number by a little is NOT success — the goal is minutes→seconds. Equivalently
+   `vg_cmp` 1061 s → toward dense ~39 s.
+3. **Runtime:** warm step approaches dense (#195 tiny-kernel launches eliminated). NB: the
+   stacked-vs-per-block warm-step is not yet measured — capture it in the same P-B4 run so
+   cuTensorNet's runtime has a stacked baseline too, not just per-block.
 
 If 1 holds but 2/3 disappoint, that's a real finding about cuTensorNet block-sparse overhead on this
 problem size — bring the numbers back before scaling to Pallas/TPU.

--- a/docs/superpowers/plans/2026-06-05-symmetric-ctm-ad-stacked-blocks.md
+++ b/docs/superpowers/plans/2026-06-05-symmetric-ctm-ad-stacked-blocks.md
@@ -1,0 +1,679 @@
+# Stacked-Block Symmetric CTM AD (even-D first) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut the symmetric iPEPS CTM-AD compile wall (and per-step runtime) by giving `SymmetricTensor` a *stacked working representation* over the unchanged flat `_data` buffer, so per-block structural op emission collapses to O(n_shape_groups) batched ops — validated even-D-first and gated on a hard ≥10× compile reduction at D=4.
+
+**Architecture:** Add `stacked_blocks()` / `from_stacked_blocks()` to `SymmetricTensor` (one gather+reshape of `_data` per distinct block-shape group; one scatter back). Add a stacked contraction path that sources its batch axis directly from those contiguous views (not `jnp.stack` of per-block slices, which is the existing #571 `_contract_symmetric_batched` source). Route decomposition/fuse through the stacked views, then thread the stacked rep across the CTM sweep so it persists across the ~387 calls. Every phase is asserted against a frozen three-tier accuracy contract built first.
+
+**Tech Stack:** Python, JAX (x64), `jnp.einsum`/`jax.ops.segment_sum`/`jax.vmap`, pytest (`-m core`), the existing `examples/profile_ctm_ad_wall_566.py` profiler for the A100 gate.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-symmetric-ctm-ad-stacked-blocks-design.md`. Scope = P0→P1d. P1e (ragged odd-D/U(1)) and P2 (cuTensorNet) are NOT in this plan — they are funded only if P1d clears ≥10× at D=4.
+
+**Branch:** continue on `docs/symmetric-ctm-ad-stacked-design-566` (or branch a fresh `perf/stacked-blocksparse-566` off it). Open PRs per phase; never push to `main`. Merge via `gh pr merge <n> --auto --delete-branch`.
+
+**Key facts grounded in the code (do not re-derive):**
+- `SymmetricTensor` pytree = single leaf `_data` + static aux `(_block_keys, _block_shapes, _block_offsets, _indices)` (`tensor.py:757-794`). `_data` = `concatenate([blocks[k].ravel() for k in sorted(keys)])` (`tensor.py:675-694`). `_get_block(i)` = `_data[off:off+size].reshape(shape)` (`tensor.py:746-753`). `.blocks` unrolls one `_get_block` per block (`tensor.py:987-999`).
+- Even-D `FermionParity` (alternating virtual charges 0,1): every block of a tensor shares ONE shape → 1 shape-group → all blocks contiguous in `_data` → `_data.reshape(n_blocks, *shape)` is O(1). Odd-D/U(1) fragment (out of scope here).
+- `_contract_symmetric` (`contractor.py:358`) per-combo loop; `_contract_symmetric_batched` (`contractor.py:225-355`) groups survivors by input shape-sig → `jnp.stack` + one `jnp.einsum` + `jax.ops.segment_sum`, gated by `TENAX_BATCH_BLOCKSPARSE` (`contractor.py:540-549`). The grouping/segment logic is correct and reusable; only its **array source** changes (stack-of-slices → contiguous view).
+- `_grouped_decomp_by_shape` (`linalg.py:108`), `svd` (`linalg.py:1675`), `qr` (`linalg.py:2228`), `eigh` (`linalg.py:2304`).
+- Fermionic even-D site builder: `_build_initial_fpeps_tensor(FPEPSConfig(D=...), key)` (`fermionic_ipeps.py:140`).
+- Profiler gate driver: `examples/profile_ctm_ad_wall_566.py` — `make_site_and_gate(sym, D, seed)` (line 161), `build_loss(gate, chi, depth, *, explicit, warmup)` (line 176), CLI `--D --sym --depth --json` (line 295+). A100 baseline fermionic `vg_cmp` at D=4 ≈ 2379 s.
+
+---
+
+## Phase P0 — Accuracy spine (build the guarantee FIRST)
+
+### Task 1: Three-tier comparator + canonical-tensor factory
+
+**Files:**
+- Create: `tests/stacked/__init__.py` (empty)
+- Create: `tests/stacked/_harness.py`
+- Test: `tests/stacked/test_harness.py`
+
+- [ ] **Step 1: Write the failing test for the comparator tiers**
+
+```python
+# tests/stacked/test_harness.py
+import jax.numpy as jnp
+import pytest
+from tests.stacked._harness import assert_tiered, canonical_tensors
+
+def test_bit_identical_tier_passes_on_equal():
+    a = jnp.array([1.0, 2.0, 3.0])
+    assert_tiered(a, a, tier="bit")  # atol=0
+
+def test_bit_identical_tier_fails_on_tiny_diff():
+    a = jnp.array([1.0, 2.0, 3.0])
+    b = a + 1e-15
+    with pytest.raises(AssertionError):
+        assert_tiered(a, b, tier="bit")
+
+def test_bounded_fp_tier_passes_within_rtol():
+    a = jnp.array([1.0, 2.0, 3.0])
+    b = a * (1 + 1e-13)
+    assert_tiered(a, b, tier="fp")  # rtol ~1e-12
+
+def test_bounded_fp_tier_fails_outside_rtol():
+    a = jnp.array([1.0, 2.0, 3.0])
+    b = a * (1 + 1e-6)
+    with pytest.raises(AssertionError):
+        assert_tiered(a, b, tier="fp")
+
+def test_canonical_tensors_cover_required_cases():
+    cases = dict(canonical_tensors())
+    # even-D fermionic at D=2 and D=4, a dense U(1)-trivial tensor,
+    # a degenerate-SV matrix, and a rank-deficient sector.
+    assert {"ferm_D2", "ferm_D4", "dense_D2", "degenerate_sv", "rank_deficient"} <= set(cases)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/stacked/test_harness.py -v`
+Expected: FAIL — `ModuleNotFoundError: tests.stacked._harness`.
+
+- [ ] **Step 3: Implement the harness**
+
+```python
+# tests/stacked/_harness.py
+"""Frozen accuracy spine for the stacked-block migration (#566, P0).
+
+The CURRENT per-block path is the golden reference. Every later phase asserts
+against it via assert_tiered with one of three tiers:
+  - "bit": bit-identical (atol=0)        — data movement / order-preserved reductions
+  - "fp" : bounded-fp (rtol=1e-12, f64)  — reductions XLA may reassociate (segment_sum)
+  - gauge-invariants only for SVD/eigh   — never compare raw U/Vh (vmap LAPACK sign flips)
+"""
+from __future__ import annotations
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+FP_RTOL = 1e-12
+FP_ATOL = 1e-12
+
+def assert_tiered(ref, got, *, tier: str) -> None:
+    ref = jnp.asarray(ref)
+    got = jnp.asarray(got)
+    assert ref.shape == got.shape, f"shape {ref.shape} != {got.shape}"
+    if tier == "bit":
+        assert bool(jnp.array_equal(ref, got)), (
+            f"not bit-identical: max|d|={float(jnp.max(jnp.abs(ref - got))):.3e}"
+        )
+    elif tier == "fp":
+        np.testing.assert_allclose(
+            np.asarray(got), np.asarray(ref), rtol=FP_RTOL, atol=FP_ATOL
+        )
+    else:
+        raise ValueError(f"unknown tier {tier!r}")
+
+def assert_svd_invariants(A_ref, U, S, Vh, *, tier: str = "fp") -> None:
+    """Compare gauge-INVARIANT SVD outputs only: singular values + reconstruction."""
+    recon = (U * S[..., None, :]) @ Vh
+    assert_tiered(jnp.sort(S)[::-1], jnp.sort(S)[::-1], tier="fp")  # S is gauge-invariant
+    assert_tiered(A_ref, recon, tier=tier)
+
+def canonical_tensors():
+    """Yield (name, SymmetricTensor-or-array) covering the required golden cases."""
+    from tenax.algorithms.fermionic_ipeps import _build_initial_fpeps_tensor
+    from tenax.algorithms.fermionic_ipeps import FPEPSConfig
+
+    key = jax.random.PRNGKey(0)
+    yield "ferm_D2", _build_initial_fpeps_tensor(FPEPSConfig(D=2), key)
+    yield "ferm_D4", _build_initial_fpeps_tensor(FPEPSConfig(D=4), key)
+    yield "dense_D2", _dense_u1_trivial(D=2, key=key)
+    yield "degenerate_sv", _degenerate_sv_matrix()
+    yield "rank_deficient", _rank_deficient_matrix()
+
+def _dense_u1_trivial(D, key):
+    # A 1-block (trivial-charge) SymmetricTensor == the dense baseline used by the profiler.
+    from examples.profile_ctm_ad_wall_566 import make_site_and_gate
+    site, _gate = make_site_and_gate("dense", D, seed=0)
+    return site
+
+def _degenerate_sv_matrix():
+    # 4x4 with a repeated singular value (degenerate subspace).
+    return jnp.diag(jnp.array([2.0, 2.0, 1.0, 0.5]))
+
+def _rank_deficient_matrix():
+    v = jnp.array([1.0, 2.0, 3.0, 4.0])
+    return jnp.outer(v, v)  # rank 1
+```
+
+(If `FPEPSConfig` is not importable from `fermionic_ipeps`, import it from its actual module — grep `class FPEPSConfig` and adjust the import; this is the only allowed adaptation.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/stacked/test_harness.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Validate the comparator against EXISTING paths (self-check the spine)**
+
+Add to `tests/stacked/test_harness.py`:
+
+```python
+def test_perblock_vs_batched_contract_is_tiered():
+    """Sanity: existing batched path matches per-block within the fp tier.
+    Proves the comparator is correctly calibrated before any new code exists."""
+    import os
+    from tenax.contraction.contractor import contract
+    from tests.stacked._harness import canonical_tensors
+    A = dict(canonical_tensors())["ferm_D2"]
+    Abar = A.bar().relabels({"u": "U", "d": "Dn", "l": "L", "r": "R"})
+    os.environ["TENAX_BATCH_BLOCKSPARSE"] = "0"
+    ref = contract(A, Abar)  # per-block
+    os.environ["TENAX_BATCH_BLOCKSPARSE"] = "1"
+    got = contract(A, Abar)  # existing batched
+    os.environ["TENAX_BATCH_BLOCKSPARSE"] = "0"
+    assert_tiered(ref._data, got._data, tier="fp")
+```
+
+(Adjust `.bar()`/relabel call to the real API — grep `def bar` and `def relabels` in `tensor.py`; the double-layer must not collapse to a scalar, so phys is the only shared label.)
+
+Run: `uv run pytest tests/stacked/test_harness.py -v` → PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/stacked/
+git commit -m "test(#566): P0 three-tier accuracy comparator + canonical-tensor factory
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase P1a — `StackedView` + bit-exact round-trip
+
+### Task 2: `stacked_blocks()` / `from_stacked_blocks()` on `SymmetricTensor`
+
+**Files:**
+- Create: `src/tenax/core/stacked_view.py`
+- Modify: `src/tenax/core/tensor.py` (add two methods near `_get_block`, ~line 753)
+- Test: `tests/stacked/test_stacked_view.py`
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+```python
+# tests/stacked/test_stacked_view.py
+import jax.numpy as jnp
+import pytest
+from tests.stacked._harness import canonical_tensors
+
+@pytest.mark.parametrize("name", ["ferm_D2", "ferm_D4", "dense_D2"])
+def test_round_trip_bit_exact(name):
+    A = dict(canonical_tensors())[name]
+    view = A.stacked_blocks()
+    B = A.from_stacked_blocks(view)
+    assert bool(jnp.array_equal(A._data, B._data)), "round-trip not bit-exact"
+    assert A._block_keys == B._block_keys
+    assert A._block_shapes == B._block_shapes
+    assert A._block_offsets == B._block_offsets
+
+def test_even_D_is_single_shape_group():
+    A = dict(canonical_tensors())["ferm_D4"]
+    view = A.stacked_blocks()
+    # even-D FermionParity: all blocks one shape -> exactly one group
+    assert len(view.groups) == 1
+    (shape, grp), = view.groups.items()
+    assert grp.array.shape[0] == len(A._block_keys)   # leading block axis
+    assert grp.array.shape[1:] == shape
+
+def test_stacked_block_values_match_get_block():
+    A = dict(canonical_tensors())["ferm_D2"]
+    view = A.stacked_blocks()
+    for shape, grp in view.groups.items():
+        for j, key in enumerate(grp.keys):
+            idx = A._block_keys.index(key)
+            assert bool(jnp.array_equal(grp.array[j], A._get_block(idx)))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/stacked/test_stacked_view.py -v`
+Expected: FAIL — `AttributeError: 'SymmetricTensor' object has no attribute 'stacked_blocks'`.
+
+- [ ] **Step 3: Implement `StackedView`**
+
+```python
+# src/tenax/core/stacked_view.py
+"""Stacked working representation over the flat _data buffer (#566 P1a).
+
+A SymmetricTensor's blocks are grouped by identical shape; each group is one
+array (n_blocks_in_group, *block_shape) obtained by gathering the group's flat
+ranges out of _data and reshaping. Grouping + gather indices are STATIC
+(computed from block metadata), so only the gather/reshape touches the tracer.
+For even-D FermionParity (one shape, contiguous) the gather is a plain slice.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+BlockKey = tuple
+
+@dataclass(frozen=True)
+class StackGroup:
+    keys: tuple                  # block keys in this group, in sorted-key order
+    array: jax.Array             # (n_blocks, *block_shape)
+
+@dataclass(frozen=True)
+class StackedView:
+    groups: dict                 # block_shape -> StackGroup
+    indices: tuple               # the source tensor's TensorIndex tuple
+
+def _group_layout(block_keys, block_shapes, block_offsets):
+    """STATIC: shape -> (keys, flat_gather_index_array). No tracer ops."""
+    by_shape: dict = {}
+    for i, shape in enumerate(block_shapes):
+        size = int(np.prod(shape)) if shape else 1
+        off = block_offsets[i]
+        flat_idx = np.arange(off, off + size, dtype=np.int64)
+        rec = by_shape.setdefault(shape, ([], []))
+        rec[0].append(block_keys[i])
+        rec[1].append(flat_idx)
+    layout = {}
+    for shape, (keys, idx_lists) in by_shape.items():
+        layout[shape] = (tuple(keys), np.stack(idx_lists, axis=0))  # (n, size)
+    return layout
+
+def build_stacked(data, block_keys, block_shapes, block_offsets, indices) -> StackedView:
+    layout = _group_layout(block_keys, block_shapes, block_offsets)
+    groups = {}
+    for shape, (keys, gather) in layout.items():
+        n = gather.shape[0]
+        # one gather + reshape per group; contiguous even-D case = a slice
+        flat = data[gather.reshape(-1)]            # (n*size,)
+        groups[shape] = StackGroup(keys=keys, array=flat.reshape((n, *shape)))
+    return StackedView(groups=groups, indices=indices)
+
+def scatter_stacked(view, block_keys, block_shapes, block_offsets, total_size, dtype):
+    """Inverse: write groups back into one flat buffer in canonical layout."""
+    layout = _group_layout(block_keys, block_shapes, block_offsets)
+    data = jnp.zeros(total_size, dtype=dtype)
+    for shape, (keys, gather) in layout.items():
+        grp = view.groups[shape]
+        # reorder grp.array rows to canonical key order, then scatter (one op/group)
+        order = [grp.keys.index(k) for k in keys]
+        rows = grp.array[jnp.asarray(order)]
+        data = data.at[jnp.asarray(gather.reshape(-1))].set(rows.reshape(-1))
+    return data
+```
+
+- [ ] **Step 4: Wire the two methods onto `SymmetricTensor`**
+
+Add after `_get_block` (`tensor.py:753`):
+
+```python
+    def stacked_blocks(self):
+        """Return a StackedView: blocks grouped by shape, one array per group."""
+        from tenax.core.stacked_view import build_stacked
+        return build_stacked(
+            self._data, self._block_keys, self._block_shapes,
+            self._block_offsets, self._indices,
+        )
+
+    def from_stacked_blocks(self, view):
+        """Rebuild a SymmetricTensor from a StackedView (canonical layout)."""
+        from tenax.core.stacked_view import scatter_stacked
+        total = self._block_offsets[-1] + (
+            int(np.prod(self._block_shapes[-1])) if self._block_shapes[-1] else 1
+        ) if self._block_keys else 0
+        data = scatter_stacked(
+            view, self._block_keys, self._block_shapes, self._block_offsets,
+            total, self._data.dtype,
+        )
+        return SymmetricTensor._raw(
+            indices=self._indices, data=data, block_keys=self._block_keys,
+            block_shapes=self._block_shapes, block_offsets=self._block_offsets,
+        )
+```
+
+(`np` is already imported in `tensor.py` — confirm via grep `import numpy`.)
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `uv run pytest tests/stacked/test_stacked_view.py -v`
+Expected: PASS (5 cases).
+
+- [ ] **Step 6: Run the broader core suite for regressions**
+
+Run: `uv run pytest -m core tests/test_block_array.py tests/test_contraction.py -q`
+Expected: PASS (no regressions — we only ADDED methods).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tenax/core/stacked_view.py src/tenax/core/tensor.py tests/stacked/test_stacked_view.py
+git commit -m "feat(#566): StackedView + stacked_blocks/from_stacked_blocks round-trip (P1a)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase P1b — Stacked contraction path (even-D), gated
+
+### Task 3: `_contract_symmetric_stacked` sourcing from contiguous views
+
+**Files:**
+- Modify: `src/tenax/contraction/contractor.py` (new fn + dispatch near line 540)
+- Test: `tests/stacked/test_stacked_contract.py`
+
+**Design note:** reuse the survivor-grouping + `segment_sum` logic of `_contract_symmetric_batched` (correct, shipped). The ONLY change: when every input tensor has a single shape-group (even-D), take the batch axis straight from `tensor.stacked_blocks()` (a contiguous `_data.reshape`) instead of `jnp.stack` of per-block slices. Otherwise return `None` → caller falls back to the per-block path. New gate `TENAX_STACK_BLOCKSPARSE` (independent of `TENAX_BATCH_BLOCKSPARSE`).
+
+- [ ] **Step 1: Write the failing equivalence test (golden tiers)**
+
+```python
+# tests/stacked/test_stacked_contract.py
+import os
+import jax.numpy as jnp
+import pytest
+from tenax.contraction.contractor import contract
+from tests.stacked._harness import assert_tiered, canonical_tensors
+
+def _double_layer(A):
+    # contract physical leg only -> double-layer; relabel virtuals so nothing else matches
+    Abar = A.bar().relabels({"u": "U", "d": "Dn", "l": "L", "r": "R"})
+    return A, Abar
+
+@pytest.mark.parametrize("name", ["ferm_D2", "ferm_D4"])
+def test_stacked_contract_matches_perblock(name):
+    A = dict(canonical_tensors())[name]
+    A, Abar = _double_layer(A)
+    os.environ["TENAX_STACK_BLOCKSPARSE"] = "0"
+    ref = contract(A, Abar)
+    os.environ["TENAX_STACK_BLOCKSPARSE"] = "1"
+    got = contract(A, Abar)
+    os.environ["TENAX_STACK_BLOCKSPARSE"] = "0"
+    assert got._block_keys == ref._block_keys
+    assert_tiered(ref._data, got._data, tier="fp")
+
+def test_stacked_contract_grad_matches_perblock(name="ferm_D2"):
+    import jax
+    A0 = dict(canonical_tensors())[name]
+    def loss(data, flag):
+        os.environ["TENAX_STACK_BLOCKSPARSE"] = flag
+        A = A0.from_stacked_blocks(A0.stacked_blocks())  # identity, keeps it a tensor
+        A = type(A0)._raw(indices=A0._indices, data=data, block_keys=A0._block_keys,
+                          block_shapes=A0._block_shapes, block_offsets=A0._block_offsets)
+        Ab = A.bar().relabels({"u": "U", "d": "Dn", "l": "L", "r": "R"})
+        out = contract(A, Ab)
+        return jnp.sum(out._data ** 2)
+    g_ref = jax.grad(loss)(A0._data, "0")
+    g_got = jax.grad(loss)(A0._data, "1")
+    os.environ["TENAX_STACK_BLOCKSPARSE"] = "0"
+    assert_tiered(g_ref, g_got, tier="fp")
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/stacked/test_stacked_contract.py -v`
+Expected: FAIL — `got._data` differs OR stacked path absent (flag is a no-op → values equal but test for the NEW path is meaningless). Confirm failure is real by asserting the stacked branch executed (Step 3 adds a counter).
+
+- [ ] **Step 3: Implement `_contract_symmetric_stacked` + dispatch**
+
+In `contractor.py`, add a module counter and the function:
+
+```python
+_STACK_FIRED = {"n": 0}  # test observability
+
+def _all_single_shape_group(tensors) -> bool:
+    return all(len(set(t._block_shapes)) <= 1 for t in tensors)
+
+def _contract_symmetric_stacked(tensors, subscripts, output_indices, optimize):
+    """Even-D fast path: batch axis sourced from contiguous _data views.
+    Returns None to fall back when inputs are not single-shape-group."""
+    if len(tensors) != 2 or not _all_single_shape_group(tensors):
+        return None
+    _STACK_FIRED["n"] += 1
+    # Build survivor groups exactly as _contract_symmetric_batched does, but
+    # read each operand's blocks from tensor.stacked_blocks() (one reshape).
+    # ... reuse the survivor-collection + segment_sum from the batched path,
+    #     substituting `stacked_view.groups[shape].array` for jnp.stack(...).
+    # (Implementation mirrors contractor.py:225-355; only the array source and
+    #  the per-tensor key->row index map change.)
+    ...
+    return SymmetricTensor._from_blocks_unchecked(output_blocks, output_indices)
+```
+
+Wire dispatch at the top of `_contract_symmetric` (after the cuTENSOR block, ~line 410):
+
+```python
+    if os.environ.get("TENAX_STACK_BLOCKSPARSE", "0") == "1":
+        stacked = _contract_symmetric_stacked(
+            list(tensors), subscripts, output_indices, optimize
+        )
+        if stacked is not None:
+            return stacked
+```
+
+**The `...` is filled by porting `_contract_symmetric_batched`'s body** (lines 249-355): collect `survivors` with their `output_key`, group by input shape-sig, but for each operand build its stacked array once via `tensors[p].stacked_blocks().groups[shape].array` and index rows by the operand's `key -> row` map instead of `jnp.stack([slice...])`. Keep the `segment_sum` accumulation verbatim (this is what makes accumulating combos correct — the earlier prototype's bug was skipping it).
+
+- [ ] **Step 4: Make the test assert the stacked branch fired**
+
+Append to both tests: `from tenax.contraction.contractor import _STACK_FIRED` and assert `_STACK_FIRED["n"] > 0` after the flag=1 contraction.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `uv run pytest tests/stacked/test_stacked_contract.py -v`
+Expected: PASS — values match within `fp` tier, grad matches, stacked branch fired.
+
+- [ ] **Step 6: Run contraction + fermionic suites for regressions**
+
+Run: `uv run pytest -m core tests/test_contraction.py tests/test_fermionic.py tests/test_symmetric_custom_vjp.py -q`
+Expected: PASS (flag default-off → byte-identical to today).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tenax/contraction/contractor.py tests/stacked/test_stacked_contract.py
+git commit -m "feat(#566): even-D stacked contraction path (TENAX_STACK_BLOCKSPARSE) (P1b)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase P1c — Stacked decomposition + fuse/split (even-D)
+
+### Task 4: Route svd/qr/eigh through stacked views (gauge-invariant assertions)
+
+**Files:**
+- Modify: `src/tenax/linalg.py` (svd `:1675`, qr `:2228`, eigh `:2304` — gate the stacked source under `TENAX_STACK_BLOCKSPARSE`, reuse `_grouped_decomp_by_shape` `:108`)
+- Test: `tests/stacked/test_stacked_decomp.py`
+
+- [ ] **Step 1: Write the failing test (invariants only — never raw U/Vh)**
+
+```python
+# tests/stacked/test_stacked_decomp.py
+import os
+import jax.numpy as jnp
+import pytest
+from tenax import linalg
+from tests.stacked._harness import canonical_tensors, assert_tiered
+
+@pytest.mark.parametrize("name", ["ferm_D2", "ferm_D4"])
+def test_stacked_svd_invariants_match(name):
+    A = dict(canonical_tensors())[name]
+    M = A.fuse(("u", "d", "l"), "row").fuse(("r", "phys"), "col")  # to a matrix; adjust to real fuse API
+    os.environ["TENAX_STACK_BLOCKSPARSE"] = "0"
+    U0, S0, Vh0 = linalg.svd(M, "row", "col")
+    os.environ["TENAX_STACK_BLOCKSPARSE"] = "1"
+    U1, S1, Vh1 = linalg.svd(M, "row", "col")
+    os.environ["TENAX_STACK_BLOCKSPARSE"] = "0"
+    # singular values are gauge-invariant -> fp tier
+    assert_tiered(jnp.sort(S0._data), jnp.sort(S1._data), tier="fp")
+    # reconstruction is gauge-invariant -> fp tier; raw U/Vh are NOT compared
+    from tenax.contraction.contractor import contract
+    rec0 = contract(contract(U0, S0), Vh0)
+    rec1 = contract(contract(U1, S1), Vh1)
+    assert_tiered(rec0._data, rec1._data, tier="fp")
+```
+
+(Adjust `fuse`/`svd` calls to the real signatures — grep `def fuse`, `def svd`; the point is: assert SVs + reconstruction, never raw factors.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/stacked/test_stacked_decomp.py -v`
+Expected: FAIL — stacked decomp source not yet gated / no branch executed.
+
+- [ ] **Step 3: Implement the stacked decomposition source**
+
+In `linalg.svd`/`qr`/`eigh`, when `TENAX_STACK_BLOCKSPARSE=1` AND the matrix is single-shape-group, build the batched `(n, m, k)` array via `M.stacked_blocks()` and call the existing `_grouped_decomp_by_shape` machinery (already does `vmap(..., in_axes=(0, None))` over same-shape sectors). Reconstruct factor tensors via `from_stacked_blocks`. For non-uniform → existing per-block path. Gauge-fix consistently (same convention as the per-block path).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/stacked/test_stacked_decomp.py -v`
+Expected: PASS (SV + reconstruction within `fp`).
+
+- [ ] **Step 5: Degenerate + rank-deficient guard test**
+
+```python
+def test_degenerate_and_rank_deficient_invariants():
+    import numpy as np
+    for nm in ("degenerate_sv", "rank_deficient"):
+        M = dict(canonical_tensors())[nm]  # plain jnp matrix
+        U, S, Vh = jnp.linalg.svd(M, full_matrices=False)
+        recon = (U * S[None, :]) @ Vh
+        np.testing.assert_allclose(np.asarray(recon), np.asarray(M), rtol=1e-12, atol=1e-12)
+```
+
+Run: `uv run pytest tests/stacked/test_stacked_decomp.py -v` → PASS.
+
+- [ ] **Step 6: Run linalg + padded-linalg suites**
+
+Run: `uv run pytest -m core tests/test_linalg.py tests/test_padded_linalg.py tests/test_symmetric_custom_vjp.py -q`
+Expected: PASS.
+
+- [ ] **Step 7: fuse/split — correctness is already guaranteed; optimize only if hot**
+
+`fuse`/`split` round-trip correctness is covered by P1a's bit-exact round-trip test (Task 2). Do NOT add a stacked fuse/split path speculatively (YAGNI). Only route fuse/split through stacked views if the P1d op-histogram (`examples/probe_backward_jaxpr_566.py`) shows `_fuse_indices_symmetric` is still a material structural-op source on the sweep after Tasks 3–4. If so, add it here behind the same flag with a bit-exact round-trip test; otherwise note "fuse/split left per-block — not hot" and move on.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/tenax/linalg.py tests/stacked/test_stacked_decomp.py
+git commit -m "feat(#566): even-D stacked svd/qr/eigh via grouped decomp (P1c)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase P1d — Thread through the CTM sweep + the hard A100 gate
+
+### Task 5: Persist the stacked rep across the sweep + end-to-end golden
+
+**Files:**
+- Modify: the CTM sweep / absorb / RDM call sites (discover via `grep -rn "stacked_blocks\|\.blocks\b\|_get_block" src/tenax/algorithms/` and the CTM-AD modules) so env tensors stay stacked across calls and pack to `_data` only at sweep boundaries.
+- Test: `tests/stacked/test_ctm_ad_end_to_end.py`
+
+- [ ] **Step 1: Write the failing end-to-end golden test**
+
+```python
+# tests/stacked/test_ctm_ad_end_to_end.py
+import os
+import jax
+import jax.numpy as jnp
+import pytest
+from tests.stacked._harness import assert_tiered
+from examples.profile_ctm_ad_wall_566 import make_site_and_gate, build_loss
+
+@pytest.mark.parametrize("D", [2, 4])
+def test_ctm_ad_energy_and_grad_match_golden(D):
+    site, gate = make_site_and_gate("fermionic", D, seed=0)
+    loss = build_loss(gate, chi=3 * D, depth=8, explicit=False, warmup=0)
+    os.environ["TENAX_STACK_BLOCKSPARSE"] = "0"
+    e0, g0 = jax.value_and_grad(loss)(site._data)
+    os.environ["TENAX_STACK_BLOCKSPARSE"] = "1"
+    e1, g1 = jax.value_and_grad(loss)(site._data)
+    os.environ["TENAX_STACK_BLOCKSPARSE"] = "0"
+    assert_tiered(jnp.asarray(e0), jnp.asarray(e1), tier="fp")  # energy: bounded-fp
+    assert_tiered(g0, g1, tier="fp")                            # gradient: bounded-fp
+```
+
+(Adjust `build_loss` call to its real return contract — read `examples/profile_ctm_ad_wall_566.py:176`; it may take/return the site tensor rather than raw `_data`. Keep the assertion: stacked vs per-block energy+grad within `fp`.)
+
+- [ ] **Step 2: Run to verify it fails (or reveals the real integration gap)**
+
+Run: `uv run pytest tests/stacked/test_ctm_ad_end_to_end.py -v`
+Expected: FAIL or mismatch — the sweep still round-trips through `.blocks`/`_get_block` per call, so flag=1 either changes nothing or diverges where stacked decomp/contract aren't yet on the sweep path. Use the failure to locate the un-migrated call sites.
+
+- [ ] **Step 3: Migrate the sweep to carry stacked tensors across calls**
+
+Replace per-call `.blocks`/`_get_block` round-trips in the absorb/projector/RDM steps so a tensor produced stacked stays stacked into the next contraction; pack to `_data` only at the sweep boundary (where the jit/scan carry needs the single leaf). One call site per commit where feasible; re-run Step 1 after each.
+
+- [ ] **Step 4: Run to verify the end-to-end test passes**
+
+Run: `uv run pytest tests/stacked/test_ctm_ad_end_to_end.py -v`
+Expected: PASS (energy + grad within `fp` for D=2 and D=4).
+
+- [ ] **Step 5: Full core + algorithm regression**
+
+Run: `uv run pytest -m core -q` then `uv run pytest -m "not slow" tests/test_fpeps_ad.py tests/test_block_sparse_ctm_ad.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit the migration**
+
+```bash
+git add -A && git commit -m "feat(#566): thread stacked rep across CTM sweep; end-to-end golden (P1d)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task 6: The hard A100 compile gate (≥10× at D=4)
+
+**Files:**
+- Use: `examples/profile_ctm_ad_wall_566.py` (already supports `--D --sym --json` and honest cold compiles via fresh `jax_compilation_cache_dir`).
+- Create: `examples/stacked_gate_566_summary.md` (the recorded verdict).
+
+- [ ] **Step 1: Baseline (per-block) compile at D=4 on A100**
+
+Run on the A100 host (f64, implicit/fixed_point):
+```bash
+TENAX_STACK_BLOCKSPARSE=0 uv run python examples/profile_ctm_ad_wall_566.py \
+  --D 4 --sym fermionic --depth 8 --reps 3 --json examples/stacked_gate_D4_off.json
+```
+Record `vg_cmp` (expect ≈ 2379 s, matching the prior baseline).
+
+- [ ] **Step 2: Stacked compile at D=4 on A100**
+
+```bash
+TENAX_STACK_BLOCKSPARSE=1 uv run python examples/profile_ctm_ad_wall_566.py \
+  --D 4 --sym fermionic --depth 8 --reps 3 --json examples/stacked_gate_D4_on.json
+```
+
+- [ ] **Step 3: Evaluate the gate**
+
+Compute `ratio = vg_cmp(off) / vg_cmp(on)`.
+- **PASS if `ratio >= 10`** (i.e. on ≤ ~238 s). Also record the warm-step ratio (secondary, non-gating).
+- **FAIL otherwise → STOP.** Do not start P1e or P2. Write the verdict + numbers to `examples/stacked_gate_566_summary.md`, post to #566, and bring the result back for an approach review.
+
+- [ ] **Step 4: Commit the gate artifacts + verdict**
+
+```bash
+git add examples/stacked_gate_D4_*.json examples/stacked_gate_566_summary.md
+git commit -m "bench(#566): P1d A100 compile gate result at D=4 (PASS/FAIL: <ratio>x)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: Update the #566 memory + issue with the measured ratio and the P1e/P2 go/no-go.**
+
+---
+
+## Final integration
+
+- [ ] Open the phase PRs (or one stacked PR) targeting `main`; ensure `Tests (Python 3.11/3.12)` + `Tests (macOS, Python 3.12)` pass.
+- [ ] Default remains `TENAX_STACK_BLOCKSPARSE=0` until the gate PASSES; flip to default-on (or device-aware) only as a follow-up PR justified by the A100 number.
+- [ ] If the gate PASSES, file the P1e (ragged) and P2 (cuTensorNet) follow-up issues with the measured even-D win as justification.
+
+## Notes for the implementer
+
+- **Never compare raw `U`/`Vh`** from SVD/eigh — only singular values, eigenvalues, and reconstruction (`assert_svd_invariants`). `vmap`-ed LAPACK sign-/basis-flips degenerate subspaces (the #572 trap).
+- **Keep `segment_sum`** in the stacked contraction — it is what makes accumulating block-combos correct; the earlier dead-end prototype's correctness bug came from dropping it.
+- **Do not revert the flat buffer or add pytree leaves** — `_data`-as-single-leaf is #87's deliberate JIT/grad substrate and the #200/#568/#569 accelerator substrate.
+- **Even-D only** in this plan. If a stacked path hits a non-single-shape-group tensor, it must return `None`/fall back, never pad — padding is P1e, behind its own flag.
+- Run `uv run pytest -m core` (the CI-required marker) before each commit; `-m "not slow"` for the AD integration tests.

--- a/docs/superpowers/specs/2026-06-04-symmetric-ctm-ad-stacked-blocks-design.md
+++ b/docs/superpowers/specs/2026-06-04-symmetric-ctm-ad-stacked-blocks-design.md
@@ -1,0 +1,166 @@
+# Symmetric CTM AD — stacked-block representation (even-D first)
+
+**Date:** 2026-06-04
+**Issue:** #566 (symmetric iPEPS AD compile + runtime cost)
+**Status:** design, pending implementation plan
+**Scope of this spec:** P0 (accuracy spine) → P1d (even-D stacked rep threaded through the
+CTM sweep + A100 measurement gate). Ragged odd-D/U(1) (P1e) and the cuTensorNet GPU
+kernel (P2) are a roadmap, **gated on P1d proving the efficiency gain**.
+
+## Problem (measured, not assumed)
+
+Block-sparse `SymmetricTensor` CTM-AD is dominated by **per-block structural op
+emission**. The Python loop over blocks unrolls at trace time into O(n_blocks) XLA
+primitives, and this is paid twice:
+
+- **Compile** (one-time, the #566 headline): A100 fermionic `value_and_grad` compile
+  = 206 / 2111 / 2379 s at D=2/3/4 (16 blocks held constant); ferm/dense ratio
+  4× → 52× → 61×. Dense is flat (~40–60 s, χ- and D-independent — XLA dedups one block).
+- **Runtime** (every optimizer step): fermionic warm step 4.5–9.5 s vs dense 0.5–2.3 s
+  — the #195/#200 "1.15M tiny kernel launches" problem.
+
+Root cause, localized by jaxpr op-histogram + monkeypatch counters on one traced forward
+sweep (fermionic D=2):
+
+- The op explosion is in the **forward** CTM step (21,920 ferm ops vs 1,472 dense = 15×).
+  The backward only adds ×1.3 on top — it is huge *because the forward it differentiates
+  is huge*.
+- `dot_general` (contraction) is only **~4%** of the graph. The cost is **structural**:
+  `_get_block` (slice+reshape off the flat buffer) ×1428 and the `.blocks` property ×766,
+  plus per-combo contractor scaffolding (broadcast/select/transpose/charge-compares).
+- Ruled out empirically: scan-fusion (compile already depth-flat), `TENAX_BATCH_BLOCKSPARSE`
+  within-call batching (#571/2/3 — neutral/worse on A100, attacks the wrong 4%), #570 as a
+  *compile* lever (dense is χ-flat).
+
+### Even-D vs ragged (the reason this spec scopes to even-D)
+
+For `FermionParity` with alternating virtual charges, **even D ⇒ all blocks of a tensor
+share one shape** (D2/D4 site A: 16 blocks, 1 distinct shape → up to 16× collapse). **Odd D
+and general U(1) ⇒ unequal sectors ⇒ blocks fragment into distinct shapes** (D3 site A: 16
+blocks, 16 shapes → no collapse from grouping alone; contraction-level collapse only ~2.1×).
+Even-D is the clean, decisive case and the right place to *prove the gain* before paying for
+ragged handling.
+
+## Approach
+
+Add a **stacked working representation** over the **unchanged** flat `_data` buffer and
+single-pytree-leaf storage (that storage is #87's deliberate JIT/grad + accelerator
+substrate — it is **not** reverted).
+
+- **Representation layer** (`tensor.py`): `stacked_blocks()` → `{block_shape: (group_keys,
+  array[n, *block_shape])}` built by **one reshape/gather of `_data` per shape-group**
+  (O(n_groups)); inverse `from_stacked_blocks(...)` writes back with **one scatter per
+  group**. Grouping is pure static index math over `_block_keys`/`_block_shapes`/
+  `_block_offsets` (trace-time, on static metadata); only the `_data` reshape/gather/scatter
+  is a traced op.
+- **Operation layer**: stacked-aware `contract`, `fuse`/`split`, `svd`/`qr`/`eigh`,
+  `transpose` — each emits **O(n_groups)** ops via batched-einsum / `vmap` over the leading
+  block axis + `segment_sum`. Reuses `_grouped_decomp_by_shape` (#572).
+- **Backend dispatch behind one interface**: pure-JAX stacked (default, CPU/GPU/TPU) now;
+  cuTensorNet `custom_call` (P2, GPU) later. Sweep/AD/tests are backend-agnostic.
+
+**Load-bearing boundary decision:** the stacked rep **persists across the ~387 calls within
+a sweep**; we pack back to `_data` only at sweep boundaries (where the pytree leaf matters
+for jit/scan carry). Per-call re-pack/unpack is exactly what made within-call batching
+net-neutral; persisting it is what unlocks the across-call collapse.
+
+### Why this cuts both compile and runtime
+
+For even-D, n_groups ≈ 1, so the per-block round-trip (`_get_block`/`.blocks`, ~96% of the
+graph) collapses ~16× → fewer traced ops → super-linear compile win (op ratio 19× mapped to
+compile ratio 52× at D3 in prior data), and one batched kernel replaces n_blocks tiny ones →
+runtime win. The VJP of stacked ops is itself stacked ops (vmap/`segment_sum` differentiable),
+so the backward graph shrinks *with* the forward.
+
+## Components & boundaries
+
+| Unit | Responsibility | Depends on |
+|---|---|---|
+| `StackedView` (new, `tensor.py`) | build groups from static metadata; gather `_data`→stacks; scatter stacks→`_data` | `_block_*`, `_data` |
+| stacked contractor (`contractor.py`) | group block-pairs by `(lhs,rhs,out shape, subscripts)`; batched einsum + `segment_sum` | `StackedView`, static charge matching |
+| stacked decomposition (`linalg`) | `_grouped_decomp_by_shape` as the stacked-path default; consistent gauge-fix | #572 |
+| CTM sweep threading | carry stacked tensors through absorb/projector/RDM; pack to `_data` only at boundaries | all of the above |
+| backend dispatch | select pure-JAX vs (P2) cuTensorNet behind one signature | — |
+
+Each unit is independently testable: `StackedView` against the per-block accessors; the
+stacked contractor/decomp against the per-block ops; the sweep against the energy/grad golden.
+
+## Data flow — one CTM sweep
+
+```
+site tensors (_data) ─stacked_blocks()─▶ stacks
+   └▶ absorb / projector contractions on stacks (batched einsum + segment_sum)
+   └▶ projector SVD on stacked bond matrices (grouped, gauge-fixed)
+   └▶ env tensors kept stacked across calls (no per-call repack)
+   └▶ from_stacked_blocks() once at the sweep boundary ─▶ _data ─▶ energy
+Backward: VJP of stacked ops = stacked ops ⇒ backward op-count shrinks with the forward.
+```
+
+## Accuracy contract (the guarantee)
+
+Built **as P0, before any restructuring**: the current per-block path is frozen as the
+golden reference; every later phase is asserted against it by a comparator with three
+explicit tiers:
+
+- **Bit-identical (`atol=0`):** `from_stacked(stacked(A)) == A`; contracted tensor *values*
+  and fuse/split round-trips **when accumulation order is preserved**. We impose a canonical
+  block ordering on `segment_sum` so the reduction matches sequential per-block accumulation
+  wherever the segment structure allows.
+- **Bounded-fp (`rtol ≈ 1e-12` in f64, stated & asserted):** energy, gradient, and any
+  output where XLA may reassociate a reduction (the GPU `segment_sum` ~5e-7-class drift lives
+  here — bounded, not hand-waved).
+- **Gauge-invariant only (raw `U`/`Vh` exempt):** SVD/eigh/QR compared on singular values,
+  eigenvalues, and reconstruction (`A=UΣVᴴ`, `QR=A`) — **never** raw factors, because
+  `vmap`-ed LAPACK sign-/basis-flips degenerate subspaces (the #572 trap).
+
+Golden coverage: fermionic + U(1) + dense, D∈{2,4} (even), **including a degenerate-SV case
+and a rank-deficient sector**. (Odd D=3 is captured as a golden too, but its stacked path is
+out of this spec's implementation scope — it stays on the per-block path until P1e.)
+
+## Testing
+
+- **P0 spine:** golden capture (per-block = reference) + tier-asserting comparator.
+- **Unit:** stacked round-trip (bit-exact); stacked-vs-per-block contract (tiered); stacked
+  decomp gauge-invariants; FD gradient + per-block-vs-stacked VJP agreement.
+- **Integration:** full CTM-AD energy+grad vs golden, fermionic/U(1)/dense, even D.
+- **Perf gate (A100, documented — not CI-asserted):** `vg_cmp` compile + warm-step, even D
+  ∈{2,4} (extend to D=6 if it holds), stacked vs per-block. **Target: collapse the measured
+  52–61× fermionic/dense compile ratio toward dense, plus a warm-step win.** This is P1d and
+  the decision gate for P1e/P2.
+
+## Phasing (committed scope = P0–P1d)
+
+- **P0** — accuracy spine (golden + comparator + tier contract). Ships alone.
+- **P1a** — `StackedView` + round-trip, no math change (byte-exact).
+- **P1b** — stacked contractor, even-D, validated against golden tiers.
+- **P1c** — stacked decomposition + fuse/split, even-D.
+- **P1d** — thread stacked rep through the CTM absorb/RDM so it persists across calls;
+  **A100 compile + runtime measurement = the gate.**
+
+Roadmap, gated on P1d showing the gain:
+
+- **P1e** — ragged odd-D/U(1) via group-by-exact-shape (+ optional pad-to-max behind a
+  sub-flag where it provably wins).
+- **P2** — cuTensorNet differentiable `custom_call` behind the same interface (GPU);
+  supersedes the existing eager `TENAX_USE_CUTENSOR_BLOCKSPARSE` path with a tracer-safe,
+  differentiable XLA op (fwd + hand-written transpose-contraction VJP).
+
+## Risks / open questions
+
+- **Forward→backward coupling (P1d):** the load-bearing assumption is that cutting forward
+  op-count shrinks the backward graph. The op-histogram (backward = ×1.3 of forward) supports
+  it, but P1d **measures** it before P1e/P2 are funded.
+- **Even-D-only win in Phase 1:** odd-D/U(1) stay on the per-block path until P1e; ragged is
+  largely P2's job. Expectation set explicitly so a strong even-D result is not over-read.
+- **Blast radius:** threading the stacked rep touches the most-used paths (contractor, fuse,
+  decomp, absorb, RDM). Mitigated by persist-at-sweep-boundaries, the P0 golden spine, and
+  shipping P1a–P1d incrementally with byte-exact gates at each step.
+- **`segment_sum` reduction order on GPU:** handled by the tier contract; the energy/grad
+  bound must be re-verified to hold on A100, not only CPU.
+
+## Non-goals
+
+- No change to flat-buffer storage or the single-pytree-leaf layout (#87 substrate).
+- No revert to list-of-blocks (undoes #87's JIT/grad win and the #200/#568/#569 substrate).
+- No within-call contraction batching as a compile lever (`TENAX_BATCH_BLOCKSPARSE` —
+  measured dead for compile; stays a harmless opt-in).

--- a/docs/superpowers/specs/2026-06-04-symmetric-ctm-ad-stacked-blocks-design.md
+++ b/docs/superpowers/specs/2026-06-04-symmetric-ctm-ad-stacked-blocks-design.md
@@ -124,9 +124,11 @@ out of this spec's implementation scope — it stays on the per-block path until
   decomp gauge-invariants; FD gradient + per-block-vs-stacked VJP agreement.
 - **Integration:** full CTM-AD energy+grad vs golden, fermionic/U(1)/dense, even D.
 - **Perf gate (A100, documented — not CI-asserted):** `vg_cmp` compile + warm-step, even D
-  ∈{2,4} (extend to D=6 if it holds), stacked vs per-block. **Target: collapse the measured
-  52–61× fermionic/dense compile ratio toward dense, plus a warm-step win.** This is P1d and
-  the decision gate for P1e/P2.
+  ∈{2,4} (extend to D=6 if it holds), stacked vs per-block.
+  **Hard pass/fail: ≥10× reduction in fermionic `value_and_grad` compile (`vg_cmp`) at D=4
+  — i.e. from the measured ~2379 s baseline to ≤ ~238 s, stacked vs per-block on A100, f64.**
+  Secondary (not gating): a measurable warm-step runtime win at D=4. If the D=4 compile gate
+  is not met, **stop** — do not fund P1e (ragged) or P2 (cuTensorNet); revisit the approach.
 
 ## Phasing (committed scope = P0–P1d)
 
@@ -135,9 +137,10 @@ out of this spec's implementation scope — it stays on the per-block path until
 - **P1b** — stacked contractor, even-D, validated against golden tiers.
 - **P1c** — stacked decomposition + fuse/split, even-D.
 - **P1d** — thread stacked rep through the CTM absorb/RDM so it persists across calls;
-  **A100 compile + runtime measurement = the gate.**
+  **A100 measurement = the gate. Hard pass/fail: ≥10× fermionic `vg_cmp` compile reduction
+  at D=4 (≤ ~238 s vs the ~2379 s baseline).**
 
-Roadmap, gated on P1d showing the gain:
+Roadmap, gated on P1d clearing the ≥10×-at-D=4 bar:
 
 - **P1e** — ragged odd-D/U(1) via group-by-exact-shape (+ optional pad-to-max behind a
   sub-flag where it provably wins).

--- a/docs/superpowers/specs/2026-06-05-blocksparse-backend-seam-design.md
+++ b/docs/superpowers/specs/2026-06-05-blocksparse-backend-seam-design.md
@@ -1,0 +1,141 @@
+# Block-sparse contraction backend seam (#200) — design
+
+**Date:** 2026-06-05
+**Issue:** #200 / #566 (symmetric iPEPS AD compile + runtime)
+**Status:** design → implementation
+**Supersedes:** the pure-JAX P1d deep-restructure path. Decision (2026-06-05): pure-JAX
+contractions-only persistence measured 0.995× on the real sweep (the 96%-structural
+fuse/construct cost is intrinsic to per-block JAX trace emission); the principled fix is a
+single custom block-sparse contraction kernel that emits O(1) ops per contraction, fixing
+*both* the compile wall (#566) and the tiny-kernel runtime (#195). cuTensorNet first (GPU),
+behind a kernel-agnostic seam so Pallas/TPU can be added later without re-plumbing.
+
+## Goal
+
+A kernel-agnostic backend seam for block-sparse `SymmetricTensor` contraction:
+
+- the **reusable ~70%** (plan + dispatch + VJP structure + accuracy harness) is pure-JAX,
+  CPU-testable, and shared by every backend;
+- **cuTensorNet** is the first GPU backend behind it;
+- **Pallas/TPU** (later) is strictly additive — a new backend against the same seam, reusing
+  the plan, the VJP convention, and the tests. Only the kernel code is hardware-specific.
+
+The flat `_data` buffer + static block metadata (PR #87) is the data contract every backend
+consumes; it is unchanged.
+
+## What carries across backends (the seam) vs what doesn't (the kernel)
+
+Reusable, built in Phase A: the dispatch seam; the flat-buffer→backend data contract; the
+**block-contraction plan** (charge matching, valid-output filtering, block-combo grouping,
+segment/accumulation structure, gather indices — the static logic already in
+`_contract_symmetric_stacked`); the JAX-primitive + **VJP structure** (the backward of a
+block-sparse contraction is transposed contractions via the same plan machinery); the
+three-tier accuracy harness. NOT reusable (and never could be): the CUDA/cuTensorNet API code
+vs Pallas/Mosaic kernel code.
+
+## Components
+
+### 1. `BlockContractPlan` (backend-agnostic, from static metadata only)
+
+Extracted from `_contract_symmetric_stacked` (contractor.py). Computed once from block
+keys/shapes (no tensor data):
+
+```python
+@dataclass(frozen=True)
+class BlockContractPlan:
+    out_indices: tuple[TensorIndex, ...]
+    out_block_keys: tuple[BlockKey, ...]
+    out_block_shapes: tuple[tuple[int, ...], ...]
+    batched_subscripts: str                 # batch label prepended
+    groups: tuple[PlanGroup, ...]           # per input-shape-group
+
+@dataclass(frozen=True)
+class PlanGroup:
+    operand_rows: tuple[tuple[int, ...], ...]   # per operand: which stacked rows feed the batched einsum
+    segment_ids: tuple[int, ...]                # output-key accumulation segments
+    num_segments: int
+    out_shape: tuple[int, ...]
+
+def build_block_contract_plan(tensors, subscripts, output_indices) -> BlockContractPlan | None:
+    # None => unsupported here (e.g. >2 tensors / multi-shape-group) -> caller falls back.
+```
+
+### 2. `BlockSparseContractBackend` protocol
+
+```python
+class BlockSparseContractBackend(Protocol):
+    name: str
+    def available(self) -> bool: ...                      # platform + library present
+    def supports(self, tensors, plan) -> bool: ...        # dtype / symmetry / shape-uniformity
+    def execute(self, operand_stacks, plan) -> jax.Array: ...   # stacked operands -> output _data
+```
+
+Backends:
+- **`StackedJaxBackend`** — Task-3 pure-JAX stacked execution (gather rows + batched einsum +
+  `segment_sum`). Available everywhere; supports 2-tensor single-shape-group. Naturally
+  differentiable (jnp ops) → no custom VJP needed.
+- **`CuTensorNetBackend`** (Phase B, GPU) — FFI `custom_call`; custom VJP via transposed plan.
+- **(future) `PallasBackend`** (TPU) — Mosaic kernel; same VJP convention.
+- The existing **per-block path** stays as the universal fallback (used when
+  `build_block_contract_plan` returns None or no backend applies).
+
+### 3. Dispatch
+
+In `_contract_symmetric`, after parsing:
+```python
+plan = build_block_contract_plan(tensors, subscripts, output_indices)
+if plan is not None:
+    backend = select_backend(tensors, plan)   # env override TENAX_BLOCKSPARSE_BACKEND,
+    if backend is not None:                    # else platform + available() + supports()
+        return _execute_backend(backend, tensors, plan)   # AD-wrapped
+# fall through to per-block path
+```
+`select_backend` precedence: explicit env (`stacked`/`cutensornet`/`perblock`/`auto`) →
+on GPU prefer an available `CuTensorNetBackend` → else `StackedJaxBackend` if it supports →
+else None (per-block fallback). Default remains **per-block** unless `TENAX_STACK_BLOCKSPARSE`/
+backend env opts in (byte-identical default, as today).
+
+### 4. VJP seam (so opaque FFI backends plug in)
+
+A block-sparse contraction is multilinear in its operands; its VJP w.r.t. operand *i* is a
+contraction of the cotangent with the other operand(s), expressible by a **transposed plan**.
+The seam provides `transpose_plan(plan, wrt_operand) -> BlockContractPlan` so every backend's
+backward reuses the same machinery:
+- `StackedJaxBackend`: JAX differentiates its jnp ops directly (free).
+- FFI backends (`CuTensorNetBackend`, `PallasBackend`): register a `jax.custom_vjp` whose
+  backward calls `execute` on the transposed plan (on the same backend), so only the forward
+  kernel is hardware-specific; the backward *structure* is shared.
+
+## Accuracy contract (unchanged)
+
+The three-tier comparator (tests/stacked/_harness.py) governs every backend: bit-identical for
+data movement, bounded-fp (rtol/atol 1e-12) for reductions, **gauge-invariant only** for SVD.
+Lesson from the P1d drift investigation: compare converged-sweep energies **only at full
+convergence** (tol 1e-12), never at a fixed loose iteration — early-iteration gauge freedom in
+the SVD projector makes raw env data differ by O(1) under 1e-16 input perturbations while the
+gauge-invariant energy is identical at convergence.
+
+## Phasing
+
+- **Phase A (CPU-local):**
+  - **A1** extract `BlockContractPlan` + `build_block_contract_plan` (pure refactor of
+    `_contract_symmetric_stacked`); existing stacked tests stay green.
+  - **A2** `BlockSparseContractBackend` protocol + `select_backend` + register
+    `StackedJaxBackend`; wire `_contract_symmetric` dispatch; equivalence preserved.
+  - **A3** VJP seam (`transpose_plan` + custom_vjp path) + a **`MockFFIBackend`** (a pure-JAX
+    stand-in that mimics an opaque `custom_call` with a hand-written transposed-plan VJP),
+    asserting value+grad match per-block at even D — **proves the seam hosts an opaque
+    differentiable backend before any GPU exists.**
+- **Phase B (A100/CUDA handoff):** `CuTensorNetBackend` — FFI `custom_call` (extend the
+  existing eager `tenax/contraction/cutensor_blocksparse.py` to a tracer-safe differentiable
+  op), register for GPU, slot in via the A3 VJP convention. Validate against the accuracy spine
+  and `StackedJaxBackend`; then the compile/runtime measurement on A100.
+
+## Non-goals / constraints
+
+- Flat-buffer storage + single pytree leaf unchanged (#87 substrate).
+- Default execution path unchanged (per-block) unless opted in; byte-identical default.
+- No Pallas code in Phase A — only the seam it will plug into. No cuTensorNet-isms allowed to
+  leak past the backend boundary (the lock-in risk): the contractor sees only the protocol.
+- Even-D / 2-tensor single-shape-group scope for the plan initially (ragged is a later backend
+  concern); per-block fallback covers everything else.

--- a/examples/measure_persist_sweep_566.py
+++ b/examples/measure_persist_sweep_566.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Real-sweep op-count + persist-hit-rate measurement for the persisting
+``StackedSymmetricTensor`` (#566 P1d slice 1). COMMITTABLE RECORD.
+
+This is the go/no-go checkpoint for the persist-across-contractions mechanism.
+It traces the FULL fused CTM-AD backward (env-sweep VJP + params-sweep VJP, the
+compile-dominant ``_jit_fused_fixed_point_bwd`` unit) with
+``TENAX_STACK_BLOCKSPARSE`` OFF vs ON-with-persist, and reports:
+
+1. Backward TOTAL jaxpr op count OFF vs ON and the ON/OFF ratio (the realized
+   op-count drop on the REAL sweep — the prior even-D within-call stacking gave
+   ~1.00x here because every call re-gathered/re-scattered ``_data``).
+
+2. PERSIST HIT-RATE: how many of the sweep's stacked ``_contract_symmetric``
+   calls consumed an already-stacked input (PERSISTED, no ``_data`` gather)
+   vs had to gather from ``_data`` (chain INTERRUPTED upstream by a
+   fuse/bar/svd/_data-read). Reported as persisted/total operands and
+   fully-persisted/total calls.
+
+Trace-only (``jax.make_jaxpr``, no XLA compile). Reuses the probe's helpers.
+
+Findings (fermionic D=2 and D=4, identical because the hit-rate is STRUCTURAL —
+block-combo counts, not intra-block dense size):
+
+* dot_general collapses 2344 -> 252 (~9.3x) — the batched einsum + segment_sum
+  core works on the real sweep.
+* backward TOTAL op-count barely moves: 0.995x (D=2) / 0.998x (D=4). The
+  non-contraction ops (the ``.fuse()`` per-block reshapes, the SVD/eigh VJP, the
+  scatter glue, and elementwise) dominate the graph and are unaffected.
+* PERSIST hit-rate: 52/194 operands persisted (27%); only 8/97 calls fully
+  persisted; 142 operands had to gather from ``_data``. The chains are short:
+  the dominant interrupter is ``.fuse()`` (reads ``_data`` via ``_get_block``,
+  ~41 materializations) — e.g. ``_build_double_layer_tensor`` does
+  ``contract(A, A_bra)`` then immediately fuses the (u,U)/(d,D)/(l,L)/(r,R)
+  pairs, materializing the stacked output one op later. A handful more come from
+  ``.dtype`` reads (~8).
+
+READ: contractions-only persistence does NOT clear the >=3-5x op-count target.
+fuse/bar must be made stacked-aware (Task 5b) to lengthen the chains; the
+contraction core itself is already ~9x leaner in dot_general.
+
+PRE-EXISTING DEFECT (unrelated to this slice, flagged for follow-up): the landed
+``TENAX_STACK_BLOCKSPARSE`` path makes the converged CTM energy drift ~4.6e-4 vs
+the per-block path (reproduces on HEAD WITHOUT the persisting return; the
+persisting return is byte-identical, dE=0.0, to the non-persisting stacked
+path). Every individual contraction is byte-identical (0/97 divergent vs
+per-block on concrete forward iterations), so the drift is a downstream
+fixed-point sensitivity in the landed stacked core, not in this slice.
+
+Run::
+
+    JAX_PLATFORMS=cpu uv run python examples/measure_persist_sweep_566.py
+    JAX_PLATFORMS=cpu uv run python examples/measure_persist_sweep_566.py 2 4
+"""
+
+from __future__ import annotations
+
+import collections
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import jax  # noqa: E402
+
+jax.config.update("jax_enable_x64", True)
+
+from probe_backward_jaxpr_566 import (  # noqa: E402
+    backward_vjp_jaxpr,
+    count_primitives,
+    make_site,
+)
+
+import tenax.algorithms._ctm_python_loop as _loop  # noqa: E402
+import tenax.contraction.contractor as _ctr  # noqa: E402
+
+STACK_FLAG = "TENAX_STACK_BLOCKSPARSE"
+
+
+def _reset_trace_caches() -> None:
+    """Force a fresh trace so the flag is re-read.
+
+    ``_make_jit_ctm_step`` caches the jitted CTM step for the process lifetime
+    (keyed by ``id(neighbors)``), and JAX caches the traced jaxpr. Without
+    clearing both, the OFF trace is reused for the ON run and the flag flip is
+    invisible. This is a measurement-harness concern only.
+    """
+    jax.clear_caches()
+    _loop._JIT_STEP_CACHE.clear()
+
+
+def total_ops(counter: collections.Counter) -> int:
+    return int(sum(counter.values()))
+
+
+def _snapshot_persist() -> dict:
+    return dict(_ctr._STACK_PERSIST)
+
+
+def measure(sym: str, D: int, chi_factor: int = 3, pbw: str = "auto") -> dict:
+    chi = chi_factor * D
+    A = make_site(sym, D)
+    n_blocks = getattr(A, "n_blocks", 1)
+
+    rows: dict[bool, tuple[int, int]] = {}
+    persist_delta: dict | None = None
+    for on in (False, True):
+        os.environ[STACK_FLAG] = "1" if on else "0"
+        _reset_trace_caches()
+        if on:
+            before = _snapshot_persist()
+        env_jx, par_jx = backward_vjp_jaxpr(A, chi, pbw, full=True)
+        c = count_primitives(env_jx) + count_primitives(par_jx)
+        rows[on] = (total_ops(c), int(c.get("dot_general", 0)))
+        if on:
+            after = _snapshot_persist()
+            persist_delta = {k: after[k] - before[k] for k in after}
+    os.environ[STACK_FLAG] = "0"
+
+    (off_tot, off_dg), (on_tot, on_dg) = rows[False], rows[True]
+    ratio = on_tot / off_tot if off_tot else float("nan")
+
+    calls = persist_delta["calls"] if persist_delta else 0
+    persisted = persist_delta["persisted_inputs"] if persist_delta else 0
+    gathered = persist_delta["gathered_inputs"] if persist_delta else 0
+    full = persist_delta["fully_persisted"] if persist_delta else 0
+    total_inputs = persisted + gathered
+
+    # The persist snapshot accumulates over BOTH the forward sweep (run once to
+    # produce ``out``) AND the env+params VJP tracing inside backward_vjp_jaxpr.
+    # We report it as-is (the realized in-trace hit-rate).
+    print(f"== {sym} D={D} chi={chi} blocks={n_blocks} ==")
+    print(
+        f"   backward TOTAL ops: off={off_tot:>7} on={on_tot:>7}  on/off={ratio:.3f}x"
+    )
+    print(f"   dot_general:        off={off_dg:>7} on={on_dg:>7}")
+    if calls:
+        pct_in = 100.0 * persisted / total_inputs if total_inputs else 0.0
+        pct_call = 100.0 * full / calls if calls else 0.0
+        print(
+            f"   PERSIST hit-rate:   operands persisted {persisted}/{total_inputs} "
+            f"({pct_in:.0f}%)  | fully-persisted calls {full}/{calls} "
+            f"({pct_call:.0f}%)  | gathered(interrupted) {gathered}"
+        )
+    else:
+        print("   PERSIST hit-rate:   no stacked contractions fired")
+    print()
+    return {
+        "D": D,
+        "ratio": ratio,
+        "calls": calls,
+        "persisted": persisted,
+        "gathered": gathered,
+        "fully_persisted": full,
+        "off_tot": off_tot,
+        "on_tot": on_tot,
+    }
+
+
+def main() -> None:
+    print(
+        f"# #566 P1d persist measurement | x64={jax.config.read('jax_enable_x64')} "
+        f"| flag={STACK_FLAG} | unit=full fused backward (env-VJP + params-VJP)\n"
+    )
+    Ds = [int(x) for x in sys.argv[1:]] or [2, 4]
+    recs = []
+    for D in Ds:
+        try:
+            recs.append(measure("fermionic", D))
+        except Exception as e:  # report partial on slow/failed D
+            print(f"!! fermionic D={D} did not complete: {type(e).__name__}: {e}\n")
+
+    # ---- VERDICT ----
+    print("VERDICT")
+    for r in recs:
+        if r["calls"]:
+            interrupted = r["gathered"]
+            total_in = r["persisted"] + r["gathered"]
+            read = (
+                "contractions-only persistence is enough"
+                if r["ratio"] <= 0.34
+                else (
+                    "fuse/bar interrupt most chains — Task 5b (stacked-aware "
+                    "fuse/bar) needed to reach >=3-5x"
+                    if interrupted > r["persisted"]
+                    else "partial persistence; some interruptions remain"
+                )
+            )
+            print(
+                f"  D={r['D']}: backward op-count ON/OFF = {r['ratio']:.3f}x | "
+                f"operands persisted {r['persisted']}/{total_in}, "
+                f"fully-persisted calls {r['fully_persisted']}/{r['calls']}, "
+                f"interrupted(gathered) {interrupted}\n"
+                f"          read: {read}."
+            )
+        else:
+            print(f"  D={r['D']}: no stacked contractions fired (even-D scope?).")
+    print()
+    print(
+        "Note: a >=3-5x backward op-count drop is the target. If interruptions "
+        "(fuse/bar/svd reading _data) dominate, every contraction chain is length "
+        "~1 and persistence cannot help until those ops are made stacked-aware "
+        "(Task 5b)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/proto_persist_sweep_566.py
+++ b/examples/proto_persist_sweep_566.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Persist-across-calls op-count ceiling prototype (#566 P1d).
+
+THROWAWAY / RECORD. Drives a go/no-go on the high-blast-radius "persist stacked
+arrays across a chain of contractions" restructure for the even-D fermionic CTM
+sweep.
+
+Background
+----------
+Task 3 (PR-landed ``TENAX_STACK_BLOCKSPARSE``) gives a *single* even-D 2-tensor
+contraction a batched einsum + segment_sum core, but on a real CTM sweep it
+measures ~1.00x op count because EACH ``contract()`` call gathers the stacked
+view from ``_data`` (``SymmetricTensor.stacked_blocks()``) on input and
+re-scatters to ``_data`` (``_from_blocks_unchecked``) on output. The per-call
+gather/scatter "glue" costs ~what the batching saves.
+
+Hypothesis tested here
+----------------------
+The real win is PERSISTING the stacked arrays ACROSS a chain of K contractions:
+gather from ``_data`` ONCE at the start, run K contractions staying in stacked-
+array form, scatter to ``_data`` ONCE at the end. We measure the op-count
+collapse of (P) persist vs (RT) round-trip as a function of chain length K, at
+even D in {2, 4}, TRACE-ONLY (``jax.make_jaxpr``, no XLA compile).
+
+Chain network
+-------------
+A STATIONARY transfer-matrix-style chain. Starting tensor (REUSING the
+``tests/stacked/test_harness.py`` ``_phys_double_layer`` construction)::
+
+    T = contract(A, A.bar().relabels({u:U, d:D, l:L, r:R}))   # rank-8, phys contracted
+
+Each step contracts the running ``T`` with a fresh "layer" (``T`` with all 8 legs
+relabelled so that exactly the (r, R) bond pair contracts) and relabels the
+output back onto ``T``'s own 8 labels (u, d, l, r, U, D, L, R). Because the
+output has identical labels / block_keys / block_shapes to the input ``T``, the
+chain can be made arbitrary length K, and the charge bookkeeping is IDENTICAL at
+every step (computed once, statically, then reused for all K contractions in the
+persist path).
+
+Correctness gate
+----------------
+For every (D, K) we assert ``rt_chain(data)`` and ``p_chain(data)`` produce the
+SAME output ``_data`` within the fp tier (rtol/atol 1e-12). A wrong persist
+contraction is a BLOCKER, not a ceiling number.
+
+Run::
+
+    JAX_PLATFORMS=cpu uv run python examples/proto_persist_sweep_566.py
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import string
+import sys
+from pathlib import Path
+
+import jax
+
+# Make the sibling examples/ probe importable when run as a script.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+jax.config.update("jax_enable_x64", True)
+
+# Reuse the recursive jaxpr primitive counter from the backward probe (load by
+# file path so this works whether or not examples/ is an importable package).
+import importlib.util as _ilu  # noqa: E402
+
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+
+from tenax.algorithms.fermionic_ipeps import (  # noqa: E402
+    FPEPSConfig,
+    _build_initial_fpeps_tensor,
+)
+from tenax.contraction.contractor import (  # noqa: E402
+    _labels_to_subscripts,
+    _parse_contraction_prelude,
+    contract,
+)
+from tenax.core.tensor import SymmetricTensor  # noqa: E402
+
+_probe_path = Path(__file__).resolve().parent / "probe_backward_jaxpr_566.py"
+_spec = _ilu.spec_from_file_location("_probe_backward_jaxpr_566", _probe_path)
+_probe = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_probe)
+count_primitives = _probe.count_primitives  # noqa: E402
+
+STACK_FLAG = "TENAX_STACK_BLOCKSPARSE"
+
+# Stationary chain bookkeeping ---------------------------------------------
+
+# T labels (rank-8 double layer). The "layer" relabels every leg so that ONLY
+# the (r, R) bond pair is shared (contracted) with the running T, and the output
+# is relabelled back onto T's own 8 labels so the chain is stationary.
+T_LABELS = ("u", "d", "l", "r", "U", "D", "L", "R")
+LAYER_RELABEL = {
+    "u": "uu",
+    "d": "dd",
+    "l": "r",  # <- shares r with running T (contracted)
+    "r": "rr",  # <- becomes the new r after final relabel
+    "U": "UU",
+    "D": "DD",
+    "L": "R",  # <- shares R with running T (contracted)
+    "R": "RR",  # <- becomes the new R after final relabel
+}
+# Free output labels of (T, layer) in the order we want, then mapped back to T.
+OUT_LABELS = ["u", "d", "l", "rr", "U", "D", "L", "RR"]
+OUT_BACK_RELABEL = {"rr": "r", "RR": "R"}
+
+
+def build_double_layer(A: SymmetricTensor) -> SymmetricTensor:
+    """REUSE the harness ``_phys_double_layer`` construction (phys-only contract)."""
+    bra = A.bar().relabels({"u": "U", "d": "D", "l": "L", "r": "R"})
+    return contract(A, bra)
+
+
+def make_layer(T: SymmetricTensor) -> SymmetricTensor:
+    """The fresh layer for one chain step: T with legs relabelled per LAYER_RELABEL."""
+    return T.relabels(LAYER_RELABEL)
+
+
+# ---- Round-trip (RT) mode: production contract() with per-call glue ----------
+
+
+def rt_step(T: SymmetricTensor) -> SymmetricTensor:
+    """One stationary transfer step via the production stacked contract path.
+
+    Each call gathers the stacked view from _data on BOTH operands and scatters
+    back to _data on output (the "glue"). With TENAX_STACK_BLOCKSPARSE=1 the
+    inner contraction uses the batched einsum + segment_sum core.
+    """
+    layer = make_layer(T)
+    out = contract(T, layer, output_labels=OUT_LABELS)
+    return out.relabels(OUT_BACK_RELABEL)
+
+
+# ---- Persist (P) mode: stacked-array-native chain, no intermediate tensors ---
+
+
+def _static_stacked_plan(T: SymmetricTensor, layer: SymmetricTensor, subscripts: str):
+    """Compute the STATIC charge bookkeeping for one stationary step ONCE.
+
+    Returns everything needed to run the contraction as pure stacked-array ops:
+        batched_subscripts : str   (one batch axis prepended to every operand)
+        per_op_rows        : list[np.ndarray]  row indices into each operand stack
+        seg_ids            : np.ndarray         segment id per survivor combo
+        n_segments         : int
+        canon_perm         : np.ndarray  permutation mapping segment order ->
+                                         canonical sorted-key order (the order
+                                         T's own stack rows live in), so the
+                                         output stack can feed back as input.
+
+    This replicates the survivor-enumeration core of
+    ``contractor._contract_symmetric_stacked`` but separates the STATIC index
+    bookkeeping (done once) from the TRACED array ops (done K times).
+    """
+    tensors = [T, layer]
+    (
+        input_subs,
+        output_part,
+        _out_indices_ordered,
+        contracted_chars,
+        contracted_chars_sorted,
+        char_to_canonical_pos,
+        _output_target,
+        valid_output_set,
+    ) = _parse_contraction_prelude(tensors, subscripts)
+
+    n_pos = len(input_subs)
+
+    # Per-tensor: covered (canonical_pos, pos_in_subs) and partial-sig -> rows.
+    tensor_covered = []
+    tensor_partial_rows = []
+    tensor_keys = []
+    for tensor, subs in zip(tensors, input_subs):
+        view = tensor.stacked_blocks()
+        (group,) = view.groups.values()
+        keys = group.keys
+        tensor_keys.append(keys)
+
+        covered = sorted(
+            (char_to_canonical_pos[c], pos)
+            for pos, c in enumerate(subs)
+            if c in contracted_chars
+        )
+        tensor_covered.append(covered)
+
+        partial_rows: dict = {}
+        for row, key in enumerate(keys):
+            partial_sig = tuple(int(key[pos]) for _, pos in covered)
+            partial_rows.setdefault(partial_sig, []).append(row)
+        tensor_partial_rows.append(partial_rows)
+
+    # Surviving combos (2-tensor scope => every contracted char in both).
+    common_sigs = set(tensor_partial_rows[0].keys())
+    for partial_rows in tensor_partial_rows[1:]:
+        common_sigs &= set(partial_rows.keys())
+
+    survivors = []  # (output_key, combo_rows)
+    for full_sig in common_sigs:
+        matching_rows = []
+        skip = False
+        for covered, partial_rows in zip(tensor_covered, tensor_partial_rows):
+            partial_sig = tuple(full_sig[cp] for cp, _ in covered)
+            rows = partial_rows.get(partial_sig)
+            if not rows:
+                skip = True
+                break
+            matching_rows.append(rows)
+        if skip:
+            continue
+        for combo_rows in itertools.product(*matching_rows):
+            keys = [tensor_keys[i][combo_rows[i]] for i in range(n_pos)]
+            char_to_charge: dict = {}
+            compatible = True
+            for key, subs in zip(keys, input_subs):
+                for char, charge in zip(subs, key):
+                    ci = int(charge)
+                    if char in char_to_charge:
+                        if char_to_charge[char] != ci:
+                            compatible = False
+                            break
+                    else:
+                        char_to_charge[char] = ci
+                if not compatible:
+                    break
+            if not compatible:
+                continue
+            output_key = tuple(char_to_charge.get(c, 0) for c in output_part)
+            if output_key not in valid_output_set:
+                continue
+            survivors.append((output_key, tuple(combo_rows)))
+
+    # Batched subscripts.
+    used_chars = set("".join(input_subs)) | set(output_part)
+    batch_char = next(c for c in string.ascii_letters if c not in used_chars)
+    batched_inputs = ",".join(batch_char + s for s in input_subs)
+    batched_subscripts = batched_inputs + "->" + batch_char + output_part
+
+    # Segment ids (combos sharing an output_key get summed).
+    distinct_keys = []
+    key_to_seg: dict = {}
+    seg_ids = []
+    per_op_rows = [[] for _ in range(n_pos)]
+    for okey, combo_rows in survivors:
+        seg = key_to_seg.get(okey)
+        if seg is None:
+            seg = len(distinct_keys)
+            key_to_seg[okey] = seg
+            distinct_keys.append(okey)
+        seg_ids.append(seg)
+        for pos in range(n_pos):
+            per_op_rows[pos].append(combo_rows[pos])
+
+    # Permutation: segment order -> canonical sorted-key order. The output
+    # SymmetricTensor stores blocks in sorted-key order; T's OWN stack rows live
+    # in that same sorted order. We map the OUT_BACK_RELABEL'd output keys to
+    # T's keys and sort, so the persisted stack rows match T's row order and can
+    # feed back as the next input.
+    out_part_labels = OUT_LABELS  # output_part chars correspond 1:1 to these
+    # output_part is the char string; map each output char-position to its label.
+    # Build label -> charge for each distinct output key, then relabel to T space.
+    char_to_label = dict(zip(output_part, out_part_labels))
+    back = OUT_BACK_RELABEL
+    # T's canonical key order:
+    t_keys = T._block_keys
+    t_labels = T.labels()
+    # For each distinct (segment) key, produce the T-space key tuple.
+    t_space_keys = []
+    for okey in distinct_keys:
+        # map output char -> charge
+        lab_to_charge = {}
+        for ch, q in zip(output_part, okey):
+            lab = char_to_label[ch]
+            lab = back.get(lab, lab)
+            lab_to_charge[lab] = int(q)
+        t_space_keys.append(tuple(lab_to_charge[lab] for lab in t_labels))
+    # canon_perm[i] = segment index whose T-space key == t_keys[i]
+    key_to_seg_idx = {k: i for i, k in enumerate(t_space_keys)}
+    canon_perm = np.array([key_to_seg_idx[k] for k in t_keys], dtype=np.int64)
+
+    assert len(distinct_keys) == len(t_keys), (
+        "stationary chain must reproduce T's block set"
+    )
+
+    return {
+        "batched_subscripts": batched_subscripts,
+        "per_op_rows": [np.asarray(r, dtype=np.int64) for r in per_op_rows],
+        "seg_ids": np.asarray(seg_ids, dtype=np.int32),
+        "n_segments": len(distinct_keys),
+        "canon_perm": canon_perm,
+        "n_pos": n_pos,
+    }
+
+
+def _persist_contract_stacked(stack_T, stack_layer, plan):
+    """One stacked-array-native contraction. IN: two (n,*shape) stacks. OUT: stack.
+
+    Pure traced ops: 2 gathers (jnp.take) + 1 batched einsum + 1 segment_sum +
+    1 reorder gather to canonical order. No SymmetricTensor, no stacked_blocks(),
+    no _from_blocks_unchecked between calls.
+    """
+    rows0 = jnp.asarray(plan["per_op_rows"][0])
+    rows1 = jnp.asarray(plan["per_op_rows"][1])
+    g0 = jnp.take(stack_T, rows0, axis=0)
+    g1 = jnp.take(stack_layer, rows1, axis=0)
+    batched = jnp.einsum(plan["batched_subscripts"], g0, g1)
+    summed = jax.ops.segment_sum(
+        batched, jnp.asarray(plan["seg_ids"]), num_segments=plan["n_segments"]
+    )
+    # Reorder segment order -> canonical sorted-key (= T row) order.
+    out_stack = jnp.take(summed, jnp.asarray(plan["canon_perm"]), axis=0)
+    return out_stack
+
+
+# ---- Traceable chain functions of the flat _data vector ----------------------
+
+
+def _rebuild_from_data(template: SymmetricTensor, data_vec) -> SymmetricTensor:
+    """Reconstruct a SymmetricTensor from a flat _data vector via type(A)._raw."""
+    return type(template)._raw(
+        indices=template._indices,
+        data=data_vec,
+        block_keys=template._block_keys,
+        block_shapes=template._block_shapes,
+        block_offsets=template._block_offsets,
+    )
+
+
+def make_rt_chain(T: SymmetricTensor, K: int):
+    """rt_chain(data_vec) -> output _data vec. Whole chain traceable on _data."""
+
+    def rt_chain(data_vec):
+        running = _rebuild_from_data(T, data_vec)
+        for _ in range(K):
+            running = rt_step(running)
+        return running._data
+
+    return rt_chain
+
+
+def make_p_chain(T: SymmetricTensor, plan, K: int):
+    """p_chain(data_vec) -> output _data vec.
+
+    Gather T's stack from _data ONCE, run K stacked contractions staying in
+    stacked-array form, scatter to _data ONCE at the end.
+    """
+    (group_shape,) = set(T._block_shapes)
+    del group_shape  # single-group invariant check only
+
+    def p_chain(data_vec):
+        # Single shape group, contiguous: gather from _data ONCE.
+        T_self = _rebuild_from_data(T, data_vec)
+        view = T_self.stacked_blocks()
+        (group,) = view.groups.values()
+        stack = group.array  # (n, *shape)
+
+        for _ in range(K):
+            # The "layer" is the running tensor relabelled; relabelling does NOT
+            # change the stack array values (just leg labels), so the layer's
+            # stack IS the same array. The plan already encodes which rows of
+            # each operand to gather, so we feed `stack` as BOTH operands.
+            stack = _persist_contract_stacked(stack, stack, plan)
+
+        # Scatter to _data ONCE: stack rows are already in canonical (T) order,
+        # and the layout is contiguous single-group, so flatten back.
+        out_data = stack.reshape(-1)
+        return out_data
+
+    return p_chain
+
+
+# ---- Measurement -------------------------------------------------------------
+
+
+def count_dot_general(jaxpr) -> int:
+    return count_primitives(jaxpr).get("dot_general", 0)
+
+
+def run_for_D(D: int, Ks, results):
+    A = _build_initial_fpeps_tensor(FPEPSConfig(D=D), jax.random.PRNGKey(0))
+    assert len(set(A._block_shapes)) == 1, (
+        f"D={D} site tensor is not single-shape-group"
+    )
+    T = build_double_layer(A)
+    assert len(set(T._block_shapes)) == 1, f"D={D} double layer not single-shape-group"
+
+    layer = make_layer(T)
+    subscripts, _ = _labels_to_subscripts([T, layer], OUT_LABELS)
+    plan = _static_stacked_plan(T, layer, subscripts)
+
+    data_vec = T._data
+
+    for K in Ks:
+        # Force the stacked path for the RT mode.
+        os.environ[STACK_FLAG] = "1"
+
+        rt_chain = make_rt_chain(T, K)
+        p_chain = make_p_chain(T, plan, K)
+
+        rt_out = rt_chain(data_vec)
+        p_out = p_chain(data_vec)
+
+        # ---- Correctness gate (MANDATORY) ----
+        np.testing.assert_allclose(
+            np.asarray(p_out), np.asarray(rt_out), rtol=1e-12, atol=1e-12
+        )
+
+        rt_jx = jax.make_jaxpr(rt_chain)(data_vec)
+        p_jx = jax.make_jaxpr(p_chain)(data_vec)
+        rt_ops = sum(count_primitives(rt_jx).values())
+        p_ops = sum(count_primitives(p_jx).values())
+        rt_dg = count_dot_general(rt_jx)
+        p_dg = count_dot_general(p_jx)
+
+        results.append(
+            {
+                "D": D,
+                "K": K,
+                "rt_ops": rt_ops,
+                "p_ops": p_ops,
+                "rt_dg": rt_dg,
+                "p_dg": p_dg,
+            }
+        )
+
+
+def main() -> None:
+    print("# #566 P1d persist-vs-roundtrip op-count ceiling prototype (trace-only)")
+    print(f"# x64={jax.config.read('jax_enable_x64')}  flag={STACK_FLAG}=1 for RT mode")
+    print("# chain = stationary rank-8 double-layer transfer; (r,R) bond contracts")
+    print(
+        "# NOTE: op counts are STRUCTURAL (one dot_general per block-combo, "
+        "independent of intra-block dense size), so even-D D=2 and D=4 share the "
+        "same 128-block double layer and thus the SAME trace-only op count; only "
+        "the dense work inside each block (and hence compile/runtime) grows with D."
+    )
+    print()
+
+    Ks = [1, 2, 4, 8]
+    results = []
+    for D in (2, 4):
+        try:
+            run_for_D(D, Ks, results)
+        except Exception as e:  # report partial completion on slow/failed D
+            print(f"!! D={D} did not fully complete: {type(e).__name__}: {e}")
+
+    # Table.
+    hdr = (
+        f"{'D':>3} {'K':>3} {'RT_ops':>8} {'P_ops':>8} {'P/RT':>7} "
+        f"{'glue/call':>10} {'RT_dg':>6} {'P_dg':>6}"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+    by_D = {}
+    for r in results:
+        by_D.setdefault(r["D"], {})[r["K"]] = r
+        ratio = r["p_ops"] / r["rt_ops"] if r["rt_ops"] else float("nan")
+        if r["K"] > 1:
+            glue = (r["rt_ops"] - r["p_ops"]) / (r["K"] - 1)
+            glue_s = f"{glue:10.1f}"
+        else:
+            glue_s = f"{'--':>10}"
+        print(
+            f"{r['D']:>3} {r['K']:>3} {r['rt_ops']:>8} {r['p_ops']:>8} "
+            f"{ratio:>6.3f} {glue_s} {r['rt_dg']:>6} {r['p_dg']:>6}"
+        )
+    print()
+
+    # ---- Verdict ----
+    print("CORRECTNESS GATE: PASSED (rt==p within fp rtol/atol=1e-12) for all (D,K).")
+    print()
+    print("VERDICT")
+    for D in sorted(by_D):
+        recs = by_D[D]
+        ks = sorted(recs)
+        ratios = [recs[k]["p_ops"] / recs[k]["rt_ops"] for k in ks]
+        dropping = all(
+            ratios[i + 1] <= ratios[i] + 1e-9 for i in range(len(ratios) - 1)
+        )
+        material = ratios[-1] < 0.9
+        # Asymptotic estimate: as K->large, RT_ops ~ a + b*K, P_ops ~ c + d*K.
+        # Use the two largest K to estimate per-step slopes.
+        if len(ks) >= 2:
+            k_lo, k_hi = ks[-2], ks[-1]
+            rt_slope = (recs[k_hi]["rt_ops"] - recs[k_lo]["rt_ops"]) / (k_hi - k_lo)
+            p_slope = (recs[k_hi]["p_ops"] - recs[k_lo]["p_ops"]) / (k_hi - k_lo)
+            asym = rt_slope / p_slope if p_slope else float("inf")
+        else:
+            asym = float("nan")
+        print(
+            f"  D={D}: P/RT drops {ratios[0]:.3f}->{ratios[-1]:.3f} over K={ks[0]}..{ks[-1]} "
+            f"| monotone-dropping={dropping} | material(<0.9)={material} "
+            f"| asymptotic RT/P per-step ~ {asym:.2f}x"
+        )
+    print()
+    print(
+        "Interpretation: the per-call glue (input stacked_blocks() gather x2 + "
+        "output scatter/_from_blocks_unchecked) is O(K) in RT and is REMOVED by "
+        "persist; persist keeps ~K dot_generals with O(1) edge gather/scatter. "
+        "A sustained op-count ratio RT/P >= 10x per step at even D would make the "
+        ">=10x COMPILE gate plausibly reachable via the persist-across-calls "
+        "restructure (compile scales super-linearly with op count, so the compile "
+        "ratio is expected LARGER than the op-count ratio -- but only the op-count "
+        "ratio is measured here; no compile claim is made)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/perblock.json
+++ b/perblock.json
@@ -1,0 +1,54 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "syms": [
+    "fermionic"
+  ],
+  "depths": [
+    8
+  ],
+  "explicit": false,
+  "rows": [
+    {
+      "sym": "fermionic",
+      "D": 2,
+      "chi": 6,
+      "depth": 8,
+      "path": "implicit",
+      "n_blocks": 16,
+      "fwd_wall_s": 56.713563580065966,
+      "fwd_compile_s": 44.66103196100004,
+      "fwd_n_compiles": 215,
+      "vg_wall_s": 223.58180046547204,
+      "vg_compile_s": 164.16622662300006,
+      "vg_n_compiles": 230,
+      "bwd_compile_s_est": 119.50519466200001,
+      "top_compile_name": "jit(_jit_fused_fixed_point_bwd)",
+      "top_compile_s": 109.389655113,
+      "warm_step_s": 4.432892246171832,
+      "energy": -0.20308408091797261,
+      "grad_finite": true
+    },
+    {
+      "sym": "fermionic",
+      "D": 4,
+      "chi": 12,
+      "depth": 8,
+      "path": "implicit",
+      "n_blocks": 16,
+      "fwd_wall_s": 566.2050974294543,
+      "fwd_compile_s": 537.349167339,
+      "fwd_n_compiles": 214,
+      "vg_wall_s": 1549.6133713684976,
+      "vg_compile_s": 1417.6323959899996,
+      "vg_n_compiles": 229,
+      "bwd_compile_s_est": 880.2832286509996,
+      "top_compile_name": "jit(_jit_fused_fixed_point_bwd)",
+      "top_compile_s": 872.791329145,
+      "warm_step_s": 5.83371499273926,
+      "energy": -0.030474469763232533,
+      "grad_finite": true
+    }
+  ]
+}

--- a/profile_566_a100_summary.md
+++ b/profile_566_a100_summary.md
@@ -1,0 +1,63 @@
+# #566 CTM-AD Compile-Wall — Phase-0 Profiler Summary (A100)
+
+**Platform:** NVIDIA A100-SXM4-80GB · x64=True · path=implicit (`adjoint_method="fixed_point"`, `_jit_fused_fixed_point_bwd`) · depth=8 · reps=5
+**Artifacts:** `profile_566_a100_Dsweep.json`, `profile_566_a100_chi.json`
+
+## (A) Dense-vs-fermionic D-scaling (χ = 4·D)
+
+| sym | D | χ | blk | fwd_cmp | **vg_cmp** | bwd_cmp | ferm/dense vg |
+|-----|---|----|-----|---------|-----------|---------|---------------|
+| fermionic | 2 | 8 | 16 | 63.8s | **206.4s** | 142.6s | 3.6× |
+| fermionic | 3 | 12 | 16 | 527.8s | **2111.3s** (~35 min) | 1583.5s | 52× |
+| fermionic | 4 | 16 | 16 | 899.0s | **2379.2s** (~40 min) | 1480.2s | 61× |
+| dense | 2 | 8 | 1 | 19.3s | 57.7s | 38.4s | — |
+| dense | 3 | 12 | 1 | 27.8s | 40.6s | 12.8s | — |
+| dense | 4 | 16 | 1 | 26.3s | 38.9s | 12.6s | — |
+
+## (B) χ-scaling at D=3
+
+| sym | χ | fwd_cmp | **vg_cmp** | bwd_cmp |
+|-----|----|---------|-----------|---------|
+| fermionic | 8 | 280.7s | 575.7s | 295.1s |
+| fermionic | 12 | 552.8s | 2135.5s | 1582.8s |
+| fermionic | 16 | 727.3s | 1365.2s | 637.9s |
+| fermionic | 24 | 1156.2s | 3568.7s | 2412.5s |
+| dense | 8 | 20.2s | 27.1s | 6.9s |
+| dense | 12 | 18.3s | 27.7s | 9.4s |
+| dense | 16 | 18.0s | 27.6s | 9.6s |
+| dense | 24 | 19.9s | 29.6s | 9.7s |
+
+## Conclusions (Phase-0 gate)
+
+1. **Wall is entirely fermionic per-block emission (finding b).** Dense `vg_cmp` is flat at ~27–58s across all D and χ — no symmetry-independent scaling problem. Fermionic/dense ratio is 20×–120× at a constant 16 blocks, so it is *not* a flat "16× dense" multiplier; per-block emission itself grows with D.
+
+2. **Backward dominates (finding d).** `bwd_cmp` is the majority of `vg_cmp` for fermionic (1583/2135s at χ=12; 2413/3569s at χ=24). The slow-op alarm fires on `jit__jit_fused_fixed_point_bwd`. The minutes-long wall is the implicit-diff fixed-point backward.
+
+3. **χ is NOT a compile lever → does not pivot to #570.** Dense compile is flat in χ (27→30s). The large-χ SVD/eigh VJP (finding c) is a *runtime* axis, not compile. #570 does not address the wall.
+
+4. **Scan-fusion is the wrong lever for compile.** The implicit path's compile is already depth-flat by construction (forward step reused across iters); scan-fusion buys eager-dispatch *runtime*, not compile. Redirect target = **reduce per-block op emission in the fermionic fixed-point backward**.
+
+### Caveats
+- **Reproducibility:** shared point D=3,χ=12 fermionic agrees across the two runs (2111s vs 2135s, ~1%) — magnitudes are solid.
+- **Non-monotonic backward in χ:** fermionic `vg_cmp` is erratic (χ=16 *lower* than χ=12). Forward compile is clean/monotonic (281→553→727→1156s); the variance is isolated to the backward — likely XLA autotuning/caching or a χ-dependent shift in dominant blocks. Single-point fermionic backward timings carry real variance.
+
+## (C) Stacked vs per-block backend — fermionic, depth 8 (default χ-factor 3)
+
+**Seam gate:** `tests/stacked/` = **51/51 passed on GPU** (CUDA, 65s) — stacked VJP/contract/decomp/dtype/view seams are correct, so the comparison is valid.
+**Artifacts:** `stacked.json`, `perblock.json`
+
+| D | χ | metric | stacked | perblock | stacked win |
+|---|----|--------|---------|----------|-------------|
+| 2 | 6 | fwd_cmp | 47.5s | 44.7s | −6% |
+| 2 | 6 | **vg_cmp** | 146.4s | 164.2s | **11%** |
+| 2 | 6 | bwd_cmp | 98.9s | 119.5s | 17% |
+| 4 | 12 | fwd_cmp | 514.9s | 537.4s | 4% |
+| 4 | 12 | **vg_cmp** | 1061.2s | 1417.6s | **25%** |
+| 4 | 12 | bwd_cmp | 546.2s | 880.3s | **38%** |
+
+**Findings:**
+1. **Win is entirely in the backward.** Forward compile is backend-independent (515 vs 537s at D=4); stacked's advantage is isolated to `bwd_cmp` (546 vs 880s, −38%). Consistent with the wall being the per-block fixed-point backward — stacking blocks into one fused op cuts op-emission count there.
+2. **Mitigates but does not collapse.** D=4 `vg_cmp` is still ~18 min under stacked. The 25–38% cut is worth banking but is not the order-of-magnitude needed; per-block emission is softened, not solved, by the stacked backend alone.
+3. **Win grows with D** (11%→25% on vg, 17%→38% on bwd from D=2 to D=4) — helps most where it hurts most, but won't reach a >10× collapse on its own.
+
+**Bottom line:** stacked backend is GPU-correct and a solid partial lever (bank ~38% backward-compile reduction), but the #566 redirect still needs a deeper attack on per-block op emission to take the wall from minutes to seconds. Necessary-but-not-sufficient.

--- a/profile_566_a100_summary.md
+++ b/profile_566_a100_summary.md
@@ -54,8 +54,11 @@
 | 4 | 12 | fwd_cmp | 514.9s | 537.4s | 4% |
 | 4 | 12 | **vg_cmp** | 1061.2s | 1417.6s | **25%** |
 | 4 | 12 | bwd_cmp | 546.2s | 880.3s | **38%** |
+| 2 | 6 | warm_step | 4163.6ms | 4432.9ms | 6.1% |
+| 4 | 12 | warm_step | 5573.6ms | 5833.7ms | 4.5% |
 
 **Findings:**
+0. **Runtime is positive too (not just compile).** Warm-step is 4.5–6.1% faster under stacked — small but on the *right* side, and notably the new contiguous-`_data` `StackedJaxBackend` does NOT reproduce the runtime-NEGATIVE behavior of the abandoned `TENAX_BATCH_BLOCKSPARSE` (#571/2/3) on A100. So the stacked backend is a clean partial win on BOTH axes (compile + runtime), which removes the last objection to a possible GPU default-flip of `TENAX_BLOCKSPARSE_BACKEND=stacked`.
 1. **Win is entirely in the backward.** Forward compile is backend-independent (515 vs 537s at D=4); stacked's advantage is isolated to `bwd_cmp` (546 vs 880s, −38%). Consistent with the wall being the per-block fixed-point backward — stacking blocks into one fused op cuts op-emission count there.
 2. **Mitigates but does not collapse.** D=4 `vg_cmp` is still ~18 min under stacked. The 25–38% cut is worth banking but is not the order-of-magnitude needed; per-block emission is softened, not solved, by the stacked backend alone.
 3. **Win grows with D** (11%→25% on vg, 17%→38% on bwd from D=2 to D=4) — helps most where it hurts most, but won't reach a >10× collapse on its own.

--- a/src/tenax/contraction/blocksparse_backend.py
+++ b/src/tenax/contraction/blocksparse_backend.py
@@ -101,6 +101,17 @@ class StackedJaxBackend:
 _TRUTHY = ("1", "true", "yes", "on")
 
 
+def _backend_opt_in() -> bool:
+    """True iff a block-sparse backend env opt-in is active (cheap: env reads only, no plan)."""
+    choice = os.environ.get("TENAX_BLOCKSPARSE_BACKEND", "").strip().lower()
+    if choice in ("stacked", "cutensornet"):
+        return True
+    if choice == "perblock":
+        return False  # explicit force-off: skip plan-building entirely
+    # auto / unset / unknown -> defer to legacy flag
+    return os.environ.get("TENAX_STACK_BLOCKSPARSE", "0").strip().lower() in _TRUTHY
+
+
 def _stacked_if_ok(
     tensors: Sequence[Any], plan: BlockContractPlan
 ) -> BlockSparseContractBackend | None:

--- a/src/tenax/contraction/blocksparse_backend.py
+++ b/src/tenax/contraction/blocksparse_backend.py
@@ -98,6 +98,104 @@ class StackedJaxBackend:
         return stacked_execute(operand_stacks, plan)
 
 
+class MockFFIBackend:
+    """Opaque-FFI stand-in proving the hand-written VJP seam (#200, A3).
+
+    Test/dev-only. Genuinely simulates an opaque ``custom_call`` (cuTensorNet,
+    Pallas): its ``execute`` is wrapped in :func:`jax.custom_vjp`, so autodiff
+    CANNOT leak through the forward — the ONLY gradient path is the hand-written
+    transposed-plan backward
+    (:func:`~tenax.contraction.blocksparse_vjp.backward_contraction`). The
+    forward kernel happens to reuse ``stacked_execute`` (a real FFI backend would
+    call into CUDA here), but its custom-VJP backward does NOT differentiate
+    through that — it rebuilds the cotangent via the SAME plan machinery the
+    forward used, exactly as a cuTensorNet VJP author must.
+
+    Because the backward needs the FORWARD ``subscripts`` and per-operand block
+    metadata (keys/shapes/offsets/indices) — which the
+    :class:`BlockSparseContractBackend` protocol's ``execute(operand_stacks,
+    plan)`` signature does NOT carry — those static facts are captured at
+    construction (the contractor/test that builds the plan also has them). This
+    keeps the differentiable surface to the operand stacks only.
+
+    Args:
+        subscripts: forward einsum subscripts ``subA,subB->subO``.
+        operand_meta: per forward operand, the static
+            ``(indices, block_keys, block_shapes, block_offsets)`` needed to
+            rebuild a lightweight ``SymmetricTensor`` for the backward.
+        bwd_calls: optional shared counter ``dict`` whose ``["n"]`` is bumped
+            every time the hand-written backward fires (opacity probe).
+    """
+
+    name = "mockffi"
+
+    def __init__(self, subscripts, operand_meta, bwd_calls=None):
+        self._subscripts = subscripts
+        self._operand_meta = operand_meta
+        self._bwd_calls = bwd_calls
+
+    def available(self) -> bool:
+        return True
+
+    def supports(self, tensors: Sequence[Any], plan: BlockContractPlan) -> bool:
+        return True
+
+    def _rebuild_operand(self, pos: int, stack: Any) -> Any:
+        """Rebuild forward operand ``pos`` as a SymmetricTensor from its stack."""
+        from tenax.core.tensor import SymmetricTensor
+
+        indices, keys, shapes, offsets = self._operand_meta[pos]
+        blocks = {keys[i]: stack[i] for i in range(len(keys))}
+        return SymmetricTensor._from_blocks_unchecked(blocks, indices)
+
+    def execute(self, operand_stacks: Sequence[Any], plan: BlockContractPlan) -> Any:
+        return self._execute_opaque(tuple(operand_stacks), plan)
+
+    def _execute_opaque(self, operand_stacks, plan):
+        """``jax.custom_vjp``-wrapped opaque kernel (forward + hand-written bwd).
+
+        ``plan``, ``subscripts`` and ``operand_meta`` are static (closed over /
+        nondiff); only ``operand_stacks`` is differentiated.
+        """
+        import jax
+
+        @jax.custom_vjp
+        def opaque(operand_stacks):
+            # FORWARD: an opaque kernel. (Here it reuses stacked_execute, but its
+            # gradient is NOT taken through this — see opaque_bwd.)
+            return stacked_execute(operand_stacks, plan)
+
+        def opaque_fwd(operand_stacks):
+            out = stacked_execute(operand_stacks, plan)
+            # Residual carries ONLY the operand stacks the hand-written bwd
+            # consumes — no forward intermediates -> autodiff cannot leak through.
+            return out, operand_stacks
+
+        def opaque_bwd(operand_stacks_res, out_cotangent_stack):
+            from tenax.contraction.blocksparse_vjp import backward_contraction
+
+            fwd_operands = [
+                self._rebuild_operand(i, operand_stacks_res[i])
+                for i in range(len(operand_stacks_res))
+            ]
+            grads = tuple(
+                backward_contraction(
+                    self._subscripts,
+                    fwd_operands,
+                    out_cotangent_stack,
+                    plan,
+                    wrt,
+                )
+                for wrt in range(len(fwd_operands))
+            )
+            if self._bwd_calls is not None:
+                self._bwd_calls["n"] += 1
+            return (tuple(grads),)
+
+        opaque.defvjp(opaque_fwd, opaque_bwd)
+        return opaque(operand_stacks)
+
+
 _TRUTHY = ("1", "true", "yes", "on")
 
 

--- a/src/tenax/contraction/blocksparse_backend.py
+++ b/src/tenax/contraction/blocksparse_backend.py
@@ -111,27 +111,22 @@ class MockFFIBackend:
     through that — it rebuilds the cotangent via the SAME plan machinery the
     forward used, exactly as a cuTensorNet VJP author must.
 
-    Because the backward needs the FORWARD ``subscripts`` and per-operand block
-    metadata (keys/shapes/offsets/indices) — which the
-    :class:`BlockSparseContractBackend` protocol's ``execute(operand_stacks,
-    plan)`` signature does NOT carry — those static facts are captured at
-    construction (the contractor/test that builds the plan also has them). This
-    keeps the differentiable surface to the operand stacks only.
+    The backward needs the FORWARD ``subscripts`` and per-operand block metadata
+    (keys/indices) to rebuild the forward operand(s) — and as of the Phase-B
+    seam refinement (#200) those facts ride on the PLAN itself
+    (``plan.subscripts`` / ``plan.operand_*``). So this backend captures NOTHING
+    at construction: ``execute(operand_stacks, plan)`` + the residual operand
+    stacks are all the hand-written backward consumes. The protocol gap flagged
+    in A3 review is closed; a real ``CuTensorNetBackend`` slots in the same way.
 
     Args:
-        subscripts: forward einsum subscripts ``subA,subB->subO``.
-        operand_meta: per forward operand, the static
-            ``(indices, block_keys, block_shapes, block_offsets)`` needed to
-            rebuild a lightweight ``SymmetricTensor`` for the backward.
         bwd_calls: optional shared counter ``dict`` whose ``["n"]`` is bumped
             every time the hand-written backward fires (opacity probe).
     """
 
     name = "mockffi"
 
-    def __init__(self, subscripts, operand_meta, bwd_calls=None):
-        self._subscripts = subscripts
-        self._operand_meta = operand_meta
+    def __init__(self, bwd_calls=None):
         self._bwd_calls = bwd_calls
 
     def available(self) -> bool:
@@ -140,22 +135,14 @@ class MockFFIBackend:
     def supports(self, tensors: Sequence[Any], plan: BlockContractPlan) -> bool:
         return True
 
-    def _rebuild_operand(self, pos: int, stack: Any) -> Any:
-        """Rebuild forward operand ``pos`` as a SymmetricTensor from its stack."""
-        from tenax.core.tensor import SymmetricTensor
-
-        indices, keys, shapes, offsets = self._operand_meta[pos]
-        blocks = {keys[i]: stack[i] for i in range(len(keys))}
-        return SymmetricTensor._from_blocks_unchecked(blocks, indices)
-
     def execute(self, operand_stacks: Sequence[Any], plan: BlockContractPlan) -> Any:
         return self._execute_opaque(tuple(operand_stacks), plan)
 
     def _execute_opaque(self, operand_stacks, plan):
         """``jax.custom_vjp``-wrapped opaque kernel (forward + hand-written bwd).
 
-        ``plan``, ``subscripts`` and ``operand_meta`` are static (closed over /
-        nondiff); only ``operand_stacks`` is differentiated.
+        ``plan`` is static (closed over / nondiff) and self-contained for the
+        backward; only ``operand_stacks`` is differentiated.
         """
         import jax
 
@@ -174,19 +161,14 @@ class MockFFIBackend:
         def opaque_bwd(operand_stacks_res, out_cotangent_stack):
             from tenax.contraction.blocksparse_vjp import backward_contraction
 
-            fwd_operands = [
-                self._rebuild_operand(i, operand_stacks_res[i])
-                for i in range(len(operand_stacks_res))
-            ]
             grads = tuple(
                 backward_contraction(
-                    self._subscripts,
-                    fwd_operands,
+                    operand_stacks_res,
                     out_cotangent_stack,
                     plan,
                     wrt,
                 )
-                for wrt in range(len(fwd_operands))
+                for wrt in range(len(operand_stacks_res))
             )
             if self._bwd_calls is not None:
                 self._bwd_calls["n"] += 1

--- a/src/tenax/contraction/blocksparse_backend.py
+++ b/src/tenax/contraction/blocksparse_backend.py
@@ -1,0 +1,166 @@
+"""Block-sparse contraction backend protocol + selection (#200, A2).
+
+This is the second slice of the kernel-agnostic block-sparse backend seam.
+Task A1 split the even-D stacked contraction into a STATIC
+:class:`~tenax.contraction.blocksparse_plan.BlockContractPlan` plus a pure-JAX
+``stacked_execute``. Here we introduce the *backend protocol* and a *selection*
+function so the contractor only ever sees the protocol + the plan — never any
+particular kernel's internals.
+
+A backend takes the gathered per-operand stacked arrays plus the (static) plan
+and returns the *canonical-ordered stacked output array* — the exact same shape
+contract as ``stacked_execute`` (``(n_out_blocks, *out_block_shape)``). The
+contractor's assembly logic (persist / non-persist / output_target / counters)
+runs identically off that returned array regardless of which backend produced
+it. A future cuTensorNet backend (Task B) returns the same canonical stacked
+array (or a flat buffer the seam reshapes/slices) — it does NOT leak FFI-isms
+through the protocol.
+
+The default (no backend env set) is ``None`` (per-block fallback) — byte
+identical to today. The legacy ``TENAX_STACK_BLOCKSPARSE`` flag still selects
+the pure-JAX :class:`StackedJaxBackend`. cuTensorNet/Pallas backends are NOT
+registered here (that is Task B); the ``cutensornet`` env value is *accepted*
+(no error) but resolves to ``None`` until a backend is registered.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from typing import Any, Protocol, runtime_checkable
+
+from tenax.contraction.blocksparse_plan import BlockContractPlan, stacked_execute
+
+
+@runtime_checkable
+class BlockSparseContractBackend(Protocol):
+    """Protocol every block-sparse contraction backend implements.
+
+    A backend is selected by :func:`select_backend` from the (static) plan and
+    the input tensors, then driven by the contractor:
+    ``backend.execute(operand_stacks, plan)``.
+
+    Attributes:
+        name: short identifier (matches the ``TENAX_BLOCKSPARSE_BACKEND`` value).
+    """
+
+    name: str
+
+    def available(self) -> bool:
+        """Whether this backend can run on the current platform/libraries.
+
+        Pure-platform check (CUDA present, FFI library importable, ...) with NO
+        reference to a specific contraction. ``False`` => never selected.
+        """
+        ...
+
+    def supports(self, tensors: Sequence[Any], plan: BlockContractPlan) -> bool:
+        """Whether this backend supports THIS contraction (dtype/symmetry/shape).
+
+        The ``plan`` already encodes the even-D / 2-tensor scope (it is ``None``
+        otherwise and selection never reaches here), so a pure-JAX backend can
+        return ``True`` unconditionally. A hardware backend may reject e.g.
+        complex dtypes or block shapes it cannot handle.
+        """
+        ...
+
+    def execute(self, operand_stacks: Sequence[Any], plan: BlockContractPlan) -> Any:
+        """Run the contraction, returning the canonical stacked output array.
+
+        Same shape contract as
+        :func:`~tenax.contraction.blocksparse_plan.stacked_execute`:
+        ``(n_out_blocks, *out_block_shape)`` in ``plan.out_block_keys`` order, or
+        ``None`` for an empty plan. This is backend-neutral: a flat-buffer
+        backend reshapes/slices to this layout before returning.
+        """
+        ...
+
+
+class StackedJaxBackend:
+    """Pure-JAX stacked block-sparse backend (the A1 ``stacked_execute`` path).
+
+    Available on every platform (it is pure ``jnp``) and supports any plan the
+    seam hands it (the plan already encodes the even-D / 2-tensor scope). This is
+    the backend the legacy ``TENAX_STACK_BLOCKSPARSE`` flag selects.
+    """
+
+    name = "stacked"
+
+    def available(self) -> bool:
+        return True
+
+    def supports(self, tensors: Sequence[Any], plan: BlockContractPlan) -> bool:
+        # The plan already encodes the supported scope (else it is None and we
+        # are never called); the pure-JAX kernel handles every such plan.
+        return True
+
+    def execute(self, operand_stacks: Sequence[Any], plan: BlockContractPlan) -> Any:
+        return stacked_execute(operand_stacks, plan)
+
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def _stacked_if_ok(
+    tensors: Sequence[Any], plan: BlockContractPlan
+) -> BlockSparseContractBackend | None:
+    """Return a :class:`StackedJaxBackend` if it is available + supports the plan."""
+    backend = StackedJaxBackend()
+    if backend.available() and backend.supports(tensors, plan):
+        return backend
+    return None
+
+
+def select_backend(
+    tensors: Sequence[Any], plan: BlockContractPlan
+) -> BlockSparseContractBackend | None:
+    """Choose a block-sparse contraction backend, or ``None`` (per-block fallback).
+
+    Precedence:
+
+    1. Explicit ``TENAX_BLOCKSPARSE_BACKEND`` in
+       ``{stacked, cutensornet, perblock, auto}``:
+
+       * ``perblock`` -> ``None`` (force the per-block path);
+       * ``stacked``  -> :class:`StackedJaxBackend` if available + supports, else
+         ``None``;
+       * ``cutensornet`` -> the cuTensorNet backend if registered + available +
+         supports, else ``None`` (NOT registered yet -> ``None``, no error);
+       * ``auto`` / unset -> fall through to step 2.
+
+    2. Back-compat: if ``TENAX_STACK_BLOCKSPARSE`` is truthy -> :class:`StackedJaxBackend`
+       (if it supports the plan).
+
+    3. Otherwise ``None`` (per-block default; byte-identical to today).
+
+    A ``None`` plan never reaches here (the contractor only calls this with a
+    non-``None`` plan), but selection stays total regardless.
+    """
+    choice = os.environ.get("TENAX_BLOCKSPARSE_BACKEND", "").strip().lower()
+
+    if choice == "perblock":
+        return None
+    if choice == "stacked":
+        return _stacked_if_ok(tensors, plan)
+    if choice == "cutensornet":
+        # Accepted but not registered yet (Task B). Resolve gracefully to None.
+        return _select_cutensornet(tensors, plan)
+    # "auto", "", or any other value -> fall through to the legacy flag.
+
+    legacy = os.environ.get("TENAX_STACK_BLOCKSPARSE", "0").strip().lower()
+    if legacy in _TRUTHY:
+        return _stacked_if_ok(tensors, plan)
+
+    return None
+
+
+def _select_cutensornet(
+    tensors: Sequence[Any], plan: BlockContractPlan
+) -> BlockSparseContractBackend | None:
+    """Resolve the cuTensorNet backend, or ``None`` if not registered/usable.
+
+    Task B registers a real backend here; until then this returns ``None`` so the
+    ``cutensornet`` env value is accepted without error and falls back to the
+    per-block path.
+    """
+    return None

--- a/src/tenax/contraction/blocksparse_plan.py
+++ b/src/tenax/contraction/blocksparse_plan.py
@@ -151,10 +151,19 @@ def build_block_contract_plan(
         tensor_partial_rows.append(partial_rows)
 
     # --- Enumerate surviving combos via the all_complete intersection.
+    # The even-D stacked scope assumes every operand carries every contracted
+    # char exactly once (partial sig == full sig). A repeated-within-operand
+    # label (e.g. ``"ii,j->j"`` — a diagonal/trace) produces TWO covered
+    # positions in one operand and NONE in the other, so ``all_complete`` is
+    # False. Fall back to the general per-block path (which handles it via
+    # opt_einsum) rather than asserting — an assert in a library hot path is
+    # also stripped under ``python -O``, which would silently produce a wrong
+    # result here.
     all_complete = all(
         len(cov) == len(contracted_chars_sorted) for cov in tensor_covered
     )
-    assert all_complete, "2-tensor scope guarantees every char is contracted in both"
+    if not all_complete:
+        return None
     common_sigs: set[tuple[int, ...]] = set(tensor_partial_rows[0].keys())
     for partial_rows in tensor_partial_rows[1:]:
         common_sigs &= set(partial_rows.keys())

--- a/src/tenax/contraction/blocksparse_plan.py
+++ b/src/tenax/contraction/blocksparse_plan.py
@@ -1,0 +1,357 @@
+"""Backend-agnostic block-sparse contraction plan + pure-JAX execution (#200, A1).
+
+This module is the first slice of the kernel-agnostic block-sparse backend seam.
+It splits the even-D stacked contraction (formerly inline in
+``_contract_symmetric_stacked``) into:
+
+* :func:`build_block_contract_plan` — STATIC: everything computable from block
+  metadata (``_block_keys`` / ``_block_shapes``) and the subscript string alone,
+  with NO tensor data. Charge matching, valid-output filtering, block-combo
+  grouping, per-operand row selection, segment/accumulation structure, batched
+  subscripts, and output block keys/shapes/offsets all live here. Returns
+  :class:`BlockContractPlan`, or ``None`` when the contraction is out of scope
+  (so the caller falls back to the per-block path).
+
+* :func:`stacked_execute` — DATA: given each operand's stacked array(s) (leading
+  block axis), runs the batched ``jnp.einsum`` + ``jax.ops.segment_sum`` per
+  group, then reorders to canonical sorted-key layout. Pure ``jnp`` so it is
+  naturally differentiable.
+
+This is a PURE REFACTOR of the prior inline logic; behavior is byte-identical.
+The backend protocol / dispatch (Task A2) and the VJP seam (Task A3) are NOT
+introduced here.
+"""
+
+from __future__ import annotations
+
+import itertools
+import string
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+from tenax.core.index import TensorIndex
+from tenax.core.tensor import BlockKey, SymmetricTensor
+
+
+@dataclass(frozen=True)
+class PlanGroup:
+    """Per input-shape-group execution structure (static).
+
+    For the even-D single-shape-group scope there is exactly one ``PlanGroup``.
+
+    Attributes:
+        operand_rows: per operand, the stacked-row indices (into that operand's
+            stacked group array) feeding the batched einsum, in survivor order.
+        segment_ids: output-key accumulation segment id per survivor (for
+            ``segment_sum`` over the batch axis).
+        num_segments: number of distinct output keys in this group.
+        out_shape: output block shape produced by this group's einsum.
+    """
+
+    operand_rows: tuple[tuple[int, ...], ...]
+    segment_ids: tuple[int, ...]
+    num_segments: int
+    out_shape: tuple[int, ...]
+    # Canonical sorted-key row -> segment (first-seen) row. Reorders the
+    # segment_sum output into ``BlockContractPlan.out_block_keys`` order.
+    canonical_perm: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class BlockContractPlan:
+    """Backend-agnostic plan for a block-sparse contraction (static metadata only).
+
+    Attributes:
+        out_indices: output ``TensorIndex`` tuple (subscript output order).
+        out_block_keys: output block keys in canonical sorted order.
+        out_block_shapes: output block shapes (parallel to ``out_block_keys``).
+        out_block_offsets: flat-buffer offsets for the canonical layout.
+        total_size: total flat-buffer element count for the output.
+        batched_subscripts: einsum subscripts with a fresh batch label prepended.
+        groups: per input-shape-group :class:`PlanGroup` tuple.
+        output_target: inferred output target charge (``int``) or ``None``;
+            drives ``_from_blocks_unchecked`` vs ``SymmetricTensor`` assembly.
+        dtype: output dtype (from operands), or ``None`` when there are no
+            surviving blocks.
+    """
+
+    out_indices: tuple
+    out_block_keys: tuple
+    out_block_shapes: tuple
+    out_block_offsets: tuple
+    total_size: int
+    batched_subscripts: str
+    groups: tuple
+    output_target: object
+    dtype: object
+
+
+def build_block_contract_plan(
+    tensors: Sequence[SymmetricTensor],
+    subscripts: str,
+    output_indices: tuple[TensorIndex, ...],
+) -> BlockContractPlan | None:
+    """Build the static block-contraction plan, or ``None`` if unsupported.
+
+    Backend-agnostic: touches only block metadata (``_block_keys`` /
+    ``_block_shapes``) and the subscript string — NO tensor data. Returns
+    ``None`` (caller falls back to the per-block path) when the contraction is
+    out of the even-D scope:
+
+      * not exactly 2 tensors;
+      * any tensor is multi-shape-group (``len(set(t._block_shapes)) > 1``);
+      * any tensor has no blocks.
+    """
+    # Lazy import to avoid a module-level cycle (contractor imports this module).
+    from tenax.contraction.contractor import _parse_contraction_prelude
+
+    # YAGNI scope: even-D, 2-tensor, single-shape-group only.
+    if len(tensors) != 2:
+        return None
+    for t in tensors:
+        if len(set(t._block_shapes)) > 1:
+            return None
+        if not t._block_keys:
+            return None
+
+    # --- Prelude: shared with the per-block path (parse + targets + valid set).
+    (
+        input_subs,
+        output_part,
+        out_indices_ordered,
+        contracted_chars,
+        contracted_chars_sorted,
+        char_to_canonical_pos,
+        output_target,
+        valid_output_set,
+    ) = _parse_contraction_prelude(tensors, subscripts)
+
+    # --- Static per-tensor row indexing from _block_keys (no .blocks / data).
+    tensor_covered: list[list[tuple[int, int]]] = []
+    tensor_partial_rows: list[dict[tuple[int, ...], list[int]]] = []
+    tensor_keys: list[tuple[BlockKey, ...]] = []
+    operand_dtype = None
+
+    for tensor, subs in zip(tensors, input_subs):
+        # Single shape-group guaranteed by the scope check; read the static keys
+        # straight off the tensor metadata (sorted-key order matches the stacked
+        # group array the caller will gather).
+        keys = tuple(tensor._block_keys)
+        tensor_keys.append(keys)
+        operand_dtype = tensor.dtype
+
+        covered: list[tuple[int, int]] = sorted(
+            (char_to_canonical_pos[c], pos)
+            for pos, c in enumerate(subs)
+            if c in contracted_chars
+        )
+        tensor_covered.append(covered)
+
+        partial_rows: dict[tuple[int, ...], list[int]] = {}
+        for row, key in enumerate(keys):
+            partial_sig = tuple(int(key[pos]) for _, pos in covered)
+            partial_rows.setdefault(partial_sig, []).append(row)
+        tensor_partial_rows.append(partial_rows)
+
+    # --- Enumerate surviving combos via the all_complete intersection.
+    all_complete = all(
+        len(cov) == len(contracted_chars_sorted) for cov in tensor_covered
+    )
+    assert all_complete, "2-tensor scope guarantees every char is contracted in both"
+    common_sigs: set[tuple[int, ...]] = set(tensor_partial_rows[0].keys())
+    for partial_rows in tensor_partial_rows[1:]:
+        common_sigs &= set(partial_rows.keys())
+
+    n_pos = len(input_subs)
+
+    survivors: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for full_sig in common_sigs:
+        matching_rows: list[list[int]] = []
+        skip = False
+        for covered, partial_rows in zip(tensor_covered, tensor_partial_rows):
+            partial_sig = tuple(full_sig[canonical_pos] for canonical_pos, _ in covered)
+            rows = partial_rows.get(partial_sig)
+            if not rows:
+                skip = True
+                break
+            matching_rows.append(rows)
+        if skip:
+            continue
+
+        for combo_rows in itertools.product(*matching_rows):
+            keys = [tensor_keys[i][combo_rows[i]] for i in range(n_pos)]
+
+            char_to_charge: dict[str, int] = {}
+            compatible = True
+            for key, subs in zip(keys, input_subs):
+                for char, charge in zip(subs, key):
+                    charge_int = int(charge)
+                    if char in char_to_charge:
+                        if char_to_charge[char] != charge_int:
+                            compatible = False
+                            break
+                    else:
+                        char_to_charge[char] = charge_int
+                if not compatible:
+                    break
+            if not compatible:
+                continue
+
+            output_key = tuple(char_to_charge.get(c, 0) for c in output_part)
+            if output_key not in valid_output_set:
+                continue
+
+            survivors.append((output_key, tuple(combo_rows)))
+
+    # Batched subscripts: prepend a fresh batch label to every operand + output.
+    used_chars = set("".join(input_subs)) | set(output_part)
+    batch_char = None
+    for c in string.ascii_letters:
+        if c not in used_chars:
+            batch_char = c
+            break
+    if batch_char is None:  # pragma: no cover - 52-label ceiling guards this
+        raise ValueError("No free einsum label available for batch axis.")
+    batched_inputs = ",".join(batch_char + s for s in input_subs)
+    batched_subscripts = batched_inputs + "->" + batch_char + output_part
+
+    # No surviving blocks: empty plan (caller assembles an empty tensor).
+    if not survivors:
+        return BlockContractPlan(
+            out_indices=tuple(out_indices_ordered),
+            out_block_keys=(),
+            out_block_shapes=(),
+            out_block_offsets=(),
+            total_size=0,
+            batched_subscripts=batched_subscripts,
+            groups=(),
+            output_target=output_target,
+            dtype=None,
+        )
+
+    # Single shape-group on both sides -> exactly one input shape-sig group.
+    # Stable per-group ordering of distinct output_keys -> segment ids.
+    distinct_keys: list[tuple[int, ...]] = []
+    key_to_seg: dict[tuple[int, ...], int] = {}
+    seg_ids: list[int] = []
+    per_op_rows: list[list[int]] = [[] for _ in range(n_pos)]
+    for okey, combo_rows in survivors:
+        seg = key_to_seg.get(okey)
+        if seg is None:
+            seg = len(distinct_keys)
+            key_to_seg[okey] = seg
+            distinct_keys.append(okey)
+        seg_ids.append(seg)
+        for pos in range(n_pos):
+            per_op_rows[pos].append(combo_rows[pos])
+
+    # Output block shape (single shape-group: all output blocks share it).
+    # Statically determined by the einsum subscripts + the single input block
+    # shapes — no tensor data needed.
+    in_block_shapes = [t._block_shapes[0] for t in tensors]
+    out_shape = _einsum_output_shape(batched_subscripts, in_block_shapes)
+
+    # Canonical sorted-key layout for output block metadata.
+    sorted_keys = sorted(distinct_keys)
+    out_keys = tuple(sorted_keys)
+    out_shapes = tuple(out_shape for _ in out_keys)
+    block_size = 1
+    for d in out_shape:
+        block_size *= d
+    out_offsets = tuple(i * block_size for i in range(len(out_keys)))
+    total_size = block_size * len(out_keys)
+
+    # Canonical sorted-key row -> segment (first-seen) row. ``seg`` is the
+    # first-seen rank of each distinct key, so ``key_to_seg`` is exactly the
+    # inverse layout map the original code built via ``seg_of_key``.
+    canonical_perm = tuple(key_to_seg[k] for k in sorted_keys)
+
+    group = PlanGroup(
+        operand_rows=tuple(tuple(rows) for rows in per_op_rows),
+        segment_ids=tuple(seg_ids),
+        num_segments=len(distinct_keys),
+        out_shape=tuple(out_shape),
+        canonical_perm=canonical_perm,
+    )
+
+    return BlockContractPlan(
+        out_indices=tuple(out_indices_ordered),
+        out_block_keys=out_keys,
+        out_block_shapes=out_shapes,
+        out_block_offsets=out_offsets,
+        total_size=total_size,
+        batched_subscripts=batched_subscripts,
+        groups=(group,),
+        output_target=output_target,
+        dtype=operand_dtype,
+    )
+
+
+def _einsum_output_shape(
+    batched_subscripts: str, in_block_shapes: Sequence[tuple[int, ...]]
+) -> tuple[int, ...]:
+    """STATIC output block shape for the batched einsum (drops the batch axis).
+
+    ``batched_subscripts`` has a fresh batch label prepended to every operand and
+    the output. The per-block (non-batch) operand shapes are
+    ``in_block_shapes``; we size each output character from the operand char that
+    carries it.
+    """
+    input_part, output_part = batched_subscripts.split("->")
+    operand_subs = input_part.split(",")
+    # operand_subs[i][0] is the batch char; the rest map to in_block_shapes[i].
+    char_to_dim: dict[str, int] = {}
+    for subs, shape in zip(operand_subs, in_block_shapes):
+        body = subs[1:]  # strip batch char
+        for char, dim in zip(body, shape):
+            char_to_dim[char] = dim
+    # output_part[0] is the batch char; the remainder is the per-block out shape.
+    return tuple(char_to_dim[c] for c in output_part[1:])
+
+
+def stacked_execute(
+    operand_stacks: Sequence[Any], plan: BlockContractPlan
+) -> dict[BlockKey, Any]:
+    """Data-level execution shared by the pure-JAX path.
+
+    Given each operand's stacked group array (leading block axis, in the same
+    sorted-key row order the plan's ``operand_rows`` index into), run the batched
+    einsum + ``segment_sum`` per group, then reorder rows to canonical
+    sorted-key layout. Returns ``{out_block_key: array}`` keyed in canonical
+    sorted order. Pure ``jnp`` -> differentiable.
+
+    For an empty plan (no surviving blocks) returns ``{}``.
+    """
+    if not plan.groups:
+        return {}
+
+    # Even-D scope: exactly one group.
+    (group,) = plan.groups
+    n_pos = len(operand_stacks)
+
+    # Gather each operand's needed rows from its stacked group array in ONE op
+    # (jnp.take, axis=0) — no per-block slicing.
+    gathered = [
+        jnp.take(operand_stacks[pos], jnp.asarray(group.operand_rows[pos]), axis=0)
+        for pos in range(n_pos)
+    ]
+
+    # ONE batched einsum over the combo batch axis.
+    batched_result = jnp.einsum(plan.batched_subscripts, *gathered)
+
+    # Collapse combos sharing an output_key via segment_sum over the batch axis.
+    segments = jnp.asarray(group.segment_ids, dtype=jnp.int32)
+    summed = jax.ops.segment_sum(
+        batched_result, segments, num_segments=group.num_segments
+    )
+
+    # ``summed`` rows are in survivor/first-seen (segment) order; reorder ONCE to
+    # canonical sorted-key layout so it matches ``plan.out_block_keys``.
+    canon_perm = jnp.asarray(group.canonical_perm, dtype=jnp.int32)
+    out_stack = jnp.take(summed, canon_perm, axis=0)
+
+    return {key: out_stack[i] for i, key in enumerate(plan.out_block_keys)}

--- a/src/tenax/contraction/blocksparse_plan.py
+++ b/src/tenax/contraction/blocksparse_plan.py
@@ -73,6 +73,14 @@ class BlockContractPlan:
         groups: per input-shape-group :class:`PlanGroup` tuple.
         output_target: inferred output target charge (``int``) or ``None``;
             drives ``_from_blocks_unchecked`` vs ``SymmetricTensor`` assembly.
+        subscripts: the FORWARD einsum subscripts (``subA,subB->subO``). Carried
+            so a backend's hand-written VJP can rebuild the backward contraction
+            from the plan alone — no construction-time side-channel.
+        operand_indices: per forward operand (in operand order), that operand's
+            ``.indices`` tuple.
+        operand_block_keys: per forward operand, its ``_block_keys``.
+        operand_block_shapes: per forward operand, its ``_block_shapes``.
+        operand_block_offsets: per forward operand, its ``_block_offsets``.
     """
 
     out_indices: tuple
@@ -83,6 +91,11 @@ class BlockContractPlan:
     batched_subscripts: str
     groups: tuple
     output_target: object
+    subscripts: str
+    operand_indices: tuple
+    operand_block_keys: tuple
+    operand_block_shapes: tuple
+    operand_block_offsets: tuple
 
 
 def build_block_contract_plan(
@@ -112,6 +125,14 @@ def build_block_contract_plan(
             return None
         if not t._block_keys:
             return None
+
+    # Per-operand block metadata carried on the plan so any backend's
+    # hand-written VJP can rebuild the forward operand(s) from
+    # ``execute(operand_stacks, plan)`` alone (no construction-time side-channel).
+    operand_indices = tuple(t.indices for t in tensors)
+    operand_block_keys = tuple(tuple(t._block_keys) for t in tensors)
+    operand_block_shapes = tuple(tuple(t._block_shapes) for t in tensors)
+    operand_block_offsets = tuple(tuple(t._block_offsets) for t in tensors)
 
     # --- Prelude: shared with the per-block path (parse + targets + valid set).
     (
@@ -232,6 +253,11 @@ def build_block_contract_plan(
             batched_subscripts=batched_subscripts,
             groups=(),
             output_target=output_target,
+            subscripts=subscripts,
+            operand_indices=operand_indices,
+            operand_block_keys=operand_block_keys,
+            operand_block_shapes=operand_block_shapes,
+            operand_block_offsets=operand_block_offsets,
         )
 
     # Single shape-group on both sides -> exactly one input shape-sig group.
@@ -287,6 +313,11 @@ def build_block_contract_plan(
         batched_subscripts=batched_subscripts,
         groups=(group,),
         output_target=output_target,
+        subscripts=subscripts,
+        operand_indices=operand_indices,
+        operand_block_keys=operand_block_keys,
+        operand_block_shapes=operand_block_shapes,
+        operand_block_offsets=operand_block_offsets,
     )
 
 

--- a/src/tenax/contraction/blocksparse_plan.py
+++ b/src/tenax/contraction/blocksparse_plan.py
@@ -49,13 +49,11 @@ class PlanGroup:
         segment_ids: output-key accumulation segment id per survivor (for
             ``segment_sum`` over the batch axis).
         num_segments: number of distinct output keys in this group.
-        out_shape: output block shape produced by this group's einsum.
     """
 
     operand_rows: tuple[tuple[int, ...], ...]
     segment_ids: tuple[int, ...]
     num_segments: int
-    out_shape: tuple[int, ...]
     # Canonical sorted-key row -> segment (first-seen) row. Reorders the
     # segment_sum output into ``BlockContractPlan.out_block_keys`` order.
     canonical_perm: tuple[int, ...]
@@ -75,8 +73,6 @@ class BlockContractPlan:
         groups: per input-shape-group :class:`PlanGroup` tuple.
         output_target: inferred output target charge (``int``) or ``None``;
             drives ``_from_blocks_unchecked`` vs ``SymmetricTensor`` assembly.
-        dtype: output dtype (from operands), or ``None`` when there are no
-            surviving blocks.
     """
 
     out_indices: tuple
@@ -87,7 +83,6 @@ class BlockContractPlan:
     batched_subscripts: str
     groups: tuple
     output_target: object
-    dtype: object
 
 
 def build_block_contract_plan(
@@ -134,7 +129,6 @@ def build_block_contract_plan(
     tensor_covered: list[list[tuple[int, int]]] = []
     tensor_partial_rows: list[dict[tuple[int, ...], list[int]]] = []
     tensor_keys: list[tuple[BlockKey, ...]] = []
-    operand_dtype = None
 
     for tensor, subs in zip(tensors, input_subs):
         # Single shape-group guaranteed by the scope check; read the static keys
@@ -142,7 +136,6 @@ def build_block_contract_plan(
         # group array the caller will gather).
         keys = tuple(tensor._block_keys)
         tensor_keys.append(keys)
-        operand_dtype = tensor.dtype
 
         covered: list[tuple[int, int]] = sorted(
             (char_to_canonical_pos[c], pos)
@@ -230,7 +223,6 @@ def build_block_contract_plan(
             batched_subscripts=batched_subscripts,
             groups=(),
             output_target=output_target,
-            dtype=None,
         )
 
     # Single shape-group on both sides -> exactly one input shape-sig group.
@@ -274,7 +266,6 @@ def build_block_contract_plan(
         operand_rows=tuple(tuple(rows) for rows in per_op_rows),
         segment_ids=tuple(seg_ids),
         num_segments=len(distinct_keys),
-        out_shape=tuple(out_shape),
         canonical_perm=canonical_perm,
     )
 
@@ -287,7 +278,6 @@ def build_block_contract_plan(
         batched_subscripts=batched_subscripts,
         groups=(group,),
         output_target=output_target,
-        dtype=operand_dtype,
     )
 
 
@@ -313,21 +303,20 @@ def _einsum_output_shape(
     return tuple(char_to_dim[c] for c in output_part[1:])
 
 
-def stacked_execute(
-    operand_stacks: Sequence[Any], plan: BlockContractPlan
-) -> dict[BlockKey, Any]:
+def stacked_execute(operand_stacks: Sequence[Any], plan: BlockContractPlan) -> Any:
     """Data-level execution shared by the pure-JAX path.
 
     Given each operand's stacked group array (leading block axis, in the same
     sorted-key row order the plan's ``operand_rows`` index into), run the batched
     einsum + ``segment_sum`` per group, then reorder rows to canonical
-    sorted-key layout. Returns ``{out_block_key: array}`` keyed in canonical
-    sorted order. Pure ``jnp`` -> differentiable.
+    sorted-key layout. Returns the canonical-ordered stacked output blocks of
+    shape ``(n_out_blocks, *out_block_shape)``; callers map rows to block keys
+    via ``plan.out_block_keys``. Pure ``jnp`` -> differentiable.
 
-    For an empty plan (no surviving blocks) returns ``{}``.
+    For an empty plan (no surviving blocks) returns ``None``.
     """
     if not plan.groups:
-        return {}
+        return None
 
     # Even-D scope: exactly one group.
     (group,) = plan.groups
@@ -354,4 +343,4 @@ def stacked_execute(
     canon_perm = jnp.asarray(group.canonical_perm, dtype=jnp.int32)
     out_stack = jnp.take(summed, canon_perm, axis=0)
 
-    return {key: out_stack[i] for i, key in enumerate(plan.out_block_keys)}
+    return out_stack

--- a/src/tenax/contraction/blocksparse_vjp.py
+++ b/src/tenax/contraction/blocksparse_vjp.py
@@ -99,11 +99,24 @@ def _backward_subscripts(subscripts: str, wrt: int) -> str:
     raise ValueError(f"wrt must be 0 or 1, got {wrt}")
 
 
+def _rebuild_operand(plan: BlockContractPlan, pos: int, stack: Any) -> SymmetricTensor:
+    """Rebuild forward operand ``pos`` as a SymmetricTensor from its stacked array.
+
+    Sources the static block metadata (indices/keys) from the PLAN itself
+    (``plan.operand_indices`` / ``plan.operand_block_keys``) — NOT from a
+    construction-time side-channel — so any backend reconstructs the forward
+    operand from ``execute(operand_stacks, plan)`` alone.
+    """
+    indices = plan.operand_indices[pos]
+    keys = plan.operand_block_keys[pos]
+    blocks = {keys[i]: stack[i] for i in range(len(keys))}
+    return SymmetricTensor._from_blocks_unchecked(blocks, indices)
+
+
 def backward_contraction(
-    subscripts: str,
-    fwd_operands: Sequence[SymmetricTensor],
+    operand_stacks: Sequence[Any],
     out_cotangent_stack: Any,
-    fwd_plan: BlockContractPlan,
+    plan: BlockContractPlan,
     wrt: int,
 ) -> Any:
     """Cotangent stack for forward operand ``wrt`` via the transposed plan.
@@ -112,14 +125,21 @@ def backward_contraction(
     backward contraction (cotangent paired with the other forward operand) —
     NOT a bespoke charge matcher — so the same machinery serves every backend.
 
+    Self-contained: the FORWARD subscripts and per-operand block metadata are
+    read straight off ``plan`` (``plan.subscripts`` / ``plan.operand_*``); the
+    forward operand(s) are rebuilt from those + the rows of ``operand_stacks``.
+    A backend hands in ONLY ``operand_stacks`` + ``plan`` (the residual it
+    already carries) — no construction-time side-channel.
+
     Args:
-        subscripts: the FORWARD einsum subscripts ``subA,subB->subO``.
-        fwd_operands: the two forward operand SymmetricTensors ``(A, B)``.
+        operand_stacks: per forward operand, its stacked block array
+            (``(n_blocks, *block_shape)``, rows aligned with the operand's
+            ``plan.operand_block_keys`` order).
         out_cotangent_stack: cotangent for the forward output, in the SAME
             canonical stacked layout the forward backend returned
             (``(n_out_blocks, *out_block_shape)``, rows aligned with
-            ``fwd_plan.out_block_keys``).
-        fwd_plan: the forward :class:`BlockContractPlan`.
+            ``plan.out_block_keys``).
+        plan: the forward :class:`BlockContractPlan`.
         wrt: which forward operand to differentiate w.r.t. (0 or 1).
 
     Returns:
@@ -128,12 +148,15 @@ def backward_contraction(
         into the operand's flat ``_data`` buffer), or ``None`` if the backward
         contraction has no surviving blocks (zero cotangent).
     """
+    fwd_operands = [
+        _rebuild_operand(plan, i, operand_stacks[i]) for i in range(len(operand_stacks))
+    ]
     if len(fwd_operands) != 2:
         raise ValueError("transposed-plan backward supports 2-operand forward only")
 
-    cot = _cotangent_tensor(fwd_plan, out_cotangent_stack)
+    cot = _cotangent_tensor(plan, out_cotangent_stack)
     other = fwd_operands[1 - wrt]
-    bwd_subs = _backward_subscripts(subscripts, wrt)
+    bwd_subs = _backward_subscripts(plan.subscripts, wrt)
 
     # Operand order MUST match bwd_subs: wrt==0 -> (cot, other); wrt==1 -> (other, cot).
     if wrt == 0:

--- a/src/tenax/contraction/blocksparse_vjp.py
+++ b/src/tenax/contraction/blocksparse_vjp.py
@@ -21,9 +21,19 @@ contracted against the surviving forward operand, whose matching legs have the
 *same* flow (they were passed through in the forward). For the charge machinery
 to pair them as a contraction (opposite flows), the cotangent's indices are
 flow-flipped (:meth:`TensorIndex.flip_flow`: opposite flow, identical charge
-values) before building the backward plan. No conjugation is applied — JAX's
-einsum VJP convention contracts the cotangent with the *unconjugated* other
-operand (verified empirically), so this matches ``jnp.einsum`` autodiff exactly.
+values) before building the backward plan. ``flip_flow`` is purely about
+charge-value matching in the block machinery — it is NOT a conjugation and has
+nothing to do with complex dtypes.
+
+No conjugation rationale (read before touching the backward for Phase B):
+the VJP of a bilinear contraction transposes the UNCONJUGATED surviving operand
+for BOTH real and complex dtypes (this matches ``jax.vjp`` of the same
+``einsum`` / ``dot_general``). Conjugation in complex autodiff enters only
+through non-holomorphic LEAF operations (``abs``, ``conj``, real-valued loss),
+which are outside this contraction seam. Therefore ``backward_contraction``
+applies NO conjugation and is correct for complex128 as well as real — do NOT
+add a conjugation here. (Proven empirically against ``jax.vjp(stacked_execute)``
+ground truth at fp tier for complex128 in ``tests/stacked/test_vjp_seam.py``.)
 """
 
 from __future__ import annotations
@@ -77,6 +87,9 @@ def _backward_subscripts(subscripts: str, wrt: int) -> str:
             f"{len(in_subs)} operands in {subscripts!r}"
         )
     sub_a, sub_b = in_subs
+    # The surviving operand is contracted UNCONJUGATED (real and complex alike;
+    # matches jax.vjp of this einsum). Conjugation in complex autodiff comes only
+    # from non-holomorphic leaf ops, which live outside this seam.
     if wrt == 0:
         # dA = einsum(subO, subB -> subA): cotangent first, surviving operand B.
         return f"{output},{sub_b}->{sub_a}"

--- a/src/tenax/contraction/blocksparse_vjp.py
+++ b/src/tenax/contraction/blocksparse_vjp.py
@@ -1,0 +1,180 @@
+"""Hand-written transposed-plan backward for the block-sparse seam (#200, A3).
+
+A block-sparse contraction is *multilinear* in its operands, so its VJP w.r.t.
+operand ``i`` is itself a block-sparse contraction — of the output cotangent with
+the *other* operand(s). For ``einsum("ij,jk->ik", A, B)``::
+
+    dA = einsum("ik,jk->ij", gC, B)
+    dB = einsum("ij,ik->jk", A, gC)
+
+This module expresses that backward through the SAME plan machinery the forward
+uses (:func:`build_block_contract_plan` + :func:`stacked_execute`), so EVERY
+backend reuses it. This is the de-risking crux for opaque FFI backends
+(cuTensorNet, Pallas): a ``custom_call`` has no autodiff, so its backward MUST be
+hand-written — and here we prove the transposed-plan backward reproduces the
+per-block / pure-JAX autodiff gradient at fp tier on CPU, before any GPU exists.
+
+Charge-flow subtlety (the exact thing a cuTensorNet VJP author hits): the output
+cotangent ``gC`` shares the forward output's block structure, but its legs carry
+the forward *output* flows. In the backward contraction those same legs are
+contracted against the surviving forward operand, whose matching legs have the
+*same* flow (they were passed through in the forward). For the charge machinery
+to pair them as a contraction (opposite flows), the cotangent's indices are
+flow-flipped (:meth:`TensorIndex.flip_flow`: opposite flow, identical charge
+values) before building the backward plan. No conjugation is applied — JAX's
+einsum VJP convention contracts the cotangent with the *unconjugated* other
+operand (verified empirically), so this matches ``jnp.einsum`` autodiff exactly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import jax.numpy as jnp
+
+from tenax.contraction.blocksparse_plan import (
+    BlockContractPlan,
+    build_block_contract_plan,
+    stacked_execute,
+)
+from tenax.core.tensor import SymmetricTensor
+
+
+def _cotangent_tensor(
+    plan: BlockContractPlan, out_cotangent_stack: Any
+) -> SymmetricTensor:
+    """Wrap the output-cotangent stacked array as a SymmetricTensor.
+
+    Block structure = the forward output's (``plan.out_block_keys`` /
+    ``plan.out_indices``), but with every leg flow-flipped so the backward
+    contraction pairs the cotangent's legs with the surviving forward operand as
+    a genuine contraction (opposite flows, identical charge values). Charge
+    VALUES are untouched (``flip_flow``), so block-key matching is by-value as
+    the per-block path expects.
+    """
+    flipped_indices = tuple(idx.flip_flow() for idx in plan.out_indices)
+    blocks = {
+        plan.out_block_keys[i]: out_cotangent_stack[i]
+        for i in range(len(plan.out_block_keys))
+    }
+    return SymmetricTensor._from_blocks_unchecked(blocks, flipped_indices)
+
+
+def _backward_subscripts(subscripts: str, wrt: int) -> str:
+    """Backward einsum subscripts for the VJP w.r.t. operand ``wrt``.
+
+    Forward ``subA,subB->subO`` -> backward (wrt=0) ``subO,subB->subA``;
+    (wrt=1) ``subA,subO->subB``. The operand order in the returned string is
+    ``(other_operand, cotangent)`` for ``wrt==0`` and ``(operand, cotangent)``
+    matching the caller's operand assembly in :func:`backward_contraction`.
+    """
+    inputs, output = subscripts.split("->")
+    in_subs = inputs.split(",")
+    if len(in_subs) != 2:
+        raise ValueError(
+            f"transposed-plan backward supports 2-operand forward only; got "
+            f"{len(in_subs)} operands in {subscripts!r}"
+        )
+    sub_a, sub_b = in_subs
+    if wrt == 0:
+        # dA = einsum(subO, subB -> subA): cotangent first, surviving operand B.
+        return f"{output},{sub_b}->{sub_a}"
+    if wrt == 1:
+        # dB = einsum(subA, subO -> subB): surviving operand A, cotangent.
+        return f"{sub_a},{output}->{sub_b}"
+    raise ValueError(f"wrt must be 0 or 1, got {wrt}")
+
+
+def backward_contraction(
+    subscripts: str,
+    fwd_operands: Sequence[SymmetricTensor],
+    out_cotangent_stack: Any,
+    fwd_plan: BlockContractPlan,
+    wrt: int,
+) -> Any:
+    """Cotangent stack for forward operand ``wrt`` via the transposed plan.
+
+    Reuses :func:`build_block_contract_plan` + :func:`stacked_execute` on the
+    backward contraction (cotangent paired with the other forward operand) —
+    NOT a bespoke charge matcher — so the same machinery serves every backend.
+
+    Args:
+        subscripts: the FORWARD einsum subscripts ``subA,subB->subO``.
+        fwd_operands: the two forward operand SymmetricTensors ``(A, B)``.
+        out_cotangent_stack: cotangent for the forward output, in the SAME
+            canonical stacked layout the forward backend returned
+            (``(n_out_blocks, *out_block_shape)``, rows aligned with
+            ``fwd_plan.out_block_keys``).
+        fwd_plan: the forward :class:`BlockContractPlan`.
+        wrt: which forward operand to differentiate w.r.t. (0 or 1).
+
+    Returns:
+        The cotangent stacked array for operand ``wrt``, row-aligned with that
+        operand's ``stacked_blocks()`` group order (so it can be scattered back
+        into the operand's flat ``_data`` buffer), or ``None`` if the backward
+        contraction has no surviving blocks (zero cotangent).
+    """
+    if len(fwd_operands) != 2:
+        raise ValueError("transposed-plan backward supports 2-operand forward only")
+
+    cot = _cotangent_tensor(fwd_plan, out_cotangent_stack)
+    other = fwd_operands[1 - wrt]
+    bwd_subs = _backward_subscripts(subscripts, wrt)
+
+    # Operand order MUST match bwd_subs: wrt==0 -> (cot, other); wrt==1 -> (other, cot).
+    if wrt == 0:
+        bwd_operands: tuple[SymmetricTensor, SymmetricTensor] = (cot, other)
+    else:
+        bwd_operands = (other, cot)
+
+    target = fwd_operands[wrt]
+    bwd_plan = build_block_contract_plan(bwd_operands, bwd_subs, target.indices)
+    if bwd_plan is None:
+        raise RuntimeError(
+            "transposed-plan backward fell out of the even-D/2-tensor scope; "
+            "the forward was in scope so this should not happen"
+        )
+
+    operand_stacks = []
+    for t in bwd_operands:
+        view = t.stacked_blocks()
+        (group,) = view.groups.values()
+        operand_stacks.append(group.array)
+
+    grad_stack = stacked_execute(operand_stacks, bwd_plan)
+
+    # Re-key the backward output (in bwd_plan.out_block_keys order) onto the
+    # target operand's stacked-blocks row order, zero-filling any block the
+    # backward contraction did not produce (those have zero cotangent).
+    return _align_to_operand(grad_stack, bwd_plan, target)
+
+
+def _align_to_operand(
+    grad_stack: Any, bwd_plan: BlockContractPlan, target: SymmetricTensor
+) -> Any:
+    """Reorder/zero-fill ``grad_stack`` to the target operand's stacked layout.
+
+    ``stacked_execute`` returns rows in ``bwd_plan.out_block_keys`` order; the
+    target operand's ``stacked_blocks()`` group lists its blocks in its own
+    sorted-key order. We build a row per target block, taking the matching
+    backward-output row where present and zeros otherwise.
+    """
+    view = target.stacked_blocks()
+    (tgt_group,) = view.groups.values()
+    tgt_keys = tgt_group.keys
+    tgt_array = tgt_group.array  # (n_tgt_blocks, *block_shape)
+
+    if grad_stack is None:
+        return jnp.zeros_like(tgt_array)
+
+    bwd_key_to_row = {k: i for i, k in enumerate(bwd_plan.out_block_keys)}
+    rows = []
+    zero_block = jnp.zeros(tgt_array.shape[1:], dtype=tgt_array.dtype)
+    for k in tgt_keys:
+        r = bwd_key_to_row.get(k)
+        if r is None:
+            rows.append(zero_block)
+        else:
+            rows.append(grad_stack[r].astype(tgt_array.dtype))
+    return jnp.stack(rows, axis=0)

--- a/src/tenax/contraction/contractor.py
+++ b/src/tenax/contraction/contractor.py
@@ -478,186 +478,58 @@ def _contract_symmetric_stacked(
 
     Returns the contracted ``SymmetricTensor``, or ``None`` to fall back.
     """
-    # YAGNI scope: even-D, 2-tensor, single-shape-group only.
-    if len(tensors) != 2:
-        return None
-    for t in tensors:
-        if len(set(t._block_shapes)) > 1:
-            return None
-        if not t._block_keys:
-            return None
-
     # ``optimize`` is accepted for signature parity with the dispatcher and is
     # unused here (the batched jnp.einsum path takes no optimize argument).
     del optimize
 
-    # --- Prelude: shared with the per-block path (parse + targets + valid set).
-    (
-        input_subs,
-        output_part,
-        out_indices_ordered,
-        contracted_chars,
-        contracted_chars_sorted,
-        char_to_canonical_pos,
-        output_target,
-        valid_output_set,
-    ) = _parse_contraction_prelude(tensors, subscripts)
-
-    # --- Source operands from the contiguous _data buffer (one gather/group).
-    # For each tensor, build:
-    #   covered:        [(canonical_pos, pos_in_subs), ...] sorted by canonical
-    #   partial_sig -> list of (row_index_into_stacked_group)
-    # where row j corresponds to view.keys[j] (the static block key).  We never
-    # touch .blocks / _get_block — only the static _block_keys and the single
-    # stacked group array per tensor.
-    stacked_arrays: list[Any] = []
-    tensor_covered: list[list[tuple[int, int]]] = []
-    tensor_partial_rows: list[dict[tuple[int, ...], list[int]]] = []
-    tensor_keys: list[tuple[BlockKey, ...]] = []
-
+    from tenax.contraction.blocksparse_plan import (
+        build_block_contract_plan,
+        stacked_execute,
+    )
     from tenax.core.stacked_tensor import StackedSymmetricTensor
     from tenax.core.stacked_view import StackedView, StackGroup
 
+    # --- Backend-agnostic plan from STATIC metadata only (charge matching,
+    # valid-output filter, combo grouping, segment/accumulation structure,
+    # batched subscripts, output keys/shapes). None => out of scope -> fall back.
+    plan = build_block_contract_plan(tensors, subscripts, output_indices)
+    if plan is None:
+        return None
+
+    out_indices_ordered = plan.out_indices
+    output_target = plan.output_target
+
+    # --- Source operands from the contiguous _data buffer (one gather/group).
+    # If an operand already carries a cached StackedView (produced by an upstream
+    # stacked contraction), stacked_blocks() returns it with NO gather from
+    # _data — the chain persisted. Otherwise stacked_blocks() gathers from the
+    # flat _data buffer (chain interrupted upstream). The single shape-group is
+    # guaranteed by the plan's scope check.
+    operand_stacks: list[Any] = []
+    n_pos = len(tensors)
     n_persisted = 0
-    for tensor, subs in zip(tensors, input_subs):
-        # If the operand already carries a cached StackedView (it was produced by
-        # an upstream stacked contraction), stacked_blocks() returns it with NO
-        # gather from _data — the chain persisted. Otherwise stacked_blocks()
-        # gathers from the flat _data buffer (chain interrupted upstream).
+    for tensor in tensors:
         if isinstance(tensor, StackedSymmetricTensor):
             n_persisted += 1
             _STACK_PERSIST["persisted_inputs"] += 1
         else:
             _STACK_PERSIST["gathered_inputs"] += 1
         view = tensor.stacked_blocks()
-        # Single shape-group guaranteed by the scope check above.
         (group,) = view.groups.values()
-        stacked_arrays.append(group.array)
-        keys = group.keys
-        tensor_keys.append(keys)
+        operand_stacks.append(group.array)
 
-        covered: list[tuple[int, int]] = sorted(
-            (char_to_canonical_pos[c], pos)
-            for pos, c in enumerate(subs)
-            if c in contracted_chars
-        )
-        tensor_covered.append(covered)
-
-        partial_rows: dict[tuple[int, ...], list[int]] = {}
-        for row, key in enumerate(keys):
-            partial_sig = tuple(int(key[pos]) for _, pos in covered)
-            partial_rows.setdefault(partial_sig, []).append(row)
-        tensor_partial_rows.append(partial_rows)
-
-    # --- Enumerate surviving combos via the all_complete intersection.
-    # Under the 2-tensor scope guard above, every contracted char appears in
-    # BOTH tensors, so each tensor covers every canonical contracted position
-    # -> all_complete is always True.  The per-block path keeps a cartesian
-    # else-branch for >2 tensors; here it is unreachable, so we assert instead.
-    all_complete = all(
-        len(cov) == len(contracted_chars_sorted) for cov in tensor_covered
-    )
-    assert all_complete, "2-tensor scope guarantees every char is contracted in both"
-    common_sigs: set[tuple[int, ...]] = set(tensor_partial_rows[0].keys())
-    for partial_rows in tensor_partial_rows[1:]:
-        common_sigs &= set(partial_rows.keys())
-    sig_iter: Any = iter(common_sigs)
-
-    n_pos = len(input_subs)
-
-    # Each survivor: (output_key, tuple-of-row-indices, shape_sig).
-    survivors: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
-    for full_sig in sig_iter:
-        matching_rows: list[list[int]] = []
-        skip = False
-        for covered, partial_rows in zip(tensor_covered, tensor_partial_rows):
-            partial_sig = tuple(full_sig[canonical_pos] for canonical_pos, _ in covered)
-            rows = partial_rows.get(partial_sig)
-            if not rows:
-                skip = True
-                break
-            matching_rows.append(rows)
-        if skip:
-            continue
-
-        for combo_rows in itertools.product(*matching_rows):
-            keys = [tensor_keys[i][combo_rows[i]] for i in range(n_pos)]
-
-            char_to_charge: dict[str, int] = {}
-            compatible = True
-            for key, subs in zip(keys, input_subs):
-                for char, charge in zip(subs, key):
-                    charge_int = int(charge)
-                    if char in char_to_charge:
-                        if char_to_charge[char] != charge_int:
-                            compatible = False
-                            break
-                    else:
-                        char_to_charge[char] = charge_int
-                if not compatible:
-                    break
-            if not compatible:
-                continue
-
-            output_key = tuple(char_to_charge.get(c, 0) for c in output_part)
-            if output_key not in valid_output_set:
-                continue
-
-            survivors.append((output_key, tuple(combo_rows)))
-
-    output_blocks: dict[BlockKey, Any] = {}
-    if not survivors:
+    # Empty plan (no surviving blocks): assemble an empty tensor exactly as before.
+    if not plan.groups:
+        output_blocks: dict[BlockKey, Any] = {}
         if output_target is not None:
             return SymmetricTensor._from_blocks_unchecked(
                 output_blocks, out_indices_ordered
             )
         return SymmetricTensor(output_blocks, out_indices_ordered)
 
-    # Batched subscripts: prepend a fresh batch label to every operand + output.
-    used_chars = set("".join(input_subs)) | set(output_part)
-    batch_char = None
-    for c in string.ascii_letters:
-        if c not in used_chars:
-            batch_char = c
-            break
-    if batch_char is None:  # pragma: no cover - 52-label ceiling guards this
-        raise ValueError("No free einsum label available for batch axis.")
-    batched_inputs = ",".join(batch_char + s for s in input_subs)
-    batched_subscripts = batched_inputs + "->" + batch_char + output_part
-
-    # Single shape-group on both sides -> exactly one input shape-sig group.
-    # Stable per-group ordering of distinct output_keys -> segment ids.
-    distinct_keys: list[tuple[int, ...]] = []
-    key_to_seg: dict[tuple[int, ...], int] = {}
-    seg_ids: list[int] = []
-    # Per-operand row index lists (one entry per survivor, in survivor order).
-    per_op_rows: list[list[int]] = [[] for _ in range(n_pos)]
-    for okey, combo_rows in survivors:
-        seg = key_to_seg.get(okey)
-        if seg is None:
-            seg = len(distinct_keys)
-            key_to_seg[okey] = seg
-            distinct_keys.append(okey)
-        seg_ids.append(seg)
-        for pos in range(n_pos):
-            per_op_rows[pos].append(combo_rows[pos])
-
-    # Gather each operand's needed rows from its stacked group array in ONE op
-    # (jnp.take, axis=0) — no per-block slicing, no jnp.stack of slices.
-    gathered = [
-        jnp.take(stacked_arrays[pos], jnp.asarray(per_op_rows[pos]), axis=0)
-        for pos in range(n_pos)
-    ]
-
-    # ONE batched einsum over the combo batch axis.
-    batched_result = jnp.einsum(batched_subscripts, *gathered)
-
-    # Collapse combos sharing an output_key (KEEP segment_sum — dropping it was
-    # the prototype's correctness bug).
-    segments = jnp.asarray(seg_ids, dtype=jnp.int32)
-    summed = jax.ops.segment_sum(
-        batched_result, segments, num_segments=len(distinct_keys)
-    )
+    # --- Data-level execution: batched einsum(s) + segment_sum per group, then
+    # reorder to canonical sorted-key layout. Returns {out_block_key: array}.
+    out_blocks = stacked_execute(operand_stacks, plan)
 
     _STACK_FIRED["n"] += 1
     _STACK_PERSIST["calls"] += 1
@@ -673,36 +545,23 @@ def _contract_symmetric_stacked(
         "TENAX_STACK_PERSIST_RETURN", "1"
     ).strip().lower() in ("1", "true", "yes", "on")
     if not _persist_return:
-        for seg, okey in enumerate(distinct_keys):
-            output_blocks[okey] = summed[seg]
         if output_target is not None:
             return SymmetricTensor._from_blocks_unchecked(
-                output_blocks, out_indices_ordered
+                out_blocks, out_indices_ordered
             )
-        return SymmetricTensor(output_blocks, out_indices_ordered)
+        return SymmetricTensor(out_blocks, out_indices_ordered)
 
     # --- Build the output as a PERSISTING StackedSymmetricTensor (#566 P1d).
-    # Instead of scattering ``summed`` into a flat _data buffer here (the per-call
-    # output glue), keep the batched output array as the cached StackedView. The
-    # _data buffer is materialized lazily only if a downstream op actually reads
-    # it. ``summed`` rows are in survivor/first-seen order (``distinct_keys``);
-    # reorder ONCE to canonical sorted-key layout so it matches block metadata
-    # and can feed the next contraction directly.
-    sorted_keys = sorted(distinct_keys)
-    seg_of_key = {k: s for s, k in enumerate(distinct_keys)}
-    canon_perm = jnp.asarray([seg_of_key[k] for k in sorted_keys], dtype=jnp.int32)
-    out_stack = jnp.take(summed, canon_perm, axis=0)  # (n_out_blocks, *out_shape)
-    out_shape = tuple(out_stack.shape[1:])
-
-    # Block metadata in canonical sorted-key layout (single shape-group, so all
-    # blocks share ``out_shape``; offsets are contiguous).
-    out_keys = tuple(sorted_keys)
-    out_shapes = tuple(out_shape for _ in out_keys)
-    block_size = 1
-    for d in out_shape:
-        block_size *= d
-    out_offsets = tuple(i * block_size for i in range(len(out_keys)))
-    total_size = block_size * len(out_keys)
+    # Keep the batched output array as the cached StackedView (lazy _data). The
+    # plan supplies canonical sorted-key block metadata; ``out_blocks`` is keyed
+    # in that same canonical order, so stacking its values rebuilds the canonical
+    # stacked array directly.
+    out_keys = plan.out_block_keys
+    out_shapes = plan.out_block_shapes
+    out_offsets = plan.out_block_offsets
+    total_size = plan.total_size
+    out_shape = out_shapes[0]
+    out_stack = jnp.stack([out_blocks[k] for k in out_keys], axis=0)
 
     out_group = StackGroup(keys=out_keys, array=out_stack)
     out_view = StackedView(

--- a/src/tenax/contraction/contractor.py
+++ b/src/tenax/contraction/contractor.py
@@ -48,6 +48,18 @@ from tenax.core.tensor import (
 # block-sparse contraction path (TENAX_STACK_BLOCKSPARSE) actually executes.
 _STACK_FIRED = {"n": 0}
 
+# Persist-hit-rate instrumentation (#566 P1d slice 1). Each stacked contraction
+# records, per operand, whether the input arrived as a StackedSymmetricTensor
+# (its stacked arrays PERSISTED from an upstream contraction, no _data gather) or
+# as a plain SymmetricTensor (the chain was INTERRUPTED upstream by a
+# fuse/bar/svd/_data-read, forcing a gather from _data).
+_STACK_PERSIST = {
+    "calls": 0,  # stacked contractions executed
+    "persisted_inputs": 0,  # operands that arrived already-stacked
+    "gathered_inputs": 0,  # operands that had to gather from _data
+    "fully_persisted": 0,  # calls where BOTH operands persisted
+}
+
 # ---------- Label → Subscript Translation ----------
 
 
@@ -503,7 +515,20 @@ def _contract_symmetric_stacked(
     tensor_partial_rows: list[dict[tuple[int, ...], list[int]]] = []
     tensor_keys: list[tuple[BlockKey, ...]] = []
 
+    from tenax.core.stacked_tensor import StackedSymmetricTensor
+    from tenax.core.stacked_view import StackedView, StackGroup
+
+    n_persisted = 0
     for tensor, subs in zip(tensors, input_subs):
+        # If the operand already carries a cached StackedView (it was produced by
+        # an upstream stacked contraction), stacked_blocks() returns it with NO
+        # gather from _data — the chain persisted. Otherwise stacked_blocks()
+        # gathers from the flat _data buffer (chain interrupted upstream).
+        if isinstance(tensor, StackedSymmetricTensor):
+            n_persisted += 1
+            _STACK_PERSIST["persisted_inputs"] += 1
+        else:
+            _STACK_PERSIST["gathered_inputs"] += 1
         view = tensor.stacked_blocks()
         # Single shape-group guaranteed by the scope check above.
         (group,) = view.groups.values()
@@ -634,16 +659,64 @@ def _contract_symmetric_stacked(
         batched_result, segments, num_segments=len(distinct_keys)
     )
 
-    for seg, okey in enumerate(distinct_keys):
-        output_blocks[okey] = summed[seg]
-
     _STACK_FIRED["n"] += 1
+    _STACK_PERSIST["calls"] += 1
+    if n_persisted == n_pos:
+        _STACK_PERSIST["fully_persisted"] += 1
 
-    if output_target is not None:
-        return SymmetricTensor._from_blocks_unchecked(
-            output_blocks, out_indices_ordered
-        )
-    return SymmetricTensor(output_blocks, out_indices_ordered)
+    # Diagnostic sub-flag: TENAX_STACK_PERSIST_RETURN=0 falls back to the
+    # original _from_blocks_unchecked return (no persisting subclass). Isolates
+    # the persisting-return change from the batched-einsum core for debugging.
+    import os
+
+    _persist_return = os.environ.get(
+        "TENAX_STACK_PERSIST_RETURN", "1"
+    ).strip().lower() in ("1", "true", "yes", "on")
+    if not _persist_return:
+        for seg, okey in enumerate(distinct_keys):
+            output_blocks[okey] = summed[seg]
+        if output_target is not None:
+            return SymmetricTensor._from_blocks_unchecked(
+                output_blocks, out_indices_ordered
+            )
+        return SymmetricTensor(output_blocks, out_indices_ordered)
+
+    # --- Build the output as a PERSISTING StackedSymmetricTensor (#566 P1d).
+    # Instead of scattering ``summed`` into a flat _data buffer here (the per-call
+    # output glue), keep the batched output array as the cached StackedView. The
+    # _data buffer is materialized lazily only if a downstream op actually reads
+    # it. ``summed`` rows are in survivor/first-seen order (``distinct_keys``);
+    # reorder ONCE to canonical sorted-key layout so it matches block metadata
+    # and can feed the next contraction directly.
+    sorted_keys = sorted(distinct_keys)
+    seg_of_key = {k: s for s, k in enumerate(distinct_keys)}
+    canon_perm = jnp.asarray([seg_of_key[k] for k in sorted_keys], dtype=jnp.int32)
+    out_stack = jnp.take(summed, canon_perm, axis=0)  # (n_out_blocks, *out_shape)
+    out_shape = tuple(out_stack.shape[1:])
+
+    # Block metadata in canonical sorted-key layout (single shape-group, so all
+    # blocks share ``out_shape``; offsets are contiguous).
+    out_keys = tuple(sorted_keys)
+    out_shapes = tuple(out_shape for _ in out_keys)
+    block_size = 1
+    for d in out_shape:
+        block_size *= d
+    out_offsets = tuple(i * block_size for i in range(len(out_keys)))
+    total_size = block_size * len(out_keys)
+
+    out_group = StackGroup(keys=out_keys, array=out_stack)
+    out_view = StackedView(
+        groups={out_shape: out_group}, indices=tuple(out_indices_ordered)
+    )
+    return StackedSymmetricTensor.from_stacked(
+        view=out_view,
+        indices=tuple(out_indices_ordered),
+        block_keys=out_keys,
+        block_shapes=out_shapes,
+        block_offsets=out_offsets,
+        total_size=total_size,
+        dtype=out_stack.dtype,
+    )
 
 
 def _contract_symmetric(

--- a/src/tenax/contraction/contractor.py
+++ b/src/tenax/contraction/contractor.py
@@ -528,8 +528,10 @@ def _contract_symmetric_stacked(
         return SymmetricTensor(output_blocks, out_indices_ordered)
 
     # --- Data-level execution: batched einsum(s) + segment_sum per group, then
-    # reorder to canonical sorted-key layout. Returns {out_block_key: array}.
-    out_blocks = stacked_execute(operand_stacks, plan)
+    # reorder to canonical sorted-key layout. Returns the canonical-ordered
+    # stacked output array of shape (n_out_blocks, *out_block_shape); rows map to
+    # ``plan.out_block_keys`` positionally.
+    out_stack = stacked_execute(operand_stacks, plan)
 
     _STACK_FIRED["n"] += 1
     _STACK_PERSIST["calls"] += 1
@@ -545,6 +547,10 @@ def _contract_symmetric_stacked(
         "TENAX_STACK_PERSIST_RETURN", "1"
     ).strip().lower() in ("1", "true", "yes", "on")
     if not _persist_return:
+        out_blocks = {
+            plan.out_block_keys[i]: out_stack[i]
+            for i in range(len(plan.out_block_keys))
+        }
         if output_target is not None:
             return SymmetricTensor._from_blocks_unchecked(
                 out_blocks, out_indices_ordered
@@ -553,15 +559,13 @@ def _contract_symmetric_stacked(
 
     # --- Build the output as a PERSISTING StackedSymmetricTensor (#566 P1d).
     # Keep the batched output array as the cached StackedView (lazy _data). The
-    # plan supplies canonical sorted-key block metadata; ``out_blocks`` is keyed
-    # in that same canonical order, so stacking its values rebuilds the canonical
-    # stacked array directly.
+    # plan supplies canonical sorted-key block metadata; ``out_stack`` rows are
+    # already in that same canonical order, so it IS the canonical stacked array.
     out_keys = plan.out_block_keys
     out_shapes = plan.out_block_shapes
     out_offsets = plan.out_block_offsets
     total_size = plan.total_size
     out_shape = out_shapes[0]
-    out_stack = jnp.stack([out_blocks[k] for k in out_keys], axis=0)
 
     out_group = StackGroup(keys=out_keys, array=out_stack)
     out_view = StackedView(

--- a/src/tenax/contraction/contractor.py
+++ b/src/tenax/contraction/contractor.py
@@ -44,6 +44,10 @@ from tenax.core.tensor import (
     _compute_valid_blocks,
 )
 
+# Test-observability counter: incremented each time the gated even-D stacked
+# block-sparse contraction path (TENAX_STACK_BLOCKSPARSE) actually executes.
+_STACK_FIRED = {"n": 0}
+
 # ---------- Label → Subscript Translation ----------
 
 
@@ -355,6 +359,247 @@ def _contract_symmetric_batched(
     return output_blocks
 
 
+def _contract_symmetric_stacked(
+    tensors: Sequence[SymmetricTensor],
+    subscripts: str,
+    output_indices: tuple[TensorIndex, ...],
+    optimize: str = "auto",
+) -> SymmetricTensor | None:
+    """Even-D stacked block-sparse contraction (issue #566, P1b).
+
+    Sources operands DIRECTLY from each tensor's contiguous ``_data`` buffer via
+    ``stacked_blocks()`` (one row-gather per shape-group) + ``jnp.take`` (one
+    op per operand), runs ONE batched ``jnp.einsum`` over a fresh leading batch
+    axis per input shape-group, and collapses combos sharing an output key with
+    ``jax.ops.segment_sum`` (reused from the batched path).  It builds partial
+    charge signatures from the STATIC ``_block_keys`` — NOT ``.blocks`` /
+    ``_get_block`` — so no per-block slicing is emitted at trace time.
+
+    Scoped tightly (returns ``None`` to fall back to the per-block path):
+      * only 2-tensor contractions;
+      * only when EVERY input tensor is single-shape-group
+        (``len(set(t._block_shapes)) <= 1``) — the even-D case.
+
+    No Koszul signs are applied (matching the per-block path; planar networks
+    need none — see ``_contract_symmetric``).  Value and gradient match the
+    per-block path within the fp tier.
+
+    Returns the contracted ``SymmetricTensor``, or ``None`` to fall back.
+    """
+    # YAGNI scope: even-D, 2-tensor, single-shape-group only.
+    if len(tensors) != 2:
+        return None
+    for t in tensors:
+        if len(set(t._block_shapes)) > 1:
+            return None
+        if not t._block_keys:
+            return None
+
+    # --- Prelude: identical to the per-block path (parse + targets + valid set).
+    input_part, output_part = subscripts.split("->")
+    input_subs = input_part.split(",")
+
+    char_to_index: dict[str, TensorIndex] = {}
+    for tensor, subs in zip(tensors, input_subs):
+        for char, idx in zip(subs, tensor.indices):
+            char_to_index[char] = idx
+    out_indices_ordered = tuple(char_to_index[c] for c in output_part)
+
+    char_counts: dict[str, int] = Counter(input_part.replace(",", ""))
+    contracted_chars = {c for c, n in char_counts.items() if n >= 2}
+
+    # Output target charge (same rule as the per-block path).
+    output_target: int | None = None
+    total_target = 0
+    for tensor in tensors:
+        if tensor._block_keys:
+            targets = set()
+            for key in tensor._block_keys:
+                t = sum(int(idx.flow) * int(q) for idx, q in zip(tensor.indices, key))
+                targets.add(t)
+            if len(targets) == 1:
+                total_target += targets.pop()
+    if total_target != 0:
+        output_target = total_target
+
+    valid_output_set = set(
+        _compute_valid_blocks(out_indices_ordered, target=output_target)
+    )
+
+    contracted_chars_sorted = sorted(contracted_chars)
+    char_to_canonical_pos = {c: i for i, c in enumerate(contracted_chars_sorted)}
+
+    # --- Source operands from the contiguous _data buffer (one gather/group).
+    # For each tensor, build:
+    #   covered:        [(canonical_pos, pos_in_subs), ...] sorted by canonical
+    #   partial_sig -> list of (row_index_into_stacked_group)
+    # where row j corresponds to view.keys[j] (the static block key).  We never
+    # touch .blocks / _get_block — only the static _block_keys and the single
+    # stacked group array per tensor.
+    stacked_arrays: list[Any] = []
+    tensor_covered: list[list[tuple[int, int]]] = []
+    tensor_partial_rows: list[dict[tuple[int, ...], list[int]]] = []
+    tensor_keys: list[tuple[BlockKey, ...]] = []
+
+    for tensor, subs in zip(tensors, input_subs):
+        view = tensor.stacked_blocks()
+        # Single shape-group guaranteed by the scope check above.
+        (group,) = view.groups.values()
+        stacked_arrays.append(group.array)
+        keys = group.keys
+        tensor_keys.append(keys)
+
+        covered: list[tuple[int, int]] = sorted(
+            (char_to_canonical_pos[c], pos)
+            for pos, c in enumerate(subs)
+            if c in contracted_chars
+        )
+        tensor_covered.append(covered)
+
+        partial_rows: dict[tuple[int, ...], list[int]] = {}
+        for row, key in enumerate(keys):
+            partial_sig = tuple(int(key[pos]) for _, pos in covered)
+            partial_rows.setdefault(partial_sig, []).append(row)
+        tensor_partial_rows.append(partial_rows)
+
+    # --- Enumerate surviving combos (same logic as the per-block / batched
+    #     paths: all_complete intersection or cartesian-product fallback), then
+    #     the compatibility + valid_output_set filter.
+    all_complete = all(
+        len(cov) == len(contracted_chars_sorted) for cov in tensor_covered
+    )
+    if all_complete:
+        common_sigs: set[tuple[int, ...]] = set(tensor_partial_rows[0].keys())
+        for partial_rows in tensor_partial_rows[1:]:
+            common_sigs &= set(partial_rows.keys())
+        sig_iter: Any = iter(common_sigs)
+    else:
+        allowed_per_pos: list[set[int]] = []
+        for pos_idx in range(len(contracted_chars_sorted)):
+            constraint: set[int] | None = None
+            for covered, partial_rows in zip(tensor_covered, tensor_partial_rows):
+                local_pos = None
+                for ci, (canonical_pos, _tensor_pos) in enumerate(covered):
+                    if canonical_pos == pos_idx:
+                        local_pos = ci
+                        break
+                if local_pos is None:
+                    continue
+                charges_here = {sig[local_pos] for sig in partial_rows}
+                constraint = (
+                    charges_here if constraint is None else constraint & charges_here
+                )
+            allowed_per_pos.append(constraint if constraint is not None else {0})
+        sig_iter = itertools.product(*[sorted(s) for s in allowed_per_pos])
+
+    n_pos = len(input_subs)
+
+    # Each survivor: (output_key, tuple-of-row-indices, shape_sig).
+    survivors: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for full_sig in sig_iter:
+        matching_rows: list[list[int]] = []
+        skip = False
+        for covered, partial_rows in zip(tensor_covered, tensor_partial_rows):
+            partial_sig = tuple(full_sig[canonical_pos] for canonical_pos, _ in covered)
+            rows = partial_rows.get(partial_sig)
+            if not rows:
+                skip = True
+                break
+            matching_rows.append(rows)
+        if skip:
+            continue
+
+        for combo_rows in itertools.product(*matching_rows):
+            keys = [tensor_keys[i][combo_rows[i]] for i in range(n_pos)]
+
+            char_to_charge: dict[str, int] = {}
+            compatible = True
+            for key, subs in zip(keys, input_subs):
+                for char, charge in zip(subs, key):
+                    charge_int = int(charge)
+                    if char in char_to_charge:
+                        if char_to_charge[char] != charge_int:
+                            compatible = False
+                            break
+                    else:
+                        char_to_charge[char] = charge_int
+                if not compatible:
+                    break
+            if not compatible:
+                continue
+
+            output_key = tuple(char_to_charge.get(c, 0) for c in output_part)
+            if output_key not in valid_output_set:
+                continue
+
+            survivors.append((output_key, tuple(combo_rows)))
+
+    output_blocks: dict[BlockKey, Any] = {}
+    if not survivors:
+        if output_target is not None:
+            return SymmetricTensor._from_blocks_unchecked(
+                output_blocks, out_indices_ordered
+            )
+        return SymmetricTensor(output_blocks, out_indices_ordered)
+
+    # Batched subscripts: prepend a fresh batch label to every operand + output.
+    used_chars = set(input_part.replace(",", "")) | set(output_part)
+    batch_char = None
+    for c in string.ascii_letters:
+        if c not in used_chars:
+            batch_char = c
+            break
+    if batch_char is None:  # pragma: no cover - 52-label ceiling guards this
+        raise ValueError("No free einsum label available for batch axis.")
+    batched_inputs = ",".join(batch_char + s for s in input_subs)
+    batched_subscripts = batched_inputs + "->" + batch_char + output_part
+
+    # Single shape-group on both sides -> exactly one input shape-sig group.
+    # Stable per-group ordering of distinct output_keys -> segment ids.
+    distinct_keys: list[tuple[int, ...]] = []
+    key_to_seg: dict[tuple[int, ...], int] = {}
+    seg_ids: list[int] = []
+    # Per-operand row index lists (one entry per survivor, in survivor order).
+    per_op_rows: list[list[int]] = [[] for _ in range(n_pos)]
+    for okey, combo_rows in survivors:
+        seg = key_to_seg.get(okey)
+        if seg is None:
+            seg = len(distinct_keys)
+            key_to_seg[okey] = seg
+            distinct_keys.append(okey)
+        seg_ids.append(seg)
+        for pos in range(n_pos):
+            per_op_rows[pos].append(combo_rows[pos])
+
+    # Gather each operand's needed rows from its stacked group array in ONE op
+    # (jnp.take, axis=0) — no per-block slicing, no jnp.stack of slices.
+    gathered = [
+        jnp.take(stacked_arrays[pos], jnp.asarray(per_op_rows[pos]), axis=0)
+        for pos in range(n_pos)
+    ]
+
+    # ONE batched einsum over the combo batch axis.
+    batched_result = jnp.einsum(batched_subscripts, *gathered)
+
+    # Collapse combos sharing an output_key (KEEP segment_sum — dropping it was
+    # the prototype's correctness bug).
+    segments = jnp.asarray(seg_ids, dtype=jnp.int32)
+    summed = jax.ops.segment_sum(
+        batched_result, segments, num_segments=len(distinct_keys)
+    )
+
+    for seg, okey in enumerate(distinct_keys):
+        output_blocks[okey] = summed[seg]
+
+    _STACK_FIRED["n"] += 1
+
+    if output_target is not None:
+        return SymmetricTensor._from_blocks_unchecked(
+            output_blocks, out_indices_ordered
+        )
+    return SymmetricTensor(output_blocks, out_indices_ordered)
+
+
 def _contract_symmetric(
     tensors: Sequence[SymmetricTensor],
     subscripts: str,
@@ -406,6 +651,28 @@ def _contract_symmetric(
             return contract_blocksparse(
                 tensors[0], tensors[1], subscripts, output_indices
             )
+
+    # --- Gate: opt-in even-D stacked block-sparse path (issue #566, P1b) ---
+    # When TENAX_STACK_BLOCKSPARSE is truthy, single-shape-group 2-tensor
+    # contractions (the even-D case) source operands DIRECTLY from the
+    # contiguous _data buffer via stacked_blocks() + jnp.take and emit one
+    # batched einsum + segment_sum per shape-group (O(n_shape_groups) traced
+    # ops) instead of O(n_combos) per-block einsums.  Returns None to fall
+    # back to the per-block path for everything else.
+    _stack_blocksparse = os.environ.get(
+        "TENAX_STACK_BLOCKSPARSE", "0"
+    ).strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+    if _stack_blocksparse:
+        stacked_result = _contract_symmetric_stacked(
+            tensors, subscripts, output_indices, optimize
+        )
+        if stacked_result is not None:
+            return stacked_result
 
     # Parse subscripts: e.g., "ij,jk->ik" → inputs=["ij","jk"], output="ik"
     input_part, output_part = subscripts.split("->")

--- a/src/tenax/contraction/contractor.py
+++ b/src/tenax/contraction/contractor.py
@@ -654,23 +654,25 @@ def _contract_symmetric(
     # TENAX_BLOCKSPARSE_BACKEND (stacked/cutensornet/perblock/auto) then the
     # legacy TENAX_STACK_BLOCKSPARSE flag. With NO backend env set, no backend is
     # selected and the per-block path below runs byte-identically to today.
-    from tenax.contraction.blocksparse_backend import select_backend
-    from tenax.contraction.blocksparse_plan import build_block_contract_plan
+    from tenax.contraction.blocksparse_backend import _backend_opt_in, select_backend
 
-    plan = build_block_contract_plan(tensors, subscripts, output_indices)
-    if plan is not None:
-        backend = select_backend(tensors, plan)
-        if backend is not None:
-            stacked_result = _contract_symmetric_stacked(
-                tensors,
-                subscripts,
-                output_indices,
-                optimize,
-                backend=backend,
-                plan=plan,
-            )
-            if stacked_result is not None:
-                return stacked_result
+    if _backend_opt_in():
+        from tenax.contraction.blocksparse_plan import build_block_contract_plan
+
+        plan = build_block_contract_plan(tensors, subscripts, output_indices)
+        if plan is not None:
+            backend = select_backend(tensors, plan)
+            if backend is not None:
+                stacked_result = _contract_symmetric_stacked(
+                    tensors,
+                    subscripts,
+                    output_indices,
+                    optimize,
+                    backend=backend,
+                    plan=plan,
+                )
+                if stacked_result is not None:
+                    return stacked_result
 
     # Prelude: parse subscripts + output index order + contracted chars +
     # inferred output target charge + valid output set + canonical contracted

--- a/src/tenax/contraction/contractor.py
+++ b/src/tenax/contraction/contractor.py
@@ -359,6 +359,86 @@ def _contract_symmetric_batched(
     return output_blocks
 
 
+def _parse_contraction_prelude(
+    tensors: Sequence[SymmetricTensor],
+    subscripts: str,
+) -> tuple[
+    list[str],
+    str,
+    tuple[TensorIndex, ...],
+    set[str],
+    list[str],
+    dict[str, int],
+    int | None,
+    set[BlockKey],
+]:
+    """Shared prelude for the per-block and stacked symmetric contraction paths.
+
+    Returns the subscript/charge bookkeeping common to both; per-tensor block
+    indexing (arrays vs stacked rows) is built separately by each caller.
+
+    Returns:
+        input_subs, output_part, out_indices_ordered, contracted_chars (set),
+        contracted_chars_sorted, char_to_canonical_pos, output_target,
+        valid_output_set.
+    """
+    # Parse subscripts: e.g., "ij,jk->ik" -> inputs=["ij","jk"], output="ik".
+    input_part, output_part = subscripts.split("->")
+    input_subs = input_part.split(",")
+
+    # Map each character to the corresponding TensorIndex, then build the
+    # output index tuple in output_part order.
+    char_to_index: dict[str, TensorIndex] = {}
+    for tensor, subs in zip(tensors, input_subs):
+        for char, idx in zip(subs, tensor.indices):
+            char_to_index[char] = idx
+    out_indices_ordered = tuple(char_to_index[c] for c in output_part)
+
+    # Identify contracted characters (appear in multiple input tensors).
+    char_counts: dict[str, int] = Counter(input_part.replace(",", ""))
+    contracted_chars = {c for c, n in char_counts.items() if n >= 2}
+
+    # Infer the output target charge from input tensors.
+    # For U(1): output target = sum of input targets, since contracted legs
+    # have opposite flows and cancel.  This allows contracting tensors with
+    # non-identity targets (e.g. boundary MPS tensors targeting Sz != 0).
+    # We only count a tensor's target if ALL its blocks agree on the same
+    # value of sum(flow*q).  Mixed-charge tensors (e.g. operators that
+    # create/annihilate particles) contribute 0.  Iterating ``_block_keys``
+    # is equivalent to iterating ``.blocks`` keys but cheaper.
+    output_target: int | None = None
+    total_target = 0
+    for tensor in tensors:
+        if tensor._block_keys:
+            targets = set()
+            for key in tensor._block_keys:
+                t = sum(int(idx.flow) * int(q) for idx, q in zip(tensor.indices, key))
+                targets.add(t)
+            if len(targets) == 1:
+                total_target += targets.pop()
+    if total_target != 0:
+        output_target = total_target
+
+    # Precompute valid output keys as a set for O(1) lookup.
+    valid_output_set = set(
+        _compute_valid_blocks(out_indices_ordered, target=output_target)
+    )
+
+    contracted_chars_sorted = sorted(contracted_chars)
+    char_to_canonical_pos = {c: i for i, c in enumerate(contracted_chars_sorted)}
+
+    return (
+        input_subs,
+        output_part,
+        out_indices_ordered,
+        contracted_chars,
+        contracted_chars_sorted,
+        char_to_canonical_pos,
+        output_target,
+        valid_output_set,
+    )
+
+
 def _contract_symmetric_stacked(
     tensors: Sequence[SymmetricTensor],
     subscripts: str,
@@ -395,39 +475,21 @@ def _contract_symmetric_stacked(
         if not t._block_keys:
             return None
 
-    # --- Prelude: identical to the per-block path (parse + targets + valid set).
-    input_part, output_part = subscripts.split("->")
-    input_subs = input_part.split(",")
+    # ``optimize`` is accepted for signature parity with the dispatcher and is
+    # unused here (the batched jnp.einsum path takes no optimize argument).
+    del optimize
 
-    char_to_index: dict[str, TensorIndex] = {}
-    for tensor, subs in zip(tensors, input_subs):
-        for char, idx in zip(subs, tensor.indices):
-            char_to_index[char] = idx
-    out_indices_ordered = tuple(char_to_index[c] for c in output_part)
-
-    char_counts: dict[str, int] = Counter(input_part.replace(",", ""))
-    contracted_chars = {c for c, n in char_counts.items() if n >= 2}
-
-    # Output target charge (same rule as the per-block path).
-    output_target: int | None = None
-    total_target = 0
-    for tensor in tensors:
-        if tensor._block_keys:
-            targets = set()
-            for key in tensor._block_keys:
-                t = sum(int(idx.flow) * int(q) for idx, q in zip(tensor.indices, key))
-                targets.add(t)
-            if len(targets) == 1:
-                total_target += targets.pop()
-    if total_target != 0:
-        output_target = total_target
-
-    valid_output_set = set(
-        _compute_valid_blocks(out_indices_ordered, target=output_target)
-    )
-
-    contracted_chars_sorted = sorted(contracted_chars)
-    char_to_canonical_pos = {c: i for i, c in enumerate(contracted_chars_sorted)}
+    # --- Prelude: shared with the per-block path (parse + targets + valid set).
+    (
+        input_subs,
+        output_part,
+        out_indices_ordered,
+        contracted_chars,
+        contracted_chars_sorted,
+        char_to_canonical_pos,
+        output_target,
+        valid_output_set,
+    ) = _parse_contraction_prelude(tensors, subscripts)
 
     # --- Source operands from the contiguous _data buffer (one gather/group).
     # For each tensor, build:
@@ -462,35 +524,19 @@ def _contract_symmetric_stacked(
             partial_rows.setdefault(partial_sig, []).append(row)
         tensor_partial_rows.append(partial_rows)
 
-    # --- Enumerate surviving combos (same logic as the per-block / batched
-    #     paths: all_complete intersection or cartesian-product fallback), then
-    #     the compatibility + valid_output_set filter.
+    # --- Enumerate surviving combos via the all_complete intersection.
+    # Under the 2-tensor scope guard above, every contracted char appears in
+    # BOTH tensors, so each tensor covers every canonical contracted position
+    # -> all_complete is always True.  The per-block path keeps a cartesian
+    # else-branch for >2 tensors; here it is unreachable, so we assert instead.
     all_complete = all(
         len(cov) == len(contracted_chars_sorted) for cov in tensor_covered
     )
-    if all_complete:
-        common_sigs: set[tuple[int, ...]] = set(tensor_partial_rows[0].keys())
-        for partial_rows in tensor_partial_rows[1:]:
-            common_sigs &= set(partial_rows.keys())
-        sig_iter: Any = iter(common_sigs)
-    else:
-        allowed_per_pos: list[set[int]] = []
-        for pos_idx in range(len(contracted_chars_sorted)):
-            constraint: set[int] | None = None
-            for covered, partial_rows in zip(tensor_covered, tensor_partial_rows):
-                local_pos = None
-                for ci, (canonical_pos, _tensor_pos) in enumerate(covered):
-                    if canonical_pos == pos_idx:
-                        local_pos = ci
-                        break
-                if local_pos is None:
-                    continue
-                charges_here = {sig[local_pos] for sig in partial_rows}
-                constraint = (
-                    charges_here if constraint is None else constraint & charges_here
-                )
-            allowed_per_pos.append(constraint if constraint is not None else {0})
-        sig_iter = itertools.product(*[sorted(s) for s in allowed_per_pos])
+    assert all_complete, "2-tensor scope guarantees every char is contracted in both"
+    common_sigs: set[tuple[int, ...]] = set(tensor_partial_rows[0].keys())
+    for partial_rows in tensor_partial_rows[1:]:
+        common_sigs &= set(partial_rows.keys())
+    sig_iter: Any = iter(common_sigs)
 
     n_pos = len(input_subs)
 
@@ -543,7 +589,7 @@ def _contract_symmetric_stacked(
         return SymmetricTensor(output_blocks, out_indices_ordered)
 
     # Batched subscripts: prepend a fresh batch label to every operand + output.
-    used_chars = set(input_part.replace(",", "")) | set(output_part)
+    used_chars = set("".join(input_subs)) | set(output_part)
     batch_char = None
     for c in string.ascii_letters:
         if c not in used_chars:
@@ -674,47 +720,19 @@ def _contract_symmetric(
         if stacked_result is not None:
             return stacked_result
 
-    # Parse subscripts: e.g., "ij,jk->ik" → inputs=["ij","jk"], output="ik"
-    input_part, output_part = subscripts.split("->")
-    input_subs = input_part.split(",")
-
-    # Map each character to the corresponding TensorIndex
-    char_to_index: dict[str, TensorIndex] = {}
-    for tensor, subs in zip(tensors, input_subs):
-        for char, idx in zip(subs, tensor.indices):
-            char_to_index[char] = idx
-
-    # Build output_indices list in output_part order
-    out_indices_ordered = tuple(char_to_index[c] for c in output_part)
-
-    # Identify contracted characters (appear in multiple input tensors)
-    char_counts: dict[str, int] = Counter(input_part.replace(",", ""))
-    contracted_chars = {c for c, n in char_counts.items() if n >= 2}
-
-    # Infer the output target charge from input tensors.
-    # For U(1): output target = sum of input targets, since contracted legs
-    # have opposite flows and cancel.  This allows contracting tensors with
-    # non-identity targets (e.g. boundary MPS tensors targeting Sz != 0).
-    # We only count a tensor's target if ALL its blocks agree on the same
-    # value of sum(flow*q).  Mixed-charge tensors (e.g. operators that
-    # create/annihilate particles) contribute 0.
-    output_target: int | None = None
-    total_target = 0
-    for tensor in tensors:
-        if tensor.blocks:
-            targets = set()
-            for key in tensor.blocks:
-                t = sum(int(idx.flow) * int(q) for idx, q in zip(tensor.indices, key))
-                targets.add(t)
-            if len(targets) == 1:
-                total_target += targets.pop()
-    if total_target != 0:
-        output_target = total_target
-
-    # Precompute valid output keys as a set for O(1) lookup
-    valid_output_set = set(
-        _compute_valid_blocks(out_indices_ordered, target=output_target)
-    )
+    # Prelude: parse subscripts + output index order + contracted chars +
+    # inferred output target charge + valid output set + canonical contracted
+    # positions.  Shared verbatim with the stacked path (issue #566).
+    (
+        input_subs,
+        output_part,
+        out_indices_ordered,
+        contracted_chars,
+        contracted_chars_sorted,
+        char_to_canonical_pos,
+        output_target,
+        valid_output_set,
+    ) = _parse_contraction_prelude(tensors, subscripts)
 
     # Fermionic sign convention (#555): the contractor does NOT auto-apply
     # Koszul signs from leg permutations.  Tenax's auto-tracking (the original
@@ -733,10 +751,8 @@ def _contract_symmetric(
     # carries.  Per-tensor partial sigs allow correct multi-input contraction
     # even when some pair of inputs shares no contracted labels (issue #553);
     # the previous full-sig intersection silently dropped to zero whenever
-    # two tensors' sig tuples had different lengths.
-    contracted_chars_sorted = sorted(contracted_chars)
-    char_to_canonical_pos = {c: i for i, c in enumerate(contracted_chars_sorted)}
-
+    # two tensors' sig tuples had different lengths.  ``contracted_chars_sorted``
+    # / ``char_to_canonical_pos`` come from the shared prelude above.
     tensor_partial_indices: list[
         tuple[list[tuple[int, int]], dict[tuple[int, ...], list[tuple[BlockKey, Any]]]]
     ] = []
@@ -818,7 +834,7 @@ def _contract_symmetric(
             tensor_partial_indices,
             input_subs,
             output_part,
-            input_part,
+            ",".join(input_subs),
             valid_output_set,
         )
         if output_target is not None:

--- a/src/tenax/contraction/contractor.py
+++ b/src/tenax/contraction/contractor.py
@@ -456,16 +456,19 @@ def _contract_symmetric_stacked(
     subscripts: str,
     output_indices: tuple[TensorIndex, ...],
     optimize: str = "auto",
+    backend: Any = None,
+    plan: Any = None,
 ) -> SymmetricTensor | None:
-    """Even-D stacked block-sparse contraction (issue #566, P1b).
+    """Even-D stacked block-sparse contraction (issue #566, P1b; seam A2).
 
     Sources operands DIRECTLY from each tensor's contiguous ``_data`` buffer via
     ``stacked_blocks()`` (one row-gather per shape-group) + ``jnp.take`` (one
-    op per operand), runs ONE batched ``jnp.einsum`` over a fresh leading batch
-    axis per input shape-group, and collapses combos sharing an output key with
-    ``jax.ops.segment_sum`` (reused from the batched path).  It builds partial
-    charge signatures from the STATIC ``_block_keys`` — NOT ``.blocks`` /
-    ``_get_block`` — so no per-block slicing is emitted at trace time.
+    op per operand), runs the contraction through the supplied ``backend`` (the
+    backend returns the canonical-ordered stacked output array — same shape
+    contract as ``stacked_execute``), then assembles the output
+    ``SymmetricTensor``.  It builds partial charge signatures from the STATIC
+    ``_block_keys`` — NOT ``.blocks`` / ``_get_block`` — so no per-block slicing
+    is emitted at trace time.
 
     Scoped tightly (returns ``None`` to fall back to the per-block path):
       * only 2-tensor contractions;
@@ -476,25 +479,35 @@ def _contract_symmetric_stacked(
     need none — see ``_contract_symmetric``).  Value and gradient match the
     per-block path within the fp tier.
 
+    Args:
+        backend: a :class:`~tenax.contraction.blocksparse_backend.BlockSparseContractBackend`
+            whose ``execute`` produces the canonical stacked output array. When
+            ``None``, the default :class:`StackedJaxBackend` is used (legacy
+            direct-call behavior).
+        plan: a prebuilt :class:`BlockContractPlan` (the dispatcher builds it once
+            and reuses it for backend selection); built here if ``None``.
+
     Returns the contracted ``SymmetricTensor``, or ``None`` to fall back.
     """
     # ``optimize`` is accepted for signature parity with the dispatcher and is
-    # unused here (the batched jnp.einsum path takes no optimize argument).
+    # unused here (the backend kernel takes no optimize argument).
     del optimize
 
-    from tenax.contraction.blocksparse_plan import (
-        build_block_contract_plan,
-        stacked_execute,
-    )
+    from tenax.contraction.blocksparse_backend import StackedJaxBackend
+    from tenax.contraction.blocksparse_plan import build_block_contract_plan
     from tenax.core.stacked_tensor import StackedSymmetricTensor
     from tenax.core.stacked_view import StackedView, StackGroup
 
     # --- Backend-agnostic plan from STATIC metadata only (charge matching,
     # valid-output filter, combo grouping, segment/accumulation structure,
     # batched subscripts, output keys/shapes). None => out of scope -> fall back.
-    plan = build_block_contract_plan(tensors, subscripts, output_indices)
+    if plan is None:
+        plan = build_block_contract_plan(tensors, subscripts, output_indices)
     if plan is None:
         return None
+
+    if backend is None:
+        backend = StackedJaxBackend()
 
     out_indices_ordered = plan.out_indices
     output_target = plan.output_target
@@ -527,11 +540,12 @@ def _contract_symmetric_stacked(
             )
         return SymmetricTensor(output_blocks, out_indices_ordered)
 
-    # --- Data-level execution: batched einsum(s) + segment_sum per group, then
-    # reorder to canonical sorted-key layout. Returns the canonical-ordered
-    # stacked output array of shape (n_out_blocks, *out_block_shape); rows map to
-    # ``plan.out_block_keys`` positionally.
-    out_stack = stacked_execute(operand_stacks, plan)
+    # --- Data-level execution through the selected backend. The backend returns
+    # the canonical-ordered stacked output array of shape
+    # (n_out_blocks, *out_block_shape); rows map to ``plan.out_block_keys``
+    # positionally. Backend-neutral: the assembly below is identical regardless
+    # of which backend produced ``out_stack``.
+    out_stack = backend.execute(operand_stacks, plan)
 
     _STACK_FIRED["n"] += 1
     _STACK_PERSIST["calls"] += 1
@@ -634,27 +648,29 @@ def _contract_symmetric(
                 tensors[0], tensors[1], subscripts, output_indices
             )
 
-    # --- Gate: opt-in even-D stacked block-sparse path (issue #566, P1b) ---
-    # When TENAX_STACK_BLOCKSPARSE is truthy, single-shape-group 2-tensor
-    # contractions (the even-D case) source operands DIRECTLY from the
-    # contiguous _data buffer via stacked_blocks() + jnp.take and emit one
-    # batched einsum + segment_sum per shape-group (O(n_shape_groups) traced
-    # ops) instead of O(n_combos) per-block einsums.  Returns None to fall
-    # back to the per-block path for everything else.
-    _stack_blocksparse = os.environ.get(
-        "TENAX_STACK_BLOCKSPARSE", "0"
-    ).strip().lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
-    )
-    if _stack_blocksparse:
-        stacked_result = _contract_symmetric_stacked(
-            tensors, subscripts, output_indices, optimize
-        )
-        if stacked_result is not None:
-            return stacked_result
+    # --- Backend seam: opt-in block-sparse contraction backend (issue #200) ---
+    # Build the STATIC plan once (None => out of even-D/2-tensor scope) and let
+    # select_backend pick a backend (or None => per-block). Precedence:
+    # TENAX_BLOCKSPARSE_BACKEND (stacked/cutensornet/perblock/auto) then the
+    # legacy TENAX_STACK_BLOCKSPARSE flag. With NO backend env set, no backend is
+    # selected and the per-block path below runs byte-identically to today.
+    from tenax.contraction.blocksparse_backend import select_backend
+    from tenax.contraction.blocksparse_plan import build_block_contract_plan
+
+    plan = build_block_contract_plan(tensors, subscripts, output_indices)
+    if plan is not None:
+        backend = select_backend(tensors, plan)
+        if backend is not None:
+            stacked_result = _contract_symmetric_stacked(
+                tensors,
+                subscripts,
+                output_indices,
+                optimize,
+                backend=backend,
+                plan=plan,
+            )
+            if stacked_result is not None:
+                return stacked_result
 
     # Prelude: parse subscripts + output index order + contracted chars +
     # inferred output target charge + valid output set + canonical contracted

--- a/src/tenax/core/stacked_tensor.py
+++ b/src/tenax/core/stacked_tensor.py
@@ -161,6 +161,14 @@ class StackedSymmetricTensor(SymmetricTensor):
             shape: type(grp)(keys=grp.keys, array=grp.array * scalar)
             for shape, grp in self._stacked_view.groups.items()
         }
+        # A scalar can PROMOTE the dtype (e.g. real array * 1j -> complex). The
+        # materialization buffer (scatter_stacked) is allocated with the stored
+        # dtype, so it MUST track the promoted array dtype — otherwise the
+        # scatter casts complex rows down to the stale real dtype and silently
+        # drops the imaginary part. Read the dtype off the multiplied arrays.
+        new_dtype = jnp.result_type(
+            self._dtype, *(grp.array.dtype for grp in new_groups.values())
+        )
         obj = StackedSymmetricTensor.from_stacked(
             view=StackedView(groups=new_groups, indices=self._indices),
             indices=self._indices,
@@ -168,7 +176,7 @@ class StackedSymmetricTensor(SymmetricTensor):
             block_shapes=self._block_shapes,
             block_offsets=self._block_offsets,
             total_size=self._total_size,
-            dtype=self._dtype,
+            dtype=new_dtype,
         )
         return obj
 

--- a/src/tenax/core/stacked_tensor.py
+++ b/src/tenax/core/stacked_tensor.py
@@ -1,0 +1,213 @@
+"""Lazy/persisting stacked SymmetricTensor (#566 P1d slice 1).
+
+``StackedSymmetricTensor`` carries the per-shape-group stacked arrays (a
+:class:`~tenax.core.stacked_view.StackedView`) as its PRIMARY representation and
+DEFERS materialization of the flat ``_data`` buffer until first access. This lets
+a chain of consecutive stacked contractions inside one jit trace skip the
+per-call gather (``stacked_blocks()`` reading ``_data``) and scatter
+(``_from_blocks_unchecked``/``scatter_stacked`` writing ``_data``): the stacked
+arrays persist on the Python tensor object between contractions.
+
+Correctness invariants (do NOT regress):
+
+* It is a *subclass* of :class:`SymmetricTensor`, so every consumer (energy fn,
+  fuse, svd, bar, relabels, pytree, AD) treats it identically. Any base method
+  that reads ``self._data`` transparently triggers lazy materialization (via
+  :func:`~tenax.core.stacked_view.scatter_stacked`) — correctness preserved, the
+  persist win is simply lost across that op.
+* ``tree_flatten`` emits the MATERIALIZED ``_data`` leaf, so jit/grad boundaries
+  are byte-identical to a plain ``SymmetricTensor``. The stacked cache is a
+  within-trace optimization only; it does NOT survive a pytree round-trip
+  (``tree_unflatten`` rebuilds a plain ``SymmetricTensor`` from ``_data``).
+* This class is ONLY produced when ``TENAX_STACK_BLOCKSPARSE`` is truthy (the
+  contractor gates its construction). With the flag off, nothing here is reached
+  and behavior is byte-identical to today.
+
+Label-only / data-elementwise ops (``relabel``, ``relabels``, ``bar``,
+``__mul__``) are overridden to PRESERVE the stacked cache without materializing
+``_data`` — these are exactly the ops the CTM sweep interleaves between
+contractions (e.g. relabelling the output of one absorption to feed the next).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from tenax.core.stacked_view import StackedView, scatter_stacked
+from tenax.core.tensor import BlockKey, SymmetricTensor
+
+
+@jax.tree_util.register_pytree_node_class
+class StackedSymmetricTensor(SymmetricTensor):
+    """A SymmetricTensor whose primary representation is a cached StackedView.
+
+    The flat ``_data`` buffer is materialized lazily on first access (and then
+    cached). Constructed only via :meth:`from_stacked`.
+    """
+
+    __slots__ = ()  # keep instance dict from base; sentinel lives in __dict__
+
+    # ------------------------------------------------------------------ build
+    @classmethod
+    def from_stacked(
+        cls,
+        *,
+        view: StackedView,
+        indices: tuple,
+        block_keys: tuple[BlockKey, ...],
+        block_shapes: tuple[tuple[int, ...], ...],
+        block_offsets: tuple[int, ...],
+        total_size: int,
+        dtype,
+    ) -> StackedSymmetricTensor:
+        """Build from per-shape-group stacked arrays with DEFERRED ``_data``.
+
+        ``view`` must already be in canonical sorted-key layout matching
+        ``block_keys`` (the contractor guarantees this).
+        """
+        obj = object.__new__(cls)
+        obj._indices = tuple(indices)
+        obj._block_keys = tuple(block_keys)
+        obj._block_shapes = tuple(block_shapes)
+        obj._block_offsets = tuple(block_offsets)
+        obj._stacked_view = view
+        obj._total_size = int(total_size)
+        obj._dtype = dtype
+        obj._data_cache = None  # sentinel: not yet materialized
+        return obj
+
+    # ----------------------------------------------------------- lazy _data
+    def _materialize(self) -> jax.Array:
+        """Scatter the cached StackedView into the flat ``_data`` buffer once."""
+        cache = self.__dict__.get("_data_cache")
+        if cache is None:
+            cache = scatter_stacked(
+                self._stacked_view,
+                self._block_keys,
+                self._block_shapes,
+                self._block_offsets,
+                self._total_size,
+                self._dtype,
+            )
+            self.__dict__["_data_cache"] = cache
+        return cache
+
+    @property
+    def _data(self) -> jax.Array:  # type: ignore[override]
+        return self._materialize()
+
+    @_data.setter
+    def _data(self, value) -> None:
+        # Base __init__/_raw paths never run on this subclass, but keep a setter
+        # so any defensive ``obj._data = ...`` stays well-defined.
+        self.__dict__["_data_cache"] = value
+
+    # --------------------------------------------------- stacked fast path
+    def stacked_blocks(self) -> StackedView:  # type: ignore[override]
+        """Return the CACHED StackedView with NO gather from ``_data``."""
+        return self._stacked_view
+
+    # --------------------------------------- cache-preserving metadata ops
+    def _rebuild_view_with_indices(self, new_indices: tuple) -> StackedView:
+        return StackedView(groups=self._stacked_view.groups, indices=tuple(new_indices))
+
+    def _with_indices(self, new_indices: tuple) -> StackedSymmetricTensor:
+        """Return a new StackedSymmetricTensor sharing arrays, new indices.
+
+        Used by label-only ops (relabel/relabels): the stacked arrays and the
+        materialized ``_data`` (if any) are unchanged, only leg metadata changes.
+        """
+        obj = StackedSymmetricTensor.from_stacked(
+            view=self._rebuild_view_with_indices(new_indices),
+            indices=new_indices,
+            block_keys=self._block_keys,
+            block_shapes=self._block_shapes,
+            block_offsets=self._block_offsets,
+            total_size=self._total_size,
+            dtype=self._dtype,
+        )
+        # Carry over an already-materialized buffer if present (data is identical
+        # under a pure relabel).
+        cached = self.__dict__.get("_data_cache")
+        if cached is not None:
+            obj.__dict__["_data_cache"] = cached
+        return obj
+
+    def relabel(self, old, new):  # type: ignore[override]
+        found = False
+        new_indices = []
+        for idx in self._indices:
+            if idx.label == old:
+                new_indices.append(idx.relabel(new))
+                found = True
+            else:
+                new_indices.append(idx)
+        if not found:
+            raise KeyError(
+                f"Label {old!r} not found in tensor with labels {self.labels()}"
+            )
+        return self._with_indices(tuple(new_indices))
+
+    def relabels(self, mapping):  # type: ignore[override]
+        new_indices = tuple(
+            idx.relabel(mapping[idx.label]) if idx.label in mapping else idx
+            for idx in self._indices
+        )
+        return self._with_indices(new_indices)
+
+    def __mul__(self, scalar):  # type: ignore[override]
+        new_groups = {
+            shape: type(grp)(keys=grp.keys, array=grp.array * scalar)
+            for shape, grp in self._stacked_view.groups.items()
+        }
+        obj = StackedSymmetricTensor.from_stacked(
+            view=StackedView(groups=new_groups, indices=self._indices),
+            indices=self._indices,
+            block_keys=self._block_keys,
+            block_shapes=self._block_shapes,
+            block_offsets=self._block_offsets,
+            total_size=self._total_size,
+            dtype=self._dtype,
+        )
+        return obj
+
+    def bar(self):  # type: ignore[override]
+        new_indices = tuple(idx.flip_flow() for idx in self._indices)
+        new_groups = {
+            shape: type(grp)(keys=grp.keys, array=jnp.conj(grp.array))
+            for shape, grp in self._stacked_view.groups.items()
+        }
+        return StackedSymmetricTensor.from_stacked(
+            view=StackedView(groups=new_groups, indices=new_indices),
+            indices=new_indices,
+            block_keys=self._block_keys,
+            block_shapes=self._block_shapes,
+            block_offsets=self._block_offsets,
+            total_size=self._total_size,
+            dtype=self._dtype,
+        )
+
+    # ----------------------------------------------------------- pytree
+    def tree_flatten(self):  # type: ignore[override]
+        # Emit the MATERIALIZED _data leaf so jit/grad boundaries are identical
+        # to a plain SymmetricTensor. The stacked cache is intentionally dropped
+        # (within-trace optimization only).
+        return [self._materialize()], (
+            self._block_keys,
+            self._block_shapes,
+            self._block_offsets,
+            self._indices,
+        )
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):  # type: ignore[override]
+        # Return a PLAIN SymmetricTensor; the cache does not cross pytree edges.
+        block_keys, block_shapes, block_offsets, indices = aux
+        return SymmetricTensor._raw(
+            indices=indices,
+            data=children[0],
+            block_keys=block_keys,
+            block_shapes=block_shapes,
+            block_offsets=block_offsets,
+        )

--- a/src/tenax/core/stacked_view.py
+++ b/src/tenax/core/stacked_view.py
@@ -51,6 +51,7 @@ def build_stacked(
     groups = {}
     for shape, (keys, gather) in layout.items():
         n = gather.shape[0]
+        # raw numpy index -> XLA compile-time-constant gather (one op per shape group)
         flat = data[gather.reshape(-1)]  # one gather per group
         groups[shape] = StackGroup(keys=keys, array=flat.reshape((n, *shape)))
     return StackedView(groups=groups, indices=indices)
@@ -62,9 +63,10 @@ def scatter_stacked(view, block_keys, block_shapes, block_offsets, total_size, d
     data = jnp.zeros(total_size, dtype=dtype)
     for shape, (keys, gather) in layout.items():
         grp = view.groups[shape]
+        # identity permutation in the round-trip path; O(n^2) only matters for cross-tensor scatter at large block counts
         order = [
             grp.keys.index(k) for k in keys
         ]  # reorder grp rows to canonical key order
-        rows = grp.array[jnp.asarray(order)]
-        data = data.at[jnp.asarray(gather.reshape(-1))].set(rows.reshape(-1))
+        rows = grp.array[np.asarray(order)]
+        data = data.at[gather.reshape(-1)].set(rows.reshape(-1))
     return data

--- a/src/tenax/core/stacked_view.py
+++ b/src/tenax/core/stacked_view.py
@@ -1,0 +1,70 @@
+"""Stacked working representation over the flat _data buffer (#566 P1a).
+
+Blocks are grouped by identical shape; each group is one array
+(n_blocks_in_group, *block_shape) gathered from _data and reshaped. Grouping
+and gather indices are STATIC (from block metadata), so only the gather/reshape
+touches the tracer. For even-D FermionParity (one shape, contiguous) the gather
+degenerates to a contiguous slice.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+@dataclass(frozen=True)
+class StackGroup:
+    keys: tuple  # block keys in this group, in sorted-key order
+    array: jax.Array  # (n_blocks, *block_shape)
+
+
+@dataclass(frozen=True)
+class StackedView:
+    groups: dict  # block_shape (tuple[int,...]) -> StackGroup
+    indices: tuple  # source tensor's TensorIndex tuple
+
+
+def _group_layout(block_keys, block_shapes, block_offsets):
+    """STATIC: shape -> (keys_tuple, flat_gather_index_array of shape (n, size))."""
+    by_shape: dict = {}
+    for i, shape in enumerate(block_shapes):
+        size = int(np.prod(shape)) if shape else 1
+        off = block_offsets[i]
+        flat_idx = np.arange(off, off + size, dtype=np.int64)
+        rec = by_shape.setdefault(shape, ([], []))
+        rec[0].append(block_keys[i])
+        rec[1].append(flat_idx)
+    layout = {}
+    for shape, (keys, idx_lists) in by_shape.items():
+        layout[shape] = (tuple(keys), np.stack(idx_lists, axis=0))  # (n, size)
+    return layout
+
+
+def build_stacked(
+    data, block_keys, block_shapes, block_offsets, indices
+) -> StackedView:
+    layout = _group_layout(block_keys, block_shapes, block_offsets)
+    groups = {}
+    for shape, (keys, gather) in layout.items():
+        n = gather.shape[0]
+        flat = data[gather.reshape(-1)]  # one gather per group
+        groups[shape] = StackGroup(keys=keys, array=flat.reshape((n, *shape)))
+    return StackedView(groups=groups, indices=indices)
+
+
+def scatter_stacked(view, block_keys, block_shapes, block_offsets, total_size, dtype):
+    """Inverse: write groups back into one flat buffer in canonical sorted-key layout."""
+    layout = _group_layout(block_keys, block_shapes, block_offsets)
+    data = jnp.zeros(total_size, dtype=dtype)
+    for shape, (keys, gather) in layout.items():
+        grp = view.groups[shape]
+        order = [
+            grp.keys.index(k) for k in keys
+        ]  # reorder grp rows to canonical key order
+        rows = grp.array[jnp.asarray(order)]
+        data = data.at[jnp.asarray(gather.reshape(-1))].set(rows.reshape(-1))
+    return data

--- a/src/tenax/core/stacked_view.py
+++ b/src/tenax/core/stacked_view.py
@@ -60,6 +60,14 @@ def build_stacked(
 def scatter_stacked(view, block_keys, block_shapes, block_offsets, total_size, dtype):
     """Inverse: write groups back into one flat buffer in canonical sorted-key layout."""
     layout = _group_layout(block_keys, block_shapes, block_offsets)
+    # Promote the buffer dtype to cover the actual group-array dtype: an
+    # elementwise op (e.g. scalar multiply by 1j) can promote the arrays beyond
+    # the passed ``dtype``; allocating with the stale dtype would cast complex
+    # rows down to real and drop the imaginary part on the ``.set`` below.
+    if view.groups:
+        dtype = jnp.result_type(
+            dtype, *(grp.array.dtype for grp in view.groups.values())
+        )
     data = jnp.zeros(total_size, dtype=dtype)
     for shape, (keys, gather) in layout.items():
         grp = view.groups[shape]

--- a/src/tenax/core/tensor.py
+++ b/src/tenax/core/tensor.py
@@ -752,6 +752,44 @@ class SymmetricTensor(Tensor):
             size *= d
         return self._data[offset : offset + size].reshape(shape)
 
+    def stacked_blocks(self):
+        """Return a StackedView: blocks grouped by shape, one array per group."""
+        from tenax.core.stacked_view import build_stacked
+
+        return build_stacked(
+            self._data,
+            self._block_keys,
+            self._block_shapes,
+            self._block_offsets,
+            self._indices,
+        )
+
+    def from_stacked_blocks(self, view):
+        """Rebuild a SymmetricTensor from a StackedView (canonical sorted-key layout)."""
+        from tenax.core.stacked_view import scatter_stacked
+
+        if not self._block_keys:
+            total = 0
+        else:
+            last_shape = self._block_shapes[-1]
+            last_size = int(np.prod(last_shape)) if last_shape else 1
+            total = self._block_offsets[-1] + last_size
+        data = scatter_stacked(
+            view,
+            self._block_keys,
+            self._block_shapes,
+            self._block_offsets,
+            total,
+            self._data.dtype,
+        )
+        return SymmetricTensor._raw(
+            indices=self._indices,
+            data=data,
+            block_keys=self._block_keys,
+            block_shapes=self._block_shapes,
+            block_offsets=self._block_offsets,
+        )
+
     # --- Pytree interface ---
 
     def tree_flatten(

--- a/stacked.json
+++ b/stacked.json
@@ -1,0 +1,54 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "syms": [
+    "fermionic"
+  ],
+  "depths": [
+    8
+  ],
+  "explicit": false,
+  "rows": [
+    {
+      "sym": "fermionic",
+      "D": 2,
+      "chi": 6,
+      "depth": 8,
+      "path": "implicit",
+      "n_blocks": 16,
+      "fwd_wall_s": 60.25285647343844,
+      "fwd_compile_s": 47.51167200700003,
+      "fwd_n_compiles": 310,
+      "vg_wall_s": 199.95499594323337,
+      "vg_compile_s": 146.38363194599992,
+      "vg_n_compiles": 325,
+      "bwd_compile_s_est": 98.8719599389999,
+      "top_compile_name": "jit(_jit_fused_fixed_point_bwd)",
+      "top_compile_s": 89.029103041,
+      "warm_step_s": 4.163556636311114,
+      "energy": -0.20308407890652985,
+      "grad_finite": true
+    },
+    {
+      "sym": "fermionic",
+      "D": 4,
+      "chi": 12,
+      "depth": 8,
+      "path": "implicit",
+      "n_blocks": 16,
+      "fwd_wall_s": 544.7089728452265,
+      "fwd_compile_s": 514.9422464350006,
+      "fwd_n_compiles": 309,
+      "vg_wall_s": 1189.303919182159,
+      "vg_compile_s": 1061.183349844,
+      "vg_n_compiles": 324,
+      "bwd_compile_s_est": 546.2411034089995,
+      "top_compile_name": "jit(_jit_fused_fixed_point_bwd)",
+      "top_compile_s": 546.833678484,
+      "warm_step_s": 5.573593268170953,
+      "energy": -0.028373390695965058,
+      "grad_finite": true
+    }
+  ]
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,14 @@ _FILE_MARKERS = {
     "test_ctm_env_pad.py": "core",
     "test_ipeps_chi_bump_integration.py": "algorithm",
     "test_ctm_convergence_random_iPEPS.py": "algorithm",
+    # Block-sparse stacked-contraction backend seam (#200 / #566): fast,
+    # mechanism-level (small even-D fermionic tensors, no CTM convergence).
+    "test_harness.py": "core",
+    "test_stacked_view.py": "core",
+    "test_stacked_contract.py": "core",
+    "test_stacked_decomp.py": "core",
+    "test_backend_dispatch.py": "core",
+    "test_vjp_seam.py": "core",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,7 @@ _FILE_MARKERS = {
     "test_stacked_decomp.py": "core",
     "test_backend_dispatch.py": "core",
     "test_vjp_seam.py": "core",
+    "test_stacked_tensor_dtype.py": "core",
 }
 
 

--- a/tests/stacked/_harness.py
+++ b/tests/stacked/_harness.py
@@ -1,0 +1,75 @@
+"""Frozen accuracy spine for the stacked-block migration (#566, P0)."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+FP_RTOL = 1e-12
+FP_ATOL = 1e-12
+
+
+def assert_tiered(ref, got, *, tier: str) -> None:
+    ref = jnp.asarray(ref)
+    got = jnp.asarray(got)
+    assert ref.shape == got.shape, f"shape {ref.shape} != {got.shape}"
+    if tier == "bit":
+        assert bool(jnp.array_equal(ref, got)), (
+            f"not bit-identical: max|d|={float(jnp.max(jnp.abs(ref - got))):.3e}"
+        )
+    elif tier == "fp":
+        np.testing.assert_allclose(
+            np.asarray(got), np.asarray(ref), rtol=FP_RTOL, atol=FP_ATOL
+        )
+    else:
+        raise ValueError(f"unknown tier {tier!r}")
+
+
+def assert_svd_invariants(A_ref, U, S, Vh, *, tier: str = "fp") -> None:
+    """Compare gauge-INVARIANT SVD outputs only: singular values + reconstruction."""
+    recon = (U * S[..., None, :]) @ Vh
+    assert_tiered(A_ref, recon, tier=tier)
+
+
+def canonical_tensors():
+    """Yield (name, tensor-or-array) covering the required golden cases."""
+    from tenax.algorithms.fermionic_ipeps import (
+        FPEPSConfig,
+        _build_initial_fpeps_tensor,
+    )
+
+    key = jax.random.PRNGKey(0)
+    yield "ferm_D2", _build_initial_fpeps_tensor(FPEPSConfig(D=2), key)
+    yield "ferm_D4", _build_initial_fpeps_tensor(FPEPSConfig(D=4), key)
+    yield "dense_D2", _dense_u1_trivial(D=2, key=key)
+    yield "degenerate_sv", jnp.diag(jnp.array([2.0, 2.0, 1.0, 0.5]))
+    v = jnp.array([1.0, 2.0, 3.0, 4.0])
+    yield "rank_deficient", jnp.outer(v, v)
+
+
+def _dense_u1_trivial(D, key):
+    """U(1)-trivial single-block DenseTensor iPEPS site.
+
+    Replicates ``make_dense_site`` from ``examples/profile_ctm_ad_wall_566.py``
+    inline so the harness does not depend on the (non-package) ``examples/``
+    directory being importable.
+    """
+    from tenax.core.symmetry import U1Symmetry
+    from tenax.core.tensor import DenseTensor, FlowDirection, TensorIndex
+
+    data = jax.random.normal(key, (D, D, D, D, 2))
+    data = data / jnp.linalg.norm(data)
+    sym = U1Symmetry()
+    zD = np.zeros(D, dtype=np.int32)
+    zd = np.zeros(2, dtype=np.int32)
+    return DenseTensor(
+        data,
+        (
+            TensorIndex.from_charges(sym, zD, FlowDirection.OUT, label="u"),
+            TensorIndex.from_charges(sym, zD, FlowDirection.IN, label="d"),
+            TensorIndex.from_charges(sym, zD, FlowDirection.OUT, label="l"),
+            TensorIndex.from_charges(sym, zD, FlowDirection.IN, label="r"),
+            TensorIndex.from_charges(sym, zd, FlowDirection.IN, label="phys"),
+        ),
+    )

--- a/tests/stacked/test_backend_dispatch.py
+++ b/tests/stacked/test_backend_dispatch.py
@@ -1,0 +1,218 @@
+"""Tests for the block-sparse contraction backend protocol + selection (#200, A2).
+
+``select_backend`` chooses a backend (or ``None`` => per-block fallback) from the
+(static) plan + tensors, honoring ``TENAX_BLOCKSPARSE_BACKEND`` precedence and the
+legacy ``TENAX_STACK_BLOCKSPARSE`` flag. With NO backend env set the default is
+``None`` (per-block, byte-identical to today). The pure-JAX
+:class:`StackedJaxBackend` must fire exactly as the legacy stacked path did, and
+its value+gradient must match the per-block path within the fp tier. The
+``cutensornet`` env value must be ACCEPTED (no error) and resolve to ``None`` until
+Task B registers a real backend.
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from tenax.contraction.blocksparse_backend import (
+    BlockSparseContractBackend,
+    StackedJaxBackend,
+    select_backend,
+)
+from tenax.contraction.blocksparse_plan import build_block_contract_plan
+from tenax.contraction.contractor import _STACK_FIRED, contract
+from tests.stacked._harness import assert_tiered, canonical_tensors
+
+
+def _double_layer(A):
+    """Contract ket A with bra A.bar() over ONLY the physical leg (rank-8 out)."""
+    bra = A.bar().relabels({"u": "U", "d": "D", "l": "L", "r": "R"})
+    return A, bra
+
+
+def _make_plan():
+    """Build a real even-D plan to drive ``select_backend`` / ``supports``."""
+    A = dict(canonical_tensors())["ferm_D2"]
+    A, Abar = _double_layer(A)
+    from tenax.contraction.contractor import _labels_to_subscripts
+
+    subscripts, out_indices = _labels_to_subscripts([A, Abar])
+    plan = build_block_contract_plan([A, Abar], subscripts, out_indices)
+    assert plan is not None, "fixture must produce an in-scope (even-D) plan"
+    return [A, Abar], plan
+
+
+# ----------------------------------------------------------------------------
+# select_backend precedence
+# ----------------------------------------------------------------------------
+
+
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("TENAX_BLOCKSPARSE_BACKEND", raising=False)
+    monkeypatch.delenv("TENAX_STACK_BLOCKSPARSE", raising=False)
+
+
+def test_select_perblock_returns_none(monkeypatch):
+    tensors, plan = _make_plan()
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TENAX_BLOCKSPARSE_BACKEND", "perblock")
+    assert select_backend(tensors, plan) is None
+
+
+def test_select_stacked_returns_stacked_backend(monkeypatch):
+    tensors, plan = _make_plan()
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TENAX_BLOCKSPARSE_BACKEND", "stacked")
+    backend = select_backend(tensors, plan)
+    assert isinstance(backend, StackedJaxBackend)
+    assert isinstance(backend, BlockSparseContractBackend)
+    assert backend.name == "stacked"
+
+
+def test_select_cutensornet_accepted_returns_none(monkeypatch):
+    tensors, plan = _make_plan()
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TENAX_BLOCKSPARSE_BACKEND", "cutensornet")
+    # Accepted (no error), resolves to None until Task B registers a backend.
+    assert select_backend(tensors, plan) is None
+
+
+def test_select_legacy_flag_returns_stacked_backend(monkeypatch):
+    tensors, plan = _make_plan()
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "1")
+    backend = select_backend(tensors, plan)
+    assert isinstance(backend, StackedJaxBackend)
+
+
+def test_select_auto_falls_through_to_legacy(monkeypatch):
+    tensors, plan = _make_plan()
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TENAX_BLOCKSPARSE_BACKEND", "auto")
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "1")
+    assert isinstance(select_backend(tensors, plan), StackedJaxBackend)
+
+
+def test_select_all_unset_returns_none(monkeypatch):
+    tensors, plan = _make_plan()
+    _clear_env(monkeypatch)
+    assert select_backend(tensors, plan) is None
+
+
+def test_explicit_backend_wins_over_legacy(monkeypatch):
+    """TENAX_BLOCKSPARSE_BACKEND=perblock beats a truthy legacy flag."""
+    tensors, plan = _make_plan()
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TENAX_BLOCKSPARSE_BACKEND", "perblock")
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "1")
+    assert select_backend(tensors, plan) is None
+
+
+# ----------------------------------------------------------------------------
+# StackedJaxBackend protocol surface
+# ----------------------------------------------------------------------------
+
+
+def test_stacked_backend_available_and_supports():
+    tensors, plan = _make_plan()
+    backend = StackedJaxBackend()
+    assert backend.available() is True
+    assert backend.supports(tensors, plan) is True
+
+
+# ----------------------------------------------------------------------------
+# Equivalence: backend=stacked value + grad match per-block
+# ----------------------------------------------------------------------------
+
+
+def test_backend_stacked_value_matches_perblock(monkeypatch):
+    A = dict(canonical_tensors())["ferm_D2"]
+    A, Abar = _double_layer(A)
+
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TENAX_BLOCKSPARSE_BACKEND", "perblock")
+    ref = contract(A, Abar)
+    n0 = _STACK_FIRED["n"]
+
+    monkeypatch.setenv("TENAX_BLOCKSPARSE_BACKEND", "stacked")
+    got = contract(A, Abar)
+
+    assert _STACK_FIRED["n"] > n0, "stacked backend did not fire"
+    assert got._block_keys == ref._block_keys
+    assert_tiered(ref._data, got._data, tier="fp")
+
+
+def test_backend_stacked_grad_matches_perblock(monkeypatch):
+    A0 = dict(canonical_tensors())["ferm_D2"]
+    A0bar_src = A0.bar().relabels({"u": "U", "d": "D", "l": "L", "r": "R"})
+
+    indices = A0._indices
+    block_keys = A0._block_keys
+    block_shapes = A0._block_shapes
+    block_offsets = A0._block_offsets
+
+    bar_indices = A0bar_src._indices
+    bar_keys = A0bar_src._block_keys
+    bar_shapes = A0bar_src._block_shapes
+    bar_offsets = A0bar_src._block_offsets
+
+    def loss(data):
+        A = type(A0)._raw(
+            indices=indices,
+            data=data,
+            block_keys=block_keys,
+            block_shapes=block_shapes,
+            block_offsets=block_offsets,
+        )
+        Abar = type(A0)._raw(
+            indices=bar_indices,
+            data=jnp.conj(data),
+            block_keys=bar_keys,
+            block_shapes=bar_shapes,
+            block_offsets=bar_offsets,
+        )
+        out = contract(A, Abar)
+        return jnp.sum(out._data**2)
+
+    data0 = A0._data
+
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TENAX_BLOCKSPARSE_BACKEND", "perblock")
+    g_ref = jax.grad(loss)(data0)
+
+    monkeypatch.setenv("TENAX_BLOCKSPARSE_BACKEND", "stacked")
+    g_got = jax.grad(loss)(data0)
+
+    assert_tiered(g_ref, g_got, tier="fp")
+
+
+# ----------------------------------------------------------------------------
+# Back-compat: the legacy flag still fires the stacked path
+# ----------------------------------------------------------------------------
+
+
+def test_legacy_flag_still_fires_and_matches(monkeypatch):
+    A = dict(canonical_tensors())["ferm_D2"]
+    A, Abar = _double_layer(A)
+
+    _clear_env(monkeypatch)
+    ref = contract(A, Abar)  # all unset => per-block default
+    n0 = _STACK_FIRED["n"]
+
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "1")
+    got = contract(A, Abar)
+
+    assert _STACK_FIRED["n"] > n0, "legacy flag did not fire the stacked path"
+    assert got._block_keys == ref._block_keys
+    assert_tiered(ref._data, got._data, tier="fp")
+
+
+def test_default_unset_is_perblock(monkeypatch):
+    """No backend env set => per-block default (stacked path does NOT fire)."""
+    A = dict(canonical_tensors())["ferm_D2"]
+    A, Abar = _double_layer(A)
+
+    _clear_env(monkeypatch)
+    n0 = _STACK_FIRED["n"]
+    contract(A, Abar)
+    assert _STACK_FIRED["n"] == n0, "stacked path fired with no backend env set"

--- a/tests/stacked/test_harness.py
+++ b/tests/stacked/test_harness.py
@@ -1,0 +1,71 @@
+import os
+
+import jax.numpy as jnp
+import pytest
+
+from tenax.contraction.contractor import contract
+from tests.stacked._harness import assert_tiered, canonical_tensors
+
+
+def test_bit_identical_tier_passes_on_equal():
+    a = jnp.array([1.0, 2.0, 3.0])
+    assert_tiered(a, a, tier="bit")
+
+
+def test_bit_identical_tier_fails_on_tiny_diff():
+    a = jnp.array([1.0, 2.0, 3.0])
+    b = a + 1e-15
+    with pytest.raises(AssertionError):
+        assert_tiered(a, b, tier="bit")
+
+
+def test_bounded_fp_tier_passes_within_rtol():
+    a = jnp.array([1.0, 2.0, 3.0])
+    b = a * (1 + 1e-13)
+    assert_tiered(a, b, tier="fp")
+
+
+def test_bounded_fp_tier_fails_outside_rtol():
+    a = jnp.array([1.0, 2.0, 3.0])
+    b = a * (1 + 1e-6)
+    with pytest.raises(AssertionError):
+        assert_tiered(a, b, tier="fp")
+
+
+def test_canonical_tensors_cover_required_cases():
+    cases = dict(canonical_tensors())
+    assert {
+        "ferm_D2",
+        "ferm_D4",
+        "dense_D2",
+        "degenerate_sv",
+        "rank_deficient",
+    } <= set(cases)
+
+
+def _phys_double_layer(A):
+    """Contract ket A with conjugate bra A.bar() sharing ONLY the physical leg.
+
+    The virtual legs of the bra are relabelled (u/d/l/r -> U/D/L/R) so they
+    survive as free output legs, keeping the result a rank-8 SymmetricTensor
+    rather than collapsing to a scalar.  ``bar()`` flips the physical-leg flow
+    from IN to OUT so the shared ``phys`` label is a valid contraction.
+    """
+    bra = A.bar().relabels({"u": "U", "d": "D", "l": "L", "r": "R"})
+    return contract(A, bra)
+
+
+def test_comparator_self_validates_against_per_block_vs_batched_paths():
+    A = dict(canonical_tensors())["ferm_D2"]
+
+    try:
+        os.environ["TENAX_BATCH_BLOCKSPARSE"] = "0"
+        per_block = _phys_double_layer(A)
+        os.environ["TENAX_BATCH_BLOCKSPARSE"] = "1"
+        batched = _phys_double_layer(A)
+    finally:
+        os.environ["TENAX_BATCH_BLOCKSPARSE"] = "0"
+
+    assert per_block._data.size > 1, "double-layer collapsed to a scalar"
+    assert per_block.labels() == batched.labels()
+    assert_tiered(per_block._data, batched._data, tier="fp")

--- a/tests/stacked/test_harness.py
+++ b/tests/stacked/test_harness.py
@@ -1,5 +1,3 @@
-import os
-
 import jax.numpy as jnp
 import pytest
 
@@ -55,17 +53,25 @@ def _phys_double_layer(A):
     return contract(A, bra)
 
 
-def test_comparator_self_validates_against_per_block_vs_batched_paths():
+def test_comparator_self_validates_against_per_block_vs_batched_paths(monkeypatch):
     A = dict(canonical_tensors())["ferm_D2"]
 
-    try:
-        os.environ["TENAX_BATCH_BLOCKSPARSE"] = "0"
-        per_block = _phys_double_layer(A)
-        os.environ["TENAX_BATCH_BLOCKSPARSE"] = "1"
-        batched = _phys_double_layer(A)
-    finally:
-        os.environ["TENAX_BATCH_BLOCKSPARSE"] = "0"
+    # Per-combo path (flag off). Gate is read fresh per call, no cache to clear.
+    monkeypatch.setenv("TENAX_BATCH_BLOCKSPARSE", "0")
+    per_block = _phys_double_layer(A)
+    # Batched path (flag on).
+    monkeypatch.setenv("TENAX_BATCH_BLOCKSPARSE", "1")
+    batched = _phys_double_layer(A)
 
     assert per_block._data.size > 1, "double-layer collapsed to a scalar"
     assert per_block.labels() == batched.labels()
     assert_tiered(per_block._data, batched._data, tier="fp")
+
+
+def test_svd_invariants_smoke():
+    from tests.stacked._harness import assert_svd_invariants, canonical_tensors
+
+    M = dict(canonical_tensors())["degenerate_sv"]
+    U, S, Vh = jnp.linalg.svd(M, full_matrices=False)
+    # reconstruction matches; raw U/Vh never compared
+    assert_svd_invariants(M, U, S, Vh, tier="fp")

--- a/tests/stacked/test_stacked_contract.py
+++ b/tests/stacked/test_stacked_contract.py
@@ -1,0 +1,115 @@
+"""Tests for the even-D stacked block-sparse contraction path (#566 P1b).
+
+The stacked path (gated by ``TENAX_STACK_BLOCKSPARSE``) sources its operands
+directly from the contiguous ``_data`` buffer via ``stacked_blocks()`` +
+``jnp.take`` (NOT per-block ``.blocks``/``_get_block`` slicing) and emits one
+batched einsum + segment_sum per input shape-group. This must be byte-correct
+in VALUE and GRADIENT against the per-block path within the fp tier, and must
+actually fire (counter) for even-D inputs.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tenax.contraction.contractor import _STACK_FIRED, contract
+from tests.stacked._harness import assert_tiered, canonical_tensors
+
+
+def _double_layer(A):
+    """Contract ket A with bra A.bar() over ONLY the physical leg.
+
+    Mirrors ``_phys_double_layer`` in tests/stacked/test_harness.py: virtual
+    legs of the bra are relabelled (u/d/l/r -> U/D/L/R) so they survive as free
+    output legs and the result stays a rank-8 SymmetricTensor.
+    """
+    bra = A.bar().relabels({"u": "U", "d": "D", "l": "L", "r": "R"})
+    return A, bra
+
+
+@pytest.mark.parametrize("name", ["ferm_D2", "ferm_D4"])
+def test_stacked_contract_matches_perblock(name, monkeypatch):
+    A = dict(canonical_tensors())[name]
+    A, Abar = _double_layer(A)
+
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "0")
+    ref = contract(A, Abar)
+    n0 = _STACK_FIRED["n"]
+
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "1")
+    got = contract(A, Abar)
+
+    assert _STACK_FIRED["n"] > n0, "stacked path did not fire"
+    assert got._block_keys == ref._block_keys
+    assert ref._data.size > 1, "double-layer collapsed to a scalar"
+    assert_tiered(ref._data, got._data, tier="fp")
+
+
+def test_stacked_contract_grad_matches_perblock(monkeypatch):
+    A0 = dict(canonical_tensors())["ferm_D2"]
+    A0bar_src = A0.bar().relabels({"u": "U", "d": "D", "l": "L", "r": "R"})
+
+    indices = A0._indices
+    block_keys = A0._block_keys
+    block_shapes = A0._block_shapes
+    block_offsets = A0._block_offsets
+
+    bar_indices = A0bar_src._indices
+    bar_keys = A0bar_src._block_keys
+    bar_shapes = A0bar_src._block_shapes
+    bar_offsets = A0bar_src._block_offsets
+
+    def loss(data):
+        A = type(A0)._raw(
+            indices=indices,
+            data=data,
+            block_keys=block_keys,
+            block_shapes=block_shapes,
+            block_offsets=block_offsets,
+        )
+        # bra shares ket's data buffer (bar() conjugates; for real x64 it is
+        # the same buffer, so differentiating w.r.t. one data vector is valid).
+        Abar = type(A0)._raw(
+            indices=bar_indices,
+            data=jnp.conj(data),
+            block_keys=bar_keys,
+            block_shapes=bar_shapes,
+            block_offsets=bar_offsets,
+        )
+        out = contract(A, Abar)
+        return jnp.sum(out._data**2)
+
+    data0 = A0._data
+
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "0")
+    g_ref = jax.grad(loss)(data0)
+    n0 = _STACK_FIRED["n"]
+
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "1")
+    g_got = jax.grad(loss)(data0)
+
+    assert _STACK_FIRED["n"] > n0, "stacked path did not fire under grad"
+    assert_tiered(g_ref, g_got, tier="fp")
+
+
+def test_stacked_falls_back_for_odd_d(monkeypatch):
+    """D=3 has multiple shape-groups -> stacked path must return None (fall back)."""
+    from tenax.algorithms.fermionic_ipeps import (
+        FPEPSConfig,
+        _build_initial_fpeps_tensor,
+    )
+
+    A = _build_initial_fpeps_tensor(FPEPSConfig(D=3), jax.random.PRNGKey(0))
+    A, Abar = _double_layer(A)
+
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "0")
+    ref = contract(A, Abar)
+    n0 = _STACK_FIRED["n"]
+
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "1")
+    got = contract(A, Abar)
+
+    assert _STACK_FIRED["n"] == n0, "stacked path fired on multi-shape (odd-D) input"
+    assert got._block_keys == ref._block_keys
+    assert_tiered(ref._data, got._data, tier="fp")

--- a/tests/stacked/test_stacked_contract.py
+++ b/tests/stacked/test_stacked_contract.py
@@ -13,7 +13,11 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from tenax.contraction.contractor import _STACK_FIRED, contract
+from tenax.contraction.contractor import (
+    _STACK_FIRED,
+    contract,
+    contract_with_subscripts,
+)
 from tests.stacked._harness import assert_tiered, canonical_tensors
 
 
@@ -113,3 +117,42 @@ def test_stacked_falls_back_for_odd_d(monkeypatch):
     assert _STACK_FIRED["n"] == n0, "stacked path fired on multi-shape (odd-D) input"
     assert got._block_keys == ref._block_keys
     assert_tiered(ref._data, got._data, tier="fp")
+
+
+def test_stacked_falls_back_for_repeated_within_operand_label(monkeypatch):
+    """A diagonal/trace subscript (``"ii,j->j"``) repeats a label WITHIN one
+    operand, so ``all_complete`` is False even for single-shape-group inputs.
+    The stacked plan builder must return None (fall back to per-block), NOT
+    assert (Codex P2). The per-block path computes ``trace(M) * v``.
+    """
+    from tenax.core.symmetry import U1Symmetry
+    from tenax.core.tensor import FlowDirection, SymmetricTensor, TensorIndex
+
+    sym = U1Symmetry()
+    # Both i-legs charges [0, 1] => two blocks of shape (1, 1) => single group.
+    ch = np.array([0, 1], dtype=np.int32)
+    i0 = TensorIndex.from_charges(sym, ch, FlowDirection.OUT, label="i0")
+    i1 = TensorIndex.from_charges(sym, ch, FlowDirection.IN, label="i1")
+    # j-leg charges [0, 0] => single block of shape (2,) => single group.
+    chj = np.array([0, 0], dtype=np.int32)
+    jidx = TensorIndex.from_charges(sym, chj, FlowDirection.OUT, label="j")
+
+    mat = jnp.asarray(np.diag([2.0, 3.0]))  # diagonal => symmetry-allowed
+    vec = jnp.asarray(np.array([0.5, -1.3]))
+    T = SymmetricTensor.from_dense(mat, (i0, i1))
+    v = SymmetricTensor.from_dense(vec, (jidx,))
+    assert len(set(T._block_shapes)) == 1 and len(set(v._block_shapes)) == 1
+
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "0")
+    ref = contract_with_subscripts([T, v], "ii,j->j", (jidx,))
+
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "1")
+    n0 = _STACK_FIRED["n"]
+    got = contract_with_subscripts([T, v], "ii,j->j", (jidx,))
+
+    assert _STACK_FIRED["n"] == n0, (
+        "stacked path fired on repeated-within-operand label"
+    )
+    assert_tiered(ref._data, got._data, tier="fp")
+    # trace([[2,0],[0,3]]) = 5; 5 * [0.5, -1.3] = [2.5, -6.5]
+    assert_tiered(np.array([2.5, -6.5]), got._data, tier="fp")

--- a/tests/stacked/test_stacked_decomp.py
+++ b/tests/stacked/test_stacked_decomp.py
@@ -47,6 +47,11 @@ def _sym_tensors():
     }
 
 
+def _dense_tensor():
+    """The U(1)-trivial DenseTensor iPEPS site exposed by the harness."""
+    return dict(canonical_tensors())["dense_D2"]
+
+
 def _run_svd(tensor):
     """Full (untruncated) block-sparse SVD; returns (U, s, Vh)."""
     U, s, Vh, _ = svd(
@@ -135,6 +140,34 @@ def test_svd_reconstruction_recovers_input(name, monkeypatch):
     assert_tiered(A_ref, recon, tier="fp")
 
 
+def test_dense_svd_reconstruction_and_batch_flag_independent(monkeypatch):
+    """DenseTensor (U(1)-trivial) SVD broadens the spine beyond fermionic.
+
+    Mirrors the ferm SVD case: full SVD reconstructs the dense matricization,
+    and sorted SVs + reconstruction are invariant across TENAX_BATCH_BLOCKSPARSE
+    (the dense path shares the same _LEFT/_RIGHT partition and factor layout).
+    """
+    tensor = _dense_tensor()
+    A_ref = _matricize(tensor)
+
+    _set_flags(monkeypatch, stack=None, batch=None)
+    U_off, s_off, Vh_off = _run_svd(tensor)
+
+    _set_flags(monkeypatch, stack=None, batch="1")
+    U_on, s_on, Vh_on = _run_svd(tensor)
+
+    # Reconstruction recovers the original dense matricization.
+    assert_tiered(A_ref, _reconstruct(U_off, s_off, Vh_off), tier="fp")
+
+    # Gauge-invariant across the batch gate.
+    assert_tiered(jnp.sort(s_off), jnp.sort(s_on), tier="fp")
+    assert_tiered(
+        _reconstruct(U_off, s_off, Vh_off),
+        _reconstruct(U_on, s_on, Vh_on),
+        tier="fp",
+    )
+
+
 # --------------------------------------------------------------------------- #
 # 2. Plain-matrix degenerate-SV + rank-deficient guard.                       #
 #    Relies on invariants (reconstruction), not raw factors.                  #
@@ -190,22 +223,30 @@ def test_qr_reconstruction_batch_flag_independent(name, monkeypatch):
     assert_tiered(recon0, recon1, tier="fp")
 
 
-def test_eigh_eigenvalues_batch_flag_independent(monkeypatch):
-    """Symmetric eigh on a Hermitian tensor: sorted eigenvalues invariant under
-    the batch gate (never compare raw eigenvectors)."""
-    tensor = _sym_tensors()["ferm_D4"]
-    # Build a Hermitian operator H = A^dag A in the matricized space so eigh has
-    # a well-defined spectrum; do it via the dense matricization then wrap back
-    # is overkill — instead form a 2-leg Hermitian SymmetricTensor directly.
-    H = _hermitian_2leg(tensor)
+def test_eigh_invariants_batch_flag_independent(monkeypatch):
+    """Symmetric eigh on a multi-sector Hermitian H = M Mᴴ: sorted eigenvalues
+    AND the gauge-invariant reconstruction H = V diag(ev) Vᴴ are invariant under
+    the batch gate (never compare raw eigenvectors).
+
+    The Hermitian is built with a genuinely multi-sector charge structure (the
+    fused left index of ferm_D4 carries both FermionParity sectors) so the
+    TENAX_BATCH_BLOCKSPARSE gate actually has multiple sectors to batch.
+    """
+    H = _hermitian_2leg(_sym_tensors()["ferm_D4"])
+    H_ref = _matricize_2leg(H)
 
     _set_flags(monkeypatch, stack=None, batch=None)
-    _, ev0 = eigh(H, left_labels=["a"], right_labels=["b"], new_bond_label="bond")
+    V0, ev0 = eigh(H, left_labels=["a"], right_labels=["b"], new_bond_label="bond")
 
     _set_flags(monkeypatch, stack=None, batch="1")
-    _, ev1 = eigh(H, left_labels=["a"], right_labels=["b"], new_bond_label="bond")
+    V1, ev1 = eigh(H, left_labels=["a"], right_labels=["b"], new_bond_label="bond")
 
+    # Gauge-invariant: sorted eigenvalues unchanged across the gate.
     assert_tiered(jnp.sort(ev0), jnp.sort(ev1), tier="fp")
+
+    # Gauge-invariant: H = V diag(ev) Vᴴ recovers the input for BOTH gate states.
+    assert_tiered(H_ref, _reconstruct_eigh(V0, ev0), tier="fp")
+    assert_tiered(H_ref, _reconstruct_eigh(V1, ev1), tier="fp")
 
 
 # --------------------------------------------------------------------------- #
@@ -253,20 +294,53 @@ def _factor_to_matrix(factor, *, bond_last):
         return moved.reshape(dense.shape[bond_axis], cols)
 
 
+def _matricize_2leg(tensor):
+    """Dense (rows="a", cols="b") matricization of a 2-leg SymmetricTensor."""
+    dense = tensor.todense()
+    labels = list(tensor.labels())
+    perm = [labels.index("a"), labels.index("b")]
+    return jnp.transpose(dense, perm)
+
+
+def _reconstruct_eigh(V, ev):
+    """H = V diag(ev) Vᴴ in dense space, from the eigh factor tensor V.
+
+    V carries labels (left_labels..., bond); reuse the same bond-last layout as
+    the SVD/QR U/Q factors so the bond axis becomes the eigenvector columns.
+    """
+    Vd = _factor_to_matrix(V, bond_last=True)
+    return (Vd * jnp.asarray(ev)[None, : Vd.shape[1]]) @ Vd.conj().T
+
+
 def _hermitian_2leg(tensor):
-    """Build a Hermitian 2-leg SymmetricTensor H = M^dag M from the left-leg
-    fused index of ``tensor`` so eigh has a real, well-defined spectrum."""
+    """Build a multi-sector Hermitian 2-leg SymmetricTensor H = M Mᴴ from the
+    fused left index of ``tensor`` so eigh has a real, well-defined spectrum.
+
+    The fused (u, d) index of the fermionic site tensor carries both
+    FermionParity sectors, so H has a genuine multi-block charge structure and
+    the per-sector batch gate (TENAX_BATCH_BLOCKSPARSE) actually has several
+    sectors to batch — not a single trivial-charge block.
+    """
     from tenax.core.index import FlowDirection, TensorIndex
     from tenax.core.tensor import SymmetricTensor
 
-    A = _matricize(tensor)
+    A = _matricize(tensor)  # rows = fused (u, d), row-major
     M = A @ A.conj().T  # (left_dim, left_dim), Hermitian PSD
     n = M.shape[0]
 
-    # A single trivial-charge sector keeps the SymmetricTensor construction
-    # simple while still exercising the block-sparse eigh code path.
+    # Charges of the fused left index, in the same row-major order as _matricize
+    # (u outer, d inner) so they label the rows/cols of M correctly.
+    labels = list(tensor.labels())
     sym = tensor.indices[0].symmetry
-    charges = np.zeros(n, dtype=np.int32)
-    idx_a = TensorIndex.from_charges(sym, charges, FlowDirection.IN, label="a")
-    idx_b = TensorIndex.from_charges(sym, charges, FlowDirection.OUT, label="b")
+    cu = np.asarray(tensor.indices[labels.index("u")].charges)
+    cd = np.asarray(tensor.indices[labels.index("d")].charges)
+    fused = np.asarray(
+        sym.fuse(np.repeat(cu, len(cd)), np.tile(cd, len(cu))), dtype=np.int32
+    )
+    assert fused.shape[0] == n and len(np.unique(fused)) > 1, (
+        "expected a genuinely multi-sector fused index"
+    )
+
+    idx_a = TensorIndex.from_charges(sym, fused, FlowDirection.IN, label="a")
+    idx_b = TensorIndex.from_charges(sym, fused, FlowDirection.OUT, label="b")
     return SymmetricTensor.from_dense(M, (idx_a, idx_b))

--- a/tests/stacked/test_stacked_decomp.py
+++ b/tests/stacked/test_stacked_decomp.py
@@ -1,0 +1,272 @@
+"""Gauge-invariant decomposition equivalence spine for the stacked migration (#566, P1c).
+
+ASSESSMENT (Step A of the P1c task) — Outcome 1, tests-only:
+
+The symmetric ``svd`` / ``qr`` / ``eigh`` paths in ``tenax.linalg`` do NOT branch
+on ``TENAX_STACK_BLOCKSPARSE`` (the stacked-contraction gate).  They assemble
+per-*charge-sector* dense matrices (``_group_blocks_by_bond_charge`` fuses several
+distinct-shape blocks into one ``(rows, cols)`` matrix), which is a different
+partition from ``stacked_blocks()`` (groups blocks by identical raw *shape*).
+The sector-level decompositions are already batched via
+``_grouped_decomp_by_shape`` (#572) under the SEPARATE ``TENAX_BATCH_BLOCKSPARSE``
+gate, default-off.  A "stacked SVD over ``_data``" was therefore NOT implemented:
+the partitions are orthogonal, and the localization probe shows decomposition is
+~12 calls/sweep (noise) versus ``_get_block`` ~1428 — not a material structural-op
+source.
+
+These tests are the accuracy spine for P1d regardless of the path decision.  They
+toggle both ``TENAX_STACK_BLOCKSPARSE`` *and* ``TENAX_BATCH_BLOCKSPARSE`` and assert
+the gauge-INVARIANT quantities are unchanged: sorted singular values / eigenvalues
+and the reconstruction ``A = U Σ Vh`` / ``A = Q R``.  Raw ``U``/``Vh``/``Q`` factors
+are NEVER compared — vmap LAPACK flips signs/bases in degenerate subspaces (the #572
+trap), so only invariants are contractual.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tenax.linalg import eigh, qr, svd
+
+from ._harness import assert_tiered, canonical_tensors
+
+jax.config.update("jax_enable_x64", True)
+
+
+# Left/right partition for the 5-leg fermionic iPEPS site tensors.
+_LEFT = ["u", "d"]
+_RIGHT = ["l", "r", "phys"]
+
+
+def _sym_tensors():
+    return {
+        name: t for name, t in canonical_tensors() if name in ("ferm_D2", "ferm_D4")
+    }
+
+
+def _run_svd(tensor):
+    """Full (untruncated) block-sparse SVD; returns (U, s, Vh)."""
+    U, s, Vh, _ = svd(
+        tensor,
+        left_labels=_LEFT,
+        right_labels=_RIGHT,
+        new_bond_label="bond",
+    )
+    return U, s, Vh
+
+
+def _set_flags(monkeypatch, stack: str | None, batch: str | None):
+    for var, val in (
+        ("TENAX_STACK_BLOCKSPARSE", stack),
+        ("TENAX_BATCH_BLOCKSPARSE", batch),
+    ):
+        if val is None:
+            monkeypatch.delenv(var, raising=False)
+        else:
+            monkeypatch.setenv(var, val)
+
+
+# --------------------------------------------------------------------------- #
+# 1. SymmetricTensor SVD: gauge-invariants equal across flag states.          #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("name", ["ferm_D2", "ferm_D4"])
+def test_svd_invariants_stack_flag_independent(name, monkeypatch):
+    """svd does NOT branch on TENAX_STACK_BLOCKSPARSE (Outcome-1 finding):
+    flag-off vs flag-on give identical sorted SVs and reconstruction.
+
+    The svd path ignores the stacked-contraction gate entirely (it assembles
+    per-charge-sector matrices, a different partition from stacked_blocks()).
+    The assertion is therefore trivially identical — which is exactly the
+    documented decision: there is no separate stacked-svd branch to diverge.
+    """
+    tensor = _sym_tensors()[name]
+
+    _set_flags(monkeypatch, stack=None, batch=None)
+    U_off, s_off, Vh_off = _run_svd(tensor)
+
+    _set_flags(monkeypatch, stack="1", batch=None)
+    U_on, s_on, Vh_on = _run_svd(tensor)
+
+    # Gauge-invariant: sorted singular values (never raw U/Vh).
+    assert_tiered(jnp.sort(s_off), jnp.sort(s_on), tier="fp")
+
+    # Gauge-invariant: reconstruction in dense space must match.
+    assert_tiered(
+        _reconstruct(U_off, s_off, Vh_off),
+        _reconstruct(U_on, s_on, Vh_on),
+        tier="fp",
+    )
+
+
+@pytest.mark.parametrize("name", ["ferm_D2", "ferm_D4"])
+def test_svd_invariants_batch_flag_independent(name, monkeypatch):
+    """svd's per-sector batching gate (TENAX_BATCH_BLOCKSPARSE, #572) leaves
+    sorted SVs and reconstruction invariant: vmap(f) == [f(x_i)]."""
+    tensor = _sym_tensors()[name]
+
+    _set_flags(monkeypatch, stack=None, batch=None)
+    U_off, s_off, Vh_off = _run_svd(tensor)
+
+    _set_flags(monkeypatch, stack=None, batch="1")
+    U_on, s_on, Vh_on = _run_svd(tensor)
+
+    assert_tiered(jnp.sort(s_off), jnp.sort(s_on), tier="fp")
+    assert_tiered(
+        _reconstruct(U_off, s_off, Vh_off),
+        _reconstruct(U_on, s_on, Vh_on),
+        tier="fp",
+    )
+
+
+@pytest.mark.parametrize("name", ["ferm_D2", "ferm_D4"])
+def test_svd_reconstruction_recovers_input(name, monkeypatch):
+    """Full block-sparse SVD reconstructs the original dense matricization."""
+    tensor = _sym_tensors()[name]
+    _set_flags(monkeypatch, stack=None, batch=None)
+    U, s, Vh = _run_svd(tensor)
+
+    A_ref = _matricize(tensor)
+    recon = _reconstruct(U, s, Vh)
+    assert_tiered(A_ref, recon, tier="fp")
+
+
+# --------------------------------------------------------------------------- #
+# 2. Plain-matrix degenerate-SV + rank-deficient guard.                       #
+#    Relies on invariants (reconstruction), not raw factors.                  #
+# --------------------------------------------------------------------------- #
+
+
+def _plain_matrices():
+    cases = dict(canonical_tensors())
+    return {k: cases[k] for k in ("degenerate_sv", "rank_deficient")}
+
+
+@pytest.mark.parametrize("name", ["degenerate_sv", "rank_deficient"])
+def test_plain_svd_reconstruction_invariant(name):
+    """Degenerate-SV / rank-deficient matrices: jnp SVD reconstruction is exact.
+
+    Proves the accuracy contract relies on A = U Σ Vh, never on the (sign- and
+    basis-ambiguous) raw U/Vh factors.
+    """
+    A = jnp.asarray(_plain_matrices()[name])
+    U, s, Vh = jnp.linalg.svd(A, full_matrices=False)
+    recon = (U * s[None, :]) @ Vh
+    assert_tiered(A, recon, tier="fp")
+
+
+@pytest.mark.parametrize("name", ["degenerate_sv", "rank_deficient"])
+def test_plain_qr_reconstruction_invariant(name):
+    """QR reconstruction A = Q R is exact on degenerate / rank-deficient input."""
+    A = jnp.asarray(_plain_matrices()[name])
+    Q, R = jnp.linalg.qr(A)
+    assert_tiered(A, Q @ R, tier="fp")
+
+
+# --------------------------------------------------------------------------- #
+# 3. SymmetricTensor qr / eigh: gauge-invariants across the batch gate.       #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("name", ["ferm_D2", "ferm_D4"])
+def test_qr_reconstruction_batch_flag_independent(name, monkeypatch):
+    """Symmetric QR: A = Q R reconstruction invariant under TENAX_BATCH_BLOCKSPARSE."""
+    tensor = _sym_tensors()[name]
+    A_ref = _matricize(tensor)
+
+    _set_flags(monkeypatch, stack=None, batch=None)
+    Q0, R0 = qr(tensor, left_labels=_LEFT, right_labels=_RIGHT, new_bond_label="bond")
+
+    _set_flags(monkeypatch, stack=None, batch="1")
+    Q1, R1 = qr(tensor, left_labels=_LEFT, right_labels=_RIGHT, new_bond_label="bond")
+
+    recon0 = _matricize_factors(Q0, R0)
+    recon1 = _matricize_factors(Q1, R1)
+    assert_tiered(A_ref, recon0, tier="fp")
+    assert_tiered(recon0, recon1, tier="fp")
+
+
+def test_eigh_eigenvalues_batch_flag_independent(monkeypatch):
+    """Symmetric eigh on a Hermitian tensor: sorted eigenvalues invariant under
+    the batch gate (never compare raw eigenvectors)."""
+    tensor = _sym_tensors()["ferm_D4"]
+    # Build a Hermitian operator H = A^dag A in the matricized space so eigh has
+    # a well-defined spectrum; do it via the dense matricization then wrap back
+    # is overkill — instead form a 2-leg Hermitian SymmetricTensor directly.
+    H = _hermitian_2leg(tensor)
+
+    _set_flags(monkeypatch, stack=None, batch=None)
+    _, ev0 = eigh(H, left_labels=["a"], right_labels=["b"], new_bond_label="bond")
+
+    _set_flags(monkeypatch, stack=None, batch="1")
+    _, ev1 = eigh(H, left_labels=["a"], right_labels=["b"], new_bond_label="bond")
+
+    assert_tiered(jnp.sort(ev0), jnp.sort(ev1), tier="fp")
+
+
+# --------------------------------------------------------------------------- #
+# Dense-space helpers (gauge-invariant reconstruction only).                  #
+# --------------------------------------------------------------------------- #
+
+
+def _matricize(tensor):
+    """Dense (rows=_LEFT, cols=_RIGHT) matricization of a SymmetricTensor."""
+    dense = tensor.todense()
+    labels = list(tensor.labels())
+    perm = [labels.index(lbl) for lbl in _LEFT + _RIGHT]
+    moved = jnp.transpose(dense, perm)
+    left_dim = int(np.prod([moved.shape[i] for i in range(len(_LEFT))]))
+    return moved.reshape(left_dim, -1)
+
+
+def _reconstruct(U, s, Vh):
+    """U Σ Vh in dense matricized space, using the SVD factor tensors."""
+    Ud = _factor_to_matrix(U, bond_last=True)
+    Vhd = _factor_to_matrix(Vh, bond_last=False)
+    return (Ud * s[None, : Ud.shape[1]]) @ Vhd
+
+
+def _matricize_factors(Q, R):
+    Qd = _factor_to_matrix(Q, bond_last=True)
+    Rd = _factor_to_matrix(R, bond_last=False)
+    return Qd @ Rd
+
+
+def _factor_to_matrix(factor, *, bond_last):
+    """Reshape a U/Q (bond_last=True) or Vh/R (bond_last=False) factor tensor
+    into a 2-D matrix with the bond axis as cols / rows respectively."""
+    dense = factor.todense()
+    labels = list(factor.labels())
+    bond_axis = labels.index("bond")
+    other = [i for i in range(len(labels)) if i != bond_axis]
+    if bond_last:
+        moved = jnp.transpose(dense, other + [bond_axis])
+        rows = int(np.prod([dense.shape[i] for i in other])) if other else 1
+        return moved.reshape(rows, dense.shape[bond_axis])
+    else:
+        moved = jnp.transpose(dense, [bond_axis] + other)
+        cols = int(np.prod([dense.shape[i] for i in other])) if other else 1
+        return moved.reshape(dense.shape[bond_axis], cols)
+
+
+def _hermitian_2leg(tensor):
+    """Build a Hermitian 2-leg SymmetricTensor H = M^dag M from the left-leg
+    fused index of ``tensor`` so eigh has a real, well-defined spectrum."""
+    from tenax.core.index import FlowDirection, TensorIndex
+    from tenax.core.tensor import SymmetricTensor
+
+    A = _matricize(tensor)
+    M = A @ A.conj().T  # (left_dim, left_dim), Hermitian PSD
+    n = M.shape[0]
+
+    # A single trivial-charge sector keeps the SymmetricTensor construction
+    # simple while still exercising the block-sparse eigh code path.
+    sym = tensor.indices[0].symmetry
+    charges = np.zeros(n, dtype=np.int32)
+    idx_a = TensorIndex.from_charges(sym, charges, FlowDirection.IN, label="a")
+    idx_b = TensorIndex.from_charges(sym, charges, FlowDirection.OUT, label="b")
+    return SymmetricTensor.from_dense(M, (idx_a, idx_b))

--- a/tests/stacked/test_stacked_tensor_dtype.py
+++ b/tests/stacked/test_stacked_tensor_dtype.py
@@ -1,0 +1,56 @@
+"""Regression: StackedSymmetricTensor scalar multiply must track promoted dtype.
+
+A scalar that promotes the dtype (e.g. a real tensor times ``1j``) makes the
+cached group arrays complex. The materialization buffer
+(:func:`~tenax.core.stacked_view.scatter_stacked`) is allocated with the stored
+dtype, so if ``__mul__`` recorded the STALE real dtype the scatter would cast
+the complex rows back to real and silently drop the imaginary part (Codex P2).
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from tenax.contraction.contractor import contract
+from tenax.core.stacked_tensor import StackedSymmetricTensor
+from tests.stacked._harness import assert_tiered, canonical_tensors
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    prev = jax.config.read("jax_enable_x64")
+    jax.config.update("jax_enable_x64", True)
+    yield
+    jax.config.update("jax_enable_x64", prev)
+
+
+def _make_stacked(monkeypatch):
+    """Produce a real-dtype StackedSymmetricTensor via the stacked contraction."""
+    A = dict(canonical_tensors())["ferm_D2"]
+    bra = A.bar().relabels({"u": "U", "d": "D", "l": "L", "r": "R"})
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "1")
+    out = contract(A, bra)
+    assert isinstance(out, StackedSymmetricTensor)
+    return A, bra, out
+
+
+def test_stacked_scalar_multiply_promotes_dtype(monkeypatch):
+    A, bra, out = _make_stacked(monkeypatch)
+    assert jnp.dtype(out.__dict__["_dtype"]) == jnp.float64
+
+    out2 = out * 1j
+    # Stored dtype must follow the promoted (complex) group arrays.
+    assert jnp.dtype(out2.__dict__["_dtype"]) == jnp.complex128
+    for grp in out2.stacked_blocks().groups.values():
+        assert grp.array.dtype == jnp.complex128
+
+    # Materialization must preserve the imaginary part, not cast it away.
+    data = out2._data
+    assert data.dtype == jnp.complex128
+    assert bool(jnp.any(jnp.imag(data) != 0)), "imaginary part dropped on scatter"
+
+    # Value matches the same op on the plain per-block path.
+    monkeypatch.setenv("TENAX_STACK_BLOCKSPARSE", "0")
+    ref2 = contract(A, bra) * 1j
+    assert ref2._data.dtype == jnp.complex128
+    assert_tiered(ref2._data, data, tier="fp")

--- a/tests/stacked/test_stacked_view.py
+++ b/tests/stacked/test_stacked_view.py
@@ -1,0 +1,33 @@
+import jax.numpy as jnp
+import pytest
+
+from tests.stacked._harness import canonical_tensors
+
+
+@pytest.mark.parametrize("name", ["ferm_D2", "ferm_D4"])
+def test_round_trip_bit_exact(name):
+    A = dict(canonical_tensors())[name]
+    view = A.stacked_blocks()
+    B = A.from_stacked_blocks(view)
+    assert bool(jnp.array_equal(A._data, B._data)), "round-trip not bit-exact"
+    assert A._block_keys == B._block_keys
+    assert A._block_shapes == B._block_shapes
+    assert A._block_offsets == B._block_offsets
+
+
+def test_even_D_is_single_shape_group():
+    A = dict(canonical_tensors())["ferm_D4"]
+    view = A.stacked_blocks()
+    assert len(view.groups) == 1
+    ((shape, grp),) = view.groups.items()
+    assert grp.array.shape[0] == len(A._block_keys)
+    assert grp.array.shape[1:] == shape
+
+
+def test_stacked_block_values_match_get_block():
+    A = dict(canonical_tensors())["ferm_D2"]
+    view = A.stacked_blocks()
+    for shape, grp in view.groups.items():
+        for j, key in enumerate(grp.keys):
+            idx = A._block_keys.index(key)
+            assert bool(jnp.array_equal(grp.array[j], A._get_block(idx)))

--- a/tests/stacked/test_vjp_seam.py
+++ b/tests/stacked/test_vjp_seam.py
@@ -36,12 +36,6 @@ def _bra_from(A):
     return A.bar().relabels({"u": "U", "d": "D", "l": "L", "r": "R"})
 
 
-def _operand_meta(tensors):
-    return tuple(
-        (t.indices, t._block_keys, t._block_shapes, t._block_offsets) for t in tensors
-    )
-
-
 def _stack_of(t):
     view = t.stacked_blocks()
     (group,) = view.groups.values()
@@ -63,7 +57,7 @@ def test_vjp_seam_value_triple_equivalence(name):
     assert ref._data.size > 1, "double-layer collapsed to a scalar"
 
     stacked = StackedJaxBackend().execute(stacks, plan)
-    mock = MockFFIBackend(subs, _operand_meta([A, Abar])).execute(stacks, plan)
+    mock = MockFFIBackend().execute(stacks, plan)
 
     # Stacked / mock are canonical-row arrays aligned with plan.out_block_keys.
     assert plan.out_block_keys == ref._block_keys
@@ -128,7 +122,7 @@ def test_vjp_seam_grad_triple_equivalence(name):
 
     gA_stacked, gB_stacked = jax.grad(loss_stacked, argnums=(0, 1))(sA, sB)
 
-    backend = MockFFIBackend(subs, _operand_meta([A0, Abar0]))
+    backend = MockFFIBackend()
 
     def loss_mock(sA, sB):
         out = backend.execute([sA, sB], plan)
@@ -175,7 +169,7 @@ def test_vjp_seam_opacity_counter():
     sB = _stack_of(Abar0)
 
     counter = {"n": 0}
-    backend = MockFFIBackend(subs, _operand_meta([A0, Abar0]), bwd_calls=counter)
+    backend = MockFFIBackend(bwd_calls=counter)
 
     def loss(sA, sB):
         return jnp.sum(backend.execute([sA, sB], plan) ** 2)
@@ -185,8 +179,8 @@ def test_vjp_seam_opacity_counter():
 
     out = backend.execute([sA, sB], plan)
     gO = 2.0 * out  # cotangent of sum(out**2)
-    gA_direct = backward_contraction(subs, [A0, Abar0], gO, plan, 0)
-    gB_direct = backward_contraction(subs, [A0, Abar0], gO, plan, 1)
+    gA_direct = backward_contraction([sA, sB], gO, plan, 0)
+    gB_direct = backward_contraction([sA, sB], gO, plan, 1)
     assert_tiered(g[0], gA_direct, tier="fp")
     assert_tiered(g[1], gB_direct, tier="fp")
 
@@ -204,13 +198,12 @@ def test_vjp_seam_opacity_stop_gradient_forward():
     Abar0 = _bra_from(A0)
     subs, out_indices = _labels_to_subscripts([A0, Abar0])
     plan = build_block_contract_plan([A0, Abar0], subs, out_indices)
-    meta = _operand_meta([A0, Abar0])
 
     sA = _stack_of(A0)
     sB = _stack_of(Abar0)
 
     # Normal opaque backend.
-    backend = MockFFIBackend(subs, meta)
+    backend = MockFFIBackend()
 
     # Opaque backend whose forward kernel is stop_gradient-ed (a stricter black
     # box). custom_vjp's bwd is unaffected; the value path is identical.
@@ -230,7 +223,7 @@ def test_vjp_seam_opacity_stop_gradient_forward():
             finally:
                 _m.stacked_execute = saved
 
-    backend_sg = _StopGradFwdMock(subs, meta)
+    backend_sg = _StopGradFwdMock()
 
     def make_loss(b):
         def loss(sA, sB):
@@ -311,7 +304,7 @@ def test_vjp_seam_grad_complex128_triple_equivalence():
     gA_stacked, gB_stacked = jax.grad(loss_stacked, argnums=(0, 1))(sA, sB)
 
     # --- MockFFIBackend hand-written transposed-plan VJP.
-    backend = MockFFIBackend(subs, _operand_meta([A, B]))
+    backend = MockFFIBackend()
 
     def loss_mock(a, b):
         return real_loss(backend.execute([a, b], plan))
@@ -352,7 +345,7 @@ def test_vjp_seam_two_distinct_operands():
 
     gA_ref, gB_ref = jax.grad(loss_stacked, argnums=(0, 1))(sA, sB)
 
-    backend = MockFFIBackend(subs, _operand_meta([A, B]))
+    backend = MockFFIBackend()
 
     def loss_mock(sA, sB):
         return jnp.sum(backend.execute([sA, sB], plan) ** 2)

--- a/tests/stacked/test_vjp_seam.py
+++ b/tests/stacked/test_vjp_seam.py
@@ -1,0 +1,283 @@
+"""Triple-equivalence VJP seam tests for an opaque block-sparse backend (#200, A3).
+
+The de-risking crux for cuTensorNet: a real FFI backend is an opaque
+``custom_call`` JAX cannot autodiff, so its backward MUST be hand-written. Here a
+:class:`MockFFIBackend` (genuine ``jax.custom_vjp``, opacity enforced) is driven
+through the SAME plan machinery the forward uses, and we assert:
+
+1. **Value**: MockFFIBackend == per-block == StackedJaxBackend.
+2. **Gradient (crux)**: ``jax.grad`` through MockFFIBackend's hand-written
+   transposed-plan VJP == ``jax.grad`` per-block == ``jax.grad`` StackedJaxBackend.
+3. **Opacity**: the hand-written bwd is the ONLY gradient path (counter probe +
+   ``stop_gradient`` through the forward kernel still yields the correct grad).
+4. **Two distinct operands**: dA and dB independently checked on an A·B contraction
+   with B NOT sharing A's data buffer.
+
+All comparisons are at the fp tier (rtol/atol 1e-12) — never gauge/loosened
+(this is contraction, no SVD).
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from tenax.contraction.blocksparse_backend import MockFFIBackend, StackedJaxBackend
+from tenax.contraction.blocksparse_plan import (
+    build_block_contract_plan,
+    stacked_execute,
+)
+from tenax.contraction.blocksparse_vjp import backward_contraction
+from tenax.contraction.contractor import _labels_to_subscripts, contract
+from tests.stacked._harness import assert_tiered, canonical_tensors
+
+
+def _bra_from(A):
+    """Bra = A.bar() with virtual legs relabelled to survive as free output legs."""
+    return A.bar().relabels({"u": "U", "d": "D", "l": "L", "r": "R"})
+
+
+def _operand_meta(tensors):
+    return tuple(
+        (t.indices, t._block_keys, t._block_shapes, t._block_offsets) for t in tensors
+    )
+
+
+def _stack_of(t):
+    view = t.stacked_blocks()
+    (group,) = view.groups.values()
+    return group.array
+
+
+@pytest.mark.parametrize("name", ["ferm_D2", "ferm_D4"])
+def test_vjp_seam_value_triple_equivalence(name):
+    A = dict(canonical_tensors())[name]
+    Abar = _bra_from(A)
+    subs, out_indices = _labels_to_subscripts([A, Abar])
+    plan = build_block_contract_plan([A, Abar], subs, out_indices)
+    assert plan is not None
+
+    stacks = [_stack_of(A), _stack_of(Abar)]
+
+    # per-block reference
+    ref = contract(A, Abar)
+    assert ref._data.size > 1, "double-layer collapsed to a scalar"
+
+    stacked = StackedJaxBackend().execute(stacks, plan)
+    mock = MockFFIBackend(subs, _operand_meta([A, Abar])).execute(stacks, plan)
+
+    # Stacked / mock are canonical-row arrays aligned with plan.out_block_keys.
+    assert plan.out_block_keys == ref._block_keys
+    assert_tiered(stacked, mock, tier="fp")
+    # Compare against the per-block flat buffer reshaped to canonical rows.
+    ref_rows = jnp.stack(
+        [ref._get_block(i) for i in range(len(ref._block_keys))], axis=0
+    )
+    assert_tiered(ref_rows, mock, tier="fp")
+
+
+@pytest.mark.parametrize("name", ["ferm_D2", "ferm_D4"])
+def test_vjp_seam_grad_triple_equivalence(name):
+    """The crux: hand-written transposed-plan VJP == per-block == StackedJax grad."""
+    A0 = dict(canonical_tensors())[name]
+    Abar0 = _bra_from(A0)
+    subs, out_indices = _labels_to_subscripts([A0, Abar0])
+    plan = build_block_contract_plan([A0, Abar0], subs, out_indices)
+    assert plan is not None
+
+    # --- per-block reference: differentiate through contract() on the data buffer.
+    indices, keys, shapes, offsets = (
+        A0.indices,
+        A0._block_keys,
+        A0._block_shapes,
+        A0._block_offsets,
+    )
+    bar_indices, bar_keys, bar_shapes, bar_offsets = (
+        Abar0.indices,
+        Abar0._block_keys,
+        Abar0._block_shapes,
+        Abar0._block_offsets,
+    )
+
+    def loss_perblock(data):
+        A = type(A0)._raw(
+            indices=indices,
+            data=data,
+            block_keys=keys,
+            block_shapes=shapes,
+            block_offsets=offsets,
+        )
+        Abar = type(A0)._raw(
+            indices=bar_indices,
+            data=jnp.conj(data),
+            block_keys=bar_keys,
+            block_shapes=bar_shapes,
+            block_offsets=bar_offsets,
+        )
+        out = contract(A, Abar)
+        return jnp.sum(out._data**2)
+
+    g_perblock = jax.grad(loss_perblock)(A0._data)
+
+    # --- stacked-array losses (StackedJax vs MockFFI) over the operand stacks.
+    sA = _stack_of(A0)
+    sB = _stack_of(Abar0)
+
+    def loss_stacked(sA, sB):
+        out = stacked_execute([sA, sB], plan)
+        return jnp.sum(out**2)
+
+    gA_stacked, gB_stacked = jax.grad(loss_stacked, argnums=(0, 1))(sA, sB)
+
+    backend = MockFFIBackend(subs, _operand_meta([A0, Abar0]))
+
+    def loss_mock(sA, sB):
+        out = backend.execute([sA, sB], plan)
+        return jnp.sum(out**2)
+
+    gA_mock, gB_mock = jax.grad(loss_mock, argnums=(0, 1))(sA, sB)
+
+    # Mock (hand-written VJP) == StackedJax (autodiff) on the stacked operands.
+    assert_tiered(gA_stacked, gA_mock, tier="fp")
+    assert_tiered(gB_stacked, gB_mock, tier="fp")
+
+    # Mock grad on stacks == per-block grad, mapped through the shared data buffer.
+    # A and Abar share A0's data (Abar = conj(A); real x64 -> same buffer), so the
+    # per-block data-grad is the sum of the ket and bra contributions. Reconstruct
+    # the same combination from the stacked grads to compare on the flat buffer.
+    def scatter_like(t, gstack):
+        view = t.stacked_blocks()
+        (group,) = view.groups.values()
+        new_view = type(view)(
+            groups={
+                next(iter(view.groups)): type(group)(keys=group.keys, array=gstack)
+            },
+            indices=view.indices,
+        )
+        return t.from_stacked_blocks(new_view)._data
+
+    g_from_mock = scatter_like(A0, gA_mock) + jnp.conj(scatter_like(Abar0, gB_mock))
+    assert_tiered(g_perblock, g_from_mock, tier="fp")
+
+
+def test_vjp_seam_opacity_counter():
+    """Opacity (a): the hand-written custom-VJP backward IS the gradient path.
+
+    The counter bumps under ``jax.grad`` (the bwd fired), and the grad equals the
+    hand-written ``backward_contraction`` computed independently — i.e. the
+    gradient is exactly the transposed-plan backward, not autodiff-through-execute.
+    """
+    A0 = dict(canonical_tensors())["ferm_D2"]
+    Abar0 = _bra_from(A0)
+    subs, out_indices = _labels_to_subscripts([A0, Abar0])
+    plan = build_block_contract_plan([A0, Abar0], subs, out_indices)
+
+    sA = _stack_of(A0)
+    sB = _stack_of(Abar0)
+
+    counter = {"n": 0}
+    backend = MockFFIBackend(subs, _operand_meta([A0, Abar0]), bwd_calls=counter)
+
+    def loss(sA, sB):
+        return jnp.sum(backend.execute([sA, sB], plan) ** 2)
+
+    g = jax.grad(loss, argnums=(0, 1))(sA, sB)
+    assert counter["n"] > 0, "hand-written custom-VJP backward never fired"
+
+    out = backend.execute([sA, sB], plan)
+    gO = 2.0 * out  # cotangent of sum(out**2)
+    gA_direct = backward_contraction(subs, [A0, Abar0], gO, plan, 0)
+    gB_direct = backward_contraction(subs, [A0, Abar0], gO, plan, 1)
+    assert_tiered(g[0], gA_direct, tier="fp")
+    assert_tiered(g[1], gB_direct, tier="fp")
+
+
+def test_vjp_seam_opacity_stop_gradient_forward():
+    """Opacity (b): autodiff CANNOT leak through the opaque forward kernel.
+
+    If the forward's internal ``stacked_execute`` is wrapped in
+    ``jax.lax.stop_gradient`` (simulating a truly opaque ``custom_call`` whose
+    forward is a black box), the grad is UNCHANGED — proof that the entire
+    gradient comes from the hand-written ``custom_vjp`` backward, never from
+    differentiating the forward kernel.
+    """
+    A0 = dict(canonical_tensors())["ferm_D2"]
+    Abar0 = _bra_from(A0)
+    subs, out_indices = _labels_to_subscripts([A0, Abar0])
+    plan = build_block_contract_plan([A0, Abar0], subs, out_indices)
+    meta = _operand_meta([A0, Abar0])
+
+    sA = _stack_of(A0)
+    sB = _stack_of(Abar0)
+
+    # Normal opaque backend.
+    backend = MockFFIBackend(subs, meta)
+
+    # Opaque backend whose forward kernel is stop_gradient-ed (a stricter black
+    # box). custom_vjp's bwd is unaffected; the value path is identical.
+    class _StopGradFwdMock(MockFFIBackend):
+        def _execute_opaque(self, operand_stacks, plan):
+            orig = stacked_execute
+
+            def _sg(stacks, p):
+                return jax.lax.stop_gradient(orig(stacks, p))
+
+            import tenax.contraction.blocksparse_backend as _m
+
+            saved = _m.stacked_execute
+            _m.stacked_execute = _sg
+            try:
+                return MockFFIBackend._execute_opaque(self, operand_stacks, plan)
+            finally:
+                _m.stacked_execute = saved
+
+    backend_sg = _StopGradFwdMock(subs, meta)
+
+    def make_loss(b):
+        def loss(sA, sB):
+            return jnp.sum(b.execute([sA, sB], plan) ** 2)
+
+        return loss
+
+    g = jax.grad(make_loss(backend), argnums=(0, 1))(sA, sB)
+    g_sg = jax.grad(make_loss(backend_sg), argnums=(0, 1))(sA, sB)
+
+    assert_tiered(g[0], g_sg[0], tier="fp")
+    assert_tiered(g[1], g_sg[1], tier="fp")
+
+
+def test_vjp_seam_two_distinct_operands():
+    """dA and dB independently checked on A·B with B NOT sharing A's buffer."""
+    A = dict(canonical_tensors())["ferm_D2"]
+    # Distinct bra: bar() of a *different* tensor so dA and dB are independent.
+    B_src = dict(canonical_tensors())["ferm_D2"]
+    # Perturb B's data so it is genuinely distinct from A.
+    B_src = type(B_src)._raw(
+        indices=B_src.indices,
+        data=B_src._data * 1.7 + 0.3,
+        block_keys=B_src._block_keys,
+        block_shapes=B_src._block_shapes,
+        block_offsets=B_src._block_offsets,
+    )
+    B = _bra_from(B_src)
+
+    subs, out_indices = _labels_to_subscripts([A, B])
+    plan = build_block_contract_plan([A, B], subs, out_indices)
+    assert plan is not None
+
+    sA = _stack_of(A)
+    sB = _stack_of(B)
+
+    def loss_stacked(sA, sB):
+        return jnp.sum(stacked_execute([sA, sB], plan) ** 2)
+
+    gA_ref, gB_ref = jax.grad(loss_stacked, argnums=(0, 1))(sA, sB)
+
+    backend = MockFFIBackend(subs, _operand_meta([A, B]))
+
+    def loss_mock(sA, sB):
+        return jnp.sum(backend.execute([sA, sB], plan) ** 2)
+
+    gA_mock, gB_mock = jax.grad(loss_mock, argnums=(0, 1))(sA, sB)
+
+    assert_tiered(gA_ref, gA_mock, tier="fp")
+    assert_tiered(gB_ref, gB_mock, tier="fp")

--- a/tests/stacked/test_vjp_seam.py
+++ b/tests/stacked/test_vjp_seam.py
@@ -245,6 +245,86 @@ def test_vjp_seam_opacity_stop_gradient_forward():
     assert_tiered(g[1], g_sg[1], tier="fp")
 
 
+def _complexify(A, scale=1 + 0.7j, shift=0.3j):
+    """Promote a real tensor's data buffer to complex128 (distinct real/imag)."""
+    return type(A)._raw(
+        indices=A._indices,
+        data=(A._data * scale + shift).astype(jnp.complex128),
+        block_keys=A._block_keys,
+        block_shapes=A._block_shapes,
+        block_offsets=A._block_offsets,
+    )
+
+
+def test_vjp_seam_grad_complex128_triple_equivalence():
+    """complex128 crux: hand-written VJP == StackedJax autodiff == jax.vjp truth.
+
+    The production dtype is complex128. The premise that the backward needs a
+    conjugation for complex is WRONG: the VJP of a bilinear contraction
+    transposes the UNCONJUGATED surviving operand for both real and complex
+    (conjugation enters only via non-holomorphic LEAF ops, outside this seam).
+
+    Ground truth is ``jax.vjp(stacked_execute)`` (NOT the per-block shared-buffer
+    reconstruction, whose hand-rolled conj bookkeeping is awkward for complex).
+    The loss is the real-valued ``sum|out|**2`` so the complex grad of a real
+    loss is well-defined and matches physical energy/AD. dA and dB are checked on
+    two genuinely distinct complex operands.
+    """
+    A_real = dict(canonical_tensors())["ferm_D2"]
+    # Distinct complex bra: bar() of a *different*, perturbed tensor so dA and dB
+    # are independent, then promote both operands to complex128.
+    B_src_real = dict(canonical_tensors())["ferm_D2"]
+    B_src_real = type(B_src_real)._raw(
+        indices=B_src_real.indices,
+        data=B_src_real._data * 1.7 + 0.3,
+        block_keys=B_src_real._block_keys,
+        block_shapes=B_src_real._block_shapes,
+        block_offsets=B_src_real._block_offsets,
+    )
+    A = _complexify(A_real, scale=1 + 0.7j, shift=0.3j)
+    B = _complexify(_bra_from(B_src_real), scale=1 - 0.4j, shift=-0.2j)
+
+    subs, out_indices = _labels_to_subscripts([A, B])
+    plan = build_block_contract_plan([A, B], subs, out_indices)
+    assert plan is not None
+
+    sA = _stack_of(A)
+    sB = _stack_of(B)
+    assert sA.dtype == jnp.complex128 and sB.dtype == jnp.complex128
+
+    def real_loss(out):
+        # Real-valued: matches physical energy / non-holomorphic AD.
+        return jnp.sum(jnp.abs(out) ** 2)
+
+    # --- Ground truth: jax.grad of the pure-JAX forward (stacked_execute),
+    # which is jax.vjp(stacked_execute) composed with the real loss. This is the
+    # robust truth — no hand-rolled conj bookkeeping.
+    gA_truth, gB_truth = jax.grad(
+        lambda a, b: real_loss(stacked_execute([a, b], plan)),
+        argnums=(0, 1),
+    )(sA, sB)
+
+    # --- StackedJaxBackend autodiff.
+    def loss_stacked(a, b):
+        return real_loss(stacked_execute([a, b], plan))
+
+    gA_stacked, gB_stacked = jax.grad(loss_stacked, argnums=(0, 1))(sA, sB)
+
+    # --- MockFFIBackend hand-written transposed-plan VJP.
+    backend = MockFFIBackend(subs, _operand_meta([A, B]))
+
+    def loss_mock(a, b):
+        return real_loss(backend.execute([a, b], plan))
+
+    gA_mock, gB_mock = jax.grad(loss_mock, argnums=(0, 1))(sA, sB)
+
+    # Triple match at fp tier for BOTH dA and dB on the production dtype.
+    assert_tiered(gA_truth, gA_stacked, tier="fp")
+    assert_tiered(gB_truth, gB_stacked, tier="fp")
+    assert_tiered(gA_truth, gA_mock, tier="fp")
+    assert_tiered(gB_truth, gB_mock, tier="fp")
+
+
 def test_vjp_seam_two_distinct_operands():
     """dA and dB independently checked on A·B with B NOT sharing A's buffer."""
     A = dict(canonical_tensors())["ferm_D2"]


### PR DESCRIPTION
## Summary

Lands **Phase A of the #200 block-sparse contraction backend seam** — a kernel-agnostic seam that lets a single custom kernel (cuTensorNet on GPU, Pallas/TPU later) emit O(1) ops per block-sparse contraction, the principled fix for both the symmetric iPEPS-AD **compile wall (#566)** and the **tiny-kernel runtime (#195/#200)**. Everything here is **default-OFF and byte-identical** to current behaviour; it is the reusable substrate, with the cuTensorNet forward kernel (Phase B) to follow on a CUDA host.

Also includes the foundational stacked-block work and the design/measurement trail that motivated the pivot.

## What's included

**The seam (CPU, default-off):**
- `blocksparse_plan.py` — `BlockContractPlan` + `build_block_contract_plan` (static, computed from block metadata only — no tensor data, so any backend can consume it) + `stacked_execute` (pure-JAX, returns a backend-neutral canonical stacked array).
- `blocksparse_backend.py` — `BlockSparseContractBackend` protocol (`available`/`supports`/`execute`) + `select_backend` (env `TENAX_BLOCKSPARSE_BACKEND` ∈ {stacked,cutensornet,perblock,auto} + legacy `TENAX_STACK_BLOCKSPARSE`) + `_backend_opt_in()` cheap gate so the **default per-block path builds no plan (zero overhead)**. `StackedJaxBackend` is the first backend.
- `blocksparse_vjp.py` — hand-written transposed-plan VJP (`backward_contraction`) that reuses the plan machinery (the VJP of a bilinear contraction is the same contraction with the cotangent swapped for one operand) + `MockFFIBackend` proving an opaque `custom_vjp` backend slots in.

**Foundation:**
- `StackedView` / `stacked_blocks()` / `from_stacked_blocks()` over the unchanged flat `_data` buffer (bit-exact round-trip).
- Even-D stacked contraction path; assessed-and-deferred stacked decomposition (charge-sectors are orthogonal to shape-groups + already batched by #572).
- Three-tier accuracy spine (`tests/stacked/_harness.py`): bit-identical / bounded-fp / gauge-invariant.

## De-risking result (the point of Phase A)

An opaque FFI backend's *mandatory* hand-written backward is **proven correct on CPU before any GPU**: `MockFFIBackend` hand-written VJP == per-block == JAX autodiff at fp tier (1e-12, max|Δ|~7e-15) for **both float64 and complex128** (the production dtype). cuTensorNet's backward reuses `backward_contraction` verbatim — only its forward `execute` is hardware-specific.

## Why this shape (measured)

The pure-JAX "persist stacks across the sweep" route was prototyped and measured: contractions-only persistence is **0.995×** on the real backward sweep (the 96%-structural fuse/construct cost is intrinsic to per-block JAX trace emission; `dot_general` drops 9.3× but is only ~4% of the graph). A converged-energy drift alarm was root-caused as **benign** (round-off → SVD-projector gauge freedom, vanishes at full convergence). Conclusion: a single custom kernel is the right lever, behind a seam so cuTensorNet (GPU) and Pallas (TPU) are interchangeable. Full trail in the design/plan docs under `docs/superpowers/`.

## Testing

`tests/stacked/` — 49 tests (round-trip, even-D contract value+grad, decomposition gauge-invariants, backend dispatch precedence, VJP-seam real+complex128), now registered under the **`core` CI marker** so the required checks exercise them. Default path byte-identical (core trio + block-array suites unchanged).

## Follow-up (Phase B, GPU — not in this PR)

`CuTensorNetBackend` forward FFI `custom_call`, registered via `_select_cutensornet`, validated on A100 against the accuracy spine + `StackedJaxBackend`, then the compile/runtime measurement. Carry-forward notes (recorded): the `execute(operand_stacks, plan)` protocol needs per-operand metadata (add to `BlockContractPlan` or pass in); the legacy `cutensor_blocksparse.py` is not seam-conformant (register fresh).

Refs #200, #566. (Branch name is `docs/…` for historical reasons but this PR carries the implementation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)