### PR TITLE
docs(#570): batching is a real ~20% compile lever (HLO); reconcile w/ #589 (structural emission, not F-matrix); conclude #570

### DIFF
--- a/docs/superpowers/handoffs/2026-06-07-570-svd-vjp-compile-finding.md
+++ b/docs/superpowers/handoffs/2026-06-07-570-svd-vjp-compile-finding.md
@@ -13,6 +13,15 @@
 > SVD VJP (lever-3)" follow-up below is **moot**. All *conclusions* stand unchanged
 > (SVD-only, `projector_method`-invariant, super-linear in χ); only the dense-vs-block-sparse
 > mechanism is corrected inline below. See `2026-06-08-570-mechanism-correction.md`.
+>
+> **Further correction (2026-06-08, PR #589).** A deeper sub-op drill-down shows the cost
+> *inside* the per-sector SVD VJP is **~60% block pack/unpack + ~25% gauge-fixing, ~0%
+> decomposition** — i.e. **#566 per-sector *structural* emission**, **not** the "SVD-gradient
+> F-matrix algebra" this doc says (e.g. the "Why (mechanistic)" bullet below). Read every
+> "F-matrix / decomposition cost" here as **structural block-pack + gauge-fix emission**. The
+> super-linear-in-χ and `projector_method`-invariant conclusions are unaffected. See
+> `2026-06-08-570-relocalized-not-decomposition.md` (PR #589) and
+> `2026-06-08-570-batching-compile-finding.md`.
 
 ## TL;DR
 
@@ -103,10 +112,12 @@ counts (52,842 / 111,934 at χ=6 / 12) in the smoke run.
   `_compute_projector_tensor` (`_ctm_projector.py`), which the production path does not use.
   (That 1×1 path *does* have the "Task 2.2" dense fallback at lines ~946–962 — but it is
   irrelevant here.)
-- So under AD, the decomposition the backward differentiates is a **block-sparse SVD: one
-  per-sector `truncated_svd_ad` per charge block, per projector** (24 such ops at D=2/χ=12).
-  Each per-sector VJP (the SVD-gradient F-matrix dense algebra over that sector's block) is
-  what grows with χ; summed over sectors × projectors, it dominates compile.
+- So under AD, the backward differentiates a **per-sector block-sparse SVD wrapper: one
+  `truncated_svd_ad` per charge block, per projector** (24 such ops at D=2/χ=12). The
+  compile cost of each per-sector VJP is **NOT the decomposition math** (the SVD-gradient
+  F-matrix is ~0% — PR #589) but the **per-sector structural emission around it** (block
+  pack/unpack ~60% + gauge-fix/sign-logic ~25%), which grows with χ via surviving-sector
+  count; summed over sectors × projectors, it dominates compile.
 
 ## Implication for #570 — the levers, re-scoped
 

--- a/docs/superpowers/handoffs/2026-06-08-570-batching-compile-finding.md
+++ b/docs/superpowers/handoffs/2026-06-08-570-batching-compile-finding.md
@@ -1,22 +1,28 @@
-# #570 — batching (`TENAX_BATCH_BLOCKSPARSE`) is the only lever that moves the compile wall (~15–22%, bounded); #570 conclusion
+# #570 — batching (`TENAX_BATCH_BLOCKSPARSE`) IS a ~15–22% compile lever (HLO-measured), correcting the op-count dismissal; #570 conclusion
 
-**Date:** 2026-06-08 (A100) · **Follows:** [`2026-06-08-570-mechanism-correction.md`](2026-06-08-570-mechanism-correction.md) · **Issue:** #570
+**Date:** 2026-06-08 (A100) · **Builds on / corrects:** PR #589 (`2026-06-08-570-relocalized-not-decomposition.md`) · **Issue:** #570
 
 ## TL;DR
 
-After the mechanism correction (the AD projector is already block-sparse per-sector SVD, so
-"lever-3" was moot), the one remaining untested compile lever was **batching** the per-sector
-block-sparse work (`TENAX_BATCH_BLOCKSPARSE`, the #566/#569 umbrella gate). Measured gate
-OFF vs ON on the sweep-VJP compile rig:
+PR #589 nailed the **mechanism**: the compile wall is **#566 per-sector *structural* emission**
+(block pack/unpack + gauge-fixing) lexically inside the SVD/projector wrapper — the decomposition
+math (SVD-gradient F-matrix) is **~0%**. (This corrects my earlier #570 docs, which wrongly
+attributed the wall to the "SVD-gradient Lorentzian F-matrix algebra" — see the correction notes
+on `2026-06-07-570-svd-vjp-compile-finding.md` etc.)
 
-- **It works — modestly.** ON reduces the compiled backward by **~15–22%** (deterministic HLO
-  instruction count), with compile time tracking. This is the **first and only** lever that
-  measurably moves the compile wall.
-- **It does not scale toward the target.** The reduction is **bounded ~20% and slightly
-  *diminishes* with χ** (it shrinks the *contraction/block-pack* part of the VJP, while the
-  dominant *per-sector SVD-VJP* — which batching cannot reduce — grows with χ).
-- **It has a runtime cost.** #569 already showed batching is a *warm-step* loss ("never a net
-  win" through D=6). So ON is a **compile↓ / runtime↑ trade-off**, not a free win.
+PR #589 also tested **batching** (`TENAX_BATCH_BLOCKSPARSE`) and dismissed it — but judged it by
+**jaxpr op-count** (svd_vjp −0.7%, TOTAL +2.8%) and concluded "not a compile lever." That measure
+is the wrong one: **jaxpr op-count ≠ lowered-HLO size**. Measured at the **HLO/compile level**, the
+gate **does** help:
+
+- **~15–22% smaller compiled backward** (deterministic HLO instruction count), compile time tracks.
+- It is the **only lever that measurably moves the compile wall** — because it *is* the partial,
+  already-available form of #589's recommended fix (stack the per-sector structural ops across
+  sectors → fewer lowered kernels: #589 noted svd kernels 48→24).
+- **Bounded** (~20%, doesn't scale with χ) and carries a **runtime penalty** (#569: warm-step loss).
+
+Reconciliation: #589's "+2.8% jaxpr ops" and this "−20% HLO instrs" are **both correct and
+consistent** — the stacked form adds a few trace-level ops but XLA lowers it to fewer kernels.
 
 ## Results (A100, fermionic, x64, sweep-VJP unit, `--full` = env+params)
 
@@ -35,65 +41,70 @@ OFF vs ON on the sweep-VJP compile rig:
 | 12 | 111,934 | 102,223 | 0.91× | 104.1 s | 100.1 s |
 | 24 | 307,580 | 240,354 | 0.78× | 296.8 s | 232.1 s |
 
-HLO instruction count is **deterministic** (independent of run/contention), so the 0.78–0.84×
-ratios are the rigorous core; compile-time ratios (measured; D=4 OFF/ON were run concurrently
-so their *absolute* timings are CPU-contended, but the OFF and ON runs were contended equally
-and the ratios match the deterministic instr ratios). Raw: `570_results/profile_570_d4_batch{off,on}.json`,
-`570_results/profile_570_batch_on_a100.json` (D=2 ON) vs `profile_570_sweepvjp_a100.json` (D=2 OFF).
+HLO instruction count is **deterministic** (independent of run/CPU contention), so the 0.78–0.84×
+ratios are the rigorous core; compile-time ratios track them. (D=4 OFF/ON ran concurrently, so their
+*absolute* timings are equally CPU-contended; the ratios still hold against the deterministic instr
+ratios.) Raw: `570_results/profile_570_d4_batch{off,on}.json`, `…/profile_570_batch_on_a100.json`
+(D=2 ON) vs `…/profile_570_sweepvjp_a100.json` (D=2 OFF).
 
-## Why it's bounded (mechanism)
+## Why ~20% and bounded (mechanism, per #589 + this)
 
-`TENAX_BATCH_BLOCKSPARSE` is an **umbrella** gate. In the AD backward it does **not** reduce the
-SVD primitives — those are single-sector per projector call (24 ops of (96,96) at D=4, identical
-on/off at the jaxpr level), so the within-call sector-batching in `_truncated_svd_symmetric_traced`
-has nothing to group. What it *does* reduce is the **contraction / block-pack** emission
-(`contractor.py` batched path): fewer `dot_general` / scatter / reshape instructions around the
-SVDs. That is a roughly **fixed-fraction** overhead, so as χ grows the un-batched SVD-VJP grows
-faster and the batching win becomes a smaller share (0.80→0.84 across χ=8→16 at D=4).
+The wall bucket is **~60% per-sector block pack/unpack + ~25% per-sector gauge-fix, ~0%
+decomposition** (#589's drill-down: `broadcast_in_dim`, `scatter_mul`, `squeeze`/`reshape`/`slice`,
+`_fix_svd_signs` sign logic). `TENAX_BATCH_BLOCKSPARSE` is an umbrella gate that **stacks the
+per-sector block/contraction ops across sectors**, so XLA lowers them to fewer kernels → ~20% fewer
+HLO instructions. But the gate does **not** vectorize the per-sector **gauge-fix / sign logic**
+(`_gauge_fix_symmetric_svd`, `_fix_svd_signs` — #589's ~25%), and the SVD primitives stay per-call.
+So the win is capped at the block-pack share and slightly **diminishes with χ** (0.80→0.84 across
+χ=8→16 at D=4) as the un-stacked gauge-fix/sign part grows with surviving sectors.
 
-(An XLA `slow_operation_alarm` fired on constant-folding a `scatter-add` of shape
-`f64[16,6,6,8,8,8]` during the D=4 backward — direct evidence that block-pack scatter emission is
-a real slice of the compile, which is exactly the part batching trims.)
+(Direct corroboration: an XLA `slow_operation_alarm` fired constant-folding a `scatter-add` of
+shape `f64[16,6,6,8,8,8]` during the D=4 backward — block-pack scatter emission is a real,
+trimmable slice of compile.)
 
-## Methodological note (so it doesn't recur)
+## Method lesson (recorded twice now, both directions)
 
-A cheap **jaxpr `svd`-primitive count** diff (off vs on) showed *identical* graphs — which led me
-to predict "no effect." That was wrong: **jaxpr primitive count ≠ lowered-HLO instruction count**.
-The umbrella gate restructures contraction lowering without changing the `svd` primitive count, so
-only the **compile/HLO measurement** revealed the ~20% win. Trust the HLO/compile measurement over
-jaxpr op-counts for compile-cost questions.
+`jaxpr` primitive op-count is **not** a proxy for lowered-HLO / compile size:
+- I earlier predicted batching = "no-op" from an identical jaxpr `svd`-count → wrong (HLO −20%).
+- #589 dismissed batching from jaxpr op-count +2.8% → also missed the HLO −20%.
+
+For any **compile-cost** question, measure the **HLO/compiled** artifact, not the jaxpr.
 
 ## #570 conclusion — levers exhausted
-
-The minutes-long fermionic CTM-AD compile wall (`_jit_fused_fixed_point_bwd`, ~549 s at D=4/χ=12)
-is dominated by the **per-sector block-sparse SVD VJP**, summed over sectors × projectors × the
-fixed-point backward. Lever inventory:
 
 | Lever | Verdict | Why |
 |---|---|---|
 | #200 cuTensorNet contraction backend | NO-GO | backend-invariant; wall isn't the contraction executor |
 | Lever-1: QR projector | NO-GO | no-op as config flip (2×2 path is SVD-only; QR only in unused 1×1) |
-| Lever-2: truncated backprop | NO-GO (compile) | per-sweep SVD-VJP irreducible; explicit unroll ≈/worse than implicit |
-| Lever-3: block-sparse per-sector SVD VJP | MOOT | already implemented — it *is* the wall |
-| **Batching (`TENAX_BATCH_BLOCKSPARSE`)** | **PARTIAL** | **~15–22% compile, bounded, doesn't scale; + runtime penalty (#569)** |
+| Lever-2: truncated backprop | NO-GO (compile) | per-sweep structural emission irreducible; explicit unroll ≈/worse than implicit. (Runtime/robustness lever, not compile — #589 §5 agrees.) |
+| Lever-3: "implement block-sparse SVD VJP" | MOOT | already implemented; and the cost isn't the decomposition anyway (#589) |
+| **Batching (`TENAX_BATCH_BLOCKSPARSE`)** | **PARTIAL** | **~15–22% compile (HLO), bounded; + runtime penalty (#569)** |
 
-**No available lever reaches the original #200 target (~40× toward a ~13 s dense floor).** The wall
-is intrinsic to differentiating N per-sector block-sparse SVDs in XLA: the SVD-gradient (Lorentzian
-F-matrix) dense algebra per sector, super-linear in χ, summed over all projectors. Batching trims
-the surrounding contraction by ~20% but cannot touch the SVD-VJP core.
+**The wall is #566 per-sector structural emission** (block pack/unpack + gauge-fix), super-linear in
+χ via surviving-sector count, summed over projectors × the fixed-point backward. No available lever
+reaches the original #200 target (~40× toward a ~13 s dense floor).
+
+### The one lever that could go further
+
+Both threads converge on it: **extend the stacked-block representation (PR #586, contraction-only)
+to the SVD/projector wrapper** — stack the per-sector pack/unpack **and** gauge-fix/sign-fix across
+sectors instead of looping. `TENAX_BATCH_BLOCKSPARSE` already does the block/contraction part (this
+doc's ~20%); the remaining prize is vectorizing `_gauge_fix_symmetric_svd` + `_fix_svd_signs` (#589's
+~25% bucket) across sectors. High blast radius (#589's lever 2/3); the larger win but the harder
+build, and a scope decision since compile is one-time.
 
 ### Recommendation
 
-- **Default stays OFF.** The ~20% compile saving doesn't justify the warm-step regression for normal
-  optimization runs (many warm steps, one compile).
-- **Niche use:** if a workflow is compile-bound (e.g. rapid recompiles, short runs, CI), flipping
-  `TENAX_BATCH_BLOCKSPARSE=1` buys ~20% off compile — document it as a knob, don't change the default.
-- **To actually beat the wall** would require attacking the SVD-VJP itself (e.g. a cheaper SVD-gradient
-  formulation, or avoiding per-projector SVDs in the differentiated path) — a research-grade change, not
-  a config or batching tweak. Out of scope for #570 as posed; #570 is **characterized and concluded**.
+- **Default `TENAX_BATCH_BLOCKSPARSE` stays OFF** — the ~20% compile saving doesn't justify the
+  warm-step regression for normal optimization runs (many steps, one compile).
+- **Flip it ON for compile-bound niches** (rapid recompiles, short runs, CI) — document as a knob.
+- **To beat the wall**, pursue the stacked-block SVD/projector wrapper (above), not a cheaper
+  decomposition (the decomposition is ~0% — #589). #570 is **characterized and concluded**.
 
 ## Artifacts
 
-- `examples/profile_570_sweepvjp_compile.py` — the rig (honors `TENAX_BATCH_BLOCKSPARSE` via env)
+- `examples/profile_570_sweepvjp_compile.py` — the rig (honors `TENAX_BATCH_BLOCKSPARSE`)
 - `570_results/profile_570_d4_batchoff.json`, `…_d4_batchon.json` — D=4 OFF/ON sweep
 - `570_results/profile_570_batch_on_a100.json` — D=2 ON (vs `profile_570_sweepvjp_a100.json` OFF)
+- See also (PR #589): `2026-06-08-570-relocalized-not-decomposition.md`,
+  `examples/probe_bwd_subop_attribution_570.py`, `probe_decomp_vjp_cost_570.py`

--- a/docs/superpowers/handoffs/2026-06-08-570-batching-compile-finding.md
+++ b/docs/superpowers/handoffs/2026-06-08-570-batching-compile-finding.md
@@ -1,0 +1,99 @@
+# #570 — batching (`TENAX_BATCH_BLOCKSPARSE`) is the only lever that moves the compile wall (~15–22%, bounded); #570 conclusion
+
+**Date:** 2026-06-08 (A100) · **Follows:** [`2026-06-08-570-mechanism-correction.md`](2026-06-08-570-mechanism-correction.md) · **Issue:** #570
+
+## TL;DR
+
+After the mechanism correction (the AD projector is already block-sparse per-sector SVD, so
+"lever-3" was moot), the one remaining untested compile lever was **batching** the per-sector
+block-sparse work (`TENAX_BATCH_BLOCKSPARSE`, the #566/#569 umbrella gate). Measured gate
+OFF vs ON on the sweep-VJP compile rig:
+
+- **It works — modestly.** ON reduces the compiled backward by **~15–22%** (deterministic HLO
+  instruction count), with compile time tracking. This is the **first and only** lever that
+  measurably moves the compile wall.
+- **It does not scale toward the target.** The reduction is **bounded ~20% and slightly
+  *diminishes* with χ** (it shrinks the *contraction/block-pack* part of the VJP, while the
+  dominant *per-sector SVD-VJP* — which batching cannot reduce — grows with χ).
+- **It has a runtime cost.** #569 already showed batching is a *warm-step* loss ("never a net
+  win" through D=6). So ON is a **compile↓ / runtime↑ trade-off**, not a free win.
+
+## Results (A100, fermionic, x64, sweep-VJP unit, `--full` = env+params)
+
+### D=4 (production-scale; SVD operands (96,96))
+
+| χ | OFF env HLO instr | ON env HLO instr | instr ratio | OFF tot compile | ON tot compile | compile ratio |
+|---:|---:|---:|---:|---:|---:|---:|
+| 8  | 326,547 | 261,328 | **0.80×** | 320.3 s | 249.8 s | 0.78× |
+| 12 | 400,940 | 326,199 | **0.81×** | 544.6 s | 474.9 s | 0.87× |
+| 16 | 471,073 | 395,980 | **0.84×** | 852.6 s | 753.1 s | 0.88× |
+
+### D=2 (corner sectors (6,6); SVD operands (24,24))
+
+| χ | OFF env HLO instr | ON env HLO instr | instr ratio | OFF tot compile | ON tot compile |
+|---:|---:|---:|---:|---:|---:|
+| 12 | 111,934 | 102,223 | 0.91× | 104.1 s | 100.1 s |
+| 24 | 307,580 | 240,354 | 0.78× | 296.8 s | 232.1 s |
+
+HLO instruction count is **deterministic** (independent of run/contention), so the 0.78–0.84×
+ratios are the rigorous core; compile-time ratios (measured; D=4 OFF/ON were run concurrently
+so their *absolute* timings are CPU-contended, but the OFF and ON runs were contended equally
+and the ratios match the deterministic instr ratios). Raw: `570_results/profile_570_d4_batch{off,on}.json`,
+`570_results/profile_570_batch_on_a100.json` (D=2 ON) vs `profile_570_sweepvjp_a100.json` (D=2 OFF).
+
+## Why it's bounded (mechanism)
+
+`TENAX_BATCH_BLOCKSPARSE` is an **umbrella** gate. In the AD backward it does **not** reduce the
+SVD primitives — those are single-sector per projector call (24 ops of (96,96) at D=4, identical
+on/off at the jaxpr level), so the within-call sector-batching in `_truncated_svd_symmetric_traced`
+has nothing to group. What it *does* reduce is the **contraction / block-pack** emission
+(`contractor.py` batched path): fewer `dot_general` / scatter / reshape instructions around the
+SVDs. That is a roughly **fixed-fraction** overhead, so as χ grows the un-batched SVD-VJP grows
+faster and the batching win becomes a smaller share (0.80→0.84 across χ=8→16 at D=4).
+
+(An XLA `slow_operation_alarm` fired on constant-folding a `scatter-add` of shape
+`f64[16,6,6,8,8,8]` during the D=4 backward — direct evidence that block-pack scatter emission is
+a real slice of the compile, which is exactly the part batching trims.)
+
+## Methodological note (so it doesn't recur)
+
+A cheap **jaxpr `svd`-primitive count** diff (off vs on) showed *identical* graphs — which led me
+to predict "no effect." That was wrong: **jaxpr primitive count ≠ lowered-HLO instruction count**.
+The umbrella gate restructures contraction lowering without changing the `svd` primitive count, so
+only the **compile/HLO measurement** revealed the ~20% win. Trust the HLO/compile measurement over
+jaxpr op-counts for compile-cost questions.
+
+## #570 conclusion — levers exhausted
+
+The minutes-long fermionic CTM-AD compile wall (`_jit_fused_fixed_point_bwd`, ~549 s at D=4/χ=12)
+is dominated by the **per-sector block-sparse SVD VJP**, summed over sectors × projectors × the
+fixed-point backward. Lever inventory:
+
+| Lever | Verdict | Why |
+|---|---|---|
+| #200 cuTensorNet contraction backend | NO-GO | backend-invariant; wall isn't the contraction executor |
+| Lever-1: QR projector | NO-GO | no-op as config flip (2×2 path is SVD-only; QR only in unused 1×1) |
+| Lever-2: truncated backprop | NO-GO (compile) | per-sweep SVD-VJP irreducible; explicit unroll ≈/worse than implicit |
+| Lever-3: block-sparse per-sector SVD VJP | MOOT | already implemented — it *is* the wall |
+| **Batching (`TENAX_BATCH_BLOCKSPARSE`)** | **PARTIAL** | **~15–22% compile, bounded, doesn't scale; + runtime penalty (#569)** |
+
+**No available lever reaches the original #200 target (~40× toward a ~13 s dense floor).** The wall
+is intrinsic to differentiating N per-sector block-sparse SVDs in XLA: the SVD-gradient (Lorentzian
+F-matrix) dense algebra per sector, super-linear in χ, summed over all projectors. Batching trims
+the surrounding contraction by ~20% but cannot touch the SVD-VJP core.
+
+### Recommendation
+
+- **Default stays OFF.** The ~20% compile saving doesn't justify the warm-step regression for normal
+  optimization runs (many warm steps, one compile).
+- **Niche use:** if a workflow is compile-bound (e.g. rapid recompiles, short runs, CI), flipping
+  `TENAX_BATCH_BLOCKSPARSE=1` buys ~20% off compile — document it as a knob, don't change the default.
+- **To actually beat the wall** would require attacking the SVD-VJP itself (e.g. a cheaper SVD-gradient
+  formulation, or avoiding per-projector SVDs in the differentiated path) — a research-grade change, not
+  a config or batching tweak. Out of scope for #570 as posed; #570 is **characterized and concluded**.
+
+## Artifacts
+
+- `examples/profile_570_sweepvjp_compile.py` — the rig (honors `TENAX_BATCH_BLOCKSPARSE` via env)
+- `570_results/profile_570_d4_batchoff.json`, `…_d4_batchon.json` — D=4 OFF/ON sweep
+- `570_results/profile_570_batch_on_a100.json` — D=2 ON (vs `profile_570_sweepvjp_a100.json` OFF)

--- a/docs/superpowers/handoffs/2026-06-08-570-lever2-truncated-backprop-nogo.md
+++ b/docs/superpowers/handoffs/2026-06-08-570-lever2-truncated-backprop-nogo.md
@@ -8,6 +8,9 @@
 > `_truncated_svd_symmetric_traced`, Issue #435), not a dense corner SVD. Consequently
 > **"lever-3" is moot — already implemented** (see `2026-06-08-570-mechanism-correction.md`).
 > The lever-2 NO-GO conclusion and all measurements are **unaffected**.
+> Further (PR #589): the per-sweep cost is **#566 structural emission** (block-pack ~60% +
+> gauge-fix ~25%, decomposition ~0%) — read "block-SVD VJP" here as that structural emission,
+> not the decomposition math. See `2026-06-08-570-relocalized-not-decomposition.md`.
 
 ## TL;DR
 

--- a/docs/superpowers/handoffs/2026-06-08-570-mechanism-correction.md
+++ b/docs/superpowers/handoffs/2026-06-08-570-mechanism-correction.md
@@ -34,12 +34,20 @@ Verification (D=2, χ=12, fermionic, `apply_Jt` traced backward):
 ## What stands unchanged
 
 All *conclusions* of both prior docs hold:
-- The wall is the **decomposition (SVD) VJP** inside `_jit_fused_fixed_point_bwd`,
+- The wall is the **per-sector SVD/projector-wrapper VJP** inside `_jit_fused_fixed_point_bwd`,
   super-linear in χ (one sweep-VJP unit 50.7 s → 522.9 s as χ 6 → 36).
 - **Lever-1 (QR projector) is a no-op as a config flip** (the 2×2 path has no QR).
 - **Lever-2 (truncated backprop) is a NO-GO for the compile wall** (best 0.88× implicit).
 
 Only the dense-vs-block-sparse *mechanism* description is corrected.
+
+> **Refinement (PR #589).** This doc still calls the wall the "decomposition (SVD) VJP." A
+> deeper drill-down shows the cost is **~0% decomposition** — it's **#566 per-sector
+> *structural* emission** (block pack/unpack ~60% + gauge-fix/sign-logic ~25%) emitted inside
+> the SVD/projector wrapper. So the lever is not a cheaper decomposition but **stacking the
+> per-sector structural ops across sectors** (`TENAX_BATCH_BLOCKSPARSE` already does the
+> block/contraction part: ~20% off compile — `2026-06-08-570-batching-compile-finding.md`).
+> See `2026-06-08-570-relocalized-not-decomposition.md`.
 
 ## Implication — the levers, re-scoped (again)
 

--- a/docs/superpowers/handoffs/570_results/profile_570_batch_on_a100.json
+++ b/docs/superpowers/handoffs/570_results/profile_570_batch_on_a100.json
@@ -1,0 +1,45 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "D": 2,
+  "methods": [
+    "svd"
+  ],
+  "chi_list": [
+    12,
+    24
+  ],
+  "full": true,
+  "projector_backward": "auto",
+  "rows": [
+    {
+      "D": 2,
+      "chi": 12,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 15.244506007060409,
+      "env_compile_s": 47.54259874206036,
+      "env_hlo_instr": 102223,
+      "par_lower_s": 16.2324302457273,
+      "par_compile_s": 52.540427510626614,
+      "par_hlo_instr": 103153,
+      "total_compile_s": 100.08302625268698
+    },
+    {
+      "D": 2,
+      "chi": 24,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 25.554228669032454,
+      "env_compile_s": 114.318439649418,
+      "env_hlo_instr": 240354,
+      "par_lower_s": 24.789226569235325,
+      "par_compile_s": 117.74078474193811,
+      "par_hlo_instr": 241154,
+      "total_compile_s": 232.0592243913561
+    }
+  ]
+}

--- a/docs/superpowers/handoffs/570_results/profile_570_d4_batchoff.json
+++ b/docs/superpowers/handoffs/570_results/profile_570_d4_batchoff.json
@@ -1,0 +1,61 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "D": 4,
+  "methods": [
+    "svd"
+  ],
+  "chi_list": [
+    8,
+    12,
+    16,
+    24
+  ],
+  "full": true,
+  "projector_backward": "auto",
+  "rows": [
+    {
+      "D": 4,
+      "chi": 8,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 28.735757681541145,
+      "env_compile_s": 154.37768038082868,
+      "env_hlo_instr": 326547,
+      "par_lower_s": 29.95405166503042,
+      "par_compile_s": 165.95837677828968,
+      "par_hlo_instr": 332152,
+      "total_compile_s": 320.33605715911835
+    },
+    {
+      "D": 4,
+      "chi": 12,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 39.02933407854289,
+      "env_compile_s": 267.83109878655523,
+      "env_hlo_instr": 400940,
+      "par_lower_s": 40.48439918179065,
+      "par_compile_s": 276.77000217232853,
+      "par_hlo_instr": 407377,
+      "total_compile_s": 544.6011009588838
+    },
+    {
+      "D": 4,
+      "chi": 16,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 49.96987915132195,
+      "env_compile_s": 422.78077664226294,
+      "env_hlo_instr": 471073,
+      "par_lower_s": 51.93044421914965,
+      "par_compile_s": 429.76557296700776,
+      "par_hlo_instr": 483188,
+      "total_compile_s": 852.5463496092707
+    }
+  ]
+}

--- a/docs/superpowers/handoffs/570_results/profile_570_d4_batchon.json
+++ b/docs/superpowers/handoffs/570_results/profile_570_d4_batchon.json
@@ -1,0 +1,61 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "D": 4,
+  "methods": [
+    "svd"
+  ],
+  "chi_list": [
+    8,
+    12,
+    16,
+    24
+  ],
+  "full": true,
+  "projector_backward": "auto",
+  "rows": [
+    {
+      "D": 4,
+      "chi": 8,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 28.189272517338395,
+      "env_compile_s": 121.08155805058777,
+      "env_hlo_instr": 261328,
+      "par_lower_s": 29.954669741913676,
+      "par_compile_s": 128.70227484498173,
+      "par_hlo_instr": 270613,
+      "total_compile_s": 249.7838328955695
+    },
+    {
+      "D": 4,
+      "chi": 12,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 39.24606418609619,
+      "env_compile_s": 241.34951428696513,
+      "env_hlo_instr": 326199,
+      "par_lower_s": 40.14485766366124,
+      "par_compile_s": 233.5657649366185,
+      "par_hlo_instr": 335516,
+      "total_compile_s": 474.91527922358364
+    },
+    {
+      "D": 4,
+      "chi": 16,
+      "method": "svd",
+      "n_blocks": 16,
+      "projector_backward": "auto",
+      "env_lower_s": 49.95745927747339,
+      "env_compile_s": 376.5828425306827,
+      "env_hlo_instr": 395980,
+      "par_lower_s": 51.116853542625904,
+      "par_compile_s": 376.4897493030876,
+      "par_hlo_instr": 405333,
+      "total_compile_s": 753.0725918337703
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Reconciles this batching thread with the parallel **PR #589** (sub-op attribution) and closes
out #570. Docs only; no `src/` changes. **Merge after #589.**

## Two threads, each corrects the other

- **#589 is right on mechanism** (and this PR adopts it): the per-sector SVD-VJP cost is
  **~60% block pack/unpack + ~25% gauge-fix, ~0% decomposition** → **#566 structural emission**,
  not the "SVD-gradient F-matrix algebra" my earlier docs claimed. This PR corrects that error
  across the lever-1 / lever-2 / mechanism-correction docs (banner notes + inline fix).
- **This PR corrects #589 on batching:** #589 dismissed `TENAX_BATCH_BLOCKSPARSE` from **jaxpr
  op-count** (+2.8%). At the **HLO/compile level** it's **−15…22%** (deterministic instr
  0.80–0.84× at D=4 χ=8/12/16; compile time tracks). jaxpr op-count ≠ HLO size — so batching
  **is** a modest, bounded compile lever (the partial, already-available form of #589's fix).

## Batching result (A100)

| D | χ | OFF env HLO instr | ON env HLO instr | ratio |
|---:|---:|---:|---:|---:|
| 4 | 8 | 326,547 | 261,328 | 0.80× |
| 4 | 12 | 400,940 | 326,199 | 0.81× |
| 4 | 16 | 471,073 | 395,980 | 0.84× |
| 2 | 24 | 307,580 | 240,354 | 0.78× |

Bounded (~20%, slightly diminishing in χ — it stacks the block/contraction ops but not the
per-sector gauge-fix/sign-logic) and carries a runtime penalty (#569).

## #570 conclusion

Wall = #566 per-sector **structural** emission. Levers: #200 / lever-1 / lever-2 NO-GO,
lever-3 MOOT, **batching PARTIAL (~20%)**. None reaches the ~40× target. The deeper lever is
**extending PR #586's stacked-block representation to the SVD/projector wrapper** (stack
gauge-fix + pack/unpack across sectors) — research-grade, out of #570 scope. **Default
`TENAX_BATCH_BLOCKSPARSE` stays OFF; flip for compile-bound niches.**

Full write-up: `docs/superpowers/handoffs/2026-06-08-570-batching-compile-finding.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
