### PR TITLE
fix(#570): address PR #599 review nits in dense large-D study

### DIFF
--- a/docs/superpowers/handoffs/2026-06-12-heisenberg-largeD-characterization.md
+++ b/docs/superpowers/handoffs/2026-06-12-heisenberg-largeD-characterization.md
@@ -32,15 +32,21 @@ the rest of #570 / #566 chased is **compile-bound**. Dense and block-sparse hit 
 
 ## Results
 
-| D | χ | E_final | dE vs −0.6694430 | jit_compile (s) | total wall (s) | median warm-step (s) | steps | conv |
-|---|---|---------|------------------|-----------------|----------------|----------------------|-------|------|
-| 2 | 8  | −0.660229 | +0.00921 | 19.8 | 551.6  | 0.549 | 150 | no |
-| 2 | 16 | −0.660231 | +0.00921 | 19.5 | 783.5  | 0.699 | 150 | no |
-| 2 | 24 | −0.660214 | +0.00923 |  8.5 | 1409.7 | 1.365 | 150 | no |
-| 2 | 32 | −0.660197 | +0.00925 |  8.6 | 2544.6 | 2.205 | 150 | no |
-| 3 | 8  | −0.663993 | +0.00545 |  8.1 | 2493.2 | 1.636 | 150 | no |
-| 3 | 16 | −0.664192 | +0.00525 | 27.2 | 6475.5 | 3.993 | 150 | no |
-| 4 | 8  | −0.667109 | +0.00233 |  9.0 | 6637.0 | 2.787 | 150 | no |
+| D | χ | E_final | dE vs −0.6694430 | jit_compile (s) | total wall (s) | wall/step (s) | steps | conv |
+|---|---|---------|------------------|-----------------|----------------|---------------|-------|------|
+| 2 | 8  | −0.660229 | +0.00921 | 19.8 | 551.6  |  3.68 | 150 | no |
+| 2 | 16 | −0.660231 | +0.00921 | 19.5 | 783.5  |  5.22 | 150 | no |
+| 2 | 24 | −0.660214 | +0.00923 |  8.5 | 1409.7 |  9.40 | 150 | no |
+| 2 | 32 | −0.660197 | +0.00925 |  8.6 | 2544.6 | 16.96 | 150 | no |
+| 3 | 8  | −0.663993 | +0.00545 |  8.1 | 2493.2 | 16.62 | 150 | no |
+| 3 | 16 | −0.664192 | +0.00525 | 27.2 | 6475.5 | 43.17 | 150 | no |
+| 4 | 8  | −0.667109 | +0.00233 |  9.0 | 6637.0 | 44.25 | 150 | no |
+
+The **wall/step** column is `total_wall / steps` — the honest full optimizer-step cost (gradient
+eval **plus** the L-BFGS Hager-Zhang line search, which re-runs CTM several times per step). An
+earlier revision of this table reported the optimizer's `step_times` median (~0.5–4 s), but that
+is stamped before the line search and is a *gradient-evaluation* time, ~10× smaller than the real
+per-step wall — corrected here per PR #599 review.
 
 Every cell past D=3 χ=8 exceeds the 1-hour per-attempt budget — D=3 χ=16 took **108 min** and
 D=4 χ=8 took **111 min** — and the full 12-cell core grid did not finish in the kill/resume
@@ -62,16 +68,16 @@ finding.
   still lives in **D**, not χ. (D=2 χ-flatness CPU-validated separately before the sweep.)
 - `converged=no` everywhere: `grad_norm` does not reach 1e-5 within 150 steps because the
   near-minimum landscape is flat/CTM-noisy, but the **energy plateaus** well before the budget,
-  so `E_final` (min over the trajectory) is the meaningful number. No cell fell below the
-  reference (the variational-floor watch never tripped).
+  so `E_final` (the final state returned by the optimizer) is the meaningful number. No cell fell
+  below the reference (the variational-floor watch, on the lowest energy seen, never tripped).
 
 ## 2. Runtime + compile scaling
 
 - **Compile is cheap and ~flat:** `jit_compile_s` ≈ 8–20 s regardless of D/χ. The dense bosonic
   backward does **not** suffer the block-sparse compile wall.
 - **Runtime is the cost and it explodes:** total wall at D=2 grows 552 → 784 → 1410 → 2545 s as
-  χ goes 8 → 32 (≈ χ^1.7); median warm-step grows 0.55 → 2.2 s. D=3 χ=8 (2493 s) already costs as
-  much as D=2 χ=32, and D=3 χ=16 (6475 s, **108 min**, warm-step 3.99 s) is the single most
+  χ goes 8 → 32 (≈ χ^1.7); the full per-step wall grows 3.7 → 17 s. D=3 χ=8 (2493 s) already costs
+  as much as D=2 χ=32, and D=3 χ=16 (6475 s, **108 min**, **43 s/step**) is the single most
   expensive completed cell. The per-step cost is the implicit-AD step: a full CTM re-convergence
   (`max_iter` up to 100 sweeps) inside each L-BFGS line-search evaluation, and that scales
   steeply in both D and χ.

--- a/examples/bench_heisenberg_largeD.py
+++ b/examples/bench_heisenberg_largeD.py
@@ -186,9 +186,32 @@ def _load_rows(path: str) -> list[dict]:
     try:
         with p.open() as f:
             data = json.load(f)
-        return data.get("rows", [])
+        return [_backfill_row(r) for r in data.get("rows", [])]
     except Exception:
         return []
+
+
+def _backfill_row(r: dict) -> dict:
+    """Upgrade a legacy checkpoint row to the current schema in place.
+
+    Rows written by an earlier version carry ``warm_step_s`` but not
+    ``wall_per_step_s``. The per-step wall is derivable as
+    ``total_wall_s / num_steps``, so backfill it (and drop the stale
+    ``warm_step_s`` label) before the row is reprinted or rewritten —
+    otherwise resumed legacy rows print ``nan`` for ``w/step`` and a
+    rewrite would persist a mixed schema. The energy fields are left as
+    stored: ``E_gs`` is not recoverable for legacy rows, and the
+    difference from the old ``min(energies)`` is negligible (5th–6th
+    decimal).
+    """
+    if "error" in r or "wall_per_step_s" in r:
+        return r
+    total = r.get("total_wall_s")
+    steps = r.get("num_steps")
+    if total is not None and steps:
+        r["wall_per_step_s"] = total / steps
+    r.pop("warm_step_s", None)
+    return r
 
 
 # ---------------------------------------------------------------------------

--- a/examples/bench_heisenberg_largeD.py
+++ b/examples/bench_heisenberg_largeD.py
@@ -126,25 +126,40 @@ def run_cell(D: int, chi: int, gs_steps: int) -> dict:
     num_steps = int(history["num_steps"])
     converged = bool(history["converged"])
 
-    E_final = float(min(energies)) if energies else float("nan")
+    # E_final: the energy of the actual final state returned by the
+    # optimizer (E_gs).  best_seen tracks the lowest energy recorded over
+    # the trajectory — only used for the variational-floor watch below, so a
+    # CTM-noisy transient can't be mistaken for the reported final energy.
+    E_final = float(E_gs)
+    # Lowest energy anywhere — the final state (E_gs) is often lower than any
+    # value in history["energies"], so include it in the minimum.
+    best_seen = min([E_final, *map(float, energies)]) if energies else E_final
     dE = E_final - REF_ENERGY
 
-    # Warm step = median of all step_times: the history accumulator stores
-    # jit_compile_time separately (step 0) and step_times contains only steps
-    # 1+ (all "warm" — already compiled), so no further slicing needed.
-    warm_step_s = statistics.median(step_times) if step_times else float("nan")
+    # grad_eval_s: history["step_times"] is stamped immediately after the
+    # jax.value_and_grad(loss_fn)(params) call, BEFORE the L-BFGS search
+    # direction + Hager-Zhang line search run, so its median is a gradient-
+    # evaluation time, NOT a full optimizer step.  The honest per-step wall is
+    # total_wall_s / num_steps (which includes line-search CTM re-evaluations).
+    grad_eval_s = statistics.median(step_times) if step_times else float("nan")
+    wall_per_step_s = total_wall_s / num_steps if num_steps else float("nan")
 
     return {
         "D": D,
         "chi": chi,
         "E_final": E_final,
+        "best_seen": best_seen,
         "dE": dE,
         "jit_compile_s": jit_compile_s,
         "total_wall_s": total_wall_s,
-        "warm_step_s": warm_step_s,
+        "wall_per_step_s": wall_per_step_s,
+        "grad_eval_s": grad_eval_s,
         "num_steps": num_steps,
         "converged": converged,
-        "below_ref": E_final < REF_ENERGY,
+        # Variational-floor watch: flag if the lowest energy *anywhere* on the
+        # trajectory dips below the QMC reference (signals a normalization/gauge
+        # bug), using best_seen rather than just the final state.
+        "below_ref": best_seen < REF_ENERGY,
     }
 
 
@@ -182,7 +197,7 @@ def _load_rows(path: str) -> list[dict]:
 
 _HEADER = (
     f"{'D':>3}  {'chi':>4}  {'E_final':>12}  {'dE':>10}  "
-    f"{'jit_s':>7}  {'wall_s':>7}  {'step_s':>7}  {'steps':>5}  "
+    f"{'jit_s':>7}  {'wall_s':>7}  {'w/step':>7}  {'steps':>5}  "
     f"{'conv':>5}  {'<ref':>5}"
 )
 _SEP = "-" * len(_HEADER)
@@ -197,10 +212,11 @@ def _print_row(r: dict) -> None:
     ref_s = "yes" if r.get("below_ref") else "no"
     jit = r.get("jit_compile_s", float("nan"))
     wall = r.get("total_wall_s", float("nan"))
-    step = r.get("warm_step_s", float("nan"))
+    # Per-step wall (full optimizer step incl. line search), not grad-eval.
+    w_step = r.get("wall_per_step_s", float("nan"))
     print(
         f"{r['D']:>3}  {r['chi']:>4}  {r['E_final']:>12.7f}  {r['dE']:>+10.6f}  "
-        f"{jit:>7.1f}  {wall:>7.1f}  {step:>7.3f}  {r['num_steps']:>5}  "
+        f"{jit:>7.1f}  {wall:>7.1f}  {w_step:>7.3f}  {r['num_steps']:>5}  "
         f"{conv_s:>5}  {ref_s:>5}"
     )
 
@@ -259,20 +275,26 @@ def main() -> None:
     except Exception:
         device_kind = "unknown"
 
+    # Load existing rows (resume support)
+    rows: list[dict] = _load_rows(args.json) if args.json else []
+    done: set[tuple[int, int]] = {
+        (r["D"], r["chi"]) for r in rows if "error" not in r
+    }
+
+    # Build metadata.  On a resume with a narrower CLI selection, the file may
+    # already hold rows outside the current --D-list/--chi-list; record the
+    # UNION of the D/chi actually present (existing rows ∪ this run's request)
+    # so the top-level metadata describes the whole sweep, not just this call.
+    d_union = sorted(set(args.D_list) | {r["D"] for r in rows})
+    chi_union = sorted(set(args.chi_list) | {r["chi"] for r in rows})
     meta = {
         "platform": platform.node(),
         "device_kind": device_kind,
         "x64": True,
         "ref_energy": REF_ENERGY,
-        "D_list": args.D_list,
-        "chi_list": args.chi_list,
+        "D_list": d_union,
+        "chi_list": chi_union,
         "gs_steps": args.gs_steps,
-    }
-
-    # Load existing rows (resume support)
-    rows: list[dict] = _load_rows(args.json) if args.json else []
-    done: set[tuple[int, int]] = {
-        (r["D"], r["chi"]) for r in rows if "error" not in r
     }
 
     # Print header


### PR DESCRIPTION
Follow-up to #599, addressing the three P2 review comments from the Codex bot on `examples/bench_heisenberg_largeD.py`. All are correctness/clarity fixes to the study script + writeup; the study's verdict (dense path is **runtime-bound, not compile-bound**) is unchanged — if anything the per-step correction reinforces it.

### 1. Report the optimizer's actual final energy
`E_final` was `min(history["energies"])`, but the optimizer applies its last line-search update *after* the final append, so the returned `E_gs` is the true final state — and is often **lower** than any recorded trajectory energy (CPU smoke: `E_gs=−0.638` vs `min(energies)=−0.6277`). Now report `E_gs`; keep `best_seen` (true minimum incl. `E_gs`) for the variational-floor watch.

### 2. Don't label grad-eval time as step time
`history["step_times"]` is stamped right after `value_and_grad`, before the L-BFGS Hager-Zhang line search (which re-runs CTM several times/step), so its median is a **gradient-eval** time — ~10× smaller than a real step (smoke: `grad_eval_s 0.13` vs `wall_per_step_s 4.15`). Added `wall_per_step_s = total_wall/num_steps` and print that; kept `grad_eval_s` as a separate field. Writeup table's per-step column recomputed from committed totals (e.g. D=3 χ=16 = **43 s/step**, not 3.99 s).

### 3. Preserve checkpoint metadata on narrowed resume
On resume with a narrower `--D-list/--chi-list`, `meta` was overwritten from the current CLI (the committed JSON said `D_list=[3]` despite holding D=2 rows). Now `meta` records the **union** of existing rows and the current selection. Rows were already self-describing, so no data was lost — only the top-level summary was misleading.

## Test Plan
- [x] CPU smoke (`--D-list 2 --chi-list 4 --gs-steps 3`) — new keys (`E_final=E_gs`, `best_seen`, `wall_per_step_s`, `grad_eval_s`) populate; meta union correct
- [x] `py_compile` clean
- [ ] CI core tests green