### PR TITLE
docs(#570): CTM-AD compile wall is the dense SVD projector VJP (projector_method-invariant)

### DIFF
--- a/docs/superpowers/handoffs/2026-06-07-570-svd-vjp-compile-finding.md
+++ b/docs/superpowers/handoffs/2026-06-07-570-svd-vjp-compile-finding.md
@@ -1,0 +1,129 @@
+# #570 finding — the CTM-AD compile wall is the dense **SVD projector VJP**, and it is `projector_method`-invariant
+
+**Date:** 2026-06-07 (A100) · **Follows:** [`2026-06-07-cutensornet-pb4-finding-nogo.md`](2026-06-07-cutensornet-pb4-finding-nogo.md) (#200 NO-GO) · **Issue:** #570
+
+## TL;DR
+
+P-B4 (#200) localized the minutes-long fermionic CTM-AD compile to the jitted
+fixed-point backward `_jit_fused_fixed_point_bwd` and proved it **backend-invariant**
+(perblock → stacked → cuTensorNet does not move it). The open #570 question was *which
+sub-op inside that backward dominates the compile*. Answer, with two parts:
+
+1. **It is the decomposition VJP — specifically a dense SVD.** The dominant repeated
+   compile unit (`apply_Jt`, one gauge-fixed sweep VJP) carries **24 dense `svd`
+   primitives** (D=2/χ=12 trace). Its cold XLA compile grows **super-linearly in χ**
+   (~χ^1.3): a *single* sweep-VJP unit goes **50.7 s → 522.9 s** as χ goes 6 → 36 (10.3×).
+   This is the χ-driver behind the ~549 s full-backward wall.
+
+2. **But it is `projector_method`-invariant — the production path is SVD-only.** The
+   default `recipe="2x2"` plaquette projector (`_ctm_tensor_projector_2x2.py`) contains
+   **no** `qr`/`eigh`/`projector_method` code — it is hardwired to `jnp.linalg.svd`.
+   `svd`/`qr`/`eigh` all trace to a **byte-identical** backward graph (TOTAL=34927; 24
+   `svd`, 0 `qr`, 0 `eigh` in every case). `projector_method` only affects the alternate
+   1×1 recipe (`_compute_projector_tensor`), which the production fermionic path does not use.
+
+**Consequence:** #570's lever-1 ("swap SVD → QR projector") is a **no-op as a config
+flip** on the production path. It requires real implementation, or pivot to lever-2
+(**truncated backprop**), which is projector-agnostic.
+
+## Method
+
+`examples/profile_570_sweepvjp_compile.py` (new) isolates `apply_Jt` — the VJP of one
+gauge-fixed CTM sweep w.r.t. the environment, documented as the dominant *repeated*
+compile unit of `_jit_fused_fixed_point_bwd` — `jax.jit`s it, and times the **cold
+`lower().compile()`** (no execution; pure compile attribution), per `projector_method`,
+swept over χ. `--full` also compiles the params-sweep VJP. Cold compiles use a fresh
+persistent-cache dir + `clear_caches()` (the #584/#585 lesson). This avoids the ~1000 s
+full `value_and_grad` compile while measuring the actual repeated unit.
+
+Cross-checked against `examples/probe_backward_jaxpr_566.py` (trace-only op histogram):
+its `decomp` bucket counts only the literal `svd`/`eigh` *primitives* (flat at 48,
+χ-blind) and **cannot** see the VJP expansion — which is why compile-time attribution was
+needed.
+
+## Results
+
+### (1) χ-scaling of the SVD sweep-VJP compile (A100, D=2 fermionic, 16 blocks, x64)
+
+| χ | env_compile (s) | env HLO instrs | total env+par (s) | ×(vs χ=6) |
+|---:|---:|---:|---:|---:|
+| 6  | 23.3  | 52,842  | 50.7  | 1.00× |
+| 12 | 49.3  | 111,934 | 104.1 | 2.05× |
+| 18 | 86.9  | 188,976 | 178.5 | 3.52× |
+| 24 | 146.4 | 307,580 | 296.8 | 5.86× |
+| 36 | 259.5 | 302,517 | 522.9 | 10.32× |
+
+Compile time tracks HLO instruction count almost exactly; both grow ~linearly-to-super-
+linearly in χ over 6→24 (instr 5.8×, compile 5.9× for a 4× χ). Past χ=24 the **instr
+count saturates** (302k) because at D=2 the corner truncation `k = min(χ, available)`
+caps out at the limited bond dim — so χ≥24 at D=2 is the saturated regime; the genuine
+χ-scaling is the 6→24 window. (A D=4 sweep would push the saturation point out; not
+needed to establish the fingerprint.) Raw: `570_results/profile_570_sweepvjp_a100.json`.
+
+### (2) `projector_method`-invariance of the backward graph (trace-only, D=2 χ=12)
+
+| method | apply_Jt TOTAL ops | `svd` | `qr` | `eigh` | `dot_general` |
+|---|---:|---:|---:|---:|---:|
+| svd  | 34927 | 24 | 0 | 0 | 1072 |
+| qr   | 34927 | 24 | 0 | 0 | 1072 |
+| eigh | 34927 | 24 | 0 | 0 | 1072 |
+
+Byte-identical. Confirmed at the compile level too: svd and qr gave identical HLO instr
+counts (52,842 / 111,934 at χ=6 / 12) in the smoke run.
+
+## Why (mechanistic)
+
+- The production fermionic CTM-AD loss (`make_ctm_energy_fn`, `iPEPSConfig` defaults,
+  `gs_implicit_ad=True`, `adjoint_method="fixed_point"`) runs the symmetric tensor sweep
+  `_ctm_tensor_sweep_multisite` with the default `recipe="2x2"`, whose projector is
+  `_compute_2x2_projector` / `_compute_plaquette_projector_pair`. That file
+  (`_ctm_tensor_projector_2x2.py`) is **SVD-only** (`_gauge_fixed_svd` → `jnp.linalg.svd`);
+  it never reads `projector_method`.
+- `projector_method` (`svd`/`qr`/`eigh`) only branches inside the **1×1** recipe's
+  `_compute_projector_tensor` (`_ctm_projector.py`), and even there the **AD-traced**
+  path deliberately densifies to an SVD VJP (the "Task 2.2" design decision, lines
+  ~946–962: backward keeps a dense fallback rather than a block-sparse AD-traced SVD).
+- So under AD, the decomposition the backward differentiates is **always a dense SVD on
+  the χ-sized corner matrix**, per projector. Its VJP (the SVD-gradient F-matrix dense
+  algebra) is what grows with χ and dominates compile.
+
+## Implication for #570 — the levers, re-scoped
+
+1. **Lever-1 "QR projector instead of SVD" is NOT a config flip.** The default 2×2 path
+   has no QR. Realizing it means *implementing* a QR-based 2×2 plaquette projector with a
+   stable AD backward (QR backward is rank-deficiency-sensitive — note `_ctm_projector.py`
+   already routes its QR *tracer* fallback through a `regularized_svd`, i.e. back to SVD,
+   precisely to dodge QR-backward instability). High effort, unproven energy/variational
+   parity. **Do not start here.**
+
+2. **Lever-2 "truncated backprop" is the recommended first move.** It differentiates
+   through a *truncated* number of CTM sweeps instead of the full fixed point, shrinking
+   the backward jaxpr **independent of the decomposition** — so it cuts the SVD-VJP count
+   directly and is orthogonal to projector choice. Lower risk; the main validation is
+   gradient/energy parity vs the exact fixed-point adjoint.
+
+3. **Lever-3 (alternative): block-sparse AD-traced SVD VJP.** Replace the dense-corner SVD
+   fallback with a per-sector truncated SVD VJP (smaller decomps). The design note flags
+   the static-shape-per-sector (`k_q` must be a Python int) complexity. Medium effort,
+   directly attacks the measured cost.
+
+## Next experiment (whichever lever)
+
+`profile_570_sweepvjp_compile.py` is the measurement rig. To validate a lever, A/B its
+sweep-VJP `total_compile_s` and `env_hlo_instr` vs the SVD baseline above:
+- **truncated backprop:** compile the N-sweep unrolled backward for N ∈ {1,2,4} and show
+  compile scales with N while energy/grad track the full adjoint.
+- **QR-in-2×2 / block-sparse SVD:** once implemented, expect `total_compile_s` to drop and
+  flatten in χ relative to the SVD curve above.
+
+## What would change the conclusion
+
+Only if the production path stopped using the SVD-only 2×2 projector (e.g. a config or
+code change routing the fermionic AD path through a method-aware projector). As of this
+commit it does not — the SVD-only finding is at the code level, not just empirical.
+
+## Artifacts
+
+- `examples/profile_570_sweepvjp_compile.py` — compile-attribution rig (new)
+- `570_results/profile_570_sweepvjp_a100.json` — raw χ-sweep data
+- `examples/probe_backward_jaxpr_566.py` — trace-only op histogram (existing; cross-check)

--- a/docs/superpowers/handoffs/570_results/profile_570_sweepvjp_a100.json
+++ b/docs/superpowers/handoffs/570_results/profile_570_sweepvjp_a100.json
@@ -1,0 +1,90 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "D": 2,
+  "methods": [
+    "svd"
+  ],
+  "chi_list": [
+    6,
+    12,
+    18,
+    24,
+    36
+  ],
+  "full": true,
+  "projector_backward": "auto",
+  "rows": [
+    {
+      "D": 2,
+      "chi": 6,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 10.65117827616632,
+      "env_compile_s": 23.2919915728271,
+      "env_hlo_instr": 52842,
+      "par_lower_s": 12.374245467595756,
+      "par_compile_s": 27.3767351526767,
+      "par_hlo_instr": 53545,
+      "total_compile_s": 50.6687267255038
+    },
+    {
+      "D": 2,
+      "chi": 12,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 15.066871707327664,
+      "env_compile_s": 49.32690402213484,
+      "env_hlo_instr": 111934,
+      "par_lower_s": 16.354916187934577,
+      "par_compile_s": 54.777322083711624,
+      "par_hlo_instr": 114060,
+      "total_compile_s": 104.10422610584646
+    },
+    {
+      "D": 2,
+      "chi": 18,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 19.2145131547004,
+      "env_compile_s": 86.93177800625563,
+      "env_hlo_instr": 188976,
+      "par_lower_s": 20.906830769963562,
+      "par_compile_s": 91.53723049722612,
+      "par_hlo_instr": 187488,
+      "total_compile_s": 178.46900850348175
+    },
+    {
+      "D": 2,
+      "chi": 24,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 23.04764862731099,
+      "env_compile_s": 146.35346805863082,
+      "env_hlo_instr": 307580,
+      "par_lower_s": 25.35971633065492,
+      "par_compile_s": 150.45558495540172,
+      "par_hlo_instr": 301775,
+      "total_compile_s": 296.80905301403254
+    },
+    {
+      "D": 2,
+      "chi": 36,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 31.932567842304707,
+      "env_compile_s": 259.4615724813193,
+      "env_hlo_instr": 302517,
+      "par_lower_s": 33.9136562673375,
+      "par_compile_s": 263.4128901557997,
+      "par_hlo_instr": 297056,
+      "total_compile_s": 522.874462637119
+    }
+  ]
+}

--- a/examples/profile_570_sweepvjp_compile.py
+++ b/examples/profile_570_sweepvjp_compile.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""#570 compile-attribution: cold XLA-compile time of the CTM sweep-VJP unit,
+projector_method = svd vs qr vs eigh, swept over chi.
+
+Why this script (and not the full value_and_grad wall)
+------------------------------------------------------
+P-B4 (#200) localized the minutes-long fermionic CTM-AD compile to the jitted
+fixed-point backward ``_jit_fused_fixed_point_bwd`` and proved it is
+**backend-invariant** (swapping the contraction executor — perblock -> stacked ->
+cuTensorNet — does not move it). The open #570 question is *which sub-op inside
+that backward dominates the compile*: the block-sparse **decomposition VJP**
+(SVD/eigh of the chi x chi corner/projector matrices) or the per-block
+contraction/packing emission (#566).
+
+The trace-only op-histogram (``probe_backward_jaxpr_566.py``) cannot answer it:
+its ``decomp`` bucket counts only the literal ``svd``/``eigh`` *primitives*
+(flat at 48, chi-blind), NOT their VJP expansion, which lowers into a large
+chi-dependent pile of elementwise/matmul/select dense algebra (the SVD-gradient
+F-matrix). So we need **compile time**, not op count.
+
+We do NOT need the full ~1000 s value_and_grad compile. ``apply_Jt`` — the VJP of
+ONE gauge-fixed CTM sweep w.r.t. the environment (``probe_backward_jaxpr_566``,
+Section B) — is the dominant *repeated* compile unit of the fused backward. We
+isolate it, ``jax.jit`` it, and time the cold ``lower().compile()`` (no run
+needed), for each ``projector_method``, swept over chi. The fingerprint:
+
+  * SVD/eigh sweep-VJP compile grows STEEPLY with chi, QR much flatter
+        => decomposition VJP is the wall  => #570 (QR projector) is the lever.
+  * all three scale alike (mild) and the growth is elsewhere
+        => the wall is per-block emission  => #566, not #570.
+
+``--full`` also compiles the params-sweep VJP (the ``_jit_chain_rule`` indirect
+term) so the measured unit covers both sweep VJPs of the fused F3 backward.
+
+Usage
+-----
+GPU (the box that shows the wall)::
+
+    JAX_PLATFORMS=cuda,cpu uv run python examples/profile_570_sweepvjp_compile.py \
+        --D 2 --chi-list 6 12 18 24 36 --methods svd qr eigh \
+        --json profile_570_sweepvjp_a100.json
+
+CPU smoke (validates the harness; small chi only)::
+
+    JAX_PLATFORMS=cpu uv run python examples/profile_570_sweepvjp_compile.py \
+        --D 2 --chi-list 6 12 --methods svd qr --reps 1
+
+JSON is rewritten after every cell so a run killed on a large-chi compile keeps
+its rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import atexit
+import json
+import platform
+import shutil
+import statistics
+import tempfile
+import time
+
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_python_loop import _make_jit_ctm_step  # noqa: E402
+from tenax.algorithms._ctm_tensor_convergence import (  # noqa: E402
+    SINGLE_SITE_NEIGHBORS,
+)
+from tenax.algorithms._ctm_tensor_init import (  # noqa: E402
+    initialize_ctm_tensor_env,
+)
+from tenax.algorithms.ad_utils import _phase_fix_ctm_tensor  # noqa: E402
+from tenax.algorithms.fermionic_ipeps import (  # noqa: E402
+    FPEPSConfig,
+    _build_initial_fpeps_tensor,
+)
+
+# --------------------------------------------------------------------------- #
+# Fresh persistent-cache dir per cold compile (the #584/#585 lesson): tenax
+# enables JAX's on-disk compile cache, so clear_caches() alone lets a repeat
+# compile load from disk and corrupt cold timings. Reap previous dirs to keep
+# /tmp from filling on long sweeps.
+# --------------------------------------------------------------------------- #
+_PRIOR_CACHE_DIRS: list[str] = []
+atexit.register(
+    lambda: [shutil.rmtree(d, ignore_errors=True) for d in _PRIOR_CACHE_DIRS]
+)
+
+
+def _fresh_cache_dir() -> None:
+    while _PRIOR_CACHE_DIRS:
+        shutil.rmtree(_PRIOR_CACHE_DIRS.pop(), ignore_errors=True)
+    d = tempfile.mkdtemp(prefix="jax_cc_570_")
+    _PRIOR_CACHE_DIRS.append(d)
+    jax.config.update("jax_compilation_cache_dir", d)
+
+
+def make_site(D: int, seed: int = 42):
+    return _build_initial_fpeps_tensor(
+        FPEPSConfig(D=D, t=1.0, V=0.0), jax.random.PRNGKey(seed)
+    )
+
+
+def build_sweep_vjps(A, chi: int, method: str, projector_backward: str = "auto"):
+    """Return (apply_Jt_env, apply_Jt_params, v) for the requested projector.
+
+    ``apply_Jt_env``   = VJP of one gauge-fixed sweep w.r.t. the ENVIRONMENT
+                         (the Neumann matvec; dominant repeated compile unit).
+    ``apply_Jt_params``= VJP w.r.t. the SITE PARAMS (the chain-rule indirect term).
+    ``v``              = a cotangent of the right structure for lowering.
+    Mirrors ``probe_backward_jaxpr_566.backward_vjp_jaxpr`` exactly, but
+    parameterized by ``projector_method`` and returned as callables to compile.
+    """
+    A_norm = A * (1.0 / (A.norm() + 1e-10))
+    site_tensors = {(0, 0): A_norm}
+    env = initialize_ctm_tensor_env(A_norm, chi)
+    envs = {(0, 0): env}
+    treedef = jax.tree.structure(envs)
+    env_leaves = tuple(jax.tree.leaves(envs))
+    param_treedef = jax.tree.structure(A_norm)
+    param_leaves = tuple(jax.tree.leaves(A_norm))
+    jit_step = _make_jit_ctm_step(SINGLE_SITE_NEIGHBORS)
+
+    def sweep_from_env(env_leaves_flat):
+        e = jax.tree.unflatten(treedef, env_leaves_flat)
+        e_out, _eps, _smin = jit_step(
+            site_tensors,
+            e,
+            chi=chi,
+            projector_method=method,
+            renormalize=True,
+            projector_backward=projector_backward,
+        )
+        return tuple(
+            jax.tree.leaves({c: _phase_fix_ctm_tensor(e_out[c]) for c in e_out})
+        )
+
+    def sweep_from_params(p_flat):
+        Ap = jax.tree.unflatten(param_treedef, p_flat)
+        e_out, _eps, _smin = jit_step(
+            {(0, 0): Ap},
+            envs,
+            chi=chi,
+            projector_method=method,
+            renormalize=True,
+            projector_backward=projector_backward,
+        )
+        return tuple(
+            jax.tree.leaves({c: _phase_fix_ctm_tensor(e_out[c]) for c in e_out})
+        )
+
+    out = sweep_from_env(env_leaves)
+    v = tuple(jnp.ones_like(o) for o in out)
+
+    def apply_Jt_env(vv):
+        return jax.vjp(sweep_from_env, env_leaves)[1](vv)
+
+    def apply_Jt_params(vv):
+        return jax.vjp(sweep_from_params, param_leaves)[1](vv)
+
+    return apply_Jt_env, apply_Jt_params, v
+
+
+def _hlo_instr_count(compiled) -> int:
+    """Best-effort HLO instruction count of a compiled executable."""
+    try:
+        txt = compiled.as_text()
+    except Exception:  # noqa: BLE001
+        return -1
+    # HLO instructions are the ' = ' assignment lines inside computations.
+    return sum(1 for ln in txt.splitlines() if " = " in ln)
+
+
+def _cold_compile(fn, v):
+    """Fresh-cold ``lower().compile()`` of ``jax.jit(fn)``; return timings+stats.
+
+    Trace+lower and compile are timed separately; compile is the XLA cost we
+    care about. No execution — pure compile attribution.
+    """
+    _fresh_cache_dir()
+    jax.clear_caches()
+    jitted = jax.jit(fn)
+    t0 = time.perf_counter()
+    lowered = jitted.lower(v)
+    t_lower = time.perf_counter() - t0
+    t1 = time.perf_counter()
+    compiled = lowered.compile()
+    t_compile = time.perf_counter() - t1
+    return t_lower, t_compile, _hlo_instr_count(compiled)
+
+
+def profile_cell(D, chi, method, *, full, reps, projector_backward):
+    A = make_site(D)
+    n_blocks = getattr(A, "n_blocks", 1)
+    env_fn, par_fn, v = build_sweep_vjps(A, chi, method, projector_backward)
+
+    def measure(fn):
+        lowers, compiles, instrs = [], [], -1
+        for _ in range(reps):
+            tl, tc, ic = _cold_compile(fn, v)
+            lowers.append(tl)
+            compiles.append(tc)
+            instrs = ic
+        return (
+            statistics.median(lowers),
+            statistics.median(compiles),
+            instrs,
+        )
+
+    env_lower, env_compile, env_instr = measure(env_fn)
+    row = {
+        "D": D,
+        "chi": chi,
+        "method": method,
+        "n_blocks": int(n_blocks),
+        "projector_backward": projector_backward,
+        "env_lower_s": env_lower,
+        "env_compile_s": env_compile,
+        "env_hlo_instr": env_instr,
+    }
+    if full:
+        par_lower, par_compile, par_instr = measure(par_fn)
+        row.update(
+            {
+                "par_lower_s": par_lower,
+                "par_compile_s": par_compile,
+                "par_hlo_instr": par_instr,
+                "total_compile_s": env_compile + par_compile,
+            }
+        )
+    return row
+
+
+def _write_json(path, meta, rows):
+    with open(path, "w") as fh:
+        json.dump({**meta, "rows": rows}, fh, indent=2)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--D", type=int, default=2)
+    ap.add_argument("--chi-list", type=int, nargs="+", default=[6, 12, 18, 24])
+    ap.add_argument(
+        "--methods", nargs="+", default=["svd", "qr", "eigh"]
+    )
+    ap.add_argument(
+        "--projector-backward",
+        default="auto",
+        choices=["auto", "lorentzian", "standard"],
+    )
+    ap.add_argument(
+        "--full",
+        action="store_true",
+        help="Also compile the params-sweep VJP (whole fused backward unit).",
+    )
+    ap.add_argument("--reps", type=int, default=1, help="Cold-compile reps (median).")
+    ap.add_argument("--json", type=str, default=None)
+    args = ap.parse_args()
+
+    dev = jax.devices()[0]
+    print("=" * 88)
+    print("# #570 sweep-VJP compile-attribution (svd vs qr vs eigh)")
+    print(f"# platform : {dev.platform}  device0={dev.device_kind}")
+    print(f"# host     : {platform.platform()}")
+    print(f"# x64      : {jax.config.read('jax_enable_x64')}  D={args.D}")
+    print(f"# methods  : {args.methods}   full={args.full}")
+    print("=" * 88)
+
+    meta = {
+        "platform": dev.platform,
+        "device_kind": dev.device_kind,
+        "x64": bool(jax.config.read("jax_enable_x64")),
+        "D": args.D,
+        "methods": args.methods,
+        "chi_list": args.chi_list,
+        "full": args.full,
+        "projector_backward": args.projector_backward,
+    }
+
+    col = "total_compile_s" if args.full else "env_compile_s"
+    hdr = (
+        f"{'method':>6} {'chi':>4} {'blk':>4} {'env_lower':>10} "
+        f"{'env_cmp':>9} {'env_instr':>10}"
+        + (f" {'par_cmp':>9} {'tot_cmp':>9}" if args.full else "")
+    )
+    print(hdr)
+    print("-" * len(hdr))
+
+    rows = []
+    for chi in args.chi_list:
+        for method in args.methods:
+            try:
+                r = profile_cell(
+                    args.D,
+                    chi,
+                    method,
+                    full=args.full,
+                    reps=args.reps,
+                    projector_backward=args.projector_backward,
+                )
+            except Exception as exc:  # noqa: BLE001
+                print(f"{method:>6} {chi:>4}  !! {type(exc).__name__}: {exc}")
+                rows.append(
+                    {
+                        "D": args.D,
+                        "chi": chi,
+                        "method": method,
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                )
+                if args.json:
+                    _write_json(args.json, meta, rows)
+                continue
+            line = (
+                f"{r['method']:>6} {r['chi']:>4} {r['n_blocks']:>4} "
+                f"{r['env_lower_s']:>9.2f}s {r['env_compile_s']:>8.2f}s "
+                f"{r['env_hlo_instr']:>10}"
+            )
+            if args.full:
+                line += f" {r['par_compile_s']:>8.2f}s {r['total_compile_s']:>8.2f}s"
+            print(line)
+            rows.append(r)
+            if args.json:
+                _write_json(args.json, meta, rows)
+
+    print("-" * len(hdr))
+    print("\nReading the table (the #570 gate):")
+    print(
+        f"  * svd {col} grows STEEPLY with chi, qr much flatter "
+        "-> decomposition VJP is the wall -> #570 (QR projector) is the lever."
+    )
+    print(
+        "  * all methods scale alike (mild) -> wall is per-block emission "
+        "-> #566, not #570."
+    )
+    if args.json:
+        print(f"\n  JSON -> {args.json}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Profiling follow-up to the #200 NO-GO (PR #587). P-B4 localized the minutes-long
fermionic CTM-AD compile to `_jit_fused_fixed_point_bwd` and proved it
**backend-invariant**. This PR answers the open #570 question — *which sub-op inside
that backward dominates the compile* — and re-scopes #570's levers accordingly. **Docs +
one example script; no `src/` changes.**

## Finding (A100)

Method: a new compile-attribution rig (`examples/profile_570_sweepvjp_compile.py`)
isolates `apply_Jt` — the VJP of one gauge-fixed CTM sweep, the dominant *repeated*
compile unit of `_jit_fused_fixed_point_bwd` — and times its **cold `lower().compile()`**
per `projector_method`, swept over χ (no ~1000 s full `value_and_grad` compile needed).

1. **The wall is the dense SVD projector VJP.** The sweep unit carries **24 dense `svd`
   primitives**; its cold compile grows **super-linearly in χ** (~χ^1.3): one unit goes
   **50.7 s → 522.9 s** as χ 6 → 36 (10.3×). Confirms #570's "decomposition, not
   contraction" instinct.

   | χ | total compile (env+par), s | ×(vs χ=6) |
   |---:|---:|---:|
   | 6 | 50.7 | 1.00× |
   | 12 | 104.1 | 2.05× |
   | 18 | 178.5 | 3.52× |
   | 24 | 296.8 | 5.86× |
   | 36 | 522.9 | 10.32× |

2. **But it is `projector_method`-invariant.** The production `recipe="2x2"` plaquette
   projector (`_ctm_tensor_projector_2x2.py`) is **SVD-only** — no `qr`/`eigh`/
   `projector_method` code. `svd`/`qr`/`eigh` trace to a **byte-identical** backward graph
   (TOTAL=34927; 24 `svd`, 0 `qr`, 0 `eigh` in every case). `projector_method` only affects
   the unused 1×1 recipe.

## Consequence for #570

- **Lever-1 "swap SVD → QR projector" is a no-op as a config flip** — the default path has
  no QR. Realizing it means implementing a QR-based 2×2 projector with a stable AD backward
  (risky; the existing 1×1 QR tracer fallback already routes through `regularized_svd` to
  dodge QR-backward instability).
- **Recommended first move: lever-2 (truncated backprop)** — projector-agnostic, shrinks
  the backward jaxpr directly, lower risk. Validate grad/energy parity vs the full adjoint.

Full write-up: `docs/superpowers/handoffs/2026-06-07-570-svd-vjp-compile-finding.md`
(raw data in `570_results/`).

## Test plan

- [x] Rig validated on CPU (smoke) and A100 (the χ-sweep above)
- [x] Docs + example only — no `src/` change; CI `-m core` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
