### PR TITLE
docs(#570): correct mechanism — AD projector is block-sparse (per-sector) SVD, not dense; lever-3 moot

### DIFF
--- a/docs/superpowers/handoffs/2026-06-07-570-svd-vjp-compile-finding.md
+++ b/docs/superpowers/handoffs/2026-06-07-570-svd-vjp-compile-finding.md
@@ -1,6 +1,18 @@
-# #570 finding — the CTM-AD compile wall is the dense **SVD projector VJP**, and it is `projector_method`-invariant
+# #570 finding — the CTM-AD compile wall is the **SVD projector VJP**, and it is `projector_method`-invariant
 
 **Date:** 2026-06-07 (A100) · **Follows:** [`2026-06-07-cutensornet-pb4-finding-nogo.md`](2026-06-07-cutensornet-pb4-finding-nogo.md) (#200 NO-GO) · **Issue:** #570
+
+> **Correction (2026-06-08).** This doc originally said the wall is a **dense** SVD on the
+> χ-sized corner (and that the AD path "densifies" via the "Task 2.2" fallback). That
+> *mechanism* is **wrong**: the production fermionic path uses the **block-sparse**
+> `_compute_2x2_projector_symmetric` (`_ctm_tensor_projector_2x2.py`), which is tracer-safe
+> end-to-end (Issue #435) and runs **per-sector** `truncated_svd_ad` via
+> `_truncated_svd_symmetric_traced`. The "Task 2.2 dense fallback" lives in the **1×1**
+> recipe (`_ctm_projector.py`), which the production path does **not** use. The wall is the
+> **block-sparse (per-sector) SVD VJP**, already implemented — so the "implement block-sparse
+> SVD VJP (lever-3)" follow-up below is **moot**. All *conclusions* stand unchanged
+> (SVD-only, `projector_method`-invariant, super-linear in χ); only the dense-vs-block-sparse
+> mechanism is corrected inline below. See `2026-06-08-570-mechanism-correction.md`.
 
 ## TL;DR
 
@@ -9,15 +21,20 @@ fixed-point backward `_jit_fused_fixed_point_bwd` and proved it **backend-invari
 (perblock → stacked → cuTensorNet does not move it). The open #570 question was *which
 sub-op inside that backward dominates the compile*. Answer, with two parts:
 
-1. **It is the decomposition VJP — specifically a dense SVD.** The dominant repeated
-   compile unit (`apply_Jt`, one gauge-fixed sweep VJP) carries **24 dense `svd`
-   primitives** (D=2/χ=12 trace). Its cold XLA compile grows **super-linearly in χ**
+1. **It is the decomposition VJP — a block-sparse, per-sector SVD.** The dominant repeated
+   compile unit (`apply_Jt`, one gauge-fixed sweep VJP) carries **24 `svd`
+   primitives** (D=2/χ=12 trace), one per charge-sector block of each projector's M matrix
+   (the corner has 2 sectors; the SVD operands here are (24,24) per-sector blocks — *not*
+   one dense χ-corner). Its cold XLA compile grows **super-linearly in χ**
    (~χ^1.3): a *single* sweep-VJP unit goes **50.7 s → 522.9 s** as χ goes 6 → 36 (10.3×).
    This is the χ-driver behind the ~549 s full-backward wall.
 
 2. **But it is `projector_method`-invariant — the production path is SVD-only.** The
    default `recipe="2x2"` plaquette projector (`_ctm_tensor_projector_2x2.py`) contains
-   **no** `qr`/`eigh`/`projector_method` code — it is hardwired to `jnp.linalg.svd`.
+   **no** `qr`/`eigh`/`projector_method` code; for SymmetricTensor inputs it always routes
+   to the block-sparse `_compute_2x2_projector_symmetric`, which uses `tenax.linalg.svd`
+   (per-sector). (The dense variant `_compute_2x2_projector` → `jnp.linalg.svd` is reached
+   only for all-DenseTensor inputs.)
    `svd`/`qr`/`eigh` all trace to a **byte-identical** backward graph (TOTAL=34927; 24
    `svd`, 0 `qr`, 0 `eigh` in every case). `projector_method` only affects the alternate
    1×1 recipe (`_compute_projector_tensor`), which the production fermionic path does not use.
@@ -76,16 +93,20 @@ counts (52,842 / 111,934 at χ=6 / 12) in the smoke run.
 - The production fermionic CTM-AD loss (`make_ctm_energy_fn`, `iPEPSConfig` defaults,
   `gs_implicit_ad=True`, `adjoint_method="fixed_point"`) runs the symmetric tensor sweep
   `_ctm_tensor_sweep_multisite` with the default `recipe="2x2"`, whose projector is
-  `_compute_2x2_projector` / `_compute_plaquette_projector_pair`. That file
-  (`_ctm_tensor_projector_2x2.py`) is **SVD-only** (`_gauge_fixed_svd` → `jnp.linalg.svd`);
-  it never reads `projector_method`.
+  `_compute_2x2_projector` / `_compute_plaquette_projector_pair`. For SymmetricTensor
+  inputs `_compute_2x2_projector` dispatches **all** cases — including tracer-bearing AD
+  backward — to the **block-sparse** `_compute_2x2_projector_symmetric` (tracer-safe
+  end-to-end, Issue #435), which calls `tenax.linalg.svd` →
+  `_truncated_svd_symmetric_traced` → **per-sector** `truncated_svd_ad`. It is **SVD-only**
+  (no `qr`/`eigh` branch) but **block-sparse**, never `jnp.linalg.svd` on the full corner.
 - `projector_method` (`svd`/`qr`/`eigh`) only branches inside the **1×1** recipe's
-  `_compute_projector_tensor` (`_ctm_projector.py`), and even there the **AD-traced**
-  path deliberately densifies to an SVD VJP (the "Task 2.2" design decision, lines
-  ~946–962: backward keeps a dense fallback rather than a block-sparse AD-traced SVD).
-- So under AD, the decomposition the backward differentiates is **always a dense SVD on
-  the χ-sized corner matrix**, per projector. Its VJP (the SVD-gradient F-matrix dense
-  algebra) is what grows with χ and dominates compile.
+  `_compute_projector_tensor` (`_ctm_projector.py`), which the production path does not use.
+  (That 1×1 path *does* have the "Task 2.2" dense fallback at lines ~946–962 — but it is
+  irrelevant here.)
+- So under AD, the decomposition the backward differentiates is a **block-sparse SVD: one
+  per-sector `truncated_svd_ad` per charge block, per projector** (24 such ops at D=2/χ=12).
+  Each per-sector VJP (the SVD-gradient F-matrix dense algebra over that sector's block) is
+  what grows with χ; summed over sectors × projectors, it dominates compile.
 
 ## Implication for #570 — the levers, re-scoped
 
@@ -102,10 +123,13 @@ counts (52,842 / 111,934 at χ=6 / 12) in the smoke run.
    directly and is orthogonal to projector choice. Lower risk; the main validation is
    gradient/energy parity vs the exact fixed-point adjoint.
 
-3. **Lever-3 (alternative): block-sparse AD-traced SVD VJP.** Replace the dense-corner SVD
-   fallback with a per-sector truncated SVD VJP (smaller decomps). The design note flags
-   the static-shape-per-sector (`k_q` must be a Python int) complexity. Medium effort,
-   directly attacks the measured cost.
+3. ~~**Lever-3 (alternative): block-sparse AD-traced SVD VJP.**~~ **MOOT — already
+   implemented.** The production 2×2 path *already* differentiates a per-sector block-sparse
+   SVD (`_truncated_svd_symmetric_traced`), so there is no dense fallback to replace. The
+   per-sector block-SVD VJP cost *is* the wall. The remaining structural lever is **batching
+   the equal-shaped per-sector SVD-VJP units** into one vmapped graph to cut the XLA-module
+   count (the #566/#569 `TENAX_BATCH_BLOCKSPARSE` axis — built and benchmarked for *runtime*
+   ["never a net win" through D=6], but its effect on the *compile* wall is unmeasured).
 
 ## Next experiment (whichever lever)
 
@@ -113,8 +137,9 @@ counts (52,842 / 111,934 at χ=6 / 12) in the smoke run.
 sweep-VJP `total_compile_s` and `env_hlo_instr` vs the SVD baseline above:
 - **truncated backprop:** compile the N-sweep unrolled backward for N ∈ {1,2,4} and show
   compile scales with N while energy/grad track the full adjoint.
-- **QR-in-2×2 / block-sparse SVD:** once implemented, expect `total_compile_s` to drop and
-  flatten in χ relative to the SVD curve above.
+- **batched block-sparse SVD VJP (`TENAX_BATCH_BLOCKSPARSE`):** re-run with the gate ON and
+  check whether `total_compile_s` / `env_hlo_instr` drop relative to the per-sector baseline
+  above (the open compile question, since #569 only measured runtime).
 
 ## What would change the conclusion
 

--- a/docs/superpowers/handoffs/2026-06-08-570-lever2-truncated-backprop-nogo.md
+++ b/docs/superpowers/handoffs/2026-06-08-570-lever2-truncated-backprop-nogo.md
@@ -2,6 +2,13 @@
 
 **Date:** 2026-06-08 (A100) · **Follows:** [`2026-06-07-570-svd-vjp-compile-finding.md`](2026-06-07-570-svd-vjp-compile-finding.md) · **Issue:** #570
 
+> **Correction (2026-06-08).** Where this doc says "**dense** block-SVD VJP" or "**dense**-corner
+> SVD fallback," read **block-sparse (per-sector) SVD VJP**: the production 2×2 path already
+> differentiates a per-sector block-sparse SVD (`_compute_2x2_projector_symmetric` →
+> `_truncated_svd_symmetric_traced`, Issue #435), not a dense corner SVD. Consequently
+> **"lever-3" is moot — already implemented** (see `2026-06-08-570-mechanism-correction.md`).
+> The lever-2 NO-GO conclusion and all measurements are **unaffected**.
+
 ## TL;DR
 
 The #570 SVD-VJP finding recommended **lever-2 (truncated backprop / TBPTT)** as the
@@ -18,7 +25,7 @@ already implemented (`ctm_energy_explicit`, `backward_steps`, #506). Measured on
   (1.27–1.28×). The explicit path emits **1254–1257 compile units** vs the implicit
   adjoint's **236**.
 
-**Why:** the per-sweep **dense block-SVD VJP** is irreducible in *both* paths — any gradient
+**Why:** the per-sweep **block-sparse (per-sector) SVD VJP** is irreducible in *both* paths — any gradient
 needs ≥1 differentiated block-sparse SVD sweep (~250 s at D=2/χ=12), and the explicit unroll
 only adds forward-unroll compile on top (it traces the *whole* forward into one XLA module;
 `stop_gradient` removes backward ops but keeps the forward sweeps, while the implicit path
@@ -27,7 +34,7 @@ changes *how many* sweeps are differentiated, not the per-sweep SVD-VJP cost.
 
 This makes **three levers, all NO-GO for the compile wall** — #200 contraction backend,
 #570 lever-1 (QR projector), #570 lever-2 (truncated backprop) — all because the wall is the
-per-sweep dense block-SVD VJP emission, which none of them touches.
+per-sweep block-sparse (per-sector) SVD VJP emission, which none of them touches.
 
 ## Method
 
@@ -89,15 +96,18 @@ unmeasured here. If the goal shifts from compile to warm-step, re-open with a ru
 
 ## Conclusion for #570
 
-The compile wall is the **per-sweep dense block-SVD VJP**, and it is irreducible under both
-the implicit adjoint and any explicit unroll (you always differentiate ≥1 block-SVD sweep).
-Projector-swap (lever-1) and backprop-truncation (lever-2) both leave that per-sweep cost
-intact. **The only remaining lever that targets it is lever-3: a block-sparse (per-sector)
-AD-traced SVD VJP** — replace the dense-corner SVD fallback (the deliberate "Task 2.2"
-densification in `_ctm_projector.py`, and the SVD-only 2×2 plaquette path) with per-sector
-truncated SVD VJPs (smaller decomps, fewer emitted ops), the static-shape-per-sector `k_q`
-being the known complication. Absent that, the wall appears intrinsic to differentiating a
-block-sparse SVD in XLA.
+The compile wall is the **per-sweep block-sparse (per-sector) SVD VJP**, and it is
+irreducible under both the implicit adjoint and any explicit unroll (you always
+differentiate ≥1 block-SVD sweep). Projector-swap (lever-1) and backprop-truncation
+(lever-2) both leave that per-sweep cost intact. **Lever-3 (a block-sparse per-sector
+AD-traced SVD VJP) is NOT a new lever — the production 2×2 path already does exactly this**
+(`_compute_2x2_projector_symmetric` → `_truncated_svd_symmetric_traced`; the "Task 2.2"
+dense fallback in `_ctm_projector.py` is in the unused 1×1 recipe). So the per-sector
+block-SVD VJP cost *is* the wall. The remaining structural lever is **batching the
+equal-shaped per-sector SVD-VJP units** into one vmapped graph (the #566/#569
+`TENAX_BATCH_BLOCKSPARSE` axis — built, benchmarked for runtime ["never a net win" through
+D=6], compile effect unmeasured). Absent a compile win there, the wall appears intrinsic to
+differentiating a block-sparse SVD in XLA.
 
 ## Artifacts
 

--- a/docs/superpowers/handoffs/2026-06-08-570-mechanism-correction.md
+++ b/docs/superpowers/handoffs/2026-06-08-570-mechanism-correction.md
@@ -1,0 +1,64 @@
+# #570 correction — the AD CTM projector is block-sparse (per-sector) SVD, not dense; "lever-3" is already implemented
+
+**Date:** 2026-06-08 · **Corrects:** [`2026-06-07-570-svd-vjp-compile-finding.md`](2026-06-07-570-svd-vjp-compile-finding.md) (lever-1), [`2026-06-08-570-lever2-truncated-backprop-nogo.md`](2026-06-08-570-lever2-truncated-backprop-nogo.md) (lever-2) · **Issue:** #570
+
+## What was wrong
+
+Both prior #570 finding docs described the CTM-AD compile wall as a **dense** SVD VJP on the
+χ-sized corner matrix, and cited the "Task 2.2 dense fallback" in `_ctm_projector.py` as the
+mechanism — concluding that a **lever-3** ("implement a block-sparse AD-traced SVD VJP") was
+the remaining work. That mechanism is **incorrect**, and lever-3 (as scoped) is **moot**.
+
+## Ground truth (code-level + verified by trace)
+
+The production fermionic CTM-AD path uses the default `recipe="2x2"` plaquette projector.
+For SymmetricTensor inputs, `_compute_2x2_projector` (`_ctm_tensor_projector_2x2.py:399-416`)
+routes **all** cases — including tracer-bearing AD-backward — to the **block-sparse**
+`_compute_2x2_projector_symmetric` ("tracer-safe end-to-end, Issue #435"). That calls
+`tenax.linalg.svd`, which under tracing dispatches to `_truncated_svd_symmetric_traced`
+(`linalg.py`), running a **per-sector** `truncated_svd_ad` on each charge block.
+
+So under AD the backward differentiates a **per-sector block-sparse SVD**, never a dense
+`jnp.linalg.svd` on the full corner. The dense `_compute_2x2_projector` →
+`_gauge_fixed_svd` → `jnp.linalg.svd` branch is reached **only for all-DenseTensor inputs**.
+The "Task 2.2 dense fallback" (`_ctm_projector.py:~946-962`) lives in the **1×1** recipe
+(`_compute_projector_tensor`), which the production path **does not use**.
+
+Verification (D=2, χ=12, fermionic, `apply_Jt` traced backward):
+- The 24 `svd` primitives operate on **(24,24) per-sector blocks**, not one dense χ-corner.
+- The corner `C1` is a SymmetricTensor with **2 charge sectors** of (6,6) — block-sparse.
+- (Method/qr/eigh still trace byte-identical because the 2×2 symmetric path has no
+  `qr`/`eigh` branch — it always uses `tensor_svd`. The `projector_method`-invariance
+  conclusion is unchanged; only "dense" was wrong.)
+
+## What stands unchanged
+
+All *conclusions* of both prior docs hold:
+- The wall is the **decomposition (SVD) VJP** inside `_jit_fused_fixed_point_bwd`,
+  super-linear in χ (one sweep-VJP unit 50.7 s → 522.9 s as χ 6 → 36).
+- **Lever-1 (QR projector) is a no-op as a config flip** (the 2×2 path has no QR).
+- **Lever-2 (truncated backprop) is a NO-GO for the compile wall** (best 0.88× implicit).
+
+Only the dense-vs-block-sparse *mechanism* description is corrected.
+
+## Implication — the levers, re-scoped (again)
+
+- **Lever-3 ("implement block-sparse SVD VJP") is moot** — it already exists and *is* the
+  wall. The per-sector block-SVD VJP, summed over sectors × projectors × the fixed-point
+  backward, is the irreducible cost.
+- The remaining structural lever to cut compile is **batching the equal-shaped per-sector
+  SVD-VJP units** into one vmapped graph (fewer XLA modules) — the #566/#569
+  `TENAX_BATCH_BLOCKSPARSE` axis. It is **built and benchmarked for runtime** ("never a net
+  win" through D=6, A100) but its effect on the **compile wall** was never measured (the
+  #569 summary is warm-step only). That is the one open, low-cost question (gate ON vs OFF,
+  `total_compile_s` / `env_hlo_instr` via `examples/profile_570_sweepvjp_compile.py`).
+- If batching doesn't cut compile either, the wall is **intrinsic** to differentiating N
+  per-sector block-sparse SVDs in XLA, and #570 should conclude.
+
+## How this happened (so it doesn't recur)
+
+The lever-1 doc inferred the dense mechanism from the *1×1* recipe's "Task 2.2" comment
+without confirming which recipe the production path runs, and read "SVD-only" (true) as
+"dense SVD" (false). The fix was a 10-minute code trace (dispatch in
+`_ctm_tensor_projector_2x2.py`) + a jaxpr shape probe. Lesson: when attributing a cost to a
+specific code path, confirm the dispatch actually reaches it before writing the mechanism.


### PR DESCRIPTION
## Summary

Corrects a **mechanism error** in the two merged #570 finding docs (PR #588, #590). They
described the CTM-AD compile wall as a **dense** SVD on the χ-corner and cited the
"Task 2.2 dense fallback" — concluding a future **lever-3** ("implement a block-sparse SVD
VJP") was needed. While scoping lever-3 I found that mechanism is **wrong** and lever-3 is
**already implemented**. Docs only; no `src/` changes.

## Ground truth (code + jaxpr trace)

- The production fermionic path's default `recipe="2x2"` plaquette projector routes **all**
  SymmetricTensor inputs — including tracer-bearing AD backward — to the **block-sparse**
  `_compute_2x2_projector_symmetric` ("tracer-safe end-to-end", Issue #435) →
  `_truncated_svd_symmetric_traced` → **per-sector** `truncated_svd_ad`.
- The 24 `svd` ops at D=2/χ=12 operate on **(24,24) per-sector blocks** (the corner `C1`
  has 2 charge sectors of (6,6)) — **not** one dense χ-corner.
- The dense `jnp.linalg.svd` 2×2 variant is reached **only for all-DenseTensor inputs**; the
  "Task 2.2 dense fallback" is in the **unused 1×1 recipe**.

## What stands (unchanged)

All *conclusions* of both docs hold: the wall is the decomposition (SVD) VJP, super-linear
in χ; **lever-1 (QR) is a no-op as a config flip**; **lever-2 (truncated backprop) is a
NO-GO for the compile wall**. Only the dense-vs-block-sparse *mechanism* is corrected.

## Consequence

- **Lever-3 is moot** — the per-sector block-SVD VJP already exists and *is* the wall.
- The only remaining, **untested** compile lever is **batching** the equal-shaped per-sector
  SVD-VJP units (`TENAX_BATCH_BLOCKSPARSE`, the #566/#569 axis — built, runtime-benchmarked
  "never a net win", compile effect unmeasured).

## Changes
- Correction banner + inline fixes on `2026-06-07-570-svd-vjp-compile-finding.md` and
  `2026-06-08-570-lever2-truncated-backprop-nogo.md`
- New standalone record `2026-06-08-570-mechanism-correction.md` (incl. how it happened)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
