### PR TITLE
perf(#566): vectorize _gauge_fix_symmetric_svd (per-column → per-sector) — ~11–23× fewer HLO instrs

### DIFF
--- a/docs/superpowers/plans/2026-06-08-gauge-fix-symmetric-svd-vectorization.md
+++ b/docs/superpowers/plans/2026-06-08-gauge-fix-symmetric-svd-vectorization.md
@@ -1,0 +1,358 @@
+# Vectorize `_gauge_fix_symmetric_svd` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the per-bond-column Python loop in `_gauge_fix_symmetric_svd` with a per-bond-charge-sector batched computation, cutting the χ-scaling op emission (~25% gauge-fix slice of the #566 CTM-AD compile wall) while producing **bit-identical** output.
+
+**Architecture:** Behavior-preserving optimization. The current loop runs over ≈χ bond columns, each emitting `argmax`/`concatenate`/per-block `.at[col].multiply`. The rewrite groups columns by their (static) bond charge — ~2 sectors for Z₂ — stacks each sector's U-blocks into one `(R, n_q)` matrix, computes all `n_q` column phases in one vectorized `argmax`, and applies them with one broadcast-multiply per block. Concatenation order is preserved so `argmax` (incl. ties) is identical. Guarded by a frozen-reference parity test (this is a refactor: the parity test is the safety net, and goes red if the vectorization is wrong).
+
+**Tech Stack:** JAX (jnp, jax.grad), NumPy (static charge arrays), tenax `SymmetricTensor` / `tenax.linalg.svd`, pytest.
+
+---
+
+## File Structure
+
+- **Modify:** `src/tenax/algorithms/_ctm_tensor_projector_2x2.py` — rewrite `_gauge_fix_symmetric_svd` (lines 53–145). Same name, signature, and output semantics; internal only.
+- **Modify (tests):** `tests/test_ctm_2x2_projector_symmetric.py` — add a frozen reference copy of the current loop plus parity/grad/edge-case tests. Reuses the existing `_make_test_matrix_tensor` helper.
+
+No other files change. No call sites change (the function is internal to the 2×2 projector). Always-on; no gate.
+
+---
+
+### Task 1: Lock current behavior with a frozen-reference parity test
+
+**Files:**
+- Modify: `tests/test_ctm_2x2_projector_symmetric.py`
+
+- [ ] **Step 1: Add the frozen reference + parity/grad/edge tests**
+
+Append to `tests/test_ctm_2x2_projector_symmetric.py` (the file already imports `jax`, `jnp`, `np`, `pytest`, `_gauge_fix_symmetric_svd`, `TensorIndex`, `FlowDirection`, `U1Symmetry`, `SymmetricTensor`):
+
+```python
+# --------------------------------------------------------------------------- #
+# Vectorization parity (#566): the per-sector rewrite of _gauge_fix_symmetric_svd
+# must be byte-identical to the original per-column loop, frozen here.
+# --------------------------------------------------------------------------- #
+def _reference_gauge_fix_loop(U_T, Vh_T):
+    """Frozen copy of the original per-column _gauge_fix_symmetric_svd loop.
+
+    Kept in the test as the behavioral oracle for the vectorized rewrite.
+    """
+    bond_idx = U_T.indices[-1]
+    bond_charges = np.asarray(bond_idx.charges, dtype=np.int32)
+
+    local_index_of: dict[int, dict[int, int]] = {}
+    counter: dict[int, int] = {}
+    for j, q in enumerate(bond_charges):
+        q_int = int(q)
+        local_index_of.setdefault(q_int, {})[j] = counter.get(q_int, 0)
+        counter[q_int] = counter.get(q_int, 0) + 1
+
+    u_blocks_by_q: dict[int, list] = {}
+    for key, block in U_T.blocks.items():
+        u_blocks_by_q.setdefault(int(key[-1]), []).append((key, block))
+    vh_blocks_by_q: dict[int, list] = {}
+    for key, block in Vh_T.blocks.items():
+        vh_blocks_by_q.setdefault(int(key[0]), []).append((key, block))
+
+    new_u_blocks = {key: block for key, block in U_T.blocks.items()}
+    new_vh_blocks = {key: block for key, block in Vh_T.blocks.items()}
+
+    sample_block = next(iter(U_T.blocks.values()))
+    is_complex = jnp.issubdtype(sample_block.dtype, jnp.complexfloating)
+
+    for j, q in enumerate(bond_charges):
+        q_int = int(q)
+        local = local_index_of[q_int][j]
+        u_entries = u_blocks_by_q.get(q_int, [])
+        vh_entries = vh_blocks_by_q.get(q_int, [])
+        if not u_entries:
+            continue
+        candidates = jnp.concatenate(
+            [jnp.reshape(new_u_blocks[key][..., local], (-1,)) for key, _ in u_entries]
+        )
+        max_idx = jnp.argmax(jnp.abs(candidates))
+        best_value = candidates[max_idx]
+        abs_best = jnp.abs(best_value)
+        phase = jnp.where(
+            abs_best > 0,
+            best_value / jnp.maximum(abs_best, jnp.asarray(1e-30, dtype=abs_best.dtype)),
+            jnp.ones_like(best_value),
+        )
+        if is_complex:
+            conj_phase = jnp.conj(phase)
+            bare_phase = phase
+        else:
+            conj_phase = jnp.real(phase)
+            bare_phase = jnp.real(phase)
+        for key, _block in u_entries:
+            new_u_blocks[key] = new_u_blocks[key].at[..., local].multiply(conj_phase)
+        for key, _block in vh_entries:
+            new_vh_blocks[key] = new_vh_blocks[key].at[local, ...].multiply(bare_phase)
+
+    U_out = SymmetricTensor._from_blocks_unchecked(new_u_blocks, U_T.indices)
+    Vh_out = SymmetricTensor._from_blocks_unchecked(new_vh_blocks, Vh_T.indices)
+    return U_out, Vh_out
+
+
+def _svd_of(M_T):
+    from tenax.linalg import svd as tensor_svd
+
+    U_T, s, Vh_T, _ = tensor_svd(
+        M_T, left_labels=("left",), right_labels=("right",), new_bond_label="bond"
+    )
+    return U_T, s, Vh_T
+
+
+def _complex_matrix_tensor(seed: int = 7) -> SymmetricTensor:
+    """Two-sector U(1) complex128 matrix tensor."""
+    sym = U1Symmetry()
+    charges = np.array([0, 0, 1, 1], dtype=np.int32)
+    left_idx = TensorIndex.from_charges(sym, charges, FlowDirection.IN, label="left")
+    right_idx = TensorIndex.from_charges(sym, charges, FlowDirection.OUT, label="right")
+    k1, k2 = jax.random.split(jax.random.PRNGKey(seed))
+    re = SymmetricTensor.random_normal((left_idx, right_idx), k1)
+    im = SymmetricTensor.random_normal((left_idx, right_idx), k2)
+    blocks = {
+        key: (re.blocks[key] + 1j * im.blocks[key]).astype(jnp.complex128)
+        for key in re.blocks
+    }
+    return SymmetricTensor._from_blocks_unchecked(blocks, re.indices)
+
+
+def _degenerate_matrix_tensor(seed: int = 3) -> SymmetricTensor:
+    """Scaled-identity-per-sector matrix → fully degenerate singular values
+    (exercises argmax ties, where concat order must match the reference)."""
+    M_T = _make_test_matrix_tensor(seed=seed)
+    blocks = {}
+    for key, block in M_T.blocks.items():
+        n = block.shape[0]
+        blocks[key] = jnp.eye(n, block.shape[1], dtype=block.dtype) * (1.0 + key[0])
+    return SymmetricTensor._from_blocks_unchecked(blocks, M_T.indices)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: _make_test_matrix_tensor(seed=0),
+        lambda: _make_test_matrix_tensor(seed=5),
+        _complex_matrix_tensor,
+        _degenerate_matrix_tensor,
+    ],
+    ids=["u1_real_a", "u1_real_b", "u1_complex", "degenerate_ties"],
+)
+def test_gauge_fix_vectorized_matches_reference_forward(factory):
+    """Vectorized gauge fix is byte-identical to the frozen per-column loop."""
+    M_T = factory()
+    U_T, _s, Vh_T = _svd_of(M_T)
+
+    U_ref, Vh_ref = _reference_gauge_fix_loop(U_T, Vh_T)
+    U_new, Vh_new = _gauge_fix_symmetric_svd(U_T, Vh_T)
+
+    for key in U_ref.blocks:
+        assert jnp.array_equal(U_new.blocks[key], U_ref.blocks[key]), f"U block {key}"
+    for key in Vh_ref.blocks:
+        assert jnp.array_equal(Vh_new.blocks[key], Vh_ref.blocks[key]), f"Vh block {key}"
+
+
+def test_gauge_fix_vectorized_matches_reference_grad():
+    """Gradient through the vectorized gauge fix matches the reference (fp tier)."""
+    M_T = _make_test_matrix_tensor(seed=2)
+    U_T, _s, Vh_T = _svd_of(M_T)
+    bond_label = "bond"
+
+    def _loss(U_T_in, Vh_T_in, gauge_fn):
+        U_fixed, Vh_fixed = gauge_fn(U_T_in, Vh_T_in)
+        # Gauge-sensitive scalar over both factors.
+        u = U_fixed.todense()
+        v = Vh_fixed.todense()
+        return jnp.real(jnp.sum(u * jnp.conj(u))) + jnp.real(jnp.sum(v))
+
+    # Differentiate w.r.t. the U block buffers (the AD-relevant inputs).
+    leaves, treedef = jax.tree.flatten(U_T)
+
+    def _from_leaves(ls, fn):
+        U_in = jax.tree.unflatten(treedef, ls)
+        return _loss(U_in, Vh_T, fn)
+
+    g_ref = jax.grad(lambda ls: _from_leaves(ls, _reference_gauge_fix_loop))(leaves)
+    g_new = jax.grad(lambda ls: _from_leaves(ls, _gauge_fix_symmetric_svd))(leaves)
+    for a, b in zip(jax.tree.leaves(g_new), jax.tree.leaves(g_ref)):
+        np.testing.assert_allclose(np.asarray(a), np.asarray(b), rtol=1e-12, atol=1e-12)
+```
+
+- [ ] **Step 2: Run the new tests against the CURRENT implementation**
+
+Run: `uv run pytest tests/test_ctm_2x2_projector_symmetric.py -q`
+Expected: PASS — the current `_gauge_fix_symmetric_svd` equals the frozen reference (establishes the oracle is faithful and the harness is correct, before any change).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_ctm_2x2_projector_symmetric.py
+git commit -m "test(#566): frozen-reference parity tests for _gauge_fix_symmetric_svd"
+```
+
+---
+
+### Task 2: Rewrite `_gauge_fix_symmetric_svd` to per-sector batched
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_tensor_projector_2x2.py:53-145`
+
+- [ ] **Step 1: Replace the function body**
+
+Replace the entire `_gauge_fix_symmetric_svd` function (lines 53–145) with:
+
+```python
+def _gauge_fix_symmetric_svd(
+    U_T: SymmetricTensor, Vh_T: SymmetricTensor
+) -> tuple[SymmetricTensor, SymmetricTensor]:
+    """Per-sector gauge fix for SymmetricTensor SVD outputs.
+
+    Mirrors :func:`_gauge_fixed_svd` (the dense 2x2 gauge convention) at the
+    block level: for each kept singular vector j, finds the entry of largest
+    ``|U[:, j]|`` across all U-blocks that share its bond charge, rotates U's
+    column and Vh's row by ``conj(phase)`` / ``phase`` so that
+    ``U @ diag(s) @ Vh == M`` is preserved.  Critical for the 2x2 closure
+    ``P_bot · P_top = I``.
+
+    Vectorized over bond-charge sectors (#566): instead of looping over every
+    bond column, we process each (static) bond charge once — stacking that
+    sector's U-blocks into one matrix, computing all column phases in a single
+    ``argmax``, and applying them with one broadcast-multiply per block.  The
+    block concatenation order matches the column-order oracle, so ``argmax``
+    (including ties) and the output are byte-identical to the per-column loop.
+    """
+    bond_idx = U_T.indices[-1]  # last leg of U is the SVD bond
+    bond_charges = np.asarray(bond_idx.charges, dtype=np.int32)
+
+    # Group U-blocks by bond charge (last key entry) and Vh-blocks by bond
+    # charge (first key entry), preserving block-dict order so the stacked
+    # argmax matches the per-column reference's concatenation order.
+    u_keys_by_q: dict[int, list] = {}
+    for key in U_T.blocks:
+        u_keys_by_q.setdefault(int(key[-1]), []).append(key)
+    vh_keys_by_q: dict[int, list] = {}
+    for key in Vh_T.blocks:
+        vh_keys_by_q.setdefault(int(key[0]), []).append(key)
+
+    new_u_blocks: dict = dict(U_T.blocks)
+    new_vh_blocks: dict = dict(Vh_T.blocks)
+
+    # Detect dtype statically so we don't promote real blocks to complex.
+    sample_block = next(iter(U_T.blocks.values()))
+    is_complex = jnp.issubdtype(sample_block.dtype, jnp.complexfloating)
+
+    for q in np.unique(bond_charges):
+        q_int = int(q)
+        u_keys = u_keys_by_q.get(q_int, [])
+        if not u_keys:
+            continue
+
+        # All U-blocks of this sector share the bond multiplicity n_q (last axis).
+        n_q = new_u_blocks[u_keys[0]].shape[-1]
+
+        # Stack each U-block's (rows_i, n_q) view → (R, n_q), same order as the
+        # per-column reference's `candidates` concatenation.
+        M_q = jnp.concatenate(
+            [jnp.reshape(new_u_blocks[key], (-1, n_q)) for key in u_keys], axis=0
+        )
+        idx = jnp.argmax(jnp.abs(M_q), axis=0)  # (n_q,)
+        best = M_q[idx, jnp.arange(n_q)]  # (n_q,)
+        abs_best = jnp.abs(best)
+        phase = jnp.where(
+            abs_best > 0,
+            best / jnp.maximum(abs_best, jnp.asarray(1e-30, dtype=abs_best.dtype)),
+            jnp.ones_like(best),
+        )
+        if is_complex:
+            conj_phase = jnp.conj(phase)
+            bare_phase = phase
+        else:
+            conj_phase = jnp.real(phase)
+            bare_phase = jnp.real(phase)
+
+        # U columns (last axis) by conj(phase); Vh rows (first axis) by phase.
+        for key in u_keys:
+            new_u_blocks[key] = new_u_blocks[key] * conj_phase
+        for key in vh_keys_by_q.get(q_int, []):
+            blk = new_vh_blocks[key]
+            bcast = jnp.reshape(bare_phase, (n_q,) + (1,) * (blk.ndim - 1))
+            new_vh_blocks[key] = blk * bcast
+
+    U_out = SymmetricTensor._from_blocks_unchecked(new_u_blocks, U_T.indices)
+    Vh_out = SymmetricTensor._from_blocks_unchecked(new_vh_blocks, Vh_T.indices)
+    return U_out, Vh_out
+```
+
+- [ ] **Step 2: Run the parity tests (the meaningful red/green checkpoint)**
+
+Run: `uv run pytest tests/test_ctm_2x2_projector_symmetric.py -q`
+Expected: PASS — vectorized output is byte-identical to the frozen reference, and grad matches. (A wrong concat order or broadcast would fail `test_gauge_fix_vectorized_matches_reference_forward`.)
+
+- [ ] **Step 3: Run the broader symmetric-CTM AD suite for no regressions**
+
+Run: `uv run pytest tests/test_ctm_2x2_projector_symmetric.py tests/stacked/ tests/test_block_sparse_ctm_ad.py -q`
+Expected: PASS (no behavior change downstream).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tenax/algorithms/_ctm_tensor_projector_2x2.py
+git commit -m "perf(#566): vectorize _gauge_fix_symmetric_svd per bond-charge sector"
+```
+
+---
+
+### Task 3: Measure the compile reduction and open the PR
+
+**Files:**
+- None modified (measurement + PR only).
+
+- [ ] **Step 1: Measure HLO/compile before vs after (GPU rig)**
+
+On the A100 (per `cutensornet-200-env` setup), capture the after-numbers and compare to the committed baseline `docs/superpowers/handoffs/570_results/profile_570_d4_batchoff.json` (D=4 OFF: χ=8/12/16 → env_hlo_instr 326547/400940/471073):
+
+Run:
+```bash
+CUDA_VISIBLE_DEVICES=2 JAX_PLATFORMS=cuda,cpu uv run python -u \
+  examples/profile_570_sweepvjp_compile.py --D 4 --chi-list 8 12 16 \
+  --methods svd --full --reps 1 --json /tmp/gaugefix_after.json
+```
+Expected: `env_hlo_instr` and `total_compile_s` **lower** than the baseline, with the gap **growing with χ** (more bond columns collapsed). Record the deltas.
+
+- [ ] **Step 2: Run the core suite once locally**
+
+Run: `uv run pytest -m core -q`
+Expected: PASS.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+git push -u origin perf/gauge-fix-symmetric-svd-vectorize-566
+gh pr create --base main --title "perf(#566): vectorize _gauge_fix_symmetric_svd (per-column → per-sector)" \
+  --body "Hoists the gauge-fix loop from ≈χ bond columns to ~n_sectors bond-charge sectors (batched argmax/phase + broadcast multiply). Byte-identical output (frozen-reference parity + grad tests); existing 2×2 + AD suites green. Compile measurement: <paste χ=8/12/16 before→after env_hlo_instr + total_compile_s>. Always-on, no interface change. Issue #566 (contained sub-lever from the #570 compile-wall localization)."
+```
+
+- [ ] **Step 4: Enable auto-merge**
+
+```bash
+gh pr merge <PR#> --auto
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Per-sector vectorization of `_gauge_fix_symmetric_svd` → Task 2. ✓
+- Bit-identical + grad parity bar → Task 1 tests (`array_equal` forward, `allclose` grad). ✓
+- Existing invariants (reconstruction, real-positive-max-row, 2×2 closure) preserved → Task 2 Step 3 runs `test_ctm_2x2_projector_symmetric.py` (which holds those) + AD suites. ✓
+- Edge cases (real/complex128, degenerate ties, single/empty sector) → Task 1 parametrization (`u1_complex`, `degenerate_ties`; empty-sector handled by the `if not u_keys: continue`). ✓
+- Always-on, no gate, no interface change → Task 2 keeps name/signature; no call-site edits. ✓
+- Measurement on the rig → Task 3. ✓
+
+**Placeholder scan:** PR body has one intentional `<paste …>` for measured numbers (filled at Task 3 Step 1) and `<PR#>` (from Step 3 output) — both resolved during execution, not plan gaps. No TODO/TBD in code.
+
+**Type/name consistency:** `_gauge_fix_symmetric_svd(U_T, Vh_T) -> (U_out, Vh_out)` unchanged across tasks; `_reference_gauge_fix_loop` used only in tests; helper names (`_svd_of`, `_complex_matrix_tensor`, `_degenerate_matrix_tensor`) defined in Task 1 and used only there; `SymmetricTensor._from_blocks_unchecked` and `_make_test_matrix_tensor` match existing code.

--- a/docs/superpowers/specs/2026-06-08-gauge-fix-symmetric-svd-vectorization-design.md
+++ b/docs/superpowers/specs/2026-06-08-gauge-fix-symmetric-svd-vectorization-design.md
@@ -1,0 +1,100 @@
+# Design — vectorize `_gauge_fix_symmetric_svd` (per-column → per-sector)
+
+**Date:** 2026-06-08 · **Issue:** #566 (contained sub-lever) · **Branch:** `perf/gauge-fix-symmetric-svd-vectorize-566`
+
+## Context
+
+The #570 compile-wall investigation localized the fermionic CTM-AD compile cost to **#566
+per-sector structural emission** inside the SVD/projector wrapper: ~60% block pack/unpack +
+**~25% gauge-fix/sign-logic**, ~0% decomposition (`docs/superpowers/handoffs/2026-06-08-570-relocalized-not-decomposition.md`,
+`…-batching-compile-finding.md`). Of the three originally-listed vectorization targets, two are
+already done — `_fuse_indices_symmetric`'s scatter (vectorized to one scatter-per-block in #569
+Milestone A) and `_fix_svd_signs` (already `argmax(axis=0)` + broadcast). The remaining real
+target is **`_gauge_fix_symmetric_svd`** (`src/tenax/algorithms/_ctm_tensor_projector_2x2.py`).
+
+## Problem
+
+`_gauge_fix_symmetric_svd` loops over **every bond column `j` (≈χ)** and per column emits an
+`argmax` + `concatenate` + a per-block `.at[..., local].multiply(...)` (lines ~104–141). The
+emitted-op count therefore grows with χ — this is the gauge-fix slice of the wall and one of
+the `scatter_mul`/`argmax` contributors #589 measured. The loop is purely a representation cost;
+the math is per-sector.
+
+## Approach (A — per-sector batched)
+
+Hoist the loop from columns (≈χ, many) to **bond-charge sectors** (`n_sectors`, few — 2 for Z₂).
+Interface is unchanged: `_gauge_fix_symmetric_svd(U_T, Vh_T) -> (U_out, Vh_out)`. Pure internal
+rewrite; no call sites, signatures, or output semantics change.
+
+For each bond charge `q` that has U-blocks (iterating `u_blocks_by_q[q]` in the **same order** the
+current code concatenates):
+
+1. Reshape each U-block (shape `(...non-bond..., n_q)`) to `(rows_i, n_q)` and `concatenate` along
+   axis 0 → `M_q` of shape `(R, n_q)`, **byte-identical layout to the current per-column
+   `candidates` concatenation** (so `argmax` tie-breaking is identical).
+2. Vectorized over all `n_q` columns at once:
+   - `idx = jnp.argmax(jnp.abs(M_q), axis=0)` → `(n_q,)`
+   - `best = M_q[idx, jnp.arange(n_q)]`
+   - `phase = jnp.where(jnp.abs(best) > 0, best / jnp.maximum(jnp.abs(best), 1e-30), 1)`
+   - real/complex split preserved: `conj_phase`/`bare_phase` as today.
+3. Multiply each U-block (charge `q`) by `conj_phase` broadcast over its column axis (one
+   broadcast-multiply per block, replacing per-column `.at[].multiply`); multiply each Vh-block
+   (charge `q`) by `bare_phase` broadcast over its row axis.
+4. Charges with no U-blocks are skipped (preserves the current `continue`).
+
+This replaces ≈χ `argmax`/`concatenate`/scatter-multiply emissions with ≈`n_sectors` batched ones.
+Sector grouping is derived from **static numpy charges** (`bond_idx.charges`), so it is
+JIT/trace-safe and does not introduce data-dependent control flow.
+
+### Why not B/C
+- **B (fully global, masked):** one `(R, χ)` masked structure with no sector loop needs padding for
+  ragged per-sector row counts; `n_sectors` is tiny so the per-sector loop already captures the win
+  without padding complexity.
+- **C (multiply-only):** keeps the per-column `argmax`/`concatenate` loop — the bulk — so it barely
+  moves compile. Rejected.
+
+## Correctness
+
+**Bar: bit-identical** `U_out` and `Vh_out` versus the current implementation on random multi-sector
+SVD outputs (order-preservation in step 1 guarantees identical `argmax`), plus **gradient** parity
+(the function is on the AD-traced projector path). Edge cases preserved: empty/absent bond sector,
+single sector, fully-degenerate columns, real vs complex128, zero `best` (phase→1).
+
+Invariants that must continue to hold (the reason this gauge fix exists):
+- `U @ diag(s) @ Vh == M` per sector (reconstruction unchanged — phases cancel).
+- max-|U| row of each kept column is real-positive.
+- the 2×2 closure `P_bot · P_top = I` (no intervening matrix to absorb `conj(phase)²`).
+
+## Testing (TDD)
+
+1. **Reference-parity test (new).** Freeze the current loop as an inline reference in the test;
+   assert the vectorized impl matches it **bit-identically** for `U_out`, `Vh_out`, and
+   `jax.grad` of a scalar gauge-invariant loss, across U(1) / Z₂ / FermionParity tensors, real and
+   complex128, including the edge cases above. Write this first (red), then implement.
+2. **Existing tests must pass unchanged:** `tests/test_ctm_2x2_projector_symmetric.py`
+   (`test_gauge_fix_symmetric_svd_preserves_reconstruction`, `…_real_positive_max_row`), and the
+   broader symmetric-CTM AD suite (`tests/stacked/`, `tests/test_block_sparse_ctm_ad.py`).
+3. Mark new tests `core` if they fit the fast tier (mechanism-level, small tensors).
+
+## Measurement
+
+Before/after on `examples/profile_570_sweepvjp_compile.py` (D=4, χ ∈ {8,12,16}, `--full`): expect
+the gauge-fix slice to shrink and the reduction to **grow with χ** (more columns collapsed).
+Report HLO instruction count + compile-time delta. This is a structural win independent of
+`TENAX_BATCH_BLOCKSPARSE`.
+
+## Scope / non-goals
+
+- **In scope:** rewrite of `_gauge_fix_symmetric_svd` only; its parity tests; a before/after
+  compile measurement.
+- **Out of scope:** the remaining per-block transpose/reshape/scatter in `_fuse_indices_symmetric`
+  (cross-block batching = #566 fix #1), and the sweep-level stacked representation. No interface or
+  default-behavior changes; always-on (correctness-neutral, no gate).
+
+## Risks
+
+- **`argmax` tie order:** mitigated by preserving the exact U-block concatenation order; covered by
+  the bit-identical parity test.
+- **Ragged per-sector row counts across U-blocks:** handled by `concatenate` along the flattened
+  row axis (all blocks of a sector share `n_q` columns); no padding needed.
+- **Dtype promotion:** preserve the static `is_complex` check so real blocks are not promoted.

--- a/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
+++ b/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
@@ -60,69 +60,57 @@ def _gauge_fix_symmetric_svd(
     ``|U[:, j]|`` across all U-blocks that share its bond charge, rotates U's
     column and Vh's row by ``conj(phase)`` / ``phase`` so that
     ``U @ diag(s) @ Vh == M`` is preserved.  Critical for the 2x2 closure
-    ``P_bot · P_top = I`` (no intervening matrix to absorb a ``conj(phase)**2``
-    factor — see the docstring of :func:`_gauge_fixed_svd`).
+    ``P_bot · P_top = I``.
+
+    Vectorized over bond-charge sectors (#566): instead of looping over every
+    bond column, we process each (static) bond charge once — stacking that
+    sector's U-blocks into one matrix, computing all column phases in a single
+    ``argmax``, and applying them with one broadcast-multiply per block.  The
+    block concatenation order matches the column-order oracle, so ``argmax``
+    (including ties) and the output are byte-identical to the per-column loop.
     """
     bond_idx = U_T.indices[-1]  # last leg of U is the SVD bond
     bond_charges = np.asarray(bond_idx.charges, dtype=np.int32)
 
-    # Per global column j, find its (charge, in-sector local index).
-    # The sector ordering matches _truncated_svd_symmetric (bond charges
-    # are listed in descending-SV global order); within a sector, the
-    # local indices are 0..n_q-1 in the order they appear in bond_charges.
-    local_index_of: dict[int, dict[int, int]] = {}  # q -> {global_j: local_idx}
-    counter: dict[int, int] = {}
-    for j, q in enumerate(bond_charges):
-        q_int = int(q)
-        local_index_of.setdefault(q_int, {})[j] = counter.get(q_int, 0)
-        counter[q_int] = counter.get(q_int, 0) + 1
+    # Group U-blocks by bond charge (last key entry) and Vh-blocks by bond
+    # charge (first key entry), preserving block-dict order so the stacked
+    # argmax matches the per-column reference's concatenation order.
+    u_keys_by_q: dict[int, list] = {}
+    for key in U_T.blocks:
+        u_keys_by_q.setdefault(int(key[-1]), []).append(key)
+    vh_keys_by_q: dict[int, list] = {}
+    for key in Vh_T.blocks:
+        vh_keys_by_q.setdefault(int(key[0]), []).append(key)
 
-    # Collect U-blocks indexed by bond charge (last key entry).
-    u_blocks_by_q: dict[int, list[tuple[tuple[int, ...], jax.Array]]] = {}
-    for key, block in U_T.blocks.items():
-        q = int(key[-1])
-        u_blocks_by_q.setdefault(q, []).append((key, block))
-
-    # Collect Vh-blocks indexed by bond charge (FIRST key entry).
-    vh_blocks_by_q: dict[int, list[tuple[tuple[int, ...], jax.Array]]] = {}
-    for key, block in Vh_T.blocks.items():
-        q = int(key[0])
-        vh_blocks_by_q.setdefault(q, []).append((key, block))
-
-    new_u_blocks: dict[tuple[int, ...], jax.Array] = {
-        key: block for key, block in U_T.blocks.items()
-    }
-    new_vh_blocks: dict[tuple[int, ...], jax.Array] = {
-        key: block for key, block in Vh_T.blocks.items()
-    }
+    new_u_blocks: dict = dict(U_T.blocks)
+    new_vh_blocks: dict = dict(Vh_T.blocks)
 
     # Detect dtype statically so we don't promote real blocks to complex.
     sample_block = next(iter(U_T.blocks.values()))
     is_complex = jnp.issubdtype(sample_block.dtype, jnp.complexfloating)
 
-    # For each global column j, compute its phase and write it back.
-    for j, q in enumerate(bond_charges):
+    for q in np.unique(bond_charges):
         q_int = int(q)
-        local = local_index_of[q_int][j]
-        u_entries = u_blocks_by_q.get(q_int, [])
-        vh_entries = vh_blocks_by_q.get(q_int, [])
-
-        if not u_entries:
+        u_keys = u_keys_by_q.get(q_int, [])
+        if not u_keys:
             continue
 
-        candidates = jnp.concatenate(
-            [jnp.reshape(new_u_blocks[key][..., local], (-1,)) for key, _ in u_entries]
+        # All U-blocks of this sector share the bond multiplicity n_q (last axis).
+        n_q = new_u_blocks[u_keys[0]].shape[-1]
+
+        # Stack each U-block's (rows_i, n_q) view → (R, n_q), same order as the
+        # per-column reference's `candidates` concatenation.
+        M_q = jnp.concatenate(
+            [jnp.reshape(new_u_blocks[key], (-1, n_q)) for key in u_keys], axis=0
         )
-        max_idx = jnp.argmax(jnp.abs(candidates))
-        best_value = candidates[max_idx]
-        abs_best = jnp.abs(best_value)
+        idx = jnp.argmax(jnp.abs(M_q), axis=0)  # (n_q,)
+        best = M_q[idx, jnp.arange(n_q)]  # (n_q,)
+        abs_best = jnp.abs(best)
         phase = jnp.where(
             abs_best > 0,
-            best_value
-            / jnp.maximum(abs_best, jnp.asarray(1e-30, dtype=abs_best.dtype)),
-            jnp.ones_like(best_value),
+            best / jnp.maximum(abs_best, jnp.asarray(1e-30, dtype=abs_best.dtype)),
+            jnp.ones_like(best),
         )
-
         if is_complex:
             conj_phase = jnp.conj(phase)
             bare_phase = phase
@@ -130,15 +118,13 @@ def _gauge_fix_symmetric_svd(
             conj_phase = jnp.real(phase)
             bare_phase = jnp.real(phase)
 
-        for key, _block in u_entries:
-            new_block = new_u_blocks[key]
-            new_block = new_block.at[..., local].multiply(conj_phase)
-            new_u_blocks[key] = new_block
-
-        for key, _block in vh_entries:
-            new_block = new_vh_blocks[key]
-            new_block = new_block.at[local, ...].multiply(bare_phase)
-            new_vh_blocks[key] = new_block
+        # U columns (last axis) by conj(phase); Vh rows (first axis) by phase.
+        for key in u_keys:
+            new_u_blocks[key] = new_u_blocks[key] * conj_phase
+        for key in vh_keys_by_q.get(q_int, []):
+            blk = new_vh_blocks[key]
+            bcast = jnp.reshape(bare_phase, (n_q,) + (1,) * (blk.ndim - 1))
+            new_vh_blocks[key] = blk * bcast
 
     U_out = SymmetricTensor._from_blocks_unchecked(new_u_blocks, U_T.indices)
     Vh_out = SymmetricTensor._from_blocks_unchecked(new_vh_blocks, Vh_T.indices)

--- a/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
+++ b/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
@@ -60,7 +60,8 @@ def _gauge_fix_symmetric_svd(
     ``|U[:, j]|`` across all U-blocks that share its bond charge, rotates U's
     column and Vh's row by ``conj(phase)`` / ``phase`` so that
     ``U @ diag(s) @ Vh == M`` is preserved.  Critical for the 2x2 closure
-    ``P_bot · P_top = I``.
+    ``P_bot · P_top = I`` (no intervening matrix to absorb a ``conj(phase)**2``
+    factor — see the docstring of :func:`_gauge_fixed_svd`).
 
     Vectorized over bond-charge sectors (#566): instead of looping over every
     bond column, we process each (static) bond charge once — stacking that
@@ -73,8 +74,10 @@ def _gauge_fix_symmetric_svd(
     bond_charges = np.asarray(bond_idx.charges, dtype=np.int32)
 
     # Group U-blocks by bond charge (last key entry) and Vh-blocks by bond
-    # charge (first key entry), preserving block-dict order so the stacked
-    # argmax matches the per-column reference's concatenation order.
+    # charge (first key entry). SymmetricTensor.blocks iterates in sorted-key
+    # order, so u_keys_by_q[q] preserves that order — the stacked M_q columns
+    # then match the original per-column loop's concatenation order, keeping
+    # the argmax (incl. ties) byte-identical.
     u_keys_by_q: dict[int, list] = {}
     for key in U_T.blocks:
         u_keys_by_q.setdefault(int(key[-1]), []).append(key)
@@ -82,8 +85,8 @@ def _gauge_fix_symmetric_svd(
     for key in Vh_T.blocks:
         vh_keys_by_q.setdefault(int(key[0]), []).append(key)
 
-    new_u_blocks: dict = dict(U_T.blocks)
-    new_vh_blocks: dict = dict(Vh_T.blocks)
+    new_u_blocks: dict[tuple[int, ...], jax.Array] = dict(U_T.blocks)
+    new_vh_blocks: dict[tuple[int, ...], jax.Array] = dict(Vh_T.blocks)
 
     # Detect dtype statically so we don't promote real blocks to complex.
     sample_block = next(iter(U_T.blocks.values()))

--- a/tests/test_ctm_2x2_projector_symmetric.py
+++ b/tests/test_ctm_2x2_projector_symmetric.py
@@ -779,3 +779,152 @@ def test_compute_2x2_projector_closure_under_tracing(symmetric_corners):
         atol=1e-6,
         err_msg="P_bot · P_top must be identity on chi_new × chi_new (Fishman closure)",
     )
+
+
+# --------------------------------------------------------------------------- #
+# Vectorization parity (#566): the per-sector rewrite of _gauge_fix_symmetric_svd
+# must be byte-identical to the original per-column loop, frozen here.
+# --------------------------------------------------------------------------- #
+def _reference_gauge_fix_loop(U_T, Vh_T):
+    """Frozen copy of the original per-column _gauge_fix_symmetric_svd loop.
+
+    Kept in the test as the behavioral oracle for the vectorized rewrite.
+    """
+    bond_idx = U_T.indices[-1]
+    bond_charges = np.asarray(bond_idx.charges, dtype=np.int32)
+
+    local_index_of: dict[int, dict[int, int]] = {}
+    counter: dict[int, int] = {}
+    for j, q in enumerate(bond_charges):
+        q_int = int(q)
+        local_index_of.setdefault(q_int, {})[j] = counter.get(q_int, 0)
+        counter[q_int] = counter.get(q_int, 0) + 1
+
+    u_blocks_by_q: dict[int, list] = {}
+    for key, block in U_T.blocks.items():
+        u_blocks_by_q.setdefault(int(key[-1]), []).append((key, block))
+    vh_blocks_by_q: dict[int, list] = {}
+    for key, block in Vh_T.blocks.items():
+        vh_blocks_by_q.setdefault(int(key[0]), []).append((key, block))
+
+    new_u_blocks = {key: block for key, block in U_T.blocks.items()}
+    new_vh_blocks = {key: block for key, block in Vh_T.blocks.items()}
+
+    sample_block = next(iter(U_T.blocks.values()))
+    is_complex = jnp.issubdtype(sample_block.dtype, jnp.complexfloating)
+
+    for j, q in enumerate(bond_charges):
+        q_int = int(q)
+        local = local_index_of[q_int][j]
+        u_entries = u_blocks_by_q.get(q_int, [])
+        vh_entries = vh_blocks_by_q.get(q_int, [])
+        if not u_entries:
+            continue
+        candidates = jnp.concatenate(
+            [jnp.reshape(new_u_blocks[key][..., local], (-1,)) for key, _ in u_entries]
+        )
+        max_idx = jnp.argmax(jnp.abs(candidates))
+        best_value = candidates[max_idx]
+        abs_best = jnp.abs(best_value)
+        phase = jnp.where(
+            abs_best > 0,
+            best_value / jnp.maximum(abs_best, jnp.asarray(1e-30, dtype=abs_best.dtype)),
+            jnp.ones_like(best_value),
+        )
+        if is_complex:
+            conj_phase = jnp.conj(phase)
+            bare_phase = phase
+        else:
+            conj_phase = jnp.real(phase)
+            bare_phase = jnp.real(phase)
+        for key, _block in u_entries:
+            new_u_blocks[key] = new_u_blocks[key].at[..., local].multiply(conj_phase)
+        for key, _block in vh_entries:
+            new_vh_blocks[key] = new_vh_blocks[key].at[local, ...].multiply(bare_phase)
+
+    U_out = SymmetricTensor._from_blocks_unchecked(new_u_blocks, U_T.indices)
+    Vh_out = SymmetricTensor._from_blocks_unchecked(new_vh_blocks, Vh_T.indices)
+    return U_out, Vh_out
+
+
+def _svd_of(M_T):
+    from tenax.linalg import svd as tensor_svd
+
+    U_T, s, Vh_T, _ = tensor_svd(
+        M_T, left_labels=("left",), right_labels=("right",), new_bond_label="bond"
+    )
+    return U_T, s, Vh_T
+
+
+def _complex_matrix_tensor(seed: int = 7) -> SymmetricTensor:
+    """Two-sector U(1) complex128 matrix tensor."""
+    sym = U1Symmetry()
+    charges = np.array([0, 0, 1, 1], dtype=np.int32)
+    left_idx = TensorIndex.from_charges(sym, charges, FlowDirection.IN, label="left")
+    right_idx = TensorIndex.from_charges(sym, charges, FlowDirection.OUT, label="right")
+    k1, k2 = jax.random.split(jax.random.PRNGKey(seed))
+    re = SymmetricTensor.random_normal((left_idx, right_idx), k1)
+    im = SymmetricTensor.random_normal((left_idx, right_idx), k2)
+    blocks = {
+        key: (re.blocks[key] + 1j * im.blocks[key]).astype(jnp.complex128)
+        for key in re.blocks
+    }
+    return SymmetricTensor._from_blocks_unchecked(blocks, re.indices)
+
+
+def _degenerate_matrix_tensor(seed: int = 3) -> SymmetricTensor:
+    """Scaled-identity-per-sector matrix → fully degenerate singular values
+    (exercises argmax ties, where concat order must match the reference)."""
+    M_T = _make_test_matrix_tensor(seed=seed)
+    blocks = {}
+    for key, block in M_T.blocks.items():
+        n = block.shape[0]
+        blocks[key] = jnp.eye(n, block.shape[1], dtype=block.dtype) * (1.0 + key[0])
+    return SymmetricTensor._from_blocks_unchecked(blocks, M_T.indices)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: _make_test_matrix_tensor(seed=0),
+        lambda: _make_test_matrix_tensor(seed=5),
+        _complex_matrix_tensor,
+        _degenerate_matrix_tensor,
+    ],
+    ids=["u1_real_a", "u1_real_b", "u1_complex", "degenerate_ties"],
+)
+def test_gauge_fix_vectorized_matches_reference_forward(factory):
+    """Vectorized gauge fix is byte-identical to the frozen per-column loop."""
+    M_T = factory()
+    U_T, _s, Vh_T = _svd_of(M_T)
+
+    U_ref, Vh_ref = _reference_gauge_fix_loop(U_T, Vh_T)
+    U_new, Vh_new = _gauge_fix_symmetric_svd(U_T, Vh_T)
+
+    for key in U_ref.blocks:
+        assert jnp.array_equal(U_new.blocks[key], U_ref.blocks[key]), f"U block {key}"
+    for key in Vh_ref.blocks:
+        assert jnp.array_equal(Vh_new.blocks[key], Vh_ref.blocks[key]), f"Vh block {key}"
+
+
+def test_gauge_fix_vectorized_matches_reference_grad():
+    """Gradient through the vectorized gauge fix matches the reference (fp tier)."""
+    M_T = _make_test_matrix_tensor(seed=2)
+    U_T, _s, Vh_T = _svd_of(M_T)
+
+    def _loss(U_T_in, Vh_T_in, gauge_fn):
+        U_fixed, Vh_fixed = gauge_fn(U_T_in, Vh_T_in)
+        u = U_fixed.todense()
+        v = Vh_fixed.todense()
+        return jnp.real(jnp.sum(u * jnp.conj(u))) + jnp.real(jnp.sum(v))
+
+    leaves, treedef = jax.tree.flatten(U_T)
+
+    def _from_leaves(ls, fn):
+        U_in = jax.tree.unflatten(treedef, ls)
+        return _loss(U_in, Vh_T, fn)
+
+    g_ref = jax.grad(lambda ls: _from_leaves(ls, _reference_gauge_fix_loop))(leaves)
+    g_new = jax.grad(lambda ls: _from_leaves(ls, _gauge_fix_symmetric_svd))(leaves)
+    for a, b in zip(jax.tree.leaves(g_new), jax.tree.leaves(g_ref)):
+        np.testing.assert_allclose(np.asarray(a), np.asarray(b), rtol=1e-12, atol=1e-12)

--- a/tests/test_ctm_2x2_projector_symmetric.py
+++ b/tests/test_ctm_2x2_projector_symmetric.py
@@ -874,7 +874,9 @@ def _complex_matrix_tensor(seed: int = 7) -> SymmetricTensor:
 
 def _degenerate_matrix_tensor(seed: int = 3) -> SymmetricTensor:
     """Scaled-identity-per-sector matrix → fully degenerate singular values
-    (exercises argmax ties, where concat order must match the reference)."""
+    (exercises argmax ties). ``seed`` only sources the index structure; all
+    block values are overwritten deterministically, so the result is
+    seed-independent."""
     M_T = _make_test_matrix_tensor(seed=seed)
     blocks = {}
     for key, block in M_T.blocks.items():
@@ -901,6 +903,8 @@ def test_gauge_fix_vectorized_matches_reference_forward(factory):
     U_ref, Vh_ref = _reference_gauge_fix_loop(U_T, Vh_T)
     U_new, Vh_new = _gauge_fix_symmetric_svd(U_T, Vh_T)
 
+    assert set(U_new.blocks) == set(U_ref.blocks)
+    assert set(Vh_new.blocks) == set(Vh_ref.blocks)
     for key in U_ref.blocks:
         assert jnp.array_equal(U_new.blocks[key], U_ref.blocks[key]), f"U block {key}"
     for key in Vh_ref.blocks:
@@ -908,7 +912,8 @@ def test_gauge_fix_vectorized_matches_reference_forward(factory):
 
 
 def test_gauge_fix_vectorized_matches_reference_grad():
-    """Gradient through the vectorized gauge fix matches the reference (fp tier)."""
+    """Gradient through the vectorized gauge fix matches the reference (fp tier),
+    differentiating w.r.t. BOTH U and Vh inputs."""
     M_T = _make_test_matrix_tensor(seed=2)
     U_T, _s, Vh_T = _svd_of(M_T)
 
@@ -916,15 +921,19 @@ def test_gauge_fix_vectorized_matches_reference_grad():
         U_fixed, Vh_fixed = gauge_fn(U_T_in, Vh_T_in)
         u = U_fixed.todense()
         v = Vh_fixed.todense()
-        return jnp.real(jnp.sum(u * jnp.conj(u))) + jnp.real(jnp.sum(v))
+        return jnp.real(jnp.sum(u * jnp.conj(u))) + jnp.real(jnp.sum(v * jnp.conj(v)))
 
-    leaves, treedef = jax.tree.flatten(U_T)
+    u_leaves, u_tree = jax.tree.flatten(U_T)
+    vh_leaves, vh_tree = jax.tree.flatten(Vh_T)
 
-    def _from_leaves(ls, fn):
-        U_in = jax.tree.unflatten(treedef, ls)
-        return _loss(U_in, Vh_T, fn)
+    def _from_leaves(ul, vl, fn):
+        U_in = jax.tree.unflatten(u_tree, ul)
+        Vh_in = jax.tree.unflatten(vh_tree, vl)
+        return _loss(U_in, Vh_in, fn)
 
-    g_ref = jax.grad(lambda ls: _from_leaves(ls, _reference_gauge_fix_loop))(leaves)
-    g_new = jax.grad(lambda ls: _from_leaves(ls, _gauge_fix_symmetric_svd))(leaves)
+    g_ref = jax.grad(lambda ul, vl: _from_leaves(ul, vl, _reference_gauge_fix_loop),
+                     argnums=(0, 1))(u_leaves, vh_leaves)
+    g_new = jax.grad(lambda ul, vl: _from_leaves(ul, vl, _gauge_fix_symmetric_svd),
+                     argnums=(0, 1))(u_leaves, vh_leaves)
     for a, b in zip(jax.tree.leaves(g_new), jax.tree.leaves(g_ref)):
         np.testing.assert_allclose(np.asarray(a), np.asarray(b), rtol=1e-12, atol=1e-12)


### PR DESCRIPTION
## Summary

Vectorizes `_gauge_fix_symmetric_svd` (the SymmetricTensor 2×2-projector gauge fix) from a
**per-bond-column Python loop** (≈χ iterations, each emitting `argmax`/`concatenate`/per-block
`.at[col].multiply`) to a **per-bond-charge-sector batched** computation (~2 sectors for Z₂):
stack each sector's U-blocks into one matrix, compute all column phases in a single `argmax`,
apply with one broadcast-multiply per block. Contained sub-lever from the #570 compile-wall
localization (#566 structural emission). **Output is byte-identical; always-on; no interface change.**

## Verified compile reduction (A100, D=4, sweep-VJP unit, `--full`)

Same-GPU before/after — the OLD baseline was re-run on the same machine and **reproduced the
committed numbers exactly** (326,547 @ χ=8, 400,940 @ χ=12), so the only difference between the
two columns is this change:

| χ | OLD env HLO instr | NEW env HLO instr | reduction | OLD total compile | NEW total compile |
|---:|---:|---:|---:|---:|---:|
| 8 | 326,547 | 29,088 | **11.2×** | 317 s | 35 s |
| 12 | 400,940 | 28,786 | **13.9×** | 539 s | 37 s |
| 16 | 471,073 | 20,857 | **22.6×** | 852 s | 40 s |

The old per-column scatter emission was the **dominant, χ-growing** term of the unit; the new
code is compact and χ-flat. This far exceeds the "~25%" the gauge fix was attributed in PR #589 —
because that figure was a **jaxpr op-count** share, whereas at the **lowered-HLO** level the
per-column `.at[].multiply` loop dominated. (jaxpr op-count ≠ HLO size — the recurring lesson.)
This is the dominant *repeated* compile unit of `_jit_fused_fixed_point_bwd`, so the end-to-end
backward wall should drop comparably (end-to-end `value_and_grad` confirmation is a cheap follow-up).

## Correctness

- **Byte-identical** forward (`jnp.array_equal` on every U/Vh block) and **gradient** parity
  (rtol=atol=1e-12, differentiating w.r.t. both U and Vh) vs a frozen copy of the old loop —
  across U(1)/complex128/degenerate-tie cases (`tests/test_ctm_2x2_projector_symmetric.py`).
  Order-preserving concatenation keeps `argmax` (incl. ties) identical.
- `tests/stacked/` + `tests/test_block_sparse_ctm_ad.py`: **87 passed**.
- Full `pytest -m core`: **959 passed, 9 skipped**.

## Scope

Single function in `src/tenax/algorithms/_ctm_tensor_projector_2x2.py`. No call-site, signature,
default-behavior, or gate changes. Spec/plan:
`docs/superpowers/specs/2026-06-08-gauge-fix-symmetric-svd-vectorization-design.md`,
`docs/superpowers/plans/2026-06-08-gauge-fix-symmetric-svd-vectorization.md`.

Refs #566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
