### PR TITLE
test(#605): xfail marker for D=3 χ=16 U(1)-Sz CTM flow-conjugation bug

### DIFF
--- a/tests/test_ipeps_u1sz.py
+++ b/tests/test_ipeps_u1sz.py
@@ -143,3 +143,37 @@ class TestU1SzSymmetricMatchesDense:
         assert float(E_sym) < -0.05, f"charged CTM sectors collapsed: E_sym={E_sym}"
         # Physical agreement with dense (not exact — see docstring).
         np.testing.assert_allclose(float(E_sym), float(E_dense), atol=2e-2)
+
+
+class TestU1SzSymmetricCTMD3:
+    @pytest.mark.xfail(
+        reason="D>=3 T4-edge flow-conjugation bug (#605): the edge's "
+        "T4g.fl = fuse(t4_d, u2) comes out charge-conjugate to the projector's "
+        "fused leg, so the 2-plaq left-absorb contraction "
+        "(_ctm_tensor_absorb_left_2plaq) hits a per-sector dim mismatch "
+        "(e.g. 19 vs 16) at D=3, chi=16. Masked at D=2 by symmetric D^2 charges; "
+        "distinct from #602 (which was per-sector order). Dense from the same "
+        "init runs fine. Flip to a correctness check (vs dense + order-invariance) "
+        "once #605 lands.",
+        strict=True,
+        raises=ValueError,
+    )
+    def test_d3_chi16_symmetric_ctm_xfail(self):
+        """D=3 chi=16 U(1)-Sz symmetric CTM currently raises in the T4 absorb (#605)."""
+        from tenax import CTMConfig, iPEPSConfig, optimize_gs_ad
+        from tenax.algorithms.ipeps import (
+            heisenberg_gate,
+            heisenberg_u1sz_init_pair,
+        )
+
+        A_sym, B_sym = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+        gate = heisenberg_gate().todense()
+        config = iPEPSConfig(
+            max_bond_dim=3,
+            ctm=CTMConfig(chi=16, max_iter=30),
+            gs_num_steps=1,
+            unit_cell="2site",
+        )
+        # Raises ValueError("Size of label 'b' ... does not match ...") in the
+        # left absorb's contract(P_left, T4g); dense from the same init is fine.
+        optimize_gs_ad(gate, (A_sym, B_sym), config)


### PR DESCRIPTION
Adds a strict `xfail` regression marker for **#605** — the D≥3 U(1)-Sz symmetric CTM flow-conjugation bug surfaced by the D-χ scaling benchmark after #602 was fixed (#604).

## What it marks

At **D=3, χ=16** the U(1)-Sz symmetric 2-site CTM raises:

```
ValueError: Size of label 'b' for operand 1 (16) does not match previous terms (19).
```

in the 2-plaq left absorb (`_ctm_tensor_absorb_left_2plaq`), because the edge's `T4g.fl = fuse(t4_d, u2)` comes out **charge-conjugate** to the projector's fused leg (per-sector dims are exact mirrors), and `_contract_symmetric` pairs blocks by equal charge value. Masked at D=2 by the symmetric D² charge structure; **distinct from #602** (which was per-sector *order*). Dense from the same init runs fine.

Full root-cause analysis is in **#605**.

## Test

`tests/test_ipeps_u1sz.py::TestU1SzSymmetricCTMD3::test_d3_chi16_symmetric_ctm_xfail`

- `strict=True, raises=ValueError` — xfails today; flips to a failing **XPASS** once #605 lands, prompting conversion into a real correctness check (vs dense + order-invariance).
- Fast: ~16 s (the error fires during the first CTM-step trace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)