### PR TITLE
diag(#570): map the CTM-AD compile wall — it is #566 structural emission, not the decomposition

### DIFF
--- a/docs/superpowers/handoffs/2026-06-08-570-relocalized-not-decomposition.md
+++ b/docs/superpowers/handoffs/2026-06-08-570-relocalized-not-decomposition.md
@@ -1,0 +1,76 @@
+# #570 re-localized: the "SVD VJP" wall is per-sector STRUCTURAL emission, not decomposition
+
+**Date:** 2026-06-08
+**Context:** PR #589 localized the CTM-AD compile wall to the `svd_vjp` bucket (61% of
+the fused backward at D=4/χ=12). Two follow-up experiments tested the obvious
+decomposition levers; **both are falsified**, and drilling into the bucket shows why.
+
+## Experiment 1 — cheaper decomposition (SVD→eigh): FALSIFIED
+`truncated_svd_via_eigh_ad` (eigh of the Gram matrix + reconstruct `U=M·V/s`) as a
+drop-in for the full `(U,s,Vh)`: backward = **274 vs 265 ops** (no win). Mechanism:
+`eigh(MᴴM)` has eigenvalues `S²`, so its F-matrix `1/(sᵢ²−sⱼ²)` is identical to the
+SVD's — no fundamental saving. (Spec
+`2026-06-08-svd-via-eigh-fishman-projector-570.md`, marked FALSIFIED.)
+
+## Experiment 2 — batch the per-sector decomposition (#572 flag): FALSIFIED
+`TENAX_BATCH_BLOCKSPARSE=1` at D=4/χ=12: svd **kernels 48→24** (sectors *do* batch),
+but **svd_vjp ops 92,368→91,760 (−0.7%)** and TOTAL **150,663→154,858 (+2.8%)** from
+stacking overhead. Batching the decomposition does not shrink the bucket.
+
+## Why — drill-down of the svd_vjp bucket (92,368 ops, D=4/χ=12)
+
+Top *innermost* emitters within the bucket:
+
+| op | share | what it is |
+|---|---:|---|
+| `broadcast_in_dim` | 20.6% | per-sector scaling / block expand |
+| `scatter_mul` | 10.8% | reverse-mode of per-sector slicing |
+| `_gauge_fix_symmetric_svd` | 10.3% | per-sector gauge fix |
+| `squeeze` | 10.2% | block pack/unpack |
+| `reshape` | 7.2% | block pack/unpack |
+| `slice` | 7.2% | block pack/unpack |
+| `concatenate` | 3.6% | sector → bond assembly |
+| `argmax`/`abs`/`lt`/`gt`/`where`/`select` | ~17% | `_fix_svd_signs` sign logic |
+| `svd` primitive / F-matrix `dot_general` | ~0% | the decomposition itself |
+
+The bucket is **per-sector block pack/unpack & scaling (~60%) + per-sector
+gauge-fixing (~25%)**. The decomposition math is negligible. This is the **#566
+per-block structural emission**, localized in `_truncated_svd_symmetric_traced`,
+`_compute_2x2_projector_symmetric`, and `_gauge_fix_symmetric_svd` — emitted once
+per charge sector, growing with χ because more sectors survive truncation.
+
+(It was attributed to `svd_vjp` because those structural ops are emitted lexically
+*inside* the SVD/projector functions — correct attribution; the name "SVD VJP" is
+just misleading about the underlying cost.)
+
+## Consequence for #570
+
+The decomposition is **not** the lever. QR-CTMRG-as-cheaper-decomposition and
+decomposition-batching are both dead for the *compile* cost. The wall is the
+per-sector structural block-assembly + gauge-fixing — the same representation cost
+the stacked-block contraction backend (PR #586) fixed for contractions but which
+still runs per-sector in the SVD/projector wrapper. The viable levers are:
+
+1. **Truncated backprop (recommended next).** Differentiate through K CTM sweeps
+   instead of the full fixed point. It reduces the compile/runtime backward
+   *regardless of per-sweep cost* — orthogonal to the representation issue, and a
+   well-scoped change validated against the exact fixed-point adjoint
+   (variational-bound + energy/grad parity). This is the Yang/Corboz #570 lever
+   that actually bites here.
+2. **Stacked-block representation extended to the SVD/projector wrapper.** Batch the
+   per-sector pack/unpack + gauge-fix across sectors (one stacked op, not a per-
+   sector loop) — the #566 deep restructure, now precisely localized. High blast
+   radius; the larger prize but the harder build.
+3. **Batch/vectorize `_gauge_fix_symmetric_svd` + `_fix_svd_signs` across sectors**
+   (~25% of the bucket) — a smaller, contained sub-lever independent of (2).
+
+## Reproduce
+```bash
+# bucket attribution (flag off vs on):
+JAX_PLATFORMS=cpu TENAX_BATCH_BLOCKSPARSE=0 uv run python \
+  examples/probe_bwd_subop_attribution_570.py --mode buckets --D 4 --chi 12 --full
+JAX_PLATFORMS=cpu TENAX_BATCH_BLOCKSPARSE=1 uv run python \
+  examples/probe_bwd_subop_attribution_570.py --mode buckets --D 4 --chi 12 --full
+# drill-down (innermost emitters within the svd_vjp bucket): see the script in
+# this PR's commit message / the inline analysis.
+```

--- a/docs/superpowers/handoffs/2026-06-08-570-truncated-backprop-not-a-compile-lever.md
+++ b/docs/superpowers/handoffs/2026-06-08-570-truncated-backprop-not-a-compile-lever.md
@@ -69,8 +69,42 @@ pragmatic split is: (i) treat compile as amortized and pursue **runtime** via TB
 projector restructure** if the one-time compile minutes are themselves the blocker.
 That is a scope decision, not a measurement question — the measurements are in.
 
+## Addendum (2026-06-08) — TBPTT is not a RUNTIME lever via the explicit path either
+
+After choosing "pursue runtime, accept compile" (#570 direction 1), measured the
+explicit-TBPTT warm-step via the production profiler (now exposes `--backward-steps`):
+
+| path (fermionic D=2 χ=6 depth=8) | warm-step |
+|---|---|
+| implicit fixed_point | **932 ms** |
+| explicit TBPTT K=4 | **8,353 ms (9.0× slower)** |
+
+Even with the backward truncated to K=4, explicit is **9× slower** — because the
+explicit path **re-runs the full forward (warmup + `backprop_steps` sweeps) unrolled
+every call**, which dominates; truncating the *backward* can't help when the
+*forward* re-execution is the cost. The implicit path caches the converged env
+(`best_env_cache`) and does incremental work. A 9× gap is unlikely to flip on GPU.
+
+**So TBPTT-via-explicit is not the runtime lever.** The viable runtime levers keep
+the implicit path's cached forward:
+1. **Truncated implicit adjoint** — cap the Neumann/fixed-point adjoint iterations
+   (truncate only the backward *solve*, keep the cached forward). The implicit
+   analog of TBPTT, without the forward re-run. Needs an iteration-cap knob +
+   gradient-accuracy validation vs the converged adjoint.
+2. **QR projector at large χ (GPU/TPU)** — the genuine Yang/Corboz runtime win (SVD
+   is the large-χ GPU bottleneck; QR batches cleanly). Needs implementation on the
+   2×2 symmetric projector path (not a config flip; see the FALSIFIED svd-via-eigh
+   spec for the projector structure). This is a real build, not a measurement.
+
+Tooling shipped: `examples/profile_ctm_ad_wall_566.py --backward-steps K` (auto-
+enables the explicit path) to measure TBPTT warm-step on the A100 if desired —
+but the CPU 9× already argues against it.
+
 ## Reproduce
 ```bash
 JAX_PLATFORMS=cpu uv run python examples/probe_truncated_backprop_570.py \
     --D 2 --depth 12 --K 1 2 4 8 --parity
+# TBPTT warm-step vs implicit (production profiler):
+JAX_PLATFORMS=cpu uv run python examples/profile_ctm_ad_wall_566.py \
+    --D 2 --chi 6 --depth 8 --sym fermionic --explicit --backward-steps 4 --reps 2
 ```

--- a/docs/superpowers/handoffs/2026-06-08-570-truncated-backprop-not-a-compile-lever.md
+++ b/docs/superpowers/handoffs/2026-06-08-570-truncated-backprop-not-a-compile-lever.md
@@ -1,0 +1,76 @@
+# Truncated backprop is accurate but NOT a compile lever for #570
+
+**Date:** 2026-06-08
+**Tool:** `examples/probe_truncated_backprop_570.py` (CPU, trace-only op-count +
+eager gradient parity at D=2).
+**Context:** After SVD-via-eigh (a) and batched-decomposition (b) were both
+falsified and the wall was re-localized to per-sector STRUCTURAL emission, this
+tests the third #570 lever: truncated backprop (TBPTT, `ctm_energy_explicit(
+backward_steps=K)`, issue #506 — differentiate only the last K CTM sweeps).
+
+## Result
+
+### Backward op-count (compile proxy), fermionic D=2 χ=6
+| K | TBPTT backward ops | per added sweep | vs implicit (63,543) |
+|---:|---:|---:|---:|
+| 1 | 103,448 | — | 1.63× |
+| 2 | 138,043 | +34,595 | 2.17× |
+| 4 | 207,233 | +34,595/sweep | 3.26× |
+| 8 | 345,613 | +34,595/sweep | 5.44× |
+
+Each differentiated sweep adds ~34,600 ops (one sweep-VJP — the #566 per-sector
+structural unit). The **implicit** fixed-point backward compiles ~one sweep-VJP
+**in a `while_loop`** (depth-flat, exact gradient via iteration). Explicit-TBPTT
+compiles **K sweep-VJPs unrolled**, so it is **strictly ≥ implicit** for compile —
+even K=1 is 1.6× (it also carries the energy VJP), and it only grows. Truncated
+backprop does **not** reduce the per-sweep VJP, which is the wall.
+
+### Gradient parity (eager, full backprop = reference), D=2
+| K | dE vs full | rel‖g − g_full‖ |
+|---:|---:|---:|
+| 1 | 0 | 3.03e-2 |
+| 2 | 0 | 5.52e-3 |
+| 4 | 0 | 1.85e-4 |
+| 8 | 0 | 1.89e-7 |
+
+The truncated gradient converges geometrically (ρ≈0.16/sweep here); by K=4–8 it is
+essentially exact. (Energy is K-independent — only the forward determines it.) So
+**TBPTT is correct and accurate** — it is simply a runtime/robustness lever, not a
+compile one.
+
+## Consolidated #570 conclusion (three falsifications)
+
+All three decomposition/truncation levers leave the compile wall intact, because
+the wall is the **per-sweep VJP op count = #566 per-block STRUCTURAL emission** in
+the symmetric SVD/projector wrapper — none of them touch it:
+
+1. **Cheaper decomposition (SVD→eigh):** same `1/(sᵢ²−sⱼ²)` F-matrix; no win.
+2. **Batched decomposition (`#572`):** kernels 48→24 but svd_vjp ops −0.7%, total +2.8%.
+3. **Truncated backprop:** strictly ≥ implicit for compile (K sweep-VJPs unrolled).
+
+**The only compile lever is the #566 representation restructure:** extend the
+stacked-block representation (PR #586, contraction-only) to the SVD/projector
+wrapper so the per-sector pack/unpack + gauge-fix batch ACROSS sectors. High blast
+radius; the bigger build; but the data says it is the *only* thing that shrinks the
+per-sweep VJP.
+
+### What #570's levers ARE good for (not compile)
+- **Truncated backprop:** accurate gradient without the implicit adjoint solve →
+  avoids the contractivity precheck / `CTMRGGradientError`, and fewer sweep-VJP
+  *executions* per step than implicit Neumann. A **runtime/robustness** lever —
+  measure warm-step (implicit ~31 s at D=4/χ=12) on A100 to quantify.
+- **QR projector + truncated backprop (Yang/Corboz):** a **large-χ GPU/TPU runtime**
+  program (QR batches cleanly on accelerators), not a compile-wall fix.
+
+### Practical recommendation
+The compile wall is a **one-time** cost. Given all cheap levers are exhausted, the
+pragmatic split is: (i) treat compile as amortized and pursue **runtime** via TBPTT
+(+ QR on GPU) where it genuinely helps; or (ii) commit to the **#566 stacked-
+projector restructure** if the one-time compile minutes are themselves the blocker.
+That is a scope decision, not a measurement question — the measurements are in.
+
+## Reproduce
+```bash
+JAX_PLATFORMS=cpu uv run python examples/probe_truncated_backprop_570.py \
+    --D 2 --depth 12 --K 1 2 4 8 --parity
+```

--- a/docs/superpowers/handoffs/2026-06-08-fixed-point-bwd-subop-attribution-570.md
+++ b/docs/superpowers/handoffs/2026-06-08-fixed-point-bwd-subop-attribution-570.md
@@ -109,6 +109,54 @@ Two caveats the data makes explicit:
   (#572, default-off). Worth re-evaluating specifically for the SVD term now that we
   know it is the χ driver.
 
+## Follow-up: is the QR/eigh lever real? (the #570 premise)
+
+Two facts complicate the obvious "swap SVD→QR" plan:
+
+1. **The compile-dominant path is SVD-hardcoded.** `_ctm_tensor_projector_2x2.py`
+   (the symmetric single-site projector that `_make_jit_ctm_step` differentiates)
+   has **no `projector_method` parameter** — it always uses the symmetric SVD
+   (`_gauge_fixed_svd` / `_compute_2x2_projector_symmetric`). Passing
+   `projector_method="eigh"/"qr"` to the step is **silently ignored** there (the
+   attribution is byte-identical svd vs eigh). `projector_method` only affects the
+   *label-based* `_ctm_projector.py`, where moreover "qr" is itself eigh-relabeled
+   (`_qr_projector_symmetric` docstring: "identical to eigh path"). So #570's QR
+   lever is **not a config flip — it must be implemented** in the 2×2 symmetric
+   path.
+
+2. **Isolated decomposition-VJP cost** (`examples/probe_decomp_vjp_cost_570.py`,
+   backward jaxpr ops on a dense n×n matrix, k = n/2):
+
+   | n | svd_prod | svd_plain | qr | eigh_prod |
+   |---:|---:|---:|---:|---:|
+   | 8 | 261 | 90 | 99 | 113 |
+   | 16 | 261 | 90 | 99 | 113 |
+   | 32 | 261 | 90 | 99 | 113 |
+   | 64 | **261** | 90 | 99 | 113 |
+
+   - **Per-decomposition VJP op count is FLAT in n.** Confirms the real backward's
+     χ-scaling is **per-sector multiplicity** (more sectors at larger χ), NOT
+     per-sector matrix size. A cheaper per-sector decomposition lowers the
+     *constant*, not the *scaling*.
+   - **Production SVD VJP (261) is ~2.6× QR (99) and ~2.3× eigh (113).** The
+     gauge/Lorentzian degeneracy machinery alone triples plain SVD (90→261); QR
+     avoids the `1/(sᵢ²−sⱼ²)` degeneracy backward entirely.
+
+### Verdict for #570
+- **QR projector = ~2.6× constant-factor win** on the dominant svd_vjp term
+  (61% → ~24% of the backward; ≈38% fewer total backward ops, plausibly more in
+  compile *time* since compile is super-linear in op count). **Worth doing, but
+  not the order-of-magnitude alone**, and it requires implementing a QR projector
+  in `_ctm_tensor_projector_2x2.py` (caveat: a production QR projector still needs
+  per-iteration gauge stabilization, so the real ratio is a bit under 2.6×).
+- **The χ-scaling is untouched by QR** (per-sector emission persists). Killing it
+  needs **batching the per-sector decompositions** (the gated `TENAX_BATCH_BLOCKSPARSE`
+  batched-SVD #572, worth re-evaluating now that the SVD term is the confirmed χ
+  driver) and/or **truncated backprop** (shrinks the differentiated depth).
+- **Strongest #570 program:** QR-or-cheaper-SVD-VJP (constant) × batched per-sector
+  decomposition (scaling) × truncated backprop (depth). Each is independently
+  CPU-prototypable; the compile-time payoff is the A100 benchmark.
+
 ## Reproduce
 
 ```bash
@@ -118,4 +166,9 @@ JAX_PLATFORMS=cpu uv run python examples/probe_bwd_subop_attribution_570.py \
     --mode buckets --D 2 --chi 4 6 8 12 16 24 --full
 JAX_PLATFORMS=cpu uv run python examples/probe_bwd_subop_attribution_570.py \
     --mode buckets --D 4 --chi 8 12 16 --full
+# projector knob (currently a no-op on the SVD-hardcoded 2x2 path — see above):
+JAX_PLATFORMS=cpu uv run python examples/probe_bwd_subop_attribution_570.py \
+    --mode raw --D 2 --chi 6 --full --projector eigh
+# isolated decomposition-VJP cost (SVD vs QR vs eigh):
+JAX_PLATFORMS=cpu uv run python examples/probe_decomp_vjp_cost_570.py --n 8 16 32 64
 ```

--- a/docs/superpowers/handoffs/2026-06-08-fixed-point-bwd-subop-attribution-570.md
+++ b/docs/superpowers/handoffs/2026-06-08-fixed-point-bwd-subop-attribution-570.md
@@ -1,0 +1,121 @@
+# Fixed-point backward sub-op attribution — the wall is the block-sparse SVD VJP (#570)
+
+**Date:** 2026-06-08
+**Context:** The #200 P-B4 measurement (PR #587) settled that the symmetric-iPEPS
+CTM-AD compile wall is the implicit-diff backward `_jit_fused_fixed_point_bwd` and
+is **backend-invariant** (per-block / stacked / cuTensorNet all ~549 s at D=4/χ=12
+on A100). The NO-GO handoff prescribed one next step: *profile WHICH sub-ops of the
+backward dominate* before committing #570 work. This is that profile — CPU,
+trace-only, source-attributed.
+**Tool:** `examples/probe_bwd_subop_attribution_570.py`
+**Verdict:** **#570 is confirmed.** The χ-scaling driver of the backward op count is
+the **block-sparse SVD VJP** — 61% of the entire fused backward at the D=4/χ=12 bar,
+and the *only* term that grows with χ. Everything else is χ-flat.
+
+---
+
+## Method (why this differs from the existing primitive histogram)
+
+`probe_backward_jaxpr_566.py` buckets ops by *primitive type*, which **hides** the
+SVD cost: an SVD-VJP emits dozens of `dot_general` / `transpose` / `div` /
+`broadcast` ops that get miscounted under contraction/transpose/elementwise. This
+probe attributes **every** op to the **source function** that emitted it, via the
+equation's traceback (`eqn.source_info.traceback.frames`), recursing into all
+sub-jaxprs. So the full dense-algebra footprint of the SVD differentiation is
+counted where it belongs. Ordered categories (decomp checked first, so an op
+emitted *inside* svd is credited to svd, not the enclosing projector):
+`svd_vjp` / `eigh_vjp` / `projector` / `contraction` / `structural` / `other`.
+
+Trace-only (no XLA compile) → runs in seconds at any D/χ; the op-count breakdown is
+platform-independent. **Validation:** the probe's D=4/χ=12 total (150,663 ops)
+reproduces the independently-recorded backward op count, confirming the unit.
+
+Profiled unit = the full fused backward (env-sweep VJP **+** params-sweep VJP,
+`--full`), fermionic FermionParity site, `projector_method="svd"` (the default).
+
+## Data (full fused backward, fermionic)
+
+### D=2 χ-sweep
+
+| χ | TOTAL | svd_vjp | eigh_vjp | projector | contraction | structural | decomp% | svd kernels |
+|---:|------:|--------:|---------:|----------:|------------:|-----------:|--------:|-----:|
+| 4  | 59,079 | 20.7% | 0% | 15.7% | 7.9% | **50.2%** | 36.5% | 48 |
+| 6  | 63,543 | 25.4% | 0% | 14.6% | 7.3% | 46.6% | 40.0% | 48 |
+| 8  | 68,007 | 29.5% | 0% | 13.7% | 6.8% | 43.6% | 43.2% | 48 |
+| 12 | 76,935 | 36.2% | 0% | 12.1% | 6.0% | 38.5% | 48.3% | 48 |
+| 16 | 85,863 | 41.5% | 0% | 10.8% | 5.4% | 34.5% | 52.4% | 48 |
+| 24 | 103,719 | **49.4%** | 0% | 9.0% | 4.5% | 28.6% | 58.4% | 48 |
+
+### D=4 χ-sweep (the A100 bar is χ=12)
+
+| χ | TOTAL | svd_vjp | eigh_vjp | projector | contraction | structural | decomp% | svd kernels |
+|---:|------:|--------:|---------:|----------:|------------:|-----------:|--------:|-----:|
+| 8  | 117,159 | 53.8% | 0% | 7.9% | 4.0% | 25.3% | 61.8% | 48 |
+| **12** | **150,663** | **61.3%** | 0% | 6.2% | 3.1% | 19.7% | 67.5% | 48 |
+| 16 | 184,167 | 66.1% | 0% | 5.1% | 2.5% | 16.1% | 71.1% | 48 |
+
+## The finding (five facts)
+
+1. **The SVD VJP is the χ-scaling driver.** Its absolute op count grows
+   12,240→51,280 (4.2×) over χ=4→24 at D=2 — that growth is **87% of the entire
+   backward's op growth**. At D=4 it reaches **61% of the whole fused backward at
+   χ=12** (66% at χ=16). It is the only category whose share rises with χ.
+
+2. **Everything else is χ-flat in absolute op count.** projector 9,304,
+   contraction 4,653, structural 29,634 — **constant across all χ AND identical at
+   D=2 and D=4.** They scale with *block count* (16, same for even D), not with D or
+   χ. They are the per-block representation scaffolding, not a χ lever.
+
+3. **It is specifically the SVD, not "SVD/eigh/projector".** `eigh_vjp = 0` at the
+   default SVD projector (eigh only appears for `projector_method="eigh"`/C4v), and
+   the projector *algebra* (Fishman matmuls around the SVD) is χ-flat. The A100
+   "block-sparse SVD/eigh/projector VJP" is, concretely, the **SVD VJP**.
+
+4. **Compile-time under-counts it further.** The 48 SVD custom-calls are χ-flat in
+   *count*, but each is disproportionately expensive to *compile* (XLA SVD lowering
+   ≫ a generic elementwise op) and grows more expensive at large χ. So in
+   compile-*time* terms the SVD dominance exceeds even its 61% op-share — consistent
+   with the A100 wall being ~100% `_jit_fused_fixed_point_bwd`.
+
+5. **Mechanism (why op count grows with χ at all).** The symmetric SVD
+   (`_truncated_svd_symmetric_traced`) emits ops **per surviving charge sector** on
+   the χ-bond; the number of sectors that survive truncation grows with χ → more
+   per-sector SVD+VJP emission. So the SVD-VJP growth is *itself* per-block (charge-
+   sector) emission, now on the χ-bond rather than the D-bonds.
+
+## Implications for #570
+
+The two #570 sub-levers map cleanly onto this data:
+
+- **QR projector instead of SVD** → directly replaces the 61%-and-growing `svd_vjp`
+  term. QR's VJP has no degeneracy/Lorentzian machinery and batches cleanly across
+  sectors, so it should compile far cheaper than the truncated-symmetric-SVD VJP.
+  **This is the highest-leverage compile fix at large χ.** (Tenax already supports
+  `projector_method="qr"` — needs energy/variational parity validation.)
+- **Truncated backprop** → shrinks the whole backward proportionally (fewer
+  differentiated sweeps); orthogonal, helps every category including the SVD term.
+
+Two caveats the data makes explicit:
+
+- **At small χ / large D the structural per-block cost dominates** (50% at D=2 χ=4),
+  and QR does **not** touch it (block↔dense pack/unpack is representation cost, not
+  decomposition). But it is **χ-flat**, so it is a shrinking fraction exactly in the
+  large-χ regime #570 targets — at D=4/χ=12 structural is already only 20%. The
+  large-χ wall is genuinely the SVD; the structural cost is the *separate* #566
+  per-block-emission axis (stacked backend = necessary-but-insufficient, already
+  measured).
+- **Batching the per-sector SVDs** (the χ-flat 48 kernels emit per-sector) is a
+  third lever orthogonal to QR — cf. the gated `TENAX_BATCH_BLOCKSPARSE` batched-SVD
+  (#572, default-off). Worth re-evaluating specifically for the SVD term now that we
+  know it is the χ driver.
+
+## Reproduce
+
+```bash
+JAX_PLATFORMS=cpu uv run python examples/probe_bwd_subop_attribution_570.py \
+    --mode raw     --D 2 --chi 6 --full      # top (file::function) emitters
+JAX_PLATFORMS=cpu uv run python examples/probe_bwd_subop_attribution_570.py \
+    --mode buckets --D 2 --chi 4 6 8 12 16 24 --full
+JAX_PLATFORMS=cpu uv run python examples/probe_bwd_subop_attribution_570.py \
+    --mode buckets --D 4 --chi 8 12 16 --full
+```

--- a/docs/superpowers/specs/2026-06-08-svd-via-eigh-fishman-projector-570.md
+++ b/docs/superpowers/specs/2026-06-08-svd-via-eigh-fishman-projector-570.md
@@ -1,0 +1,160 @@
+# SVD-via-eigh in the Fishman 2×2 projector — banking the #570 decomposition-VJP win
+
+**Date:** 2026-06-08
+**Status:** ❌ FALSIFIED 2026-06-08 (prototype measured, premise does not hold) — see below.
+**Issue:** #570 (CTM-AD compile wall = block-sparse SVD VJP, confirmed in PR #589).
+**Branch:** `feat/svd-via-eigh-projector-570` (off `main`).
+
+---
+
+## ❌ FALSIFICATION (2026-06-08) — do not pursue SVD-via-eigh as a compile lever
+
+Prototyped `truncated_svd_via_eigh_ad` (eigh of the Gram matrix + reconstruct
+`U = M·V/s`) and measured its backward against `truncated_svd_ad` on the SAME full
+`(U, s, Vh)` contract the Fishman projector needs:
+
+- **No op-count win:** eigh-route backward = **274 ops** vs `truncated_svd_ad` =
+  **265** (break-even / slightly worse) on a 16×16 matrix, k=8.
+- **Mechanistic root cause (decisive):** `eigh(MᴴM)` has eigenvalues `w = S²`, so
+  its degeneracy F-matrix is `1/(wᵢ−wⱼ) = 1/(sᵢ²−sⱼ²)` — **identical** to the SVD's.
+  There is no *fundamental* backward saving from SVD→eigh for a full decomposition.
+  The earlier "~2.6×" (probe_decomp_vjp_cost_570: 261 vs 113) compared eigh's bare
+  `(w, v)` loss against svd's `(U, s, Vh)` loss — **apples to oranges**. Once you
+  reconstruct the `U = M·V/s` (and form `MᴴM` and differentiate through it) that
+  the projector requires, the leaner eigh backward is fully offset.
+- Secondary symptom: the naive reconstruction's **complex128 gradient was wrong**
+  (max|Δ|≈32 vs `truncated_svd_ad`) — a Gram-matrix conjugation subtlety. Moot
+  given the op-count result.
+
+**Conclusion:** "cheaper per-sector decomposition" is NOT a real #570 lever; the SVD
+backward's cost is intrinsic (the `1/(sᵢ²−sⱼ²)` F-matrix), shared by eigh-of-Gram.
+The prototype + test were reverted (no broken/no-win primitive shipped). **Pivot to
+(b): batch the per-sector decompositions** — that attacks the confirmed χ-driver
+(per-SECTOR multiplicity: PR #589 showed per-decomp VJP is flat in size, so the
+χ-scaling is *count of sectors*, not their size). Collapsing N per-sector SVD VJPs
+into ONE batched SVD VJP removes the per-sector emission the loop creates — cf. the
+gated `TENAX_BATCH_BLOCKSPARSE` batched-SVD (#572), now specifically justified.
+Truncated backprop remains the orthogonal depth lever.
+
+The original design follows as the record of the road not taken.
+
+---
+
+## Goal
+
+Bank the measured **~2.3–2.6× cheaper decomposition VJP** on the compile-dominant
+symmetric CTM-AD path, **without changing the CTM fixed point** (so energy/gradient
+parity holds). PR #589 established: the fused backward's only χ-scaling term is the
+block-sparse SVD VJP (61% at D=4/χ=12), and an isolated dense decomposition VJP is
+261 ops (production SVD) vs 113 (eigh) — the SVD's Lorentzian/gauge F-matrix
+machinery is the overhead, which eigh's backward avoids.
+
+## Key idea (why parity is preserved)
+
+For `M = U S Vᴴ`, the Gram matrix `Mᴴ M = V S² Vᴴ` is Hermitian. So:
+`eigh(Mᴴ M)` → eigenvalues `= S²`, eigenvectors `= V`. Reconstruct
+`S = sqrt(eigenvalues)`, `U = M V S⁻¹`. The singular **subspaces are identical** to
+`svd(M)` (up to the usual sign/phase gauge, which the projector's
+`_fix_svd_signs` / `_gauge_fix_symmetric_svd` already canonicalize). So the Fishman
+two-projector construction is **mathematically unchanged** — same projectors, same
+fixed point, same energy — but the differentiated decomposition is now `eigh`
+(cheap Lorentzian VJP) instead of `svd` (expensive F-matrix VJP).
+
+Numerical caveat (the thing the parity test gates): `Mᴴ M` squares the condition
+number, so singular values below ~√(machine-eps)·σ_max lose precision. In f64 with
+Fishman's existing `eps=1e-12` truncation this is expected to be benign in the
+truncated regime; the energy/FD-gradient parity test is the gate. Compute the Gram
+matrix on the **smaller** dimension (`MᴴM` if m≥n else `M Mᴴ`) for stability + cost.
+
+## Architecture (4 pieces, smallest-blast-radius first)
+
+### 1. `truncated_svd_via_eigh_ad(M, chi)` — `_ad_primitives.py`
+A **drop-in for `truncated_svd_ad`**: same `(U[m,k], s[k], Vh[k,n])` contract and
+the same `_fix_svd_signs` gauge. Computed via `regularized_eigh` on the Gram matrix
+so the VJP is the eigh backward (no SVD F-matrix). It is **NOT** a new `custom_vjp`
+— the cheap backward comes for free by routing the eigendecomposition through the
+existing `regularized_eigh` custom_vjp and doing the `S=√w`, `U=M V/s`
+reconstruction with plain differentiable ops.
+
+```python
+def truncated_svd_via_eigh_ad(M, chi):
+    m, n = M.shape
+    k = min(chi, min(m, n))
+    if m >= n:
+        w, V = regularized_eigh(M.conj().T @ M)       # w asc, = S²; V = right vecs
+        w_desc = w[::-1]; V = V[:, ::-1]
+        s = jnp.sqrt(jnp.clip(w_desc[:k], a_min=0.0))
+        Vk = V[:, :k]
+        s_inv = jnp.where(s > _SV_FLOOR, 1.0 / s, 0.0)
+        U = (M @ Vk) * s_inv[None, :]                 # (m,k)
+        Vh = Vk.conj().T
+    else:
+        w, U_ = regularized_eigh(M @ M.conj().T)      # left vecs
+        ... symmetric reconstruction (Vh = U_ᴴ M / s) ...
+    return _fix_svd_signs(U, s, Vh)
+```
+`_SV_FLOOR` mirrors the existing zero-SV handling; `_zero_subrank_singular_values`
+parity is checked by the test, not assumed.
+
+### 2. eigh variant of `_truncated_svd_symmetric_traced` — `linalg.py`
+The per-sector loop already calls `truncated_svd_ad` (linalg.py:625/803). Add a
+`decomp="svd"|"eigh"` parameter (default `"svd"`, byte-identical) that selects
+`truncated_svd_via_eigh_ad` per sector instead. Thread it through
+`_truncated_svd_symmetric` → the public `tenax.linalg.svd`'s symmetric path via a
+keyword (default off).
+
+### 3. wire into `_compute_2x2_projector_symmetric` — `_ctm_tensor_projector_2x2.py`
+Add `decomp="svd"` param; pass it to the three `tensor_svd` calls. When `"eigh"`,
+the Fishman construction is identical but each SVD uses the eigh route.
+
+### 4. dispatch from the CTM step
+`_make_jit_ctm_step` / the symmetric single-site step gains a way to select the
+eigh decomposition. **Decision:** use a dedicated env/config knob
+(`TENAX_CTM_DECOMP=eigh`, default `svd`) rather than overloading
+`projector_method="qr"` (whose existing meaning is the isometric density-matrix
+projector on the *other* path — overloading it would be confusing). The projector
+*algorithm* is unchanged (still Fishman); only the decomposition backend changes,
+so a separate knob is the honest name.
+
+## Testing (the parity gate — TDD, each piece before wiring the next)
+
+`tests/test_svd_via_eigh_570.py` (mark `core`):
+1. **Value parity (gauge-invariant).** `truncated_svd_via_eigh_ad(M,k)` vs
+   `truncated_svd_ad(M,k)`: reconstruction `U·diag(s)·Vh` and singular values `s`
+   match at fp tier (1e-10), for well-conditioned + rank-deficient + degenerate-SV
+   matrices, real **and** complex128. (Never compare raw U/Vh — gauge.)
+2. **Gradient parity (the crux).** `jax.grad` of a gauge-invariant scalar loss
+   (`sum(s²)` and `‖U diag(s) Vh‖²`) through the eigh route == through
+   `truncated_svd_ad` == finite-difference, fp tier, real + complex128. Well-
+   conditioned matrices first; then a moderate-conditioning case to bound the
+   `MᴴM`-squaring error.
+3. **VJP op-count win.** `len(make_jaxpr(grad(eigh_route)))` < `truncated_svd_ad`
+   on the same matrix (the #570 lever, ~2.3×); assert strict reduction.
+4. **Symmetric parity.** `_truncated_svd_symmetric_traced(decomp="eigh")` vs
+   `decomp="svd"`: per-sector reconstruction + bond spectrum match, FermionParity
+   ferm_D2/D4 sites.
+
+`tests/test_ctm_decomp_eigh_parity_570.py` (mark `algorithm`):
+5. **Energy parity.** A CTM-converged energy with `TENAX_CTM_DECOMP=eigh` matches
+   `svd` to ≤1e-8 on a small fermionic/Heisenberg iPEPS — the fixed-point gate.
+6. **End-to-end gradient parity.** `value_and_grad` of the CTM energy: eigh vs svd
+   gradient agree at fp tier (and FD-consistent) — proves the AD path is correct.
+
+Plus a **backward-attribution re-run** (not a unit test): with the eigh path wired,
+`probe_bwd_subop_attribution_570.py` should show `svd_vjp` collapse and
+`eigh_vjp` rise at D=4/χ=12 — the direct evidence the lever fired.
+
+## Scope / non-goals
+- **Default unchanged.** `decomp="svd"` everywhere by default; the eigh route is
+  opt-in (env/kwarg) until the A100 compile-time benefit + parity are confirmed.
+- **Does NOT change the χ-scaling** (per-sector emission persists — that's #572
+  batched-decomp + truncated backprop, separate levers). This banks the constant.
+- **No true QR-CTMRG** (separate, larger effort).
+- **No GPU default-flip** (pending the A100 compile-time measurement).
+
+## Risks
+- **Conditioning** (`MᴴM` squares κ): the central risk; gated by tests 1/2/5. If a
+  well-conditioned projector regime passes but degenerate cases fail, restrict the
+  eigh route to where κ is safe, or fall back per-sector.
+- **Gradient through `U = M V/s`** near small `s`: mirror the existing zero-SV floor;
+  test 2's degenerate case is the gate.

--- a/examples/probe_bwd_subop_attribution_570.py
+++ b/examples/probe_bwd_subop_attribution_570.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""SOURCE-attributed op histogram of the #566 fixed-point backward (for #570).
+
+The #200 P-B4 measurement (PR #587) settled that the symmetric-iPEPS CTM-AD
+compile wall is the implicit-diff backward ``_jit_fused_fixed_point_bwd`` and is
+*backend-invariant* (per-block / stacked / cuTensorNet contraction backends all
+land at ~549 s at D=4/chi=12 on A100). The redirect is #570: the large-chi
+block-sparse **SVD / eigh / projector VJP** inside that backward.
+
+The existing ``probe_backward_jaxpr_566.py`` buckets ops by PRIMITIVE TYPE, which
+HIDES the decomposition cost: an SVD-VJP emits dozens of ``dot_general`` /
+``transpose`` / ``div`` / ``broadcast`` ops that get miscounted under
+contraction/transpose/elementwise rather than under "SVD". This probe instead
+attributes EVERY op to the SOURCE function that emitted it, via the equation's
+traceback (``eqn.source_info.traceback.frames``), so the full op footprint of the
+SVD / eigh / projector differentiation is counted where it belongs.
+
+It is trace-only (no XLA compile), so it runs in seconds at any D/chi and the
+op-count breakdown is platform-independent — exactly the CPU-faithful localization
+the NO-GO handoff prescribes ("profile WHICH sub-ops dominate") before committing
+#570 work.
+
+Two modes:
+  --mode raw     : top (file::function) emitters, data-driven (no preset buckets)
+  --mode buckets : categorized (svd_vjp / eigh_vjp / projector / contraction /
+                   structural / other) + a chi-sweep, the decisive #570 readout
+
+Usage::
+
+    JAX_PLATFORMS=cpu uv run python examples/probe_bwd_subop_attribution_570.py \
+        --mode raw --D 2 --chi 6
+    JAX_PLATFORMS=cpu uv run python examples/probe_bwd_subop_attribution_570.py \
+        --mode buckets --D 2 --chi 4 6 8 12 --full
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import os
+
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_python_loop import _make_jit_ctm_step  # noqa: E402
+from tenax.algorithms._ctm_tensor_convergence import (  # noqa: E402
+    SINGLE_SITE_NEIGHBORS,
+)
+from tenax.algorithms._ctm_tensor_init import (  # noqa: E402
+    initialize_ctm_tensor_env,
+)
+from tenax.algorithms.ad_utils import _phase_fix_ctm_tensor  # noqa: E402
+from tenax.algorithms.fermionic_ipeps import (  # noqa: E402
+    FPEPSConfig,
+    _build_initial_fpeps_tensor,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Construction of the fused backward's VJP graph(s) — mirrors                  #
+# probe_backward_jaxpr_566.py so the unit profiled is the SAME compile unit.   #
+# --------------------------------------------------------------------------- #
+def make_site(D: int, seed: int = 42):
+    return _build_initial_fpeps_tensor(
+        FPEPSConfig(D=D, t=1.0, V=0.0), jax.random.PRNGKey(seed)
+    )
+
+
+def backward_vjp_jaxprs(A, chi: int, *, full: bool):
+    """Return the fused-backward VJP jaxpr(s): env-sweep VJP (+ params-sweep)."""
+    A_norm = A * (1.0 / (A.norm() + 1e-10))
+    site_tensors = {(0, 0): A_norm}
+    env = initialize_ctm_tensor_env(A_norm, chi)
+    envs = {(0, 0): env}
+    treedef = jax.tree.structure(envs)
+    env_leaves = tuple(jax.tree.leaves(envs))
+    param_treedef = jax.tree.structure(A_norm)
+    param_leaves = tuple(jax.tree.leaves(A_norm))
+    jit_step = _make_jit_ctm_step(SINGLE_SITE_NEIGHBORS)
+
+    def sweep_from_env(env_leaves_flat):
+        e = jax.tree.unflatten(treedef, env_leaves_flat)
+        e_out, _eps, _smin = jit_step(
+            site_tensors,
+            e,
+            chi=chi,
+            projector_method="svd",
+            renormalize=True,
+            projector_backward="auto",
+        )
+        return tuple(
+            jax.tree.leaves({c: _phase_fix_ctm_tensor(e_out[c]) for c in e_out})
+        )
+
+    out = sweep_from_env(env_leaves)
+    v = tuple(jnp.ones_like(o) for o in out)
+    env_jx = jax.make_jaxpr(lambda vv: jax.vjp(sweep_from_env, env_leaves)[1](vv))(v)
+    if not full:
+        return [env_jx]
+
+    def sweep_from_params(p_flat):
+        Ap = jax.tree.unflatten(param_treedef, p_flat)
+        e_out, _eps, _smin = jit_step(
+            {(0, 0): Ap},
+            envs,
+            chi=chi,
+            projector_method="svd",
+            renormalize=True,
+            projector_backward="auto",
+        )
+        return tuple(
+            jax.tree.leaves({c: _phase_fix_ctm_tensor(e_out[c]) for c in e_out})
+        )
+
+    par_jx = jax.make_jaxpr(lambda vv: jax.vjp(sweep_from_params, param_leaves)[1](vv))(
+        v
+    )
+    return [env_jx, par_jx]
+
+
+# --------------------------------------------------------------------------- #
+# Source attribution                                                          #
+# --------------------------------------------------------------------------- #
+# Frames that are pure tracing machinery — never the "source" of an op.
+_NOISE_FILES = (
+    "source_info_util.py",
+    "partial_eval.py",
+    "core.py",
+    "interpreters/ad.py",
+    "/ad.py",
+    "linear_util.py",
+    "api.py",
+    "api_util.py",
+    "traceback_util.py",
+    "pjit.py",
+    "custom_derivatives.py",
+    "tree_util.py",
+    "util.py",
+)
+
+
+def _is_noise(file_name: str) -> bool:
+    return any(n in file_name for n in _NOISE_FILES)
+
+
+def _signif_frames(eqn):
+    """Significant (file_name, function) frames for an eqn, innermost-first."""
+    tb = eqn.source_info.traceback
+    if tb is None:
+        return []
+    out = []
+    for fr in tb.frames:
+        fn = fr.file_name
+        if _is_noise(fn):
+            continue
+        out.append((fn.split("/")[-1], fr.function_name))
+    return out
+
+
+def walk_eqns(jaxpr):
+    """Yield every primitive eqn (recursing into nested sub-jaxprs)."""
+    jpr = getattr(jaxpr, "jaxpr", jaxpr)
+
+    def rec(jx):
+        for eqn in jx.eqns:
+            yield eqn
+            for vparam in eqn.params.values():
+                items = vparam if isinstance(vparam, (list, tuple)) else (vparam,)
+                for it in items:
+                    sub = getattr(it, "jaxpr", it)
+                    if hasattr(sub, "eqns"):
+                        yield from rec(sub)
+
+    yield from rec(jpr)
+
+
+# Ordered category rules (first match on ANY significant frame wins). Decomp is
+# checked first so an op emitted *inside* svd/eigh (whose frames also include the
+# outer projector) is credited to the decomposition, not the projector.
+def _categorize(frames) -> str:
+    files = [f for f, _ in frames]
+    funcs = [c.lower() for _, c in frames]
+    fc = list(zip(files, funcs))
+
+    def any_match(pred):
+        return any(pred(f, c) for f, c in fc)
+
+    if any_match(lambda f, c: "svd" in c or f == "ad_utils.py" and "svd" in c):
+        return "svd_vjp"
+    if any_match(lambda f, c: "svd" in f.lower()):
+        return "svd_vjp"
+    if any_match(
+        lambda f, c: "eigh" in c or f in ("_lorentzian_eigh.py", "_ad_primitives.py")
+    ):
+        return "eigh_vjp"
+    if any_match(
+        lambda f, c: (
+            "_ctm_compiled_moves.py" in f
+            or "projector" in f.lower()
+            or "projector" in c
+            or "_ctm_projector" in f
+        )
+    ):
+        return "projector"
+    if any_match(lambda f, c: f == "contractor.py" or "_contract" in c):
+        return "contraction"
+    if any_match(
+        lambda f, c: (
+            f
+            in (
+                "tensor.py",
+                "stacked_view.py",
+                "index.py",
+                "symmetry.py",
+                "stacked_tensor.py",
+            )
+            or "fuse" in c
+        )
+    ):
+        return "structural"
+    return "other"
+
+
+# Expensive-to-COMPILE kernels (each XLA custom-call lowering costs far more
+# compile time than a generic elementwise op — op COUNT under-weights these).
+_KERNEL_PRIMS = (
+    "svd",
+    "eigh",
+    "qr",
+    "geqrf",
+    "householder_product",
+    "triangular_solve",
+    "lu",
+    "eig",
+)
+
+
+def analyze(jaxprs):
+    by_cat: collections.Counter = collections.Counter()
+    by_source: collections.Counter = collections.Counter()
+    kernels: collections.Counter = collections.Counter()
+    total = 0
+    for jx in jaxprs:
+        for eqn in walk_eqns(jx):
+            total += 1
+            frames = _signif_frames(eqn)
+            by_cat[_categorize(frames)] += 1
+            top = frames[0] if frames else ("<none>", "<none>")
+            by_source[f"{top[0]}::{top[1]}"] += 1
+            if eqn.primitive.name in _KERNEL_PRIMS:
+                kernels[eqn.primitive.name] += 1
+    return total, by_cat, by_source, kernels
+
+
+# --------------------------------------------------------------------------- #
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--mode", choices=["raw", "buckets"], default="buckets")
+    ap.add_argument("--D", type=int, default=2)
+    ap.add_argument("--chi", type=int, nargs="+", default=[4, 6, 8, 12])
+    ap.add_argument(
+        "--full",
+        action="store_true",
+        help="Include the params-sweep VJP (whole fused backward), not just "
+        "apply_Jt (the env-sweep Neumann matvec).",
+    )
+    args = ap.parse_args()
+
+    os.environ.setdefault("TENAX_BATCH_BLOCKSPARSE", "0")
+    unit = (
+        "env+params sweep VJP (full fused backward)"
+        if args.full
+        else "env-sweep VJP (apply_Jt / Neumann matvec)"
+    )
+    print(f"# #570 source-attributed backward op histogram | D={args.D} | unit={unit}")
+    print(f"# x64={jax.config.read('jax_enable_x64')} | projector=svd\n")
+
+    A = make_site(args.D)
+
+    if args.mode == "raw":
+        chi = args.chi[0]
+        jaxprs = backward_vjp_jaxprs(A, chi, full=args.full)
+        total, by_cat, by_source, kernels = analyze(jaxprs)
+        print(f"== RAW top emitters | D={args.D} chi={chi} | TOTAL ops={total} ==")
+        print("  -- by category --")
+        for cat, n in by_cat.most_common():
+            print(f"    {cat:<28} {n:>8} {100 * n / total:>6.1f}%")
+        print("  -- top 25 (file::function) --")
+        for src, n in by_source.most_common(25):
+            print(f"    {src:<52} {n:>7} {100 * n / total:>5.1f}%")
+        print(f"  -- decomposition kernels (expensive to compile) -- {dict(kernels)}")
+        return
+
+    # buckets mode: chi-sweep, the decisive #570 readout
+    cats = ["svd_vjp", "eigh_vjp", "projector", "contraction", "structural", "other"]
+    print(
+        f"{'chi':>5} {'TOTAL':>9} "
+        + " ".join(f"{c:>11}" for c in cats)
+        + f" {'decomp%':>8} {'kernels':>9}"
+    )
+    rows = []
+    for chi in args.chi:
+        jaxprs = backward_vjp_jaxprs(A, chi, full=args.full)
+        total, by_cat, _src, kernels = analyze(jaxprs)
+        decomp = by_cat["svd_vjp"] + by_cat["eigh_vjp"] + by_cat["projector"]
+        rows.append((chi, total, by_cat, decomp, kernels))
+        cells = " ".join(
+            f"{by_cat[c]:>5}/{100 * by_cat[c] / total:>4.1f}%" for c in cats
+        )
+        nkern = sum(kernels.values())
+        print(f"{chi:>5} {total:>9} {cells} {100 * decomp / total:>7.1f}% {nkern:>9}")
+
+    print("\n# DECISIVE #570 READOUT:")
+    print(
+        "#  - If (svd_vjp+eigh_vjp+projector) op-SHARE GROWS with chi -> #570 "
+        "(large-chi decomp VJP) IS the compile lever."
+    )
+    print(
+        "#  - If decomp share stays small/flat while 'structural' dominates -> "
+        "the wall is per-block pack/unpack, not the decomposition."
+    )
+    print(
+        "#  - 'kernels' = count of svd/eigh custom-calls (each is "
+        "disproportionately expensive to COMPILE; op-count under-weights them)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/probe_bwd_subop_attribution_570.py
+++ b/examples/probe_bwd_subop_attribution_570.py
@@ -68,8 +68,14 @@ def make_site(D: int, seed: int = 42):
     )
 
 
-def backward_vjp_jaxprs(A, chi: int, *, full: bool):
-    """Return the fused-backward VJP jaxpr(s): env-sweep VJP (+ params-sweep)."""
+def backward_vjp_jaxprs(A, chi: int, *, full: bool, projector: str = "svd"):
+    """Return the fused-backward VJP jaxpr(s): env-sweep VJP (+ params-sweep).
+
+    ``projector`` selects the CTM projector method the differentiated step uses
+    (``"svd"`` default, ``"eigh"``, or ``"qr"``). This is the #570 compile-lever
+    knob: it determines whether the dominant ``svd_vjp`` term is replaced by a
+    (hopefully cheaper) ``eigh_vjp``.
+    """
     A_norm = A * (1.0 / (A.norm() + 1e-10))
     site_tensors = {(0, 0): A_norm}
     env = initialize_ctm_tensor_env(A_norm, chi)
@@ -86,7 +92,7 @@ def backward_vjp_jaxprs(A, chi: int, *, full: bool):
             site_tensors,
             e,
             chi=chi,
-            projector_method="svd",
+            projector_method=projector,
             renormalize=True,
             projector_backward="auto",
         )
@@ -106,7 +112,7 @@ def backward_vjp_jaxprs(A, chi: int, *, full: bool):
             {(0, 0): Ap},
             envs,
             chi=chi,
-            projector_method="svd",
+            projector_method=projector,
             renormalize=True,
             projector_backward="auto",
         )
@@ -266,6 +272,13 @@ def main() -> None:
         help="Include the params-sweep VJP (whole fused backward), not just "
         "apply_Jt (the env-sweep Neumann matvec).",
     )
+    ap.add_argument(
+        "--projector",
+        choices=["svd", "eigh", "qr"],
+        default="svd",
+        help="CTM projector method the differentiated step uses (#570 lever: "
+        "does 'eigh'/'qr' replace the dominant svd_vjp with a cheaper eigh_vjp?).",
+    )
     args = ap.parse_args()
 
     os.environ.setdefault("TENAX_BATCH_BLOCKSPARSE", "0")
@@ -275,13 +288,13 @@ def main() -> None:
         else "env-sweep VJP (apply_Jt / Neumann matvec)"
     )
     print(f"# #570 source-attributed backward op histogram | D={args.D} | unit={unit}")
-    print(f"# x64={jax.config.read('jax_enable_x64')} | projector=svd\n")
+    print(f"# x64={jax.config.read('jax_enable_x64')} | projector={args.projector}\n")
 
     A = make_site(args.D)
 
     if args.mode == "raw":
         chi = args.chi[0]
-        jaxprs = backward_vjp_jaxprs(A, chi, full=args.full)
+        jaxprs = backward_vjp_jaxprs(A, chi, full=args.full, projector=args.projector)
         total, by_cat, by_source, kernels = analyze(jaxprs)
         print(f"== RAW top emitters | D={args.D} chi={chi} | TOTAL ops={total} ==")
         print("  -- by category --")
@@ -302,7 +315,7 @@ def main() -> None:
     )
     rows = []
     for chi in args.chi:
-        jaxprs = backward_vjp_jaxprs(A, chi, full=args.full)
+        jaxprs = backward_vjp_jaxprs(A, chi, full=args.full, projector=args.projector)
         total, by_cat, _src, kernels = analyze(jaxprs)
         decomp = by_cat["svd_vjp"] + by_cat["eigh_vjp"] + by_cat["projector"]
         rows.append((chi, total, by_cat, decomp, kernels))

--- a/examples/probe_decomp_vjp_cost_570.py
+++ b/examples/probe_decomp_vjp_cost_570.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Isolated decomposition-VJP compile-cost: SVD vs QR vs eigh (the #570 premise).
+
+`probe_bwd_subop_attribution_570.py` showed the CTM-AD compile wall is the
+block-sparse **SVD VJP** (61% of the fused backward at D=4/χ=12, the only
+χ-scaling term). And `_ctm_tensor_projector_2x2.py` (the compile-dominant
+symmetric single-site projector) hardcodes SVD — so #570's "QR projector" lever
+is NOT a config flip; it must be *implemented* there. Before paying that, test
+the PREMISE in isolation:
+
+    Is a QR / eigh decomposition VJP actually cheaper to compile than the SVD VJP,
+    and how does each scale with matrix size n (= per-sector χ)?
+
+This traces the **backward** (`jax.vjp`) jaxpr of each decomposition on a dense
+n×n matrix and counts ops + decomposition kernels, sweeping n. Two things matter:
+  (1) the constant factor (ops at fixed n) — the per-sector compile cost;
+  (2) the n-scaling — whether per-sector matrix SIZE drives op count (vs the
+      separate per-SECTOR multiplicity that drives the real backward's χ-scaling).
+
+Decompositions compared (all reduced to a comparable "keep top-k subspace" use,
+loss = ‖reconstruct/subspace‖² so the VJP is exercised):
+  * svd_prod : `truncated_svd_ad` (the PRODUCTION SVD VJP, gauge/Lorentzian);
+  * svd_plain: `jnp.linalg.svd` (baseline);
+  * qr       : `jnp.linalg.qr` (the Yang/Corboz-style lever);
+  * eigh_prod: `regularized_eigh` on MᴴM (the PRODUCTION eigh VJP).
+
+Usage::
+
+    JAX_PLATFORMS=cpu uv run python examples/probe_decomp_vjp_cost_570.py \
+        --n 8 16 32 64
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ad_primitives import regularized_eigh  # noqa: E402
+from tenax.algorithms.ad_utils import truncated_svd_ad  # noqa: E402
+
+_KERNEL_PRIMS = (
+    "svd",
+    "eigh",
+    "qr",
+    "geqrf",
+    "householder_product",
+    "triangular_solve",
+    "lu",
+    "eig",
+    "custom_linear_solve",
+)
+
+
+def _count(jaxpr) -> tuple[int, collections.Counter]:
+    """(total ops, kernel-primitive counts), recursing into sub-jaxprs."""
+    total = 0
+    kernels: collections.Counter = collections.Counter()
+    jpr = getattr(jaxpr, "jaxpr", jaxpr)
+
+    def rec(jx):
+        nonlocal total
+        for eqn in jx.eqns:
+            total += 1
+            if eqn.primitive.name in _KERNEL_PRIMS:
+                kernels[eqn.primitive.name] += 1
+            for vparam in eqn.params.values():
+                items = vparam if isinstance(vparam, (list, tuple)) else (vparam,)
+                for it in items:
+                    sub = getattr(it, "jaxpr", it)
+                    if hasattr(sub, "eqns"):
+                        rec(sub)
+
+    rec(jpr)
+    return total, kernels
+
+
+def _vjp_ops(loss_fn, M) -> tuple[int, collections.Counter]:
+    """Count the backward (cotangent) jaxpr ops of ``loss_fn`` at ``M``."""
+    jx = jax.make_jaxpr(lambda m: jax.vjp(loss_fn, m)[1](1.0))(M)
+    return _count(jx)
+
+
+def make_losses(k: int):
+    """Real-valued losses that exercise each decomposition's top-k subspace VJP."""
+
+    def svd_prod(M):
+        U, S, Vh = truncated_svd_ad(M, k)
+        return jnp.sum(jnp.abs(S) ** 2) + jnp.real(jnp.sum(jnp.abs(U) ** 2))
+
+    def svd_plain(M):
+        U, S, Vh = jnp.linalg.svd(M, full_matrices=False)
+        return jnp.sum(S[:k] ** 2) + jnp.real(jnp.sum(jnp.abs(U[:, :k]) ** 2))
+
+    def qr(M):
+        Q, R = jnp.linalg.qr(M, mode="reduced")
+        # Top-k "subspace" use: diag of R (analogue of singular values) + Q cols.
+        return jnp.sum(jnp.abs(jnp.diagonal(R)[:k]) ** 2) + jnp.real(
+            jnp.sum(jnp.abs(Q[:, :k]) ** 2)
+        )
+
+    def eigh_prod(M):
+        # Density matrix MᴴM -> Hermitian eigh (the eigh-projector construction).
+        w, v = regularized_eigh(M.conj().T @ M)
+        return jnp.sum(jnp.abs(w[-k:]) ** 2) + jnp.real(
+            jnp.sum(jnp.abs(v[:, -k:]) ** 2)
+        )
+
+    return {
+        "svd_prod": svd_prod,
+        "svd_plain": svd_plain,
+        "qr": qr,
+        "eigh_prod": eigh_prod,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--n", type=int, nargs="+", default=[8, 16, 32, 64])
+    ap.add_argument(
+        "--k-frac",
+        type=float,
+        default=0.5,
+        help="keep k = round(k_frac * n) (truncation ratio).",
+    )
+    args = ap.parse_args()
+
+    print(
+        f"# #570 isolated decomposition-VJP op cost | x64={jax.config.read('jax_enable_x64')}"
+    )
+    print(
+        f"# backward (jax.vjp) jaxpr ops on a dense n×n matrix | k = {args.k_frac}·n\n"
+    )
+
+    methods = ["svd_prod", "svd_plain", "qr", "eigh_prod"]
+    print(f"{'n':>5} {'k':>4} " + " ".join(f"{m:>22}" for m in methods))
+    key = jax.random.PRNGKey(0)
+    for n in args.n:
+        k = max(1, round(args.k_frac * n))
+        M = jax.random.normal(key, (n, n))
+        losses = make_losses(k)
+        cells = []
+        for m in methods:
+            try:
+                total, kern = _vjp_ops(losses[m], M)
+                ksum = sum(kern.values())
+                cells.append(f"{total:>6} ops/{ksum}k")
+            except Exception as e:  # pragma: no cover - diagnostic
+                cells.append(f"ERR:{type(e).__name__}")
+        print(f"{n:>5} {k:>4} " + " ".join(f"{c:>22}" for c in cells))
+
+    print("\n# READOUT:")
+    print(
+        "#  - Compare svd_prod vs qr / eigh_prod at fixed n: the per-sector "
+        "compile-cost ratio of the #570 lever."
+    )
+    print(
+        "#  - Compare the n-scaling: if svd_prod ops are ~FLAT in n, the real "
+        "backward's χ-scaling is per-SECTOR multiplicity (a #566 representation"
+    )
+    print(
+        "#    issue), and a cheaper per-sector decomp (QR) lowers the CONSTANT "
+        "but not the scaling. If svd_prod GROWS with n, size matters too."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/probe_truncated_backprop_570.py
+++ b/examples/probe_truncated_backprop_570.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Truncated backprop (TBPTT) as a #570 lever — op-count + gradient parity (CPU).
+
+PR #589 re-localized the CTM-AD compile wall to per-sector STRUCTURAL emission in
+the symmetric SVD/projector wrapper (not the decomposition). Truncated backprop
+(``ctm_energy_explicit(backward_steps=K)``, issue #506) attacks a different axis:
+it differentiates only the last ``K`` CTM sweeps (the rest under
+``stop_gradient``), so it cuts the backward *regardless of per-sweep cost*.
+
+This probe answers, on CPU (the D=4/χ=12 compile-*time* itself is an A100 task):
+
+  1. **Is TBPTT a compile lever?** Count the backward (``jax.grad``) jaxpr ops vs
+     ``backward_steps`` K, and vs the implicit fixed-point backward. The explicit
+     differentiated sweeps are an UNROLLED checkpoint loop, so the backward graph
+     should scale ~linearly in K — meaning small K is a real op-count cut. Compare
+     K=1 against the implicit fused backward to see if either is fundamentally
+     smaller (the implicit compiles ONE sweep-VJP in a while_loop + adjoint
+     machinery; explicit-K compiles K sweep-VJPs unrolled).
+  2. **Is the truncated gradient accurate?** At D=2 (cheap), compute the actual
+     gradient with full backprop vs TBPTT-K and report the relative error. CTM is
+     contractive, so the error should decay geometrically in K.
+
+Usage::
+
+    JAX_PLATFORMS=cpu uv run python examples/probe_truncated_backprop_570.py \
+        --D 2 --depth 12 --K 1 2 4 8
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_energy_ad import _default_energy  # noqa: E402
+from tenax.algorithms._ctm_python_loop import _make_jit_ctm_step  # noqa: E402
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS  # noqa: E402
+from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env  # noqa: E402
+from tenax.algorithms.fermionic_ipeps import (  # noqa: E402
+    FPEPSConfig,
+    _build_initial_fpeps_tensor,
+    spinless_fermion_gate,
+)
+from tenax.algorithms.ipeps_ad_policy import make_ctm_energy_fn  # noqa: E402
+from tenax.algorithms.ipeps_config import CTMConfig  # noqa: E402
+
+
+def make_site_and_gate(D: int, seed: int = 42):
+    cfg = FPEPSConfig(D=D, t=1.0, V=0.0)
+    A = _build_initial_fpeps_tensor(cfg, jax.random.PRNGKey(seed))
+    gate = spinless_fermion_gate(cfg).todense().reshape(2, 2, 2, 2)
+    return A, gate
+
+
+def _count_jaxpr(jx):
+    """Total jaxpr ops, recursing into sub-jaxprs."""
+
+    def rec(jaxpr):
+        jpr = getattr(jaxpr, "jaxpr", jaxpr)
+        n = 0
+        for eqn in jpr.eqns:
+            n += 1
+            for v in eqn.params.values():
+                for it in v if isinstance(v, (list, tuple)) else (v,):
+                    sub = getattr(it, "jaxpr", it)
+                    if hasattr(sub, "eqns"):
+                        n += rec(sub)
+        return n
+
+    return rec(jx)
+
+
+def k_sweep_backward_ops(A, gate, chi, K):
+    """Op-count of the TBPTT-K backward: grad through K differentiated CTM sweeps.
+
+    Mirrors ``ctm_energy_explicit``'s backprop loop (the last K sweeps are the
+    differentiated unit; the leading sweeps are stop_gradient'd, contributing no
+    backward). Traceable (no host convergence loop), so make_jaxpr(grad) works —
+    unlike the full production energy_fn, whose forward uses a host Python loop.
+    """
+    A_norm = A * (1.0 / (A.norm() + 1e-10))
+    env0 = jax.lax.stop_gradient(initialize_ctm_tensor_env(A_norm, chi))
+    envs0 = {(0, 0): env0}
+    jit_step = _make_jit_ctm_step(SINGLE_SITE_NEIGHBORS)
+
+    def loss(Ap):
+        An = Ap * (1.0 / (Ap.norm() + 1e-10))
+        envs = envs0
+        for _ in range(K):
+            envs, _eps, _smin = jit_step(
+                {(0, 0): An},
+                envs,
+                chi=chi,
+                projector_method="svd",
+                renormalize=True,
+                projector_backward="auto",
+            )
+        return _default_energy(
+            {(0, 0): An}, envs, gate, [(0, 0)], SINGLE_SITE_NEIGHBORS
+        )
+
+    return _count_jaxpr(jax.make_jaxpr(jax.grad(loss))(A))
+
+
+def build_loss(gate, chi, depth, *, explicit, warmup=3, backward_steps=None):
+    ctm_cfg = CTMConfig(chi=chi, max_iter=depth, conv_tol=1e-4)
+    energy_fn = make_ctm_energy_fn(
+        neighbors=SINGLE_SITE_NEIGHBORS,
+        gate=gate,
+        get_ctm_cfg=lambda: ctm_cfg,
+        env_cache={},
+        use_explicit=explicit,
+        explicit_warmup=warmup,
+        explicit_steps=depth,
+        explicit_backward_steps=backward_steps,
+    )
+
+    def loss_fn(A_param):
+        A_norm = A_param * (1.0 / (A_param.norm() + 1e-10))
+        return energy_fn({(0, 0): A_norm})
+
+    return loss_fn
+
+
+def _gnorm(g):
+    return jnp.sqrt(sum(jnp.sum(jnp.abs(x) ** 2) for x in jax.tree.leaves(g)))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--D", type=int, default=2)
+    ap.add_argument("--chi-factor", type=int, default=3)
+    ap.add_argument("--depth", type=int, default=12, help="backprop_steps (explicit).")
+    ap.add_argument("--K", type=int, nargs="+", default=[1, 2, 4, 8])
+    ap.add_argument(
+        "--parity",
+        action="store_true",
+        help="Also compute actual eager gradients and report TBPTT-vs-full error.",
+    )
+    args = ap.parse_args()
+    chi = args.chi_factor * args.D
+    A, gate = make_site_and_gate(args.D)
+
+    print(f"# #570 truncated backprop probe | D={args.D} chi={chi} depth={args.depth}")
+    print(f"# x64={jax.config.read('jax_enable_x64')} | fermionic\n")
+
+    # ---- (1) backward op-count vs K (compile proxy; the K-sweep differentiated
+    #          unit, traced directly since the full energy_fn has a host loop) ----
+    print("## TBPTT backward op-count (compile proxy, trace-only)")
+    print("#   (implicit fixed-point sweep-VJP baseline at this D/chi from")
+    print("#    probe_bwd_subop_attribution_570: D2/chi6=63543, D4/chi12=150663)")
+    n_prev = None
+    for K in args.K:
+        nK = k_sweep_backward_ops(A, gate, chi, K)
+        delta = (
+            f"  (+{nK - n_prev} vs K={args.K[args.K.index(K) - 1]})" if n_prev else ""
+        )
+        print(f"  TBPTT K={K:<2} backward ops : {nK:>9}{delta}")
+        n_prev = nK
+
+    # ---- (2) gradient + energy parity vs K (eager grad on the REAL energy_fn) ----
+    if args.parity:
+        print("\n## gradient + energy parity (eager; full backprop = reference)")
+        full = build_loss(gate, chi, args.depth, explicit=True, backward_steps=None)
+        e_full = full(A)
+        gfull = jax.grad(full)(A)
+        gfull_norm = _gnorm(gfull)
+        print(
+            f"  full (K={args.depth}): E={float(e_full):.10f}  |g|={float(gfull_norm):.6e}"
+        )
+        # implicit reference too (production default path).
+        imp = build_loss(gate, chi, args.depth, explicit=False)
+        e_imp = imp(A)
+        print(
+            f"  implicit:    E={float(e_imp):.10f}  dE_vs_full={float(e_imp - e_full):+.2e}"
+        )
+        for K in args.K:
+            if K > args.depth:
+                continue
+            lf = build_loss(gate, chi, args.depth, explicit=True, backward_steps=K)
+            eK = lf(A)
+            gK = jax.grad(lf)(A)
+            diff = jax.tree.map(lambda a, b: a - b, gK, gfull)
+            rel = float(_gnorm(diff) / (gfull_norm + 1e-30))
+            print(
+                f"  K={K:<2}: E={float(eK):.10f}  dE={float(eK - e_full):+.2e}"
+                f"  rel|g-g_full|={rel:.3e}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/profile_ctm_ad_wall_566.py
+++ b/examples/profile_ctm_ad_wall_566.py
@@ -173,8 +173,15 @@ def make_site_and_gate(sym: str, D: int, seed: int):
 # --------------------------------------------------------------------------- #
 # Loss closure: the real production dispatcher
 # --------------------------------------------------------------------------- #
-def build_loss(gate, chi: int, depth: int, *, explicit: bool, warmup: int):
-    """``A -> energy`` via make_ctm_energy_fn (implicit fixed_point default)."""
+def build_loss(
+    gate, chi: int, depth: int, *, explicit: bool, warmup: int, backward_steps=None
+):
+    """``A -> energy`` via make_ctm_energy_fn (implicit fixed_point default).
+
+    ``backward_steps=K`` (explicit only) enables TBPTT (#506): only the last K of
+    the ``depth`` checkpointed sweeps are differentiated. Use to measure the
+    truncated-backprop RUNTIME lever (#570): warm-step vs implicit on the A100.
+    """
     ctm_cfg = CTMConfig(
         chi=chi,
         max_iter=depth,
@@ -189,7 +196,7 @@ def build_loss(gate, chi: int, depth: int, *, explicit: bool, warmup: int):
         use_explicit=explicit,
         explicit_warmup=warmup,
         explicit_steps=depth,
-        explicit_backward_steps=None,
+        explicit_backward_steps=backward_steps,
     )
 
     def loss_fn(A_param):
@@ -238,11 +245,20 @@ def _cold(fn, A, cap: _CompileCapture):
     return wall, list(cap.events), out
 
 
-def profile_config(sym, D, chi, depth, *, explicit, warmup, reps, cap):
+def profile_config(
+    sym, D, chi, depth, *, explicit, warmup, reps, cap, backward_steps=None
+):
     """One (sym,D,chi,depth,path) cell: cold fwd + cold v&g + warm steps."""
     A, gate = make_site_and_gate(sym, D, seed=42)
     n_blocks = getattr(A, "n_blocks", 1)
-    loss_fn = build_loss(gate, chi, depth, explicit=explicit, warmup=warmup)
+    loss_fn = build_loss(
+        gate,
+        chi,
+        depth,
+        explicit=explicit,
+        warmup=warmup,
+        backward_steps=backward_steps,
+    )
     vg = jax.value_and_grad(loss_fn)
 
     # (4a) cold forward-only: forward-step compile + run, NO backward graph.
@@ -270,6 +286,7 @@ def profile_config(sym, D, chi, depth, *, explicit, warmup, reps, cap):
         "chi": chi,
         "depth": depth,
         "path": "explicit" if explicit else "implicit",
+        "backward_steps": backward_steps,
         "n_blocks": int(n_blocks),
         "fwd_wall_s": fwd_wall,
         "fwd_compile_s": fwd_compile,
@@ -315,8 +332,19 @@ def main() -> None:
     )
     ap.add_argument("--warmup", type=int, default=3, help="Explicit warmup sweeps.")
     ap.add_argument("--reps", type=int, default=3, help="Warm steady-state reps.")
+    ap.add_argument(
+        "--backward-steps",
+        type=int,
+        default=None,
+        help="Explicit TBPTT (#506/#570): differentiate only the last K sweeps. "
+        "Implies the explicit path; use to measure the truncated-backprop RUNTIME "
+        "lever (warm-step vs implicit). Default None = full backprop.",
+    )
     ap.add_argument("--json", type=str, default=None)
     args = ap.parse_args()
+    # --backward-steps only affects the explicit path; auto-enable it.
+    if args.backward_steps is not None:
+        args.explicit = True
 
     cap = _install_compile_capture()
     dev = jax.devices()[0]
@@ -338,6 +366,7 @@ def main() -> None:
         "syms": args.sym,
         "depths": args.depth,
         "explicit": args.explicit,
+        "backward_steps": args.backward_steps,
     }
 
     # Build the (sym, D, chi, depth, path) grid.
@@ -376,6 +405,7 @@ def main() -> None:
                 warmup=args.warmup,
                 reps=args.reps,
                 cap=cap,
+                backward_steps=args.backward_steps if explicit else None,
             )
         except Exception as exc:  # noqa: BLE001 - record + continue the sweep
             print(


### PR DESCRIPTION
## Summary

A CPU, trace-only diagnostic of the symmetric CTM-AD compile wall, following the #200 P-B4 NO-GO (PR #587) which settled the wall is the **backend-invariant** implicit-diff backward `_jit_fused_fixed_point_bwd` and prescribed: *profile which sub-ops dominate before committing #570 work.* This PR does that — then tests every cheap #570 lever to exhaustion. **Net result: the cheap compile levers are all falsified; the wall is #566 per-block structural emission in the SVD/projector wrapper.**

No production code is changed — diagnostics + findings only.

## Findings

1. **Source-attributed localization.** The `svd_vjp` bucket is **61% of the fused backward at D=4/χ=12** and the only χ-scaling term. Probe validated (reproduces the recorded 150,663-op backward).
2. **QR/eigh premise.** The compile-dominant 2×2 symmetric projector is **SVD-hardcoded** (`projector_method` is a no-op there).
3. **SVD-via-eigh — FALSIFIED.** eigh of the Gram matrix has the *same* `1/(sᵢ²−sⱼ²)` F-matrix; 274 vs 265 backward ops with full `(U,s,Vh)` reconstruction. No win.
4. **Re-localization (key result).** Drilling `svd_vjp`: **~60% per-sector block pack/unpack + ~25% per-sector gauge-fixing, ~0% decomposition** — #566 per-block structural emission localized in the wrapper. Batched-decomposition (`TENAX_BATCH_BLOCKSPARSE=1`) halves kernels (48→24) but ops −0.7%.
5. **Truncated backprop — accurate but NOT a compile lever.** TBPTT op-count is *strictly ≥* implicit (K sweep-VJPs unrolled vs one in a while_loop); gradient converges geometrically (rel err 1.9e-7 at K=8). A runtime/robustness lever.

## Consolidated verdict

All three decomposition/truncation levers leave the wall intact, because it is the **per-sweep VJP op count = #566 per-block structural emission**. The only compile lever is extending the **stacked-block representation (PR #586, contraction-only) to the SVD/projector wrapper**. #570's QR + truncated-backprop are **large-χ GPU/TPU runtime** levers, not a compile fix. Compile is one-time — pursuing it further is a scope decision; the measurements are complete.

## Artifacts
- `examples/probe_bwd_subop_attribution_570.py`, `probe_decomp_vjp_cost_570.py`, `probe_truncated_backprop_570.py`
- `docs/superpowers/handoffs/2026-06-08-{fixed-point-bwd-subop-attribution,570-relocalized-not-decomposition,570-truncated-backprop-not-a-compile-lever}-570*.md`
- `docs/superpowers/specs/2026-06-08-svd-via-eigh-fishman-projector-570.md` (FALSIFIED record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)