### PR TITLE
test(#570): run fast reduced-corner QR tests in the required CI gate

### DIFF
--- a/tests/test_reduced_corner_qr.py
+++ b/tests/test_reduced_corner_qr.py
@@ -66,6 +66,7 @@ def _build_dense_enlarged_corners(chi: int, D: int = 2, seed: int = 0):
     return C1g, C4g
 
 
+@pytest.mark.core
 @pytest.mark.parametrize("chi", [4, 8])
 def test_reduced_qr_projector_is_isometry(chi):
     """``P`` has labels ``(fused, chi_new)`` and ``P^dagger P = I_chi``."""
@@ -81,6 +82,7 @@ def test_reduced_qr_projector_is_isometry(chi):
     np.testing.assert_allclose(np.asarray(gram), np.eye(chi), atol=1e-9)
 
 
+@pytest.mark.core
 def test_compute_projector_tensor_qr_uses_reduced_qr_dense():
     """Dense forward ``projector_method='qr'`` dispatch routes through the
     canonical ``_reduced_qr_projector`` (consolidation, issue #570 Phase 1)."""
@@ -100,6 +102,7 @@ def test_compute_projector_tensor_qr_uses_reduced_qr_dense():
     np.testing.assert_allclose(np.asarray(g), np.eye(g.shape[0]), atol=1e-9)
 
 
+@pytest.mark.core
 def test_gauge_fix_qr_dense_makes_diag_R_nonneg_and_preserves_QR():
     key = jax.random.PRNGKey(3)
     M = jax.random.normal(key, (12, 6))
@@ -115,6 +118,7 @@ def test_gauge_fix_qr_dense_makes_diag_R_nonneg_and_preserves_QR():
     assert jnp.allclose(jnp.imag(d), 0.0, atol=1e-10)
 
 
+@pytest.mark.core
 def test_gauge_fix_qr_dense_is_smooth_under_perturbation():
     key = jax.random.PRNGKey(5)
     M = jax.random.normal(key, (12, 6))


### PR DESCRIPTION
Addresses the Codex review comment on #595.

## Problem
`tests/test_reduced_corner_qr.py` isn't listed in `tests/conftest.py`'s `_FILE_MARKERS`, so its tests get no auto-marker. The fast tests guarding the new production QR dispatch (isometry, gauge fix, `projector_method="qr"` routing) had **no** marker → silently deselected by the required `pytest -m core` check. Only the slow energy/convergence tests carried explicit `@pytest.mark.algorithm`. Net: the dense reduced-corner QR dispatch was unguarded in required CI.

## Fix
Mark the four fast tests `@pytest.mark.core` so they run in the required gate; leave the slow energy/convergence tests as `@pytest.mark.algorithm` (kept out of the fast gate — they do ipeps simple-update + CTM, ~tens of seconds). Per-test marks (not a whole-file `_FILE_MARKERS` entry) because the file deliberately mixes fast and slow tests.

Verified: `pytest -m core tests/test_reduced_corner_qr.py` selects 5 fast cases (isometry[4], isometry[8], dispatch, gauge×2), deselects the 4 slow ones, passes in ~10s. `ruff check src/ tests/` clean.

## Test Plan
- [ ] `uv run pytest -m core tests/test_reduced_corner_qr.py` (5 selected, pass)
- [ ] CI: Tests (Python 3.11 / 3.12 / macOS 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)