### PR TITLE
study(#570): dense Heisenberg large-D characterization

### DIFF
--- a/docs/superpowers/handoffs/2026-06-12-heisenberg-largeD-characterization.md
+++ b/docs/superpowers/handoffs/2026-06-12-heisenberg-largeD-characterization.md
@@ -1,0 +1,94 @@
+# Dense 2D-Heisenberg large-D characterization — findings
+
+**Date:** 2026-06-12
+**Issue:** #570 (the never-evaluated "large-D energy + runtime + compile" acceptance criterion)
+**Branch:** `study/heisenberg-largeD-characterization`
+**Script:** `examples/bench_heisenberg_largeD.py` · **Data:** `examples/heisenberg_largeD_a100.json`
+**Spec/plan:** `docs/superpowers/{specs,plans}/2026-06-12-heisenberg-largeD-characterization*`
+
+## TL;DR
+
+The dense single-site (C4v, phase-gauge, implicit-AD, SVD-projector) iPEPS path **works and
+scales in the right direction** — energy improves with D toward the −0.6694430 reference — but
+it is **runtime-bound**, not compile-bound, and the per-cell cost explodes fast enough that the
+dense path **cannot reach the regime needed for competitive energies** (the literature reference
+is D=7 χ=300; here a single **D=2 χ=32** cell already costs **42 min**). The lever to go further
+is **U(1)/Sz symmetry**, which is out of this study's scope and is the recommended next step.
+
+A second, contrasting finding: the dense path's wall is **per-step runtime**
+(cold XLA-compile is only ~10–20 s/cell), whereas the fermionic / block-sparse CTM-AD path that
+the rest of #570 / #566 chased is **compile-bound**. Dense and block-sparse hit *different* walls.
+
+## Setup
+
+- Model: `sublattice_rotate_gate(heisenberg_gate())` — Néel → uniform, single C4v tensor.
+- Path: `optimize_gs_ad`, `gs_c4v=True`, `forward_gauge="phase"`, `projector_method="svd"`,
+  implicit AD, `gs_conv_criterion="grad_norm"` (tol 1e-5), SU-init, `gs_num_steps=150`.
+  (phase+svd is **forced** by `validate_ctm_for_implicit_ad`; the older
+  `examples/heisenberg_ipeps_ad.py` sigma+eigh+gmres config is now API-invalid — see the spec
+  correction. Its docstring's −0.6625 came from that invalid config; the valid path gives −0.6602.)
+- Hardware: A100-SXM4-80GB, x64, cold-compile + runtime per cell, JSON-checkpointed.
+- Reference: E/site = **−0.6694430** (Corboz QR-CTMRG / QMC).
+
+## Results
+
+| D | χ | E_final | dE vs −0.6694430 | jit_compile (s) | total wall (s) | median warm-step (s) | steps | conv |
+|---|---|---------|------------------|-----------------|----------------|----------------------|-------|------|
+| 2 | 8  | −0.660229 | +0.00921 | 19.8 | 551.6  | 0.549 | 150 | no |
+| 2 | 16 | −0.660231 | +0.00921 | 19.5 | 783.5  | 0.699 | 150 | no |
+| 2 | 24 | −0.660214 | +0.00923 |  8.5 | 1409.7 | 1.365 | 150 | no |
+| 2 | 32 | −0.660197 | +0.00925 |  8.6 | 2544.6 | 2.205 | 150 | no |
+| 3 | 8  | −0.663993 | +0.00545 |  8.1 | 2493.2 | 1.636 | 150 | no |
+| 3 | 16 | −0.664192 | +0.00525 | 27.2 | 6475.5 | 3.993 | 150 | no |
+
+D=4 χ=8 (a stretch cell) was not completed: the core grid did not stay tractable, so per the
+plan the D≥4 / χ≥48 stretch was not pursued to completion. Every cell past D=3 χ=8 exceeds the
+1-hour per-attempt budget — D=3 χ=16 alone took **108 min** — and the full 12-cell core grid did
+not finish in 4 hours of kill/resume (≈ one expensive cell per hour). The non-completion of the
+larger grid *is* the runtime-wall finding.
+
+## 1. Energy vs (D, χ)
+
+- **D-scaling works.** D=2 → −0.6602 (dE +0.0092), D=3 → −0.6642 (dE +0.0053): the D=2→3
+  step closes ~43% of the gap to −0.6694430, the expected variational improvement with bond
+  dimension. The path reaches sensible, literature-consistent energies (D=2 iPEPS for 2D
+  Heisenberg sits at ≈ −0.660).
+- **χ-scaling is flat at D=2, marginal at D=3.** At D=2, E is constant to <4e-5 across
+  χ ∈ {8,16,24,32} — correct physics: the double-layer bond is D²=4, so the CTM environment is
+  χ-saturated by χ≈8. At D=3 (double-layer bond D²=9) χ=8 is slightly under-resolved and
+  χ=8→16 buys a small but real gain (−0.663993 → −0.664192, ≈2e-4). The dominant energy signal
+  still lives in **D**, not χ. (D=2 χ-flatness CPU-validated separately before the sweep.)
+- `converged=no` everywhere: `grad_norm` does not reach 1e-5 within 150 steps because the
+  near-minimum landscape is flat/CTM-noisy, but the **energy plateaus** well before the budget,
+  so `E_final` (min over the trajectory) is the meaningful number. No cell fell below the
+  reference (the variational-floor watch never tripped).
+
+## 2. Runtime + compile scaling
+
+- **Compile is cheap and ~flat:** `jit_compile_s` ≈ 8–20 s regardless of D/χ. The dense bosonic
+  backward does **not** suffer the block-sparse compile wall.
+- **Runtime is the cost and it explodes:** total wall at D=2 grows 552 → 784 → 1410 → 2545 s as
+  χ goes 8 → 32 (≈ χ^1.7); median warm-step grows 0.55 → 2.2 s. D=3 χ=8 (2493 s) already costs as
+  much as D=2 χ=32, and D=3 χ=16 (6475 s, **108 min**, warm-step 3.99 s) is the single most
+  expensive completed cell. The per-step cost is the implicit-AD step: a full CTM re-convergence
+  (`max_iter` up to 100 sweeps) inside each L-BFGS line-search evaluation, and that scales
+  steeply in both D and χ.
+
+## 3. Where the dense wall hits
+
+The practical ceiling of this dense path (gs_steps=150, A100): **~D=3 χ=8 within an hour.** D=3
+χ=16 already costs 108 min, and D≥4 was not reached; the reference scale (D=7 χ=300) is many
+orders of magnitude out of reach (D=2 χ=32 alone = 42 min, D=3 χ=16 = 108 min). The wall is
+**wall-clock runtime**, set by per-step CTM convergence × line search × steps — not memory and
+not compile (compile stays ≤27 s even at the largest cell).
+
+## 4. Conclusion / next step
+
+The dense path is **correct and directionally competitive** (energy improves with D toward the
+QMC reference) but **does not scale**: it is runtime-bound and impractical beyond small D. This
+directly answers #570 for the dense path. The lever to push toward competitive large-D energies
+is **U(1)/Sz symmetry**: block-diagonalizing the site/CTM tensors shrinks per-step contraction
+and decomposition cost and unlocks larger D/χ — the natural, scoped follow-up study (the builtin
+`heisenberg_gate()` currently carries trivial charges). The block-sparse CTM-AD compile wall
+explored elsewhere in #570/#566 is a *separate* axis: that path is compile-bound; this dense one
+is runtime-bound.

--- a/docs/superpowers/plans/2026-06-12-heisenberg-largeD-characterization.md
+++ b/docs/superpowers/plans/2026-06-12-heisenberg-largeD-characterization.md
@@ -1,0 +1,430 @@
+# Dense 2D-Heisenberg large-D characterization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone study script that sweeps the dense 2D-Heisenberg iPEPS-AD path over (D, χ) and records final energy (vs −0.6694430), cold-compile time, and runtime — then run it on the A100 and write up where the dense wall hits.
+
+**Architecture:** One self-contained `examples/bench_heisenberg_largeD.py` that mirrors the known-good `examples/heisenberg_ipeps_ad.py` configuration (sublattice-rotated Heisenberg, C4v 1-site, sigma gauge, SVD projector, SU-init) inside a `(D, χ)` grid loop with JSON checkpoint/resume and per-cell error capture. Verification is operational (CPU smoke + the D=2 χ=8 ≈ −0.6625 sanity anchor), not unit tests — consistent with the repo's other `bench_*`/`profile_*` scripts.
+
+**Tech Stack:** Python, JAX (x64, CUDA on A100), tenax `optimize_gs_ad`.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-heisenberg-largeD-characterization-design.md`
+
+> **No-unit-test note:** The spec explicitly excludes pytest tests for this `examples/` script. Each task's "verify" step runs the script and inspects stdout/JSON. This is a deliberate, spec-sanctioned deviation from default TDD, matching `examples/bench_qr_vs_svd_optimize_570.py` and `examples/profile_570_sweepvjp_compile.py` (neither has tests).
+
+---
+
+## File structure
+
+- **Create:** `examples/bench_heisenberg_largeD.py` — the entire study script (problem builder, single-cell runner, grid loop, JSON I/O, table printer, CLI).
+- **Generated (not committed by build tasks):** `examples/heisenberg_largeD_a100.json` — results, written by the run.
+- **Create (Task 6):** `docs/superpowers/handoffs/2026-06-12-heisenberg-largeD-characterization.md` — the findings writeup.
+
+No `src/` changes. No other files.
+
+---
+
+## Task 1: Lock the exact API from the existing example, then scaffold the single-cell runner
+
+**Files:**
+- Read first: `examples/heisenberg_ipeps_ad.py` (ground-truth API), `src/tenax/algorithms/ipeps.py` (gate constructors), `src/tenax/algorithms/ipeps_config.py` (`iPEPSConfig`, `CTMConfig` field names), `src/tenax/algorithms/ipeps_optimize.py:864` (`optimize_gs_ad` signature + `return_history` dict keys).
+- Create: `examples/bench_heisenberg_largeD.py`
+
+- [ ] **Step 1: Read the ground-truth example and confirm exact names**
+
+Read `examples/heisenberg_ipeps_ad.py` end to end and note the EXACT:
+- import paths for `heisenberg_gate`, `sublattice_rotate_gate`,
+- how the SU-init `A_init` is produced (config flag `su_init=True` vs an explicit init call),
+- the `iPEPSConfig` / `CTMConfig` field names actually used (`max_bond_dim`, `ctm`, `chi`, `gs_c4v`, `forward_gauge`, `gs_num_steps`, `gs_conv_criterion`, `gs_grad_norm_tol`, `return_history`),
+- the exact return arity of `optimize_gs_ad(..., return_history=True)` and the history dict keys (`energies`, `step_times`, `jit_compile_time`, `num_steps`, `converged`).
+
+If any name below differs from the example, **use the example's name** (it is the source of truth) and adjust the code in later steps accordingly.
+
+- [ ] **Step 2: Write the scaffold with `build_problem` and `run_cell` (single cell)**
+
+Create `examples/bench_heisenberg_largeD.py`:
+
+```python
+#!/usr/bin/env python3
+"""#570 dense 2D-Heisenberg large-D characterization.
+
+Sweeps the dense iPEPS-AD path (sublattice-rotated Heisenberg, C4v 1-site, sigma
+gauge, SVD projector, SU-init) over (D, chi) and records final energy vs the
+-0.6694430 reference, cold XLA-compile time, and runtime. Mirrors the known-good
+examples/heisenberg_ipeps_ad.py configuration inside a grid with JSON
+checkpoint/resume. See docs/superpowers/specs/2026-06-12-heisenberg-largeD-characterization-design.md.
+
+Usage (A100):
+    CUDA_VISIBLE_DEVICES=2 JAX_PLATFORMS=cuda,cpu \\
+      uv run python examples/bench_heisenberg_largeD.py \\
+      --D-list 2 3 4 --chi-list 8 16 24 32 --gs-steps 100 \\
+      --json examples/heisenberg_largeD_a100.json
+
+CPU smoke:
+    JAX_PLATFORMS=cpu uv run python examples/bench_heisenberg_largeD.py \\
+      --D-list 2 --chi-list 8 --gs-steps 30
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import statistics
+import time
+
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+# NOTE: confirm these import paths against examples/heisenberg_ipeps_ad.py in Step 1.
+from tenax.algorithms.ipeps import heisenberg_gate, sublattice_rotate_gate  # noqa: E402
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig  # noqa: E402
+from tenax.algorithms.ipeps_optimize import optimize_gs_ad  # noqa: E402
+
+REF_ENERGY = -0.6694430  # 2D Heisenberg E/site (Corboz QR-CTMRG / QMC)
+
+
+def build_problem(D: int, chi: int, gs_steps: int):
+    """Return (gate, A_init, config) for one (D, chi) cell.
+
+    Mirrors examples/heisenberg_ipeps_ad.py: sublattice-rotated Heisenberg gate,
+    SU-init at this D, C4v 1-site, sigma gauge, SVD projector, grad-norm exit.
+    """
+    gate = sublattice_rotate_gate(heisenberg_gate())
+    ctm = CTMConfig(chi=chi)  # defaults max_iter=100, conv_tol=1e-8, projector_method="svd"
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        ctm=ctm,
+        gs_c4v=True,
+        forward_gauge="sigma",
+        gs_num_steps=gs_steps,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-5,
+        su_init=True,            # confirm this is the SU-init flag in Step 1
+        return_history=True,
+    )
+    A_init = None  # su_init=True builds the initial tensor; confirm in Step 1
+    return gate, A_init, config
+
+
+def run_cell(D: int, chi: int, gs_steps: int) -> dict:
+    """Optimize one (D, chi) cell; return a result row."""
+    gate, A_init, config = build_problem(D, chi, gs_steps)
+    t0 = time.perf_counter()
+    out = optimize_gs_ad(gate, A_init, config)
+    total_wall = time.perf_counter() - t0
+    # return_history=True -> (A_opt, env, E_gs, history)
+    *_head, history = out
+    energies = list(history["energies"])
+    step_times = list(history.get("step_times", []))
+    e_final = float(min(energies)) if energies else float("nan")
+    warm = step_times[1:] if len(step_times) > 1 else step_times
+    return {
+        "D": D,
+        "chi": chi,
+        "E_final": e_final,
+        "dE": e_final - REF_ENERGY,
+        "jit_compile_s": float(history.get("jit_compile_time", float("nan"))),
+        "total_wall_s": total_wall,
+        "warm_step_s": float(statistics.median(warm)) if warm else float("nan"),
+        "num_steps": int(history.get("num_steps", len(energies))),
+        "converged": bool(history.get("converged", False)),
+        "below_ref": e_final < REF_ENERGY,  # variational-floor watch
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--D-list", type=int, nargs="+", default=[2])
+    ap.add_argument("--chi-list", type=int, nargs="+", default=[8])
+    ap.add_argument("--gs-steps", type=int, default=100)
+    args = ap.parse_args()
+
+    dev = jax.devices()[0]
+    print(f"# heisenberg large-D | {dev.platform} {dev.device_kind} | ref={REF_ENERGY}")
+    for D in args.D_list:
+        for chi in args.chi_list:
+            row = run_cell(D, chi, args.gs_steps)
+            print(row)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 3: CPU smoke — verify one cell runs and lands near the reference**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run python examples/bench_heisenberg_largeD.py \
+  --D-list 2 --chi-list 8 --gs-steps 30
+```
+Expected: prints one row dict with `E_final` ≈ −0.66 (descended from a higher value), `converged` possibly False at 30 steps, finite `jit_compile_s`/`warm_step_s`. If `E_final` is positive or NaN, the API wiring is wrong — fix names against the Step-1 reading before proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/bench_heisenberg_largeD.py
+git commit -m "bench(#570): heisenberg large-D study — single-cell runner scaffold"
+```
+
+---
+
+## Task 2: Grid loop + JSON checkpoint/resume
+
+**Files:**
+- Modify: `examples/bench_heisenberg_largeD.py`
+
+- [ ] **Step 1: Add JSON I/O + resume + cheap-first ordering to `main`**
+
+Replace `main` with:
+
+```python
+def _write_json(path, meta, rows):
+    with open(path, "w") as fh:
+        json.dump({**meta, "rows": rows}, fh, indent=2)
+
+
+def _load_rows(path):
+    if path and os.path.exists(path):
+        with open(path) as fh:
+            return json.load(fh).get("rows", [])
+    return []
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--D-list", type=int, nargs="+", default=[2])
+    ap.add_argument("--chi-list", type=int, nargs="+", default=[8])
+    ap.add_argument("--gs-steps", type=int, default=100)
+    ap.add_argument("--json", type=str, default=None)
+    args = ap.parse_args()
+
+    dev = jax.devices()[0]
+    meta = {
+        "platform": dev.platform,
+        "device_kind": dev.device_kind,
+        "x64": bool(jax.config.read("jax_enable_x64")),
+        "ref_energy": REF_ENERGY,
+        "D_list": args.D_list,
+        "chi_list": args.chi_list,
+        "gs_steps": args.gs_steps,
+    }
+    rows = _load_rows(args.json)
+    done = {(r["D"], r["chi"]) for r in rows}
+
+    print(f"# heisenberg large-D | {dev.platform} {dev.device_kind} | ref={REF_ENERGY}")
+    hdr = f"{'D':>3} {'chi':>4} {'E_final':>11} {'dE':>9} {'cmp_s':>8} {'wall_s':>8} {'step_s':>8} {'steps':>6} {'cnv':>4}"
+    print(hdr)
+    print("-" * len(hdr))
+    for r in rows:  # reprint resumed rows
+        _print_row(r)
+
+    # cheap-first: smallest D*chi first so a kill leaves the expensive tail undone
+    cells = sorted(
+        ((D, chi) for D in args.D_list for chi in args.chi_list if (D, chi) not in done),
+        key=lambda dc: dc[0] * dc[0] * dc[1],
+    )
+    for D, chi in cells:
+        row = run_cell(D, chi, args.gs_steps)
+        rows.append(row)
+        _print_row(row)
+        if args.json:
+            _write_json(args.json, meta, rows)
+
+
+def _print_row(r):
+    if "error" in r:
+        print(f"{r['D']:>3} {r['chi']:>4}  !! {r['error']}")
+        return
+    print(
+        f"{r['D']:>3} {r['chi']:>4} {r['E_final']:>11.6f} {r['dE']:>9.5f} "
+        f"{r['jit_compile_s']:>8.1f} {r['total_wall_s']:>8.1f} "
+        f"{r['warm_step_s']:>8.3f} {r['num_steps']:>6} {str(r['converged'])[:1]:>4}"
+    )
+```
+
+- [ ] **Step 2: Verify grid + JSON write**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run python examples/bench_heisenberg_largeD.py \
+  --D-list 2 --chi-list 8 16 --gs-steps 20 --json /tmp/hl_smoke.json
+```
+Expected: a 2-row table (D=2 χ=8 then χ=16), and `/tmp/hl_smoke.json` exists with `meta` + 2 `rows`. Check: `python -c "import json;print(len(json.load(open('/tmp/hl_smoke.json'))['rows']))"` prints `2`.
+
+- [ ] **Step 3: Verify resume (skip done cells)**
+
+Run the SAME command again. Expected: it reprints the 2 resumed rows and runs **no** new cells (both `(2,8)` and `(2,16)` already in JSON). Confirm wall-clock is near-instant (no optimization).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/bench_heisenberg_largeD.py
+git commit -m "bench(#570): heisenberg large-D study — grid loop, JSON checkpoint + resume"
+```
+
+---
+
+## Task 3: Per-cell error capture + cost-ceiling pre-skip
+
+**Files:**
+- Modify: `examples/bench_heisenberg_largeD.py`
+
+- [ ] **Step 1: Wrap the cell run in error capture and add a cost ceiling**
+
+In `main`, add the CLI arg and replace the per-cell call:
+
+```python
+    ap.add_argument(
+        "--max-cost", type=int, default=None,
+        help="Skip cells where D*D*chi exceeds this (records a skip row). "
+             "Pre-skip guard for the expensive tail; hard hangs are handled "
+             "externally via `timeout` + resume.",
+    )
+```
+
+```python
+    for D, chi in cells:
+        cost = D * D * chi
+        if args.max_cost is not None and cost > args.max_cost:
+            row = {"D": D, "chi": chi, "error": f"skipped: cost {cost} > {args.max_cost}"}
+        else:
+            try:
+                row = run_cell(D, chi, args.gs_steps)
+            except Exception as exc:  # noqa: BLE001 — OOM / solver failure -> record, continue
+                row = {"D": D, "chi": chi, "error": f"{type(exc).__name__}: {exc}"}
+        rows.append(row)
+        _print_row(row)
+        if args.json:
+            _write_json(args.json, meta, rows)
+```
+
+- [ ] **Step 2: Verify error row + resume interaction**
+
+Run (force a skip):
+```bash
+JAX_PLATFORMS=cpu uv run python examples/bench_heisenberg_largeD.py \
+  --D-list 2 --chi-list 8 64 --gs-steps 10 --max-cost 100 --json /tmp/hl_err.json
+```
+Expected: `(2,8)` runs (cost 32 ≤ 100); `(2,64)` prints `!! skipped: cost 256 > 100` and its row has an `error` field. Confirm the sweep does **not** crash and `/tmp/hl_err.json` holds both rows.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/bench_heisenberg_largeD.py
+git commit -m "bench(#570): heisenberg large-D study — error capture + cost-ceiling skip"
+```
+
+---
+
+## Task 4: Sanity anchor — reproduce the example's D=2 χ=8 energy
+
+**Files:**
+- Run only (no code change unless the anchor fails).
+
+- [ ] **Step 1: Run the anchor cell to convergence**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run python examples/bench_heisenberg_largeD.py \
+  --D-list 2 --chi-list 8 --gs-steps 60 --json /tmp/hl_anchor.json
+```
+Expected: `E_final` ≈ **−0.6625** (the value `examples/heisenberg_ipeps_ad.py` reports at D=2 χ=8), `dE` ≈ +0.007, `below_ref` = False.
+
+- [ ] **Step 2: Decision gate**
+
+If `E_final` is within ~0.002 of −0.6625 → harness is correct; proceed to Task 5.
+If it differs materially (or is positive/NaN/below −0.6694), the configuration does not match the example — diff `build_problem` against `examples/heisenberg_ipeps_ad.py` (gauge, c4v, su_init, gate construction) and fix, then re-run this task. **Do not run the A100 sweep until the anchor passes.**
+
+- [ ] **Step 3: Commit (only if a fix was needed)**
+
+```bash
+git add examples/bench_heisenberg_largeD.py
+git commit -m "bench(#570): heisenberg large-D study — fix config to match example anchor"
+```
+
+---
+
+## Task 5: Run the A100 sweep (core grid, then stretch)
+
+**Files:**
+- Run only. Produces `examples/heisenberg_largeD_a100.json`.
+
+- [ ] **Step 1: Pick a free GPU**
+
+Run `nvidia-smi --query-gpu=index,memory.used --format=csv,noheader` and choose an index with ~0 MiB used (other users share this box). Use it as `CUDA_VISIBLE_DEVICES` below.
+
+- [ ] **Step 2: Run the core grid in the background with external timeout + resume**
+
+```bash
+cat > /tmp/run_hl.sh <<'EOF'
+set -e
+export CUDA_VISIBLE_DEVICES=<FREE_GPU>
+export JAX_PLATFORMS=cuda,cpu
+cd /home/yjkao/tenax
+# `timeout` bounds each whole-sweep attempt; resume continues if a cell kills it.
+for attempt in 1 2 3; do
+  timeout 3600 uv run python examples/bench_heisenberg_largeD.py \
+    --D-list 2 3 4 --chi-list 8 16 24 32 --gs-steps 100 \
+    --json examples/heisenberg_largeD_a100.json && break
+  echo "### attempt $attempt timed out/killed; resuming ###"
+done
+echo "### CORE DONE ###"
+EOF
+nohup bash /tmp/run_hl.sh > /tmp/hl_core.log 2>&1 &
+echo "core PID $!"
+```
+Monitor with an until-loop on `### CORE DONE ###`/`!!` in `/tmp/hl_core.log`. Each cell appends to the JSON; a kill loses only the in-flight cell.
+
+- [ ] **Step 3: Inspect the core grid, then attempt the stretch**
+
+Read `examples/heisenberg_largeD_a100.json`. If D=4 cells completed within budget and energies are still improving with χ, run the stretch (reuses the same JSON; resume skips completed cells):
+```bash
+CUDA_VISIBLE_DEVICES=<FREE_GPU> JAX_PLATFORMS=cuda,cpu \
+  timeout 5400 uv run python examples/bench_heisenberg_largeD.py \
+  --D-list 5 6 --chi-list 32 48 64 --gs-steps 100 \
+  --json examples/heisenberg_largeD_a100.json
+```
+Record which stretch cells hit the wall (OOM error row / timeout-killed-and-not-resumed / no energy gain).
+
+- [ ] **Step 4: Commit the results JSON**
+
+```bash
+git add examples/heisenberg_largeD_a100.json
+git commit -m "bench(#570): heisenberg large-D A100 sweep results (dense path)"
+```
+
+---
+
+## Task 6: Write the characterization handoff
+
+**Files:**
+- Create: `docs/superpowers/handoffs/2026-06-12-heisenberg-largeD-characterization.md`
+
+- [ ] **Step 1: Write the findings doc from the JSON**
+
+Populate from `examples/heisenberg_largeD_a100.json`. Sections (fill with the actual numbers — no placeholders):
+1. **Result table** — one row per (D, χ): `E_final`, `dE` vs −0.6694430, `jit_compile_s`, `total_wall_s`, `warm_step_s`, `num_steps`, `converged`.
+2. **Energy vs (D, χ)** — how close the dense path gets to −0.6694430; best cell; whether energy is still improving with D and with χ at the largest cells.
+3. **Runtime + compile scaling** — how `jit_compile_s` and `warm_step_s` grow with D and χ; the dominant cost.
+4. **Where the dense wall hits** — first cell that OOM'd / timed out / stopped gaining energy; the practical (D, χ) ceiling of the dense path on an 80 GB A100.
+5. **Conclusion** — the #570 answer for the dense path, and the explicit statement that **U(1)/Sz symmetry** is the lever to push toward the reference scale (D=7 χ=300) — out of this study's scope, candidate next step.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/handoffs/2026-06-12-heisenberg-largeD-characterization.md
+git commit -m "docs(#570): dense Heisenberg large-D characterization — findings"
+```
+
+---
+
+## Self-review (completed by plan author)
+
+- **Spec coverage:** measurement protocol → Task 1+2 (`run_cell` row fields match the spec list); grid + cheap-first + resume → Task 2; time-boxing/error capture → Task 3 (external `timeout`+resume for hard hangs, documented deviation from the spec's in-process "cap" since XLA compile can't be interrupted mid-flight); sanity anchor → Task 4; variational-floor watch → `below_ref` field (Task 1) + writeup §4; A100 sweep + stretch → Task 5; outputs (script, JSON, writeup) → Tasks 1–3, 5, 6; non-goals respected (no U(1), no 2-site, no fermionic, no QR, no tests). `eps_T`/smallest-S omitted per spec ("only if already returned… otherwise omitted").
+- **Placeholder scan:** none — all code shown; the only deliberate `<FREE_GPU>` token in Task 5 is an operator-supplied runtime value with explicit instructions to obtain it.
+- **Type consistency:** `run_cell` returns the exact keys `_print_row` and the writeup consume (`D, chi, E_final, dE, jit_compile_s, total_wall_s, warm_step_s, num_steps, converged, below_ref`, or `error`); resume keys on `(D, chi)` consistently.
+- **API caveat:** Task 1 Step 1 mandates confirming import paths and config field names against `examples/heisenberg_ipeps_ad.py` before relying on the scaffold, since those are reconstructed from exploration, not verified line-by-line.

--- a/docs/superpowers/specs/2026-06-12-heisenberg-largeD-characterization-design.md
+++ b/docs/superpowers/specs/2026-06-12-heisenberg-largeD-characterization-design.md
@@ -37,18 +37,25 @@ would be needed (U(1) symmetry) to push further.
   `examples/heisenberg_ipeps_ad.py`.
 - **Optimizer:** `optimize_gs_ad` with
   - `gs_c4v=True` (single-tensor C4v, 1-site `unit_cell="1x1"`),
-  - `forward_gauge="sigma"` (implicit-AD-stable gauge, per the example),
+  - `forward_gauge="phase"` + `projector_method="svd"` — **forced** by
+    `validate_ctm_for_implicit_ad` (`src/tenax/algorithms/ipeps_ad_policy.py`), which rejects
+    the sigma-gauge / eigh / gmres path for implicit AD,
   - `gs_implicit_ad=True` (default; differentiate the CTM fixed point),
-  - `projector_method="svd"`, `gs_recipe="2x2"` (production defaults),
+  - `gs_recipe="2x2"` (production default),
   - `gs_conv_criterion="grad_norm"`, `gs_grad_norm_tol=1e-5` (#448),
   - fixed `gs_num_steps` budget (CLI; default 100),
   - `return_history=True`.
 - **CTM:** defaults (`max_iter=100`, `conv_tol=1e-8`) unless a cell needs a cap; no χ-schedule
   (fixed χ per cell — cleanest scaling signal).
 
-Rationale: this is exactly the configuration the existing `examples/heisenberg_ipeps_ad.py`
-uses and validates (D=2 χ=8 → E/site ≈ −0.6625), so the study extends a known-good setup
-rather than introducing variables.
+**Correction (2026-06-12, found during implementation):** the existing
+`examples/heisenberg_ipeps_ad.py` is **API-stale** — it uses `forward_gauge="sigma"` +
+`projector_method="eigh"` + `ad_backward_method="gmres"`, all now rejected by
+`validate_ctm_for_implicit_ad`. Its docstring's E/site ≈ −0.6625 came from that invalid
+config. The current valid implicit-AD path (phase + svd) converges to **E/site ≈ −0.6602**
+at D=2 χ=8 — and CPU validation shows the D=2 energy is **flat across χ ∈ {8,16,24}**
+(−0.66019 → −0.66015), i.e. χ-saturated by χ=8 because D=2 ⇒ double-layer bond D²=4. The
+study's energy signal therefore lives in **D-scaling**, not χ-scaling.
 
 ## Measurement protocol (per (D, χ) cell)
 
@@ -114,8 +121,10 @@ rather than introducing variables.
 
 ## Correctness guards
 
-- **Sanity anchor:** the D=2 χ=8 cell must reproduce E/site ≈ −0.6625 (the existing example's
-  number). If it doesn't, the harness is mis-wired — stop and fix before trusting the sweep.
+- **Sanity anchor:** the D=2 χ=8 cell must land at E/site ≈ −0.6602 (the current valid
+  phase+svd implicit-AD value; **not** the stale −0.6625 from the API-invalid example) and the
+  D=2 energy must be ~flat across χ. Validated on CPU 2026-06-12 (−0.66019 at χ=8, flat to
+  χ=24). If a cell deviates materially, the harness is mis-wired — stop before trusting the sweep.
 - **Variational-floor watch:** finite-χ CTM is not a strict variational bound, but any cell
   with `E_final` meaningfully **below** −0.6694430 is flagged in the row/writeup (signals a
   normalization/gauge problem), recorded — not crashed on.

--- a/docs/superpowers/specs/2026-06-12-heisenberg-largeD-characterization-design.md
+++ b/docs/superpowers/specs/2026-06-12-heisenberg-largeD-characterization-design.md
@@ -1,0 +1,127 @@
+# Design: Dense 2D-Heisenberg large-D characterization study
+
+**Date:** 2026-06-12
+**Status:** approved (design); spec under review
+**Issue:** #570 (the never-evaluated "large-D GPU energy + runtime + compile" acceptance criterion)
+**Branch:** `study/heisenberg-largeD-characterization`
+
+## Goal
+
+Answer the question #570 named but never evaluated, for the **dense** path:
+
+> How does tenax's dense iPEPS-AD perform on the 2D spin-½ Heisenberg model as the PEPS
+> bond dimension **D** and CTM bond dimension **χ** grow — the **final energy** relative to
+> the **E/site = −0.6694430** reference (Corboz QR-CTMRG / QMC), and the **runtime + cold
+> XLA-compile** cost — and **where does the dense wall hit** (OOM / compile-time / no further
+> energy gain)?
+
+This is a **characterization** study of the path that exists today. It builds **no** new
+physics machinery. The deliverable is an honest scaling picture plus a statement of what
+would be needed (U(1) symmetry) to push further.
+
+## Non-goals (explicitly out of scope)
+
+- U(1)/Sz-symmetric Heisenberg (the lever for genuinely large D — flagged, not built).
+- 2-site bipartite unit cell (the sublattice-rotated C4v 1-site path is used instead).
+- Fermionic iPEPS / the #392 certification gap (separate thread).
+- The QR projector (block-sparse Phase 3 = NO-GO, PR #598; `projector_method="svd"` only).
+- Reaching the reference scale D=7 χ=300 (dense is not expected to get there).
+- TPU; plotting infrastructure; unit tests (this is an `examples/` study script, matching
+  the existing `bench_*` / `profile_*` scripts which carry no tests).
+
+## Configuration (single, fixed across all cells)
+
+- **Model gate:** `sublattice_rotate_gate(heisenberg_gate())` — the sublattice rotation maps
+  the Néel antiferromagnet to a uniform state representable by a single C4v tensor.
+- **Init:** simple-update initialization at the target D (`su_init=True`), matching
+  `examples/heisenberg_ipeps_ad.py`.
+- **Optimizer:** `optimize_gs_ad` with
+  - `gs_c4v=True` (single-tensor C4v, 1-site `unit_cell="1x1"`),
+  - `forward_gauge="sigma"` (implicit-AD-stable gauge, per the example),
+  - `gs_implicit_ad=True` (default; differentiate the CTM fixed point),
+  - `projector_method="svd"`, `gs_recipe="2x2"` (production defaults),
+  - `gs_conv_criterion="grad_norm"`, `gs_grad_norm_tol=1e-5` (#448),
+  - fixed `gs_num_steps` budget (CLI; default 100),
+  - `return_history=True`.
+- **CTM:** defaults (`max_iter=100`, `conv_tol=1e-8`) unless a cell needs a cap; no χ-schedule
+  (fixed χ per cell — cleanest scaling signal).
+
+Rationale: this is exactly the configuration the existing `examples/heisenberg_ipeps_ad.py`
+uses and validates (D=2 χ=8 → E/site ≈ −0.6625), so the study extends a known-good setup
+rather than introducing variables.
+
+## Measurement protocol (per (D, χ) cell)
+
+1. Build gate + SU-init `A_init` at D.
+2. Time the full `optimize_gs_ad` call (wall-clock around it).
+3. From the returned history dict, capture: energy trajectory, `step_times`,
+   `jit_compile_time`, `num_steps`, `converged`.
+4. Record one row:
+   - `D`, `chi`
+   - `E_final` — best (lowest) energy in the trajectory
+   - `dE` = `E_final − (−0.6694430)`
+   - `jit_compile_s` — `jit_compile_time` (cold XLA compile)
+   - `total_wall_s` — wall around the call
+   - `warm_step_s` — median of `step_times` excluding the first (compile-laden) step
+   - `num_steps`, `converged`
+   - `eps_T` / smallest-S only if already returned by the optimizer/CTM history without
+     extra computation; otherwise omitted (not a blocker for v1)
+   - `error` — populated instead of the metrics if the cell raised/OOM'd
+
+## Grid and time-boxing
+
+- **Core grid:** D ∈ {2, 3, 4} × χ ∈ {8, 16, 24, 32}. The full cross-product is run;
+  cells with χ < D² are kept (they characterize the under-resolved regime) but expected to
+  converge poorly — this is a reported observation, not a filter.
+- **Stretch:** D ∈ {5, 6} and χ ∈ {48, 64} — attempted only if the core grid stays tractable.
+- **Per-cell budget:** a `--time-budget-s` cap; a cell that exceeds it (or OOMs) is recorded
+  with an `error` string and skipped, not allowed to hang the sweep.
+- **Hardware:** A100, pinned to a free GPU (`CUDA_VISIBLE_DEVICES`), `JAX_PLATFORMS=cuda,cpu`,
+  x64. A CPU smoke on a tiny grid validates the harness before the GPU sweep.
+- **Resume:** the JSON is rewritten after every cell; a re-run skips cells already present
+  (keyed by `(D, χ)`), so a sweep killed on a large cell keeps its rows.
+
+## Script architecture
+
+`examples/bench_heisenberg_largeD.py`:
+
+- `build_problem(D) -> (gate, A_init, config_template)` — gate, SU-init, base `iPEPSConfig`.
+- `run_cell(D, chi, args) -> dict` — one optimization, returns the row (or an error row).
+- `main()` — parse CLI, load any existing JSON (resume), loop the grid, checkpoint JSON +
+  print the running table after each cell.
+- **CLI:** `--D-list`, `--chi-list`, `--gs-steps`, `--time-budget-s`, `--json`,
+  `--su-init/--no-su-init`.
+- **JSON schema:**
+  ```json
+  {
+    "platform": "...", "device_kind": "...", "x64": true,
+    "ref_energy": -0.6694430, "D_list": [...], "chi_list": [...],
+    "rows": [ { "D": 2, "chi": 8, "E_final": -0.6625, "dE": 0.0069,
+                "jit_compile_s": ..., "total_wall_s": ..., "warm_step_s": ...,
+                "num_steps": ..., "converged": true } ]
+  }
+  ```
+
+## Outputs / deliverables
+
+1. `examples/bench_heisenberg_largeD.py` (the study script).
+2. JSON result file(s) under `examples/` (the evidence; checkpointed).
+3. A handoff writeup in `docs/superpowers/handoffs/2026-06-12-heisenberg-largeD-characterization.md`:
+   - the energy-vs-(D, χ) table and how close to −0.6694430 the dense path gets,
+   - runtime + cold-compile scaling vs (D, χ),
+   - where the dense wall hits (OOM / compile budget / energy plateau),
+   - the conclusion: what U(1) symmetry would unlock to approach the reference scale.
+
+## Correctness guards
+
+- **Sanity anchor:** the D=2 χ=8 cell must reproduce E/site ≈ −0.6625 (the existing example's
+  number). If it doesn't, the harness is mis-wired — stop and fix before trusting the sweep.
+- **Variational-floor watch:** finite-χ CTM is not a strict variational bound, but any cell
+  with `E_final` meaningfully **below** −0.6694430 is flagged in the row/writeup (signals a
+  normalization/gauge problem), recorded — not crashed on.
+
+## Testing
+
+No unit tests (consistent with the other `examples/bench_*` / `profile_*` scripts). Validation
+is operational: (1) the CPU smoke runs end-to-end on a tiny grid; (2) the D=2 χ=8 sanity
+anchor reproduces the known ≈ −0.6625.

--- a/examples/bench_heisenberg_largeD.py
+++ b/examples/bench_heisenberg_largeD.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Dense 2D-Heisenberg iPEPS-AD characterization study (issue #570).
+
+Sweeps Tenax's dense single-site (C4v, sigma gauge) iPEPS-AD over a grid of
+bond dimension D and environment bond dimension chi.  For each (D, chi) cell
+the script records:
+
+  - Final variational energy E_final and deviation dE = E_final - REF_ENERGY
+    from the QMC reference E/site ~ -0.6694430.
+  - Cold XLA-compile time (first L-BFGS step).
+  - Total wall time and warm step time (median of steps 1+).
+  - Number of steps taken and convergence flag.
+
+Purpose: establish a runtime / accuracy baseline for the dense path before
+evaluating block-sparse QR-CTMRG speedups in Phase 3 of issue #570.
+
+Usage::
+
+    # CPU smoke test (D=2, chi=8, 30 steps ~ 1-2 min)
+    JAX_PLATFORMS=cpu uv run python examples/bench_heisenberg_largeD.py \\
+        --D-list 2 --chi-list 8 --gs-steps 30
+
+    # Full grid with JSON checkpointing (A100 recommended for D>=3)
+    uv run python examples/bench_heisenberg_largeD.py \\
+        --D-list 2 3 4 --chi-list 8 16 32 --gs-steps 200 \\
+        --json results/heisenberg_largeD_a100.json
+
+    # Resume an interrupted run (skips already-completed cells)
+    uv run python examples/bench_heisenberg_largeD.py \\
+        --D-list 2 3 4 --chi-list 8 16 32 --gs-steps 200 \\
+        --json results/heisenberg_largeD_a100.json
+
+    # Limit cost to avoid long-running cells
+    uv run python examples/bench_heisenberg_largeD.py \\
+        --D-list 2 3 --chi-list 8 16 32 --gs-steps 100 --max-cost 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import platform
+import statistics
+import time
+from pathlib import Path
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax import (  # noqa: E402
+    CTMConfig,
+    heisenberg_gate,
+    iPEPSConfig,
+    optimize_gs_ad,
+    sublattice_rotate_gate,
+)
+
+# ---------------------------------------------------------------------------
+# Reference energy (QMC)
+# ---------------------------------------------------------------------------
+
+REF_ENERGY = -0.6694430
+
+
+# ---------------------------------------------------------------------------
+# Problem builder
+# ---------------------------------------------------------------------------
+
+
+def build_problem(D: int, chi: int, gs_steps: int):
+    """Build gate, config, and A_init for a single (D, chi) cell.
+
+    Returns (gate, A_init, config).  A_init=None lets optimize_gs_ad
+    run simple-update initialization (su_init=True).
+    """
+    gate = sublattice_rotate_gate(heisenberg_gate())
+    ctm = CTMConfig(
+        chi=chi,
+        max_iter=100,
+        conv_tol=1e-8,
+        # forward_gauge defaults to "phase" — required for implicit AD
+        # (validate_ctm_for_implicit_ad enforces phase+svd+elementwise)
+    )
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        ctm=ctm,
+        gs_c4v=True,
+        gs_num_steps=gs_steps,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-5,
+        su_init=True,
+        return_history=True,
+    )
+    A_init = None
+    return gate, A_init, config
+
+
+# ---------------------------------------------------------------------------
+# Single-cell runner
+# ---------------------------------------------------------------------------
+
+
+def run_cell(D: int, chi: int, gs_steps: int) -> dict:
+    """Run one (D, chi) optimization cell and return a metrics dict."""
+    gate, A_init, config = build_problem(D, chi, gs_steps)
+
+    t_wall_start = time.perf_counter()
+    result = optimize_gs_ad(gate, A_init, config)
+    total_wall_s = time.perf_counter() - t_wall_start
+
+    # Unpack: with return_history=True the result is (A, env, E_gs, history)
+    _A, _env, E_gs, history = result
+
+    energies = history["energies"]
+    step_times = history["step_times"]
+    jit_compile_s = float(history["jit_compile_time"])
+    num_steps = int(history["num_steps"])
+    converged = bool(history["converged"])
+
+    E_final = float(min(energies)) if energies else float("nan")
+    dE = E_final - REF_ENERGY
+
+    # Warm step = median of all step_times: the history accumulator stores
+    # jit_compile_time separately (step 0) and step_times contains only steps
+    # 1+ (all "warm" — already compiled), so no further slicing needed.
+    warm_step_s = statistics.median(step_times) if step_times else float("nan")
+
+    return {
+        "D": D,
+        "chi": chi,
+        "E_final": E_final,
+        "dE": dE,
+        "jit_compile_s": jit_compile_s,
+        "total_wall_s": total_wall_s,
+        "warm_step_s": warm_step_s,
+        "num_steps": num_steps,
+        "converged": converged,
+        "below_ref": E_final < REF_ENERGY,
+    }
+
+
+# ---------------------------------------------------------------------------
+# JSON checkpoint helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_json(path: str, meta: dict, rows: list[dict]) -> None:
+    """Write meta + rows to a JSON file (atomic-ish via temp rename)."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(".tmp")
+    with tmp.open("w") as f:
+        json.dump({"meta": meta, "rows": rows}, f, indent=2)
+    tmp.rename(p)
+
+
+def _load_rows(path: str) -> list[dict]:
+    """Load rows from a JSON checkpoint; return [] if missing or invalid."""
+    p = Path(path)
+    if not p.exists():
+        return []
+    try:
+        with p.open() as f:
+            data = json.load(f)
+        return data.get("rows", [])
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Pretty-print helpers
+# ---------------------------------------------------------------------------
+
+_HEADER = (
+    f"{'D':>3}  {'chi':>4}  {'E_final':>12}  {'dE':>10}  "
+    f"{'jit_s':>7}  {'wall_s':>7}  {'step_s':>7}  {'steps':>5}  "
+    f"{'conv':>5}  {'<ref':>5}"
+)
+_SEP = "-" * len(_HEADER)
+
+
+def _print_row(r: dict) -> None:
+    """Print a single result row (handles error rows)."""
+    if "error" in r:
+        print(f"  D={r['D']:>2}  chi={r['chi']:>4}  !! {r['error']}")
+        return
+    conv_s = "yes" if r.get("converged") else "no"
+    ref_s = "yes" if r.get("below_ref") else "no"
+    jit = r.get("jit_compile_s", float("nan"))
+    wall = r.get("total_wall_s", float("nan"))
+    step = r.get("warm_step_s", float("nan"))
+    print(
+        f"{r['D']:>3}  {r['chi']:>4}  {r['E_final']:>12.7f}  {r['dE']:>+10.6f}  "
+        f"{jit:>7.1f}  {wall:>7.1f}  {step:>7.3f}  {r['num_steps']:>5}  "
+        f"{conv_s:>5}  {ref_s:>5}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Dense 2D-Heisenberg iPEPS-AD characterization study (#570)."
+    )
+    parser.add_argument(
+        "--D-list",
+        nargs="+",
+        type=int,
+        default=[2],
+        metavar="D",
+        help="Bond dimensions to sweep (default: 2)",
+    )
+    parser.add_argument(
+        "--chi-list",
+        nargs="+",
+        type=int,
+        default=[8],
+        metavar="CHI",
+        help="Environment bond dimensions to sweep (default: 8)",
+    )
+    parser.add_argument(
+        "--gs-steps",
+        type=int,
+        default=100,
+        metavar="N",
+        help="Max GS-AD optimizer steps per cell (default: 100)",
+    )
+    parser.add_argument(
+        "--json",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="JSON file path for checkpointing/resuming results",
+    )
+    parser.add_argument(
+        "--max-cost",
+        type=int,
+        default=None,
+        metavar="C",
+        help="Skip cells where D*D*chi > C (default: no limit)",
+    )
+    args = parser.parse_args()
+
+    # Build metadata
+    try:
+        device_kind = jax.devices()[0].device_kind
+    except Exception:
+        device_kind = "unknown"
+
+    meta = {
+        "platform": platform.node(),
+        "device_kind": device_kind,
+        "x64": True,
+        "ref_energy": REF_ENERGY,
+        "D_list": args.D_list,
+        "chi_list": args.chi_list,
+        "gs_steps": args.gs_steps,
+    }
+
+    # Load existing rows (resume support)
+    rows: list[dict] = _load_rows(args.json) if args.json else []
+    done: set[tuple[int, int]] = {
+        (r["D"], r["chi"]) for r in rows if "error" not in r
+    }
+
+    # Print header
+    print(f"\nDense Heisenberg iPEPS-AD sweep  |  ref E = {REF_ENERGY}")
+    print(f"device: {device_kind}  |  x64: True  |  gs_steps: {args.gs_steps}")
+    if args.max_cost is not None:
+        print(f"max-cost: {args.max_cost}  (D*D*chi)")
+    print(_SEP)
+    print(_HEADER)
+    print(_SEP)
+
+    # Reprint resumed rows
+    for r in rows:
+        _print_row(r)
+
+    # Build work list: cross-product sorted cheap-first (D^2 * chi)
+    all_cells = [
+        (D, chi)
+        for D in args.D_list
+        for chi in args.chi_list
+        if (D, chi) not in done
+    ]
+    all_cells.sort(key=lambda dc: dc[0] * dc[0] * dc[1])
+
+    # Run each cell
+    for D, chi in all_cells:
+        cost = D * D * chi
+        if args.max_cost is not None and cost > args.max_cost:
+            row: dict = {
+                "D": D,
+                "chi": chi,
+                "error": f"skipped: cost {cost} > {args.max_cost}",
+            }
+        else:
+            try:
+                row = run_cell(D, chi, args.gs_steps)
+            except Exception as exc:
+                row = {"D": D, "chi": chi, "error": f"{type(exc).__name__}: {exc}"}
+
+        rows.append(row)
+        _print_row(row)
+
+        if args.json:
+            _write_json(args.json, meta, rows)
+
+    print(_SEP)
+    print(f"Total cells: {len(rows)}  (done this run: {len(all_cells)})")
+    if args.json:
+        print(f"Results saved to: {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/bench_heisenberg_largeD.py
+++ b/examples/bench_heisenberg_largeD.py
@@ -45,7 +45,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import platform
 import statistics
 import time

--- a/examples/bench_heisenberg_largeD.py
+++ b/examples/bench_heisenberg_largeD.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Dense 2D-Heisenberg iPEPS-AD characterization study (issue #570).
 
-Sweeps Tenax's dense single-site (C4v, sigma gauge) iPEPS-AD over a grid of
-bond dimension D and environment bond dimension chi.  For each (D, chi) cell
-the script records:
+Sweeps Tenax's dense single-site (C4v, phase gauge, implicit-AD) iPEPS over a
+grid of bond dimension D and environment bond dimension chi.  For each (D, chi)
+cell the script records:
 
   - Final variational energy E_final and deviation dE = E_final - REF_ENERGY
     from the QMC reference E/site ~ -0.6694430.
@@ -13,6 +13,12 @@ the script records:
 
 Purpose: establish a runtime / accuracy baseline for the dense path before
 evaluating block-sparse QR-CTMRG speedups in Phase 3 of issue #570.
+
+Anchor: D=2, chi=8, 100 steps → E ~ -0.6602 (implicit-AD / phase-gauge path).
+QMC reference: E/site ~ -0.6694430.  Note: the ``heisenberg_ipeps_ad.py``
+example docstring quotes E ~ -0.6625 for a sigma+eigh+gmres config that is
+incompatible with the current API (``validate_ctm_for_implicit_ad`` enforces
+phase+svd+elementwise); the reachable energy on the implicit-AD path is -0.6602.
 
 Usage::
 
@@ -85,6 +91,8 @@ def build_problem(D: int, chi: int, gs_steps: int):
     )
     config = iPEPSConfig(
         max_bond_dim=D,
+        num_imaginary_steps=200,
+        dt=0.05,
         ctm=ctm,
         gs_c4v=True,
         gs_num_steps=gs_steps,

--- a/examples/heisenberg_largeD_a100.json
+++ b/examples/heisenberg_largeD_a100.json
@@ -1,0 +1,89 @@
+{
+  "meta": {
+    "platform": "dgxsa1h",
+    "device_kind": "NVIDIA A100-SXM4-80GB",
+    "x64": true,
+    "ref_energy": -0.669443,
+    "D_list": [
+      3
+    ],
+    "chi_list": [
+      16
+    ],
+    "gs_steps": 150
+  },
+  "rows": [
+    {
+      "D": 2,
+      "chi": 8,
+      "E_final": -0.660228703196764,
+      "dE": 0.009214296803236044,
+      "jit_compile_s": 19.840049857273698,
+      "total_wall_s": 551.6154555752873,
+      "warm_step_s": 0.5493958536535501,
+      "num_steps": 150,
+      "converged": false,
+      "below_ref": false
+    },
+    {
+      "D": 2,
+      "chi": 16,
+      "E_final": -0.6602306340268481,
+      "dE": 0.009212365973151893,
+      "jit_compile_s": 19.472965758293867,
+      "total_wall_s": 783.4731979481876,
+      "warm_step_s": 0.6993497740477324,
+      "num_steps": 150,
+      "converged": false,
+      "below_ref": false
+    },
+    {
+      "D": 3,
+      "chi": 8,
+      "E_final": -0.663993131553185,
+      "dE": 0.005449868446815054,
+      "jit_compile_s": 8.148931032046676,
+      "total_wall_s": 2493.2089373972267,
+      "warm_step_s": 1.635966893285513,
+      "num_steps": 150,
+      "converged": false,
+      "below_ref": false
+    },
+    {
+      "D": 2,
+      "chi": 24,
+      "E_final": -0.6602144625073598,
+      "dE": 0.009228537492640188,
+      "jit_compile_s": 8.510691015049815,
+      "total_wall_s": 1409.6838775761425,
+      "warm_step_s": 1.3651357609778643,
+      "num_steps": 150,
+      "converged": false,
+      "below_ref": false
+    },
+    {
+      "D": 2,
+      "chi": 32,
+      "E_final": -0.6601968320645122,
+      "dE": 0.009246167935487826,
+      "jit_compile_s": 8.638338325545192,
+      "total_wall_s": 2544.57846692577,
+      "warm_step_s": 2.20535783842206,
+      "num_steps": 150,
+      "converged": false,
+      "below_ref": false
+    },
+    {
+      "D": 3,
+      "chi": 16,
+      "E_final": -0.6641915527336046,
+      "dE": 0.00525144726639537,
+      "jit_compile_s": 27.165753465145826,
+      "total_wall_s": 6475.452394368127,
+      "warm_step_s": 3.992904331535101,
+      "num_steps": 150,
+      "converged": false,
+      "below_ref": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Characterizes Tenax's **dense** single-site iPEPS-AD path (C4v, phase-gauge, implicit-AD,
SVD-projector) on the 2D spin-½ Heisenberg model — the never-evaluated "large-D energy +
runtime + compile" acceptance criterion of #570. **No production code changes**; `src/` is
byte-identical to `main`. Deliverable = a standalone study script + A100 evidence + findings.

### Findings (6 completed cells, A100-80GB, gs_steps=150)

| D | χ | E_final | dE vs −0.6694430 | jit (s) | wall (s) | warm-step (s) |
|---|---|---------|------|------|------|------|
| 2 | 8  | −0.660229 | +0.00921 | 19.8 | 552  | 0.55 |
| 2 | 16 | −0.660231 | +0.00921 | 19.5 | 783  | 0.70 |
| 2 | 24 | −0.660214 | +0.00923 |  8.5 | 1410 | 1.37 |
| 2 | 32 | −0.660197 | +0.00925 |  8.6 | 2545 | 2.21 |
| 3 | 8  | −0.663993 | +0.00545 |  8.1 | 2493 | 1.64 |
| 3 | 16 | −0.664192 | +0.00525 | 27.2 | 6475 | 3.99 |

- **Energy scales correctly in D** (−0.6602 → −0.6642 from D=2→3, ~43% of the gap to the
  −0.6694430 QMC reference closed); **χ-flat at D=2** (double-layer bond D²=4 saturates by χ≈8).
- **Runtime-bound, not compile-bound:** cold XLA compile stays ≤27 s; the cost is per-step CTM
  re-convergence inside the L-BFGS line search, exploding ~χ^1.7. D=3 χ=16 = **108 min**.
- **The wall:** ~D=3 χ=8 within an hour; the reference scale (D=7 χ=300) is out of dense reach.
  D=4 (stretch) was not reached — the intractable core grid *is* the wall finding.
- **Lever for a scoped follow-up: U(1)/Sz symmetry.** This contrasts with the block-sparse /
  fermionic CTM-AD path (#566) which is *compile*-bound — a different wall.

### Contents
- `examples/bench_heisenberg_largeD.py` — the study script (resume/checkpoint, cost-ceiling).
- `examples/heisenberg_largeD_a100.json` — A100 results.
- `docs/superpowers/{specs,plans,handoffs}/2026-06-12-heisenberg-largeD-characterization*` —
  design, plan, and findings writeup.

## Test Plan
- [x] `src/` unchanged vs `main` (no production code; core tests cannot regress)
- [x] Study script `py_compile`s and imports cleanly (full tenax import chain) on CPU
- [ ] CI core tests green