### PR TITLE
study(#570): add D=4 χ=8 cell to large-D characterization

### DIFF
--- a/docs/superpowers/handoffs/2026-06-12-heisenberg-largeD-characterization.md
+++ b/docs/superpowers/handoffs/2026-06-12-heisenberg-largeD-characterization.md
@@ -40,19 +40,21 @@ the rest of #570 / #566 chased is **compile-bound**. Dense and block-sparse hit 
 | 2 | 32 | −0.660197 | +0.00925 |  8.6 | 2544.6 | 2.205 | 150 | no |
 | 3 | 8  | −0.663993 | +0.00545 |  8.1 | 2493.2 | 1.636 | 150 | no |
 | 3 | 16 | −0.664192 | +0.00525 | 27.2 | 6475.5 | 3.993 | 150 | no |
+| 4 | 8  | −0.667109 | +0.00233 |  9.0 | 6637.0 | 2.787 | 150 | no |
 
-D=4 χ=8 (a stretch cell) was not completed: the core grid did not stay tractable, so per the
-plan the D≥4 / χ≥48 stretch was not pursued to completion. Every cell past D=3 χ=8 exceeds the
-1-hour per-attempt budget — D=3 χ=16 alone took **108 min** — and the full 12-cell core grid did
-not finish in 4 hours of kill/resume (≈ one expensive cell per hour). The non-completion of the
-larger grid *is* the runtime-wall finding.
+Every cell past D=3 χ=8 exceeds the 1-hour per-attempt budget — D=3 χ=16 took **108 min** and
+D=4 χ=8 took **111 min** — and the full 12-cell core grid did not finish in the kill/resume
+budget (≈ one expensive cell per hour). The larger χ stretch (χ≥24 at D≥3, all D≥5) was not
+pursued: the per-cell wall makes it impractical, and that intractability *is* the runtime-wall
+finding.
 
 ## 1. Energy vs (D, χ)
 
-- **D-scaling works.** D=2 → −0.6602 (dE +0.0092), D=3 → −0.6642 (dE +0.0053): the D=2→3
-  step closes ~43% of the gap to −0.6694430, the expected variational improvement with bond
-  dimension. The path reaches sensible, literature-consistent energies (D=2 iPEPS for 2D
-  Heisenberg sits at ≈ −0.660).
+- **D-scaling works, monotonically.** D=2 → −0.6602 (dE +0.0092), D=3 → −0.6642 (dE +0.0053),
+  D=4 χ=8 → −0.6671 (dE +0.0023): each bond-dimension step closes a large fraction of the
+  remaining gap to −0.6694430 (≈43% at D=2→3, then ≈56% at D=3→4), the expected variational
+  improvement with D. The path reaches sensible, literature-consistent energies (D=2 iPEPS for
+  2D Heisenberg sits at ≈ −0.660; D=4 is already within 0.0023 of the QMC reference).
 - **χ-scaling is flat at D=2, marginal at D=3.** At D=2, E is constant to <4e-5 across
   χ ∈ {8,16,24,32} — correct physics: the double-layer bond is D²=4, so the CTM environment is
   χ-saturated by χ≈8. At D=3 (double-layer bond D²=9) χ=8 is slightly under-resolved and
@@ -77,10 +79,11 @@ larger grid *is* the runtime-wall finding.
 ## 3. Where the dense wall hits
 
 The practical ceiling of this dense path (gs_steps=150, A100): **~D=3 χ=8 within an hour.** D=3
-χ=16 already costs 108 min, and D≥4 was not reached; the reference scale (D=7 χ=300) is many
-orders of magnitude out of reach (D=2 χ=32 alone = 42 min, D=3 χ=16 = 108 min). The wall is
-**wall-clock runtime**, set by per-step CTM convergence × line search × steps — not memory and
-not compile (compile stays ≤27 s even at the largest cell).
+χ=16 (108 min) and D=4 χ=8 (111 min) each take ~2 h per cell; larger χ at D≥3 and all D≥5 were
+not pursued. The reference scale (D=7 χ=300) is many orders of magnitude out of reach (D=2 χ=32
+alone = 42 min). The wall is **wall-clock runtime**, set by per-step CTM convergence × line
+search × steps — not memory and not compile (compile stays ≤27 s even at the largest cell;
+notably D=4 χ=8 compiled in 9 s yet still ran 111 min, underscoring that the cost is *runtime*).
 
 ## 4. Conclusion / next step
 

--- a/examples/heisenberg_largeD_a100.json
+++ b/examples/heisenberg_largeD_a100.json
@@ -5,10 +5,10 @@
     "x64": true,
     "ref_energy": -0.669443,
     "D_list": [
-      3
+      4
     ],
     "chi_list": [
-      16
+      8
     ],
     "gs_steps": 150
   },
@@ -81,6 +81,18 @@
       "jit_compile_s": 27.165753465145826,
       "total_wall_s": 6475.452394368127,
       "warm_step_s": 3.992904331535101,
+      "num_steps": 150,
+      "converged": false,
+      "below_ref": false
+    },
+    {
+      "D": 4,
+      "chi": 8,
+      "E_final": -0.6671087782169047,
+      "dE": 0.0023342217830952805,
+      "jit_compile_s": 9.016008719801903,
+      "total_wall_s": 6636.997869975865,
+      "warm_step_s": 2.7874950524419546,
       "num_steps": 150,
       "converged": false,
       "below_ref": false


### PR DESCRIPTION
Follow-up to #599. The D=4 χ=8 stretch cell finished after #599 merged; it is the most
informative point (closest to the reference) and is folded into the study here.

**D=4 χ=8 (A100, gs_steps=150):** E=−0.667109, dE **+0.00233** vs −0.6694430; compiled in
**9 s**, ran **111 min**, warm-step 2.79 s.

- Sharpens the D-scaling story to a clean monotone: −0.6602 (D=2) → −0.6640 (D=3) →
  −0.6671 (D=4), each step closing a large fraction of the remaining gap (~43%, ~56%).
- Reinforces the **runtime-bound** verdict: 9 s compile vs 111 min runtime.

Docs (writeup table + D-scaling/wall narrative) and `examples/heisenberg_largeD_a100.json`
updated. No production code changes.

## Test Plan
- [x] `src/` unchanged vs `main`
- [ ] CI core tests green