### PR TITLE
study(#610): U(1)-Sz CTM env de-fragmentation spike — NO-GO-by-obstruction

### DIFF
--- a/census_u1sz_baseline_610.json
+++ b/census_u1sz_baseline_610.json
@@ -1,0 +1,62 @@
+[
+  {
+    "D": 3,
+    "chi": 12,
+    "rows": [
+      {
+        "tensor": "site",
+        "n_blocks": 32,
+        "n_distinct_shapes": 1,
+        "collapse_ceiling": 32.0
+      },
+      {
+        "tensor": "C1",
+        "n_blocks": 5,
+        "n_distinct_shapes": 3,
+        "collapse_ceiling": 1.667
+      },
+      {
+        "tensor": "C2",
+        "n_blocks": 5,
+        "n_distinct_shapes": 3,
+        "collapse_ceiling": 1.667
+      },
+      {
+        "tensor": "C3",
+        "n_blocks": 5,
+        "n_distinct_shapes": 3,
+        "collapse_ceiling": 1.667
+      },
+      {
+        "tensor": "C4",
+        "n_blocks": 5,
+        "n_distinct_shapes": 3,
+        "collapse_ceiling": 1.667
+      },
+      {
+        "tensor": "T1",
+        "n_blocks": 19,
+        "n_distinct_shapes": 10,
+        "collapse_ceiling": 1.9
+      },
+      {
+        "tensor": "T2",
+        "n_blocks": 19,
+        "n_distinct_shapes": 10,
+        "collapse_ceiling": 1.9
+      },
+      {
+        "tensor": "T3",
+        "n_blocks": 19,
+        "n_distinct_shapes": 10,
+        "collapse_ceiling": 1.9
+      },
+      {
+        "tensor": "T4",
+        "n_blocks": 19,
+        "n_distinct_shapes": 10,
+        "collapse_ceiling": 1.9
+      }
+    ]
+  }
+]

--- a/census_u1sz_candidateC_610.json
+++ b/census_u1sz_candidateC_610.json
@@ -1,0 +1,62 @@
+[
+  {
+    "D": 3,
+    "chi": 12,
+    "keep": [
+      -1,
+      0,
+      1
+    ],
+    "rows": [
+      {
+        "tensor": "C1",
+        "n_blocks": 5,
+        "kept": 3,
+        "reduction": 1.667
+      },
+      {
+        "tensor": "C2",
+        "n_blocks": 5,
+        "kept": 3,
+        "reduction": 1.667
+      },
+      {
+        "tensor": "C3",
+        "n_blocks": 5,
+        "kept": 3,
+        "reduction": 1.667
+      },
+      {
+        "tensor": "C4",
+        "n_blocks": 5,
+        "kept": 3,
+        "reduction": 1.667
+      },
+      {
+        "tensor": "T1",
+        "n_blocks": 19,
+        "kept": 9,
+        "reduction": 2.111
+      },
+      {
+        "tensor": "T2",
+        "n_blocks": 19,
+        "kept": 9,
+        "reduction": 2.111
+      },
+      {
+        "tensor": "T3",
+        "n_blocks": 19,
+        "kept": 9,
+        "reduction": 2.111
+      },
+      {
+        "tensor": "T4",
+        "n_blocks": 19,
+        "kept": 9,
+        "reduction": 2.111
+      }
+    ],
+    "median_reduction": 2.111
+  }
+]

--- a/docs/superpowers/handoffs/2026-06-17-u1sz-env-defrag-findings.md
+++ b/docs/superpowers/handoffs/2026-06-17-u1sz-env-defrag-findings.md
@@ -1,0 +1,130 @@
+# U(1)-Sz CTM env de-fragmentation spike — Findings (#610)
+
+**Date:** 2026-06-17
+**Branch:** `spike/610-u1sz-env-defrag` (off `origin/main` @ 3b51689)
+**Spec:** `docs/superpowers/specs/2026-06-16-u1sz-env-defrag-design.md`
+**Plan:** `docs/superpowers/plans/2026-06-17-u1sz-env-defrag-spike.md`
+**Verdict:** **NO-GO-by-obstruction.** The make-or-break Gate-B measurement is **structurally
+unattainable via runtime monkeypatch**; confirming the lever requires the structural CTM change the
+spike was meant to gate. No committed `src/` change (per scope).
+
+## Question
+
+Does reducing the distinct charge-sector count on the U(1)-Sz CTM **environment** tensors (the
+sector-dropping "C-lever": keep only `|Sz| ≤ 1` on the chi bonds) shrink the backward **charge-mask
+op cluster** (#609's ~35%), and buy D=3 χ=12 iPEPS-AD runtime to ≥ parity-with-dense within 1%
+energy?
+
+## Answer: the forward drop is real, but it cannot reach the backward that matters — without a structural change.
+
+Three-gate staircase, cheapest-decisive-first. Gate A passed; Gate B is **blocked**, not failed.
+
+### Gate A — static sector census (PASS)
+
+Baseline (D=3 χ=12, `census_u1sz_baseline_610.json`): env block counts **C1–C4 = 5, T1–T4 = 19**
+(median collapse ceiling 1.90× — heavy fragmentation, vs ~16× even-D). `E_frag = −0.0617` (a
+**random, un-optimized** `heisenberg_u1sz_init_pair` site — a same-input baseline, *not* a ground
+state; see Risks).
+
+Static candidate-C prediction (`predict_sectors_under_keep`, dropping `|Sz|>1` on the chi bonds,
+`census_u1sz_candidateC_610.json`):
+
+| tensor | n_blocks | kept | reduction |
+|---|---|---|---|
+| C1–C4 | 5 | 3 | 1.667× |
+| T1–T4 | 19 | 9 | 2.111× |
+
+**Median = 2.111× ≥ 2×** → Gate A PASS. Total env blocks 96 → 48 (exactly 2×). The forward
+prototype reproduces this exactly: under `sector_dropping_truncation()` the converged `ctm_tensor`
+env has block counts `{C: 3, T: 9}`, energy finite/sane — the representation change **is
+constructible and faithful in the forward path** (`examples/u1sz_defrag_prototype_610.py`,
+`tests/test_u1sz_defrag_prototype_610.py`).
+
+### Gate B — backward charge-mask re-profile (BLOCKED by structural obstruction)
+
+The forward drop bites the **paired-moves** projector path (`ctm_tensor`), but the **backward** the
+spike must measure — `_make_jit_ctm_step` → `_ctm_tensor_sweep_multisite`, the **2×2 plaquette**
+path used by both the Gate-B probe **and** production `_ctm_energy_ad` — does **not** honor the drop.
+We attacked it with three coordinated monkeypatches (no `src/` edits):
+
+1. filter `_ctm_tensor_paired_moves._get_base_charges` (forward), and
+2. filter the **separate** `_ctm_tensor_convergence._get_base_charges` (the multisite/backward
+   base_charges source — a distinct function; this was the first reason the drop never reached the
+   backward), and
+3. restrict the Phase-2 χ-backfill in `tenax.linalg._truncated_svd_symmetric_traced`
+   (`src/tenax/linalg.py:732–747`) to `keep` sectors, so it stops re-adding ±2 to saturate χ
+   (`chi_new` honestly shrinks to ~10 at D=3 χ=12).
+
+Even with all three, the **cold** backward VJP trace raises (independently reproduced):
+
+```
+ValueError: Size of label 'd' for operand 1 (4) does not match previous terms (5).
+  _build_enlarged_corner -> contract(C_r, T_v)   (_ctm_tensor_projector_2x2.py:238)
+```
+
+**Root cause (structural):** `initialize_ctm_tensor_env` seeds every chi bond at the full 5-sector
+`{−2..+2}`, and the 2×2 multisite sweep refreshes only the legs along the *current* absorption
+direction per move. So a single sweep that transitions 5→3 sectors mid-sweep contracts a
+freshly-dropped 3-sector leg (`t4_u` ∈ `{−1,0,1}`) against an un-refreshed 5-sector perpendicular
+corner leg (`c4_u` ∈ `{−2..+2}`) — a **mixed-generation chi-bond mismatch**. This is *not* the
+earlier post-hoc-bond-drop trap; the truncation is self-consistent per move, but the sweep contracts
+tensors from different truncation generations. A monkeypatch cannot fix it: making the backward
+honor the drop needs **env-init to seed a uniform sector set** *and* the 2×2 sweep to refresh **all**
+chi bonds to that uniform set per sweep — a structural change to the most-used symmetric CTM paths.
+
+Because the defrag jaxpr never builds, the charge-mask reduction is **undefined** — there is no
+measured drop to assess against the ≥25% bar. Baseline backward (built fine): **63,612** total ops,
+**7,398** charge-mask/index-arith ops (`probe_u1sz_baseline_610.txt`).
+
+**Cold-trace caveat (load-bearing for any future re-test):** the monkeypatch only bites if the
+patched `_make_jit_ctm_step` unit is traced **cold** under the patch. A prior un-patched trace of
+the same jit unit (identical avals) seeds the `jax.jit` cache, so a later prototype-wrapped call
+silently reuses the un-patched trace — neither erroring nor dropping. Any "it traced fine" claim must
+verify cold tracing (`jax.clear_caches()`), or it is measuring the baseline.
+
+### Gate C — not reached.
+
+## The honest signal (inference, not measurement)
+
+The forward env-block count drops **exactly 2×**, and #609 **measured** the backward op count to be
+~linear in block count (~1.1 ops/block; D=2→D=3 was 19,319→63,612). The baseline here (63,612 ops,
+7,398 charge-mask) is consistent with that scaling. So a *faithful* sector-dropped backward would
+**plausibly** cut the charge-mask cluster ~proportionally (~40–50%, clearing the 25% bar). But this
+is **inference**, exactly what the brief warned against relying on — and the structural obstruction
+is precisely what prevents converting it to a measurement cheaply.
+
+## Recommendation / next lever
+
+**Do not fund the structural build on inference within a measure-first spike** (cheapest-kill
+discipline, mirroring #609). The de-fragmentation idea is *not* refuted — it is **un-measurable
+without building most of the real thing**. Recommended scoped follow-up (filed as a separate issue):
+
+> Implement a **uniform-sector env representation** for the multisite 2×2 CTM: seed
+> `initialize_ctm_tensor_env` chi bonds with the chosen `keep` sector set, and make the 2×2 sweep
+> refresh **all** chi bonds to that uniform set per sweep (no mixed-generation contraction). Then the
+> backward becomes traceable under the drop and Gate B + Gate C can be measured for real. Gate the
+> build on the inferred ~2× backward-block reduction being judged worth the blast radius (env-init +
+> sweep refresh + projector truncation — the most-used symmetric paths).
+
+For D≥3 U(1)-Sz today, the **dense** path remains pragmatic (memory `u1sz-perf-study-d3-findings`).
+
+## Artifacts (all on the branch; no `src/` touched)
+
+- `examples/census_u1sz_block_shapes_566.py` — extended with `predict_sectors_under_keep`,
+  `candidate_report`, `_chi_axes_for` (chi-bond discriminator: underscore-in-label), `--candidate-keep`.
+- `tests/test_u1sz_defrag_census_610.py` — static predictor unit tests.
+- `examples/u1sz_defrag_prototype_610.py` — the throwaway C-lever prototype (3 coordinated
+  monkeypatches + the surgical traced-backfill copy). Never imported by `src/`.
+- `tests/test_u1sz_defrag_prototype_610.py` — faithfulness guard (forward drop + energy) + the
+  pinned `test_backward_trace_does_not_survive_surgical_drop` obstruction test.
+- `examples/probe_backward_jaxpr_566.py` — added `--defrag` flag + a dedicated charge-mask bucket.
+- `examples/_e_frag_610.py`, `census_u1sz_baseline_610.json`, `census_u1sz_candidateC_610.json`,
+  `probe_u1sz_baseline_610.txt`, `probe_u1sz_defrag_610.txt`.
+
+## Risks / caveats recorded
+
+- **`E_frag` is a random-site baseline** (≈ −0.06, not a ground state). Gate C's 1%-relative energy
+  tolerance would have been hypersensitive against this near-zero scale; the follow-up's energy gate
+  must use an **optimized** state (a few AD steps), not this init. (Moot here — Gate C not reached.)
+- **Verdict scope:** NO-GO is for the *cheap measure-first route*, not for the physics of the lever.
+  The forward evidence is favorable; the obstruction is a CTM-architecture property, not a refutation.

--- a/docs/superpowers/plans/2026-06-17-u1sz-env-defrag-spike.md
+++ b/docs/superpowers/plans/2026-06-17-u1sz-env-defrag-spike.md
@@ -1,0 +1,498 @@
+# U(1)-Sz CTM env de-fragmentation spike — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Measure whether a representation-level change that reduces the distinct charge-sector count on the U(1)-Sz CTM environment tensors materially shrinks the backward charge-mask op cluster and buys D=3 χ=12 iPEPS-AD runtime to ≥ parity-with-dense within 1% energy — and emit a documented GO/NO-GO finding.
+
+**Architecture:** A three-gate measurement staircase, cheapest-decisive-first (static sector census → trace-only backward re-profile → A100 end-to-end + energy). Each gate can kill the spike before the next is funded. The representation prototype is a **branch-local monkeypatch over `tenax.algorithms._ctm_utils._derive_charges`** (the per-sector χ-allocation knob, re-imported inside `_retruncate_by_base_charges` so the patch takes effect) — **no committed `src/` change**.
+
+**Tech Stack:** Python, JAX (x64), pytest, the Tenax block-sparse `SymmetricTensor` CTM-AD path. Reuses the #609 spike assets (`examples/census_u1sz_block_shapes_566.py`, `examples/probe_backward_jaxpr_566.py`, `examples/profile_ctm_ad_wall_566.py`, `tests/test_profiler_u1sz_arm.py`).
+
+**Research-spike note (read before executing):** This is a measurement spike, not a feature build. The deterministic tooling (static census predictor, faithfulness guard) gets full TDD. The prototype *mechanism* (the exact `_derive_charges` filter) may need one or two iterations to converge a valid env — the plan makes the **acceptance criteria** crisp (faithfulness guard passes; sector count actually drops) even where the mechanism is tuned. **Honor the gates: if a gate fails, stop at that task, record the finding, and skip the remaining gated tasks.** No `src/` file is committed at any point.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-u1sz-env-defrag-design.md`
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility |
+|---|---|---|
+| `examples/census_u1sz_block_shapes_566.py` | Modify | Add a **static candidate-evaluation** function: filter baseline env block-keys by a candidate keep-set and report predicted post-candidate sector count (Gate A). Keep the existing shape census. |
+| `tests/test_u1sz_defrag_census_610.py` | Create | Unit test for the static candidate predictor (deterministic, synthetic block-keys). |
+| `examples/u1sz_defrag_prototype_610.py` | Create | The throwaway C-lever prototype: a context manager that monkeypatches `_derive_charges` to drop \|Sz\|>1 / enforce uniform per-sector χ. Branch-local; never imported by `src/`. |
+| `tests/test_u1sz_defrag_prototype_610.py` | Create | Faithfulness guard: under the prototype, CTM converges and energy is finite/sane at D=3 χ=12. |
+| `examples/probe_backward_jaxpr_566.py` | Use (no edit if `--sym u1sz` already wired) | Gate B: backward op-histogram, baseline vs under-prototype. |
+| `examples/profile_ctm_ad_wall_566.py` | Use | Gate C: off/on compile+runtime grid on A100. |
+| `docs/superpowers/handoffs/2026-06-17-u1sz-env-defrag-findings.md` | Create (last task) | The GO/NO-GO finding writeup. |
+
+---
+
+## Task 1: Baseline lock (Stage 0)
+
+Record the fragmented baseline at D=3 χ=12: env sector/shape census and the unconstrained-truncation energy `E_frag`. No code change — run existing tools and capture numbers.
+
+**Files:**
+- Use: `examples/census_u1sz_block_shapes_566.py`
+- Use: `tests/test_profiler_u1sz_arm.py` (`_u1sz_energy` helper pattern)
+
+- [ ] **Step 1: Confirm D=3 χ=12 U(1)-Sz CTM-AD runs on this branch**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_profiler_u1sz_arm.py::test_u1sz_ctm_forward_runs -v
+```
+Expected: PASS for `[2-8]` and `[3-8]` (post-#605/#608 unfused-projector fix). If it fails, STOP — the prerequisite is broken; record and report.
+
+- [ ] **Step 2: Capture the baseline shape/sector census at D=3 χ=12**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run python examples/census_u1sz_block_shapes_566.py \
+    --D 3 --chi-factor 4 --json census_u1sz_baseline_610.json
+```
+Expected: prints per-tensor `n_blocks`, `n_distinct_shapes`, `collapse_ceiling`; writes JSON. Record the env (C1–C4, T1–T4) `n_blocks` — this is the baseline **sector count** the candidate must reduce.
+
+- [ ] **Step 3: Capture `E_frag` (unconstrained-truncation energy) at D=3 χ=12**
+
+Add a tiny throwaway script `examples/_e_frag_610.py` (kept on the branch, never committed to `src/`):
+```python
+# examples/_e_frag_610.py — record the unconstrained-truncation baseline energy.
+import jax
+from tenax.algorithms._ctm_tensor import ctm_tensor
+from tenax import compute_energy_ctm_tensor
+from tenax.algorithms.ipeps import heisenberg_gate_u1sz, heisenberg_u1sz_init_pair
+
+jax.config.update("jax_enable_x64", True)
+A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+env, _ = ctm_tensor(A, chi=12, max_iter=20, conv_tol=1e-7)
+gate = heisenberg_gate_u1sz()
+print("E_frag(D=3,chi=12) =", float(compute_energy_ctm_tensor(A, env, gate)))
+```
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run python examples/_e_frag_610.py
+```
+Expected: a finite negative energy near the D=3 Heisenberg estimate. Record `E_frag`.
+
+- [ ] **Step 4: Commit the baseline artifacts**
+
+```bash
+git add examples/_e_frag_610.py census_u1sz_baseline_610.json
+git commit -m "study(#610): lock D=3 chi=12 fragmented baseline (census + E_frag)"
+```
+
+---
+
+## Task 2: Gate A — static sector-count prediction under candidates (Stage 1)
+
+Predict, **with no compile**, the post-candidate env sector count by filtering the baseline env tensors' block-keys. This is the cheapest decisive kill: if no candidate cuts the sector count ≥2× on paper, NO-GO before building anything.
+
+**Files:**
+- Modify: `examples/census_u1sz_block_shapes_566.py`
+- Test: `tests/test_u1sz_defrag_census_610.py`
+
+- [ ] **Step 1: Write the failing test for the static predictor**
+
+Create `tests/test_u1sz_defrag_census_610.py`:
+```python
+"""Static candidate-evaluation predictor for #610 Gate A."""
+from examples.census_u1sz_block_shapes_566 import predict_sectors_under_keep
+
+
+def test_drop_high_sz_sectors_reduces_block_count():
+    # block-keys: each key is a per-axis charge tuple; axes (chi_a, chi_b, d2).
+    # Keep-set {-1,0,1} on the chi axes (axes 0 and 1) drops any block whose
+    # chi charge has |q| > 1.
+    block_keys = [
+        (0, 0, 0), (1, -1, 0), (-1, 1, 0),   # all chi charges within {-1,0,1}
+        (2, 0, -2), (-2, 0, 2), (0, 2, -2),  # contain a chi charge with |q|=2
+    ]
+    kept = predict_sectors_under_keep(block_keys, chi_axes=(0, 1), keep={-1, 0, 1})
+    assert kept == 3  # only the first three survive
+
+
+def test_keep_all_is_identity():
+    block_keys = [(0, 0, 0), (2, 0, -2)]
+    kept = predict_sectors_under_keep(block_keys, chi_axes=(0, 1), keep={-2, -1, 0, 1, 2})
+    assert kept == 2
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_u1sz_defrag_census_610.py -v
+```
+Expected: FAIL with `ImportError: cannot import name 'predict_sectors_under_keep'`.
+
+- [ ] **Step 3: Implement the predictor + candidate evaluation in the census**
+
+Append to `examples/census_u1sz_block_shapes_566.py` (after `census_one`):
+```python
+def predict_sectors_under_keep(block_keys, chi_axes, keep) -> int:
+    """Count blocks that survive restricting the chi-axis charges to ``keep``.
+
+    Static Gate-A proxy for the post-candidate sector count: a block survives
+    iff every chi-axis charge component lies in ``keep`` (the sector-dropping
+    candidate, e.g. keep={-1,0,1} drops |Sz|=2 chi sectors).
+    """
+    keep = set(keep)
+    return sum(
+        all(k[a] in keep for a in chi_axes)
+        for k in block_keys
+    )
+
+
+def _chi_axes_for(tensor) -> tuple:
+    """Indices of legs whose label starts with 'chi' (the truncated bonds)."""
+    labels = [ix.label for ix in tensor.indices]
+    return tuple(i for i, lab in enumerate(labels) if lab.lower().startswith("chi"))
+
+
+def candidate_report(D: int, chi: int, keep) -> dict:
+    """For each env tensor, baseline n_blocks vs predicted-kept under ``keep``."""
+    A, _B = heisenberg_u1sz_init_pair(D=D, key=jax.random.PRNGKey(0))
+    env, _ = ctm_tensor(A, chi=chi, max_iter=4, conv_tol=1e-4)
+    rows = []
+    for name in env._fields:
+        t = getattr(env, name)
+        keys = list(getattr(t, "_block_keys", ()))
+        chi_axes = _chi_axes_for(t)
+        n0 = len(keys)
+        n1 = predict_sectors_under_keep(keys, chi_axes, keep) if chi_axes else n0
+        rows.append({
+            "tensor": name, "n_blocks": n0, "kept": n1,
+            "reduction": round(n0 / n1, 3) if n1 else float("inf"),
+        })
+    return {"D": D, "chi": chi, "keep": sorted(keep), "rows": rows}
+```
+Add a `--candidate-keep` CLI branch in `main()` that, when passed (e.g. `-1 0 1`), prints `candidate_report` for each D and the **median reduction** across env tensors.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_u1sz_defrag_census_610.py -v
+```
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Run the Gate-A measurement at D=3 χ=12**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run python examples/census_u1sz_block_shapes_566.py \
+    --D 3 --chi-factor 4 --candidate-keep -1 0 1 \
+    --json census_u1sz_candidateC_610.json
+```
+Record the median env-tensor `reduction`. Also note: the brief flags that **B (alt virtual-leg charge set) is cramped at D=3** — if you want B in the report, additionally evaluate `keep={-1,0,1}` is the same as C here; B's distinct lever (changing the *init* charge multiset) has no sub-`{0,+1,-1}` option at D=3, so record "B: no headroom at D=3" rather than running it.
+
+- [ ] **Step 6: GATE A decision**
+
+**Pass criterion:** median env-tensor sector-count `reduction` ≥ **2×** under candidate C.
+- If **≥2×** → record PASS, proceed to Task 3.
+- If **<2×** → record **NO-GO** in a note, jump to Task 6 (findings), and skip Tasks 3–5.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add examples/census_u1sz_block_shapes_566.py tests/test_u1sz_defrag_census_610.py census_u1sz_candidateC_610.json
+git commit -m "study(#610): Gate A — static sector-count predictor + D=3 candidate-C census"
+```
+
+---
+
+## Task 3: Build the C-lever prototype + faithfulness guard (Stage 2 setup)
+
+Only if Gate A passed. Build the throwaway prototype that produces a uniform/sector-dropped env, and prove it produces a *valid* env (converges, energy finite) before profiling.
+
+**Files:**
+- Create: `examples/u1sz_defrag_prototype_610.py`
+- Test: `tests/test_u1sz_defrag_prototype_610.py`
+
+- [ ] **Step 1: Write the failing faithfulness-guard test**
+
+Create `tests/test_u1sz_defrag_prototype_610.py`:
+```python
+"""Faithfulness guard for the #610 C-lever prototype (Stage 2 prereq)."""
+import jax
+import numpy as np
+
+from examples.u1sz_defrag_prototype_610 import sector_dropping_derive_charges
+from tenax.algorithms._ctm_tensor import ctm_tensor
+from tenax import compute_energy_ctm_tensor
+from tenax.algorithms.ipeps import heisenberg_gate_u1sz, heisenberg_u1sz_init_pair
+
+
+def test_prototype_ctm_converges_and_energy_is_sane():
+    jax.config.update("jax_enable_x64", True)
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    with sector_dropping_derive_charges(keep={-1, 0, 1}):
+        env, _ = ctm_tensor(A, chi=12, max_iter=20, conv_tol=1e-7)
+        for name in env._fields:
+            t = getattr(env, name)
+            assert np.all(np.isfinite(np.asarray(t._data))), f"{name} non-finite"
+        e = float(compute_energy_ctm_tensor(A, env, heisenberg_gate_u1sz()))
+    assert np.isfinite(e), "prototype energy non-finite"
+    assert -2.0 < e < 0.0, f"prototype energy {e} outside sane Heisenberg window"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_u1sz_defrag_prototype_610.py -v
+```
+Expected: FAIL with `ImportError` (module/function not yet defined).
+
+- [ ] **Step 3: Implement the prototype monkeypatch**
+
+Create `examples/u1sz_defrag_prototype_610.py`:
+```python
+"""Throwaway #610 C-lever prototype: sector-dropping chi-bond truncation.
+
+Monkeypatches the per-sector chi allocation knob
+``tenax.algorithms._ctm_utils._derive_charges`` so chi_new charges with
+|Sz| outside ``keep`` are removed before tiling. NEVER imported by src/.
+This exists only to produce a uniform/sector-dropped env to profile.
+"""
+import contextlib
+
+import numpy as np
+
+import tenax.algorithms._ctm_utils as _cu
+
+_orig_derive = _cu._derive_charges
+
+
+@contextlib.contextmanager
+def sector_dropping_derive_charges(keep=frozenset({-1, 0, 1})):
+    keep = set(keep)
+
+    def patched(base_charges, target_dim):
+        base = np.asarray(base_charges, dtype=np.int32)
+        filt = np.array([q for q in base if int(q) in keep], dtype=np.int32)
+        if filt.size == 0:           # degenerate guard: never empty the bond
+            filt = base
+        return _orig_derive(filt, target_dim)
+
+    _cu._derive_charges = patched
+    try:
+        yield
+    finally:
+        _cu._derive_charges = _orig_derive
+```
+
+- [ ] **Step 4: Run the faithfulness guard to verify it passes**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_u1sz_defrag_prototype_610.py -v
+```
+Expected: PASS. If it FAILS (env non-finite, energy out of window, or `_derive_charges` not the binding knob), **iterate the mechanism**: confirm `_retruncate_by_base_charges` is the active truncation path at D=3 χ=12 (add a print in `patched` to confirm it is called), and adjust the filter (e.g. also enforce uniform per-sector counts) until the env is valid. Do not proceed to Task 4 until the guard passes — an invalid env makes the re-profile meaningless.
+
+- [ ] **Step 5: Confirm the prototype actually drops sectors (sanity)**
+
+Add a quick check (can be a `print` run, not committed): under the context manager, re-run the census `candidate_report`-style block-key count on the prototype env and confirm env `n_blocks` dropped ≈ the Gate-A prediction. This links the static prediction (Task 2) to the real prototype env.
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run python -c "
+import jax; jax.config.update('jax_enable_x64', True)
+from examples.u1sz_defrag_prototype_610 import sector_dropping_derive_charges
+from tenax.algorithms._ctm_tensor import ctm_tensor
+from tenax.algorithms.ipeps import heisenberg_u1sz_init_pair
+A,_=heisenberg_u1sz_init_pair(D=3,key=jax.random.PRNGKey(0))
+with sector_dropping_derive_charges():
+    env,_=ctm_tensor(A,chi=12,max_iter=8,conv_tol=1e-6)
+    print({n: len(getattr(env,n)._block_keys) for n in env._fields})
+"
+```
+Expected: env `n_blocks` materially below the Task-1 baseline. Record.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/u1sz_defrag_prototype_610.py tests/test_u1sz_defrag_prototype_610.py
+git commit -m "study(#610): C-lever sector-dropping prototype + faithfulness guard"
+```
+
+---
+
+## Task 4: Gate B — make-or-break backward re-profile (Stage 2)
+
+The decisive Tier-1 measurement: does the charge-mask cluster shrink under the prototype? Trace-only, CPU, no XLA compile.
+
+**Files:**
+- Use: `examples/probe_backward_jaxpr_566.py` (u1sz arm; `backward_vjp_jaxpr`, `bucketize`)
+- Use: `examples/u1sz_defrag_prototype_610.py`
+
+- [ ] **Step 1: Capture the baseline backward op-histogram (u1sz, no prototype)**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run python examples/probe_backward_jaxpr_566.py \
+    --sym u1sz --D 3 --chi-factor 4 > probe_u1sz_baseline_610.txt
+```
+Expected: the bucketized histogram (buffer-pack / charge-mask / math clusters) printed. Record the **charge-mask cluster** absolute op count and total backward op count. (If the existing arm only runs D=2, run at the largest D it supports and note it; the cluster *shares* are the comparison, not absolute D.)
+
+- [ ] **Step 2: Capture the under-prototype histogram**
+
+The probe builds the site and traces the backward internally, so wrap its measurement call in the prototype context. Add a `--defrag` flag to `examples/probe_backward_jaxpr_566.py` that, when set, wraps the `backward_vjp_jaxpr` trace in `sector_dropping_derive_charges()`:
+```python
+# in main(), near the per-(sym,D,chi) loop:
+import contextlib
+ctx = contextlib.nullcontext()
+if args.defrag:
+    from examples.u1sz_defrag_prototype_610 import sector_dropping_derive_charges
+    ctx = sector_dropping_derive_charges()
+with ctx:
+    counts = backward_vjp_jaxpr(A, chi, on=on)   # match the existing call site
+```
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run python examples/probe_backward_jaxpr_566.py \
+    --sym u1sz --D 3 --chi-factor 4 --defrag > probe_u1sz_defrag_610.txt
+```
+Expected: a histogram with **fewer** charge-mask ops. Record the charge-mask cluster count and total.
+
+- [ ] **Step 3: Compute the charge-mask reduction**
+
+Compute `1 - (charge_mask_defrag / charge_mask_baseline)` and the total-op reduction. Record both.
+
+- [ ] **Step 4: GATE B decision (make-or-break, Tier 1)**
+
+**Pass criterion:** charge-mask cluster op count drops **≥ 25%** (well beyond #609's ~1% noise) under the prototype, with total backward ops dropping commensurately.
+- If **≥25%** → record PASS, proceed to Task 5 (A100).
+- If **<25%** → record **NO-GO** (the representation lever does not attack the charge-mask third), jump to Task 6, skip Task 5. **Do not spend A100.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/probe_backward_jaxpr_566.py probe_u1sz_baseline_610.txt probe_u1sz_defrag_610.txt
+git commit -m "study(#610): Gate B — backward charge-mask re-profile under prototype"
+```
+
+---
+
+## Task 5: Gate C — A100 end-to-end + energy (Stage 3, conditional)
+
+Only if Gate B passed. The worth-it tier: does the runtime reach ≥ parity-with-dense, and is the energy within 1% of `E_frag`? Run on the A100 box (see memory `a100-gpu-env`: `uv sync --extra cuda13`, `JAX_PLATFORMS=cuda,cpu`, x64).
+
+**Files:**
+- Use: `examples/profile_ctm_ad_wall_566.py` (u1sz arm)
+- Use: `examples/u1sz_defrag_prototype_610.py`
+
+- [ ] **Step 1: Baseline + dense reference grid at D=3 χ=12 (A100)**
+
+Run:
+```bash
+JAX_PLATFORMS=cuda,cpu uv run python examples/profile_ctm_ad_wall_566.py \
+    --sym u1sz dense --D 3 --chi 12 --json profile_d3_baseline_610.json
+```
+Record `vg_cmp` and `warm_ms` for u1sz (fragmented) and dense. The dense `warm_ms`/`vg_cmp` define the parity-with-dense target.
+
+- [ ] **Step 2: Under-prototype grid (A100)**
+
+Add the same `--defrag` flag wrapping to `examples/profile_ctm_ad_wall_566.py`'s u1sz measurement call (mirror Task 4 Step 2). Run:
+```bash
+JAX_PLATFORMS=cuda,cpu uv run python examples/profile_ctm_ad_wall_566.py \
+    --sym u1sz --D 3 --chi 12 --defrag --json profile_d3_defrag_610.json
+```
+Record `vg_cmp` and `warm_ms` under the prototype.
+
+- [ ] **Step 3: Energy under the prototype vs `E_frag`**
+
+Run:
+```bash
+JAX_PLATFORMS=cuda,cpu uv run python -c "
+import jax; jax.config.update('jax_enable_x64', True)
+from examples.u1sz_defrag_prototype_610 import sector_dropping_derive_charges
+from tenax.algorithms._ctm_tensor import ctm_tensor
+from tenax import compute_energy_ctm_tensor
+from tenax.algorithms.ipeps import heisenberg_gate_u1sz, heisenberg_u1sz_init_pair
+A,_=heisenberg_u1sz_init_pair(D=3,key=jax.random.PRNGKey(0))
+with sector_dropping_derive_charges():
+    env,_=ctm_tensor(A,chi=12,max_iter=20,conv_tol=1e-7)
+    print('E_uniform =', float(compute_energy_ctm_tensor(A,env,heisenberg_gate_u1sz())))
+"
+```
+Record `E_uniform`. Compute `abs(E_uniform - E_frag) / abs(E_frag)`.
+
+- [ ] **Step 4: GATE C decision (worth-it, Tier 2)**
+
+**Pass criterion (both):**
+1. `vg_cmp` **and/or** `warm_ms` under the prototype reaches **≥ parity with dense** (≈3× faster than the fragmented u1sz baseline), **and**
+2. `abs(E_uniform - E_frag) / abs(E_frag) ≤ 0.01`.
+
+- Both pass → **GO**.
+- Runtime passes but energy fails (or vice versa) → **documented partial** (mechanism real, accuracy/worth-it cost too high).
+- Neither → **NO-GO**.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/profile_ctm_ad_wall_566.py profile_d3_baseline_610.json profile_d3_defrag_610.json
+git commit -m "study(#610): Gate C — A100 end-to-end + energy under prototype"
+```
+
+---
+
+## Task 6: Findings, memory, and follow-up (always run)
+
+Reached on any terminal gate (PASS-through to GO, or any NO-GO). Write the finding the way #609 did.
+
+**Files:**
+- Create: `docs/superpowers/handoffs/2026-06-17-u1sz-env-defrag-findings.md`
+- Modify: `/home/yjkao/.claude/projects/-home-yjkao-tenax/memory/` (new memory + `MEMORY.md` pointer)
+
+- [ ] **Step 1: Write the findings handoff**
+
+Create `docs/superpowers/handoffs/2026-06-17-u1sz-env-defrag-findings.md` with: the verdict (GO / NO-GO / partial), which gate was binding, the recorded numbers (baseline census + `E_frag`; Gate-A reduction; Gate-B charge-mask drop; Gate-C runtime + energy if reached), the candidate that was prototyped (C sector-dropping), and the recommendation. Mirror the structure of `2026-06-16-u1sz-stacked-spike-findings.md`.
+
+- [ ] **Step 2: Write a memory file + MEMORY.md pointer**
+
+Create `/home/yjkao/.claude/projects/-home-yjkao-tenax/memory/610-u1sz-env-defrag.md` (type `project`) capturing the verdict, the binding gate, and the non-obvious takeaway (e.g. "charge-mask third is/ isn't reducible by sector-dropping"). Link `[[566-u1sz-stacking-nogo]]` and `[[u1sz-perf-study-d3-findings]]`. Add a one-line pointer to `MEMORY.md`.
+
+- [ ] **Step 3: If GO — open the follow-up implementation issue**
+
+Only if Gate C = GO:
+```bash
+gh issue create --title "feat(#566): implement U(1)-Sz CTM env de-fragmentation (sector-dropping truncation)" \
+  --body "Spike #610 GO: the sector-dropping chi-bond truncation prototype cut the backward charge-mask cluster by <X>% and reached parity-with-dense at D=3 chi=12 within 1% energy. Implement it as a committed src/ change behind the accuracy spine. See docs/superpowers/handoffs/2026-06-17-u1sz-env-defrag-findings.md and spec 2026-06-16-u1sz-env-defrag-design.md."
+```
+
+- [ ] **Step 4: Commit the findings + memory pointer**
+
+```bash
+git add docs/superpowers/handoffs/2026-06-17-u1sz-env-defrag-findings.md
+git commit -m "docs(#610): U(1)-Sz CTM env de-fragmentation spike — <GO|NO-GO|partial> finding"
+```
+
+- [ ] **Step 5: Open the spike PR**
+
+```bash
+git push -u origin spike/610-u1sz-env-defrag
+gh pr create --title "study(#610): U(1)-Sz CTM env de-fragmentation spike — <verdict>" \
+  --body "Measure-first GO/NO-GO spike per docs/superpowers/specs/2026-06-16-u1sz-env-defrag-design.md. Three-gate staircase; no committed src/. Verdict: <...>. 🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+Note: the throwaway `examples/_e_frag_610.py` and prototype examples stay on the branch as spike artifacts (mirroring #609, which kept its census/probe tools); **no `src/` file is modified by this spike.**
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3 Stage 0 baseline lock → Task 1. ✓
+- §3 Stage 1 static sector census + Gate A → Task 2. ✓
+- §3 Stage 2 prototype + faithfulness guard + Gate B re-profile → Tasks 3–4. ✓
+- §3 Stage 3 A100 end-to-end + energy + Gate C → Task 5. ✓
+- §4 candidate C lead / B cramped-at-D=3 noted → Task 2 Step 5. ✓
+- §5 faithfulness guard before profiling → Task 3 Step 4 (gates Task 4). ✓
+- §7 deliverables (census, prototype, re-profile, findings, memory, follow-up issue) → Tasks 2,3,4,6. ✓
+- §8 GO definition (A and B and C) → gate-decision steps in Tasks 2/4/5. ✓
+- §10 non-goal "no committed src/" → enforced in every task (monkeypatch only); restated in Task 6 Step 5. ✓
+
+**Placeholder scan:** No TBD/TODO. The `<X>%`/`<verdict>` tokens in Task 6 are intentional fill-from-measurement values in human-authored prose, not code placeholders.
+
+**Type consistency:** `predict_sectors_under_keep(block_keys, chi_axes, keep)` defined in Task 2 Step 3, used with the same signature in the Task 2 Step 1 test. `sector_dropping_derive_charges(keep=...)` context manager defined in Task 3 Step 3, used identically in Tasks 3/4/5. `_derive_charges(base_charges, target_dim)` matches the real signature in `src/tenax/algorithms/_ctm_utils.py:45`.

--- a/docs/superpowers/specs/2026-06-16-u1sz-env-defrag-design.md
+++ b/docs/superpowers/specs/2026-06-16-u1sz-env-defrag-design.md
@@ -1,0 +1,140 @@
+# U(1)-Sz CTM env de-fragmentation — measure-first GO/NO-GO spike (#610)
+
+**Date:** 2026-06-16
+**Tracking issue:** #610 · **Parent:** #566 · **Predecessor spike:** PR #609 (NO-GO)
+**Branch:** `spike/610-u1sz-env-defrag` (off `origin/main` @ 3b51689, which carries the #609 assets)
+**Kickoff brief:** `docs/superpowers/handoffs/2026-06-16-u1sz-env-defrag-research-kickoff.md`
+**Status:** design, pending implementation plan.
+**Scope ceiling:** a measure-first spike that ends in a documented **GO/NO-GO finding**. No
+committed `src/` change this round — the prototype representation stays throwaway on the branch,
+mirroring #609. If GO, a *separate* follow-up issue implements the representation change.
+
+---
+
+## 1. Objective & question
+
+Determine whether a **representation-level** change that reduces the *distinct charge-sector
+count* on the U(1)-Sz CTM environment tensors materially shrinks the backward **charge-mask op
+cluster** (#609's ~35% of backward ops), and whether that buys end-to-end D=3 χ=12 iPEPS-AD
+runtime at least to **parity with dense**, within a **1% energy tolerance**.
+
+Output: a documented GO/NO-GO finding plus reusable measurement tooling — *not* a shipped
+representation change.
+
+## 2. Fixed facts (established by #609 — do NOT re-derive)
+
+From PR #609 / `docs/superpowers/handoffs/2026-06-16-u1sz-stacked-spike-findings.md`:
+
+1. **Stacking is dead for fragmented U(1)-Sz.** Block-shape collapse ceiling on the hot env
+   tensors is only 1.5–1.9× (vs ~16× for even-D FermionParity); the stacked contractor runs and
+   amortizes nothing (`persisted_inputs=0`); the backward op cost is diffuse (~37% buffer-pack,
+   **~35% charge-mask / index arithmetic**, ~30% math) with no single fusable chain.
+2. **The charge-mask third shrinks only if the distinct-sector count shrinks** — it is index
+   arithmetic emitted *per distinct sector*. This is a property of the **representation** (how
+   virtual legs are charged + how chi bonds are truncated), not of the execution backend. That is
+   the precise reason stacking failed and the load-bearing premise of this spike.
+3. **Where the fragmentation comes from.** U(1)-Sz unequal Sz-sector multiplicities on the
+   virtual legs, plus the `D²`-fuse producing charges `{−2..+2}` on the chi bonds after projector
+   SVD truncation ⇒ env C/T blocks carry many distinct sectors with unequal shapes. Even D / Z₂
+   are self-dual so this is masked.
+4. **Baseline behavior:** symmetry **wins at D=2** (1.37×→1.78× as χ grows) but **loses at D=3**
+   (≈0.32× vs dense — the #566 dispatch overhead over fragmented sectors). D=3 U(1)-Sz CTM-AD
+   **runs** on this branch (post-#605/#608 unfused-projector fix).
+
+## 3. Measurement staircase (the spike) — three kill-gates, cheapest decisive first
+
+Each rung can kill the spike before the next is funded. Mirrors #609's measure-first / kill-switch
+discipline and realizes the two-tier gate (cheap mechanism gate, then end-to-end worth-it gate).
+
+| Stage | What | Cost | Gate |
+|---|---|---|---|
+| **0 — baseline lock** | Confirm D=3 χ=12 U(1)-Sz CTM-AD runs on this branch. Record the *fragmented* baseline: env distinct-sector **and** distinct-shape census, plus the unconstrained-truncation energy `E_frag` at D=3 χ=12. | CPU, cheap | — (prerequisite) |
+| **1 — static sector census** | Extend the census to count distinct *charges/sectors* on the env C/T tensors (not just shapes) under each candidate representation. | No compile | **Gate A:** at least one candidate cuts the env distinct-sector count **≥2×** (toward the even-D ~1 regime) at tolerable expressivity cost. Else **NO-GO** before any compile. |
+| **2 — make-or-break re-profile** | Build a throwaway prototype of the census-winning candidate; re-run the S3 backward op-histogram under it. | Trace-only, CPU | **Gate B (Tier 1):** the charge-mask cluster op count drops **materially — target ≥25% relative**, well beyond #609's ~1% noise — and the total backward op count drops commensurate with the sector reduction. Else **NO-GO**; do not spend A100. |
+| **3 — end-to-end + energy** | Off/on compile+runtime grid under the prototype vs the fragmented baseline; compute `E_uniform`. | A100, **only if Gate B passes** | **Gate C (Tier 2):** `vg_cmp` **and/or** warm-step reaches **≥ parity with dense** (≈3× faster than the fragmented sym baseline) **AND** `\|E_uniform − E_frag\| / \|E_frag\| ≤ 1%`. Else documented **partial / NO-GO**. |
+
+**Why this ordering.** Gate A is free (static metadata, no compile) and kills the whole idea if no
+candidate even reduces the sector count on paper. Gate B is the make-or-break the brief names — it
+directly tests the load-bearing premise (charge-mask ∝ sector count) for the cost of one trace,
+before any A100 time. Only a representation that passes both cheap gates earns the A100
+end-to-end + energy measurement.
+
+## 4. Candidate representations (the census evaluates; C leads at D=3)
+
+- **C — sector-dropping symmetric truncation (lead).** Constrain the projector SVD truncation to
+  keep only `|Sz| ≤ 1` on the chi bond and/or enforce **uniform per-sector χ**. The chi bonds
+  literally set the env block shapes, so this is the most direct control of env fragmentation, and
+  the accuracy cost (dropping the `|Sz|=2` sectors) directly exercises the energy gate.
+  **Injection site:** `_fishman_truncate_S` and the `chi`-keep step in `build_2x2_projectors`,
+  both in `src/tenax/algorithms/_ctm_tensor_projector_2x2.py`.
+- **B — alternative virtual-leg charge set / multiplicities.** Attack sectors at the source.
+  **Cramped at D=3:** virtual legs need at least `{0,+1,−1}` (pure ±1 hits the parity obstruction
+  documented in `heisenberg_u1sz_init_pair`), so B likely loses the census at D=3; kept for
+  completeness and to record D≥4 headroom. **Injection site:** `heisenberg_u1sz_init_pair`,
+  `src/tenax/algorithms/ipeps.py:96`.
+- **A — pad-to-uniform-multiplicity (deprioritized, not prototyped).** Keeps the same charge set
+  and only equalizes per-sector dims → fewer distinct *shapes* (helps the buffer-pack third +
+  stacking, both already shown weak by #609) but unchanged sector *count* → will not move the
+  charge-mask third. Recorded as the contrast that motivates the sector-count framing.
+
+## 5. Prototype mechanism (throwaway, branch-local)
+
+Inject the census-winning lever behind a **branch-local flag / monkeypatch** at the named site —
+**no committed `src/` change.** The prototype exists only to produce a uniform-representation env
+to profile.
+
+**Faithfulness guard (mandatory before profiling):** verify the prototype CTM **converges** and
+`E_uniform` is **finite and physically sane** at D=3 χ=12. A truncation hack that yields an invalid
+charge-conserving env makes the re-profile and energy numbers meaningless; the guard runs before
+Gate B and before Gate C.
+
+## 6. Reused assets (all on the branch from #609)
+
+- `examples/census_u1sz_block_shapes_566.py` — extend to a distinct *sector* count and to evaluate
+  candidate representations (Stage 1).
+- `examples/probe_backward_jaxpr_566.py` (u1sz arm) — the S3 backward op-histogram = Gate B (the
+  make-or-break re-profile tool).
+- `examples/profile_ctm_ad_wall_566.py` (u1sz arm) — off/on compile+runtime grid = Gate C.
+- `tests/test_profiler_u1sz_arm.py` — D=3 forward smoke + drift harness (faithfulness guard).
+
+## 7. Deliverables
+
+- Extended census tool (distinct-sector count + candidate evaluation).
+- Throwaway prototype of the winning candidate (branch only — never merged to `src/`).
+- Re-profile op-histogram numbers (Gate B) and, if reached, the A100 end-to-end + energy numbers
+  (Gate C).
+- A findings handoff doc (`docs/superpowers/handoffs/`) recording the GO/NO-GO finding with the
+  decision recorded at the binding gate, mirroring #609's writeup.
+- A memory update.
+- **If GO:** open a follow-up implementation issue for the representation change. Do **not**
+  implement it in this spike.
+
+## 8. Success criteria (the GO definition, restated)
+
+**GO** = Gate A passes (a candidate cuts env distinct-sector count ≥2×) **and** Gate B passes
+(charge-mask cluster ops drop ≥25%, beyond noise) **and** Gate C passes (≥ parity-with-dense on
+`vg_cmp` and/or warm-step at D=3 χ=12 **and** `|E_uniform − E_frag| / |E_frag| ≤ 1%`).
+**NO-GO** = any gate fails; the spike stops at that gate and documents why (cheapest-possible
+kill). A pass on A+B but fail on C is a documented **partial** (mechanism real, not yet worth it).
+
+## 9. Risks / kill-switches
+
+- **Charge-mask partly irreducible** — Gate B catches it cheaply (trace-only) before A100 spend.
+- **B cramped at D=3** — the census surfaces it; C is the lead lever by design.
+- **Sector-dropping accuracy cost** — may blow the 1% energy gate even if runtime improves; that is
+  exactly Gate C's job to expose (documented partial, not a silent pass).
+- **Prototype unfaithfulness** — the faithfulness guard (§5) runs before any profiling.
+- **Blast radius (deferred):** a *real* fix would touch iPEPS init + projector truncation + env
+  construction — but this spike makes **no committed `src/` change**, so the blast radius is
+  confined to the throwaway branch prototype. The blast-radius cost is a concern for the follow-up
+  implementation issue, not for this measurement spike.
+
+## 10. Non-goals
+
+- No committed `src/` representation change this round (GO/NO-GO finding only).
+- No stacking revisit (conclusively dead per #609).
+- Not chasing D=2 (symmetry already wins there) or D≥4 (the census may *note* headroom, but the
+  binding gate is D=3 χ=12, the case where symmetry currently loses).
+- No accuracy-spine / golden infrastructure build-out (that belongs to the follow-up
+  implementation if GO; the spike's accuracy check is the §5 faithfulness guard + the Gate C
+  energy comparison).

--- a/examples/_e_frag_610.py
+++ b/examples/_e_frag_610.py
@@ -1,0 +1,11 @@
+# examples/_e_frag_610.py — record the unconstrained-truncation baseline energy.
+import jax
+from tenax.algorithms._ctm_tensor import ctm_tensor
+from tenax import compute_energy_ctm_tensor
+from tenax.algorithms.ipeps import heisenberg_gate_u1sz, heisenberg_u1sz_init_pair
+
+jax.config.update("jax_enable_x64", True)
+A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+env, _ = ctm_tensor(A, chi=12, max_iter=20, conv_tol=1e-7)
+gate = heisenberg_gate_u1sz()
+print("E_frag(D=3,chi=12) =", float(compute_energy_ctm_tensor(A, env, gate)))

--- a/examples/census_u1sz_block_shapes_566.py
+++ b/examples/census_u1sz_block_shapes_566.py
@@ -35,12 +35,102 @@ def census_one(D: int, chi: int) -> dict:
     return {"D": D, "chi": chi, "rows": rows}
 
 
+def predict_sectors_under_keep(block_keys, chi_axes, keep) -> int:
+    """Count blocks that survive restricting the chi-axis charges to ``keep``.
+
+    Static Gate-A proxy for the post-candidate sector count: a block survives
+    iff every chi-axis charge component lies in ``keep`` (the sector-dropping
+    candidate, e.g. keep={-1,0,1} drops |Sz|=2 chi sectors).
+    """
+    keep = set(keep)
+    return sum(
+        all(k[a] in keep for a in chi_axes)
+        for k in block_keys
+    )
+
+
+def _chi_axes_for(tensor) -> tuple:
+    """Indices of the truncated CTM (chi) bond legs.
+
+    DISCRIMINATOR — chosen by introspecting real D=3 env tensors (see #610):
+    the candidate drops |Sz|>1 on the *chi* environment bonds, NOT on the
+    physical D^2 leg. Observed leg schema (fixed by ``_ctm_tensor_init.py``):
+
+        corners  C1..C4 : 2 legs, labels 'c{i}_{dir}'  (both chi bonds)
+        edges    T1..T4 : 3 legs, labels 't{i}_{dir}', '{dir}2', 't{i}_{dir}'
+                          -> axes 0 & 2 are chi bonds; axis 1 is the D^2 leg
+                          labeled 'u2'/'r2'/'d2'/'l2' (dim == D^2).
+
+    The naive label-prefix test ('chi'...) returns () here (labels are
+    'c1_d'/'t1_l', not 'chi*') -> bogus 1.0x reduction. A dim-based test
+    (dim == chi) is ALSO unsafe: at chi==D^2 (e.g. chi=9, D=3) the D^2 leg
+    is indistinguishable by dimension, and at chi<D^2 it picks the wrong leg.
+
+    Robust, chi-independent discriminator: a chi bond's label contains an
+    underscore ('c1_d', 't1_r'), while the D^2 leg label never does
+    ('u2','r2','d2','l2'). We keep an explicit 'chi'-prefix branch first as a
+    forward-compatible fallback for any path that does emit chi-labeled bonds.
+    """
+    labels = [str(ix.label) for ix in tensor.indices]
+    pref = tuple(i for i, lab in enumerate(labels) if lab.lower().startswith("chi"))
+    if pref:
+        return pref
+    # CTM env legs: chi bonds carry an underscore ('c#_dir'/'t#_dir');
+    # the D^2 physical leg ('u2'/'r2'/'d2'/'l2') does not.
+    return tuple(i for i, lab in enumerate(labels) if "_" in lab)
+
+
+def candidate_report(D: int, chi: int, keep) -> dict:
+    """For each env tensor, baseline n_blocks vs predicted-kept under ``keep``."""
+    A, _B = heisenberg_u1sz_init_pair(D=D, key=jax.random.PRNGKey(0))
+    env, _ = ctm_tensor(A, chi=chi, max_iter=4, conv_tol=1e-4)
+    rows = []
+    for name in env._fields:
+        t = getattr(env, name)
+        keys = list(getattr(t, "_block_keys", ()))
+        chi_axes = _chi_axes_for(t)
+        n0 = len(keys)
+        n1 = predict_sectors_under_keep(keys, chi_axes, keep) if chi_axes else n0
+        rows.append({
+            "tensor": name, "n_blocks": n0, "kept": n1,
+            "reduction": round(n0 / n1, 3) if n1 else float("inf"),
+        })
+    return {"D": D, "chi": chi, "keep": sorted(keep), "rows": rows}
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--D", type=int, nargs="+", default=[2, 3])
     ap.add_argument("--chi-factor", type=int, default=4)
+    ap.add_argument("--candidate-keep", type=int, nargs="+", default=None,
+                    help="Sector-keep set on chi bonds, e.g. -1 0 1. When given, "
+                         "print the static Gate-A candidate report instead of "
+                         "the fragmentation census.")
     ap.add_argument("--json", type=str, default=None)
     args = ap.parse_args()
+
+    if args.candidate_keep is not None:
+        keep = set(args.candidate_keep)
+        out = []
+        for D in args.D:
+            chi = args.chi_factor * D
+            res = candidate_report(D, chi, keep)
+            out.append(res)
+            print(f"\n=== U(1)-Sz candidate report D={D} chi={chi} "
+                  f"keep={sorted(keep)} ===")
+            print(f"{'tensor':>6} {'n_blocks':>9} {'kept':>6} {'reduction':>10}")
+            for r in res["rows"]:
+                print(f"{r['tensor']:>6} {r['n_blocks']:>9} "
+                      f"{r['kept']:>6} {r['reduction']:>10}")
+            reductions = sorted(r["reduction"] for r in res["rows"])
+            median = reductions[len(reductions) // 2]
+            res["median_reduction"] = median
+            print(f"  median env-tensor reduction = {median:.3f}")
+        if args.json:
+            with open(args.json, "w") as f:
+                json.dump(out, f, indent=2)
+            print(f"\nwrote {args.json}")
+        return
 
     out = []
     for D in args.D:

--- a/examples/probe_backward_jaxpr_566.py
+++ b/examples/probe_backward_jaxpr_566.py
@@ -222,6 +222,25 @@ BUCKETS = {
         "pad",
     ],
     "transpose": ["transpose"],
+    # Charge-mask / index arithmetic: the per-charge-sector comparisons, casts
+    # and index iotas/argmaxes that the block-sparse SVD-VJP emits to mask and
+    # route each sector.  This cluster scales with the NUMBER of chi-bond charge
+    # sectors, so it is the one the #610 sector-drop is expected to shrink.
+    "charge-mask / index arith": [
+        "lt",
+        "le",
+        "gt",
+        "ge",
+        "eq",
+        "ne",
+        "and",
+        "or",
+        "not",
+        "convert_element_type",
+        "iota",
+        "argmax",
+        "argmin",
+    ],
     "elementwise(add/mul/...)": [
         "add",
         "mul",
@@ -290,6 +309,14 @@ def main() -> None:
         help="Also print the per-primitive raw counts (top-20) alongside the bucket "
         "summary, useful for identifying dominant individual ops.",
     )
+    ap.add_argument(
+        "--defrag",
+        action="store_true",
+        help="#610 Gate B: wrap the backward trace in "
+        "examples.u1sz_defrag_prototype_610.sector_dropping_truncation() so the "
+        "traced CTM truncation drops the |Sz|>1 chi-bond sectors. Compare the "
+        "'charge-mask / index arith' cluster vs the un-wrapped baseline.",
+    )
     args = ap.parse_args()
 
     pbw = args.projector_backward
@@ -307,13 +334,36 @@ def main() -> None:
     print(f"# unit = {unit}")
     print(f"# projector_backward = {pbw}\n")
 
-    def hist(A, chi, on):
-        os.environ[FLAG] = "1" if on else "0"
+    # #610 Gate B: optionally wrap the backward trace so the CTM truncation
+    # drops |Sz|>1 chi-bond sectors. Mirrors backward_vjp_jaxpr's call signature
+    # exactly; the only change is the surrounding sector_dropping_truncation().
+    if args.defrag:
+        import importlib.util as _ilu
+        import pathlib as _pl
+
+        _spec = _ilu.spec_from_file_location(
+            "u1sz_defrag_prototype_610",
+            _pl.Path(__file__).parent / "u1sz_defrag_prototype_610.py",
+        )
+        _defrag_mod = _ilu.module_from_spec(_spec)
+        _spec.loader.exec_module(_defrag_mod)
+        _sector_drop = _defrag_mod.sector_dropping_truncation
+    else:
+        _sector_drop = None
+
+    def _trace(A, chi):
         if args.full:
             env_jx, par_jx = backward_vjp_jaxpr(A, chi, pbw, full=True)
-            raw = _combine(count_primitives(env_jx), count_primitives(par_jx))
+            return _combine(count_primitives(env_jx), count_primitives(par_jx))
+        return count_primitives(backward_vjp_jaxpr(A, chi, pbw))
+
+    def hist(A, chi, on):
+        os.environ[FLAG] = "1" if on else "0"
+        if _sector_drop is not None:
+            with _sector_drop():
+                raw = _trace(A, chi)
         else:
-            raw = count_primitives(backward_vjp_jaxpr(A, chi, pbw))
+            raw = _trace(A, chi)
         return bucketize(raw), raw
 
     for sym in args.sym:

--- a/examples/u1sz_defrag_prototype_610.py
+++ b/examples/u1sz_defrag_prototype_610.py
@@ -76,14 +76,20 @@ import jax.numpy as jnp
 import numpy as np
 
 import tenax.algorithms._ctm_projector as _proj
+import tenax.algorithms._ctm_tensor_convergence as _conv
 import tenax.algorithms._ctm_tensor_paired_moves as _pm
 import tenax.linalg as _linalg
-from tenax.core.index import TensorIndex
+from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.tensor import SymmetricTensor
 
 # Pristine originals captured once at import so repeated / nested use always
 # restores the genuine implementations.
 _ORIG_GET_BASE_CHARGES = _pm._get_base_charges
+# The AD backward path (_make_jit_ctm_step -> _ctm_tensor_sweep_multisite, used by
+# both the Gate-B probe and production _ctm_energy_ad) reads base_charges from a
+# SECOND, distinct function in _ctm_tensor_convergence — NOT the paired-moves one.
+# Both must be filtered for the drop to reach the traced backward (see Step 0/#610).
+_ORIG_CONV_GET_BASE_CHARGES = _conv._get_base_charges
 _ORIG_SVD_PROJECTOR = _proj._svd_projector_symmetric
 _ORIG_TRACED_SVD = _linalg._truncated_svd_symmetric_traced
 
@@ -203,56 +209,366 @@ def _patched_traced_svd(
     return U_T, s_trunc, Vh_T, s_trunc
 
 
+def _make_keep_filtered_traced_svd(keep: set[int]):
+    """Build a drop-in for ``_truncated_svd_symmetric_traced`` that allocates
+    ZERO singular values to any new-bond sector ``q`` with ``int(q) not in keep``.
+
+    This is a faithful COPY of ``tenax.linalg._truncated_svd_symmetric_traced``
+    (``src/tenax/linalg.py`` lines 583-864 at the time of writing) with EXACTLY
+    two minimal edits, nothing else changed:
+
+      1. In the Phase-1 ``base_charges is not None`` allocation and the defensive
+         ``else`` fallback: a sector ``q`` outside ``keep`` is forced to
+         ``k_per_sector[q] = 0`` (dropped — never requests SVs for it).
+      2. In the Phase-2 greedy χ-backfill loop: ``if int(q) not in keep:
+         continue`` so the leftover χ budget is NEVER refilled from a
+         non-``keep`` sector (the bug that re-added ±2 at D=3 χ=12).
+
+    Consequence: ``chi_new`` is the SUM of kept-sector allocations and may be
+    < ``max_singular_values`` (e.g. ~10 at D=3 χ=12). That smaller bond is the
+    HONEST sector-dropped bond dim, produced BY the truncation itself, so the
+    downstream enlarged-corner contraction accepts it (unlike the post-hoc
+    column drop in ``_drop_bond_sectors_usv``, which broke the trace).
+
+    All library internals are referenced through the ``_linalg`` module so the
+    copy stays pinned to the same helpers (`_group_blocks_by_bond_charge`,
+    `_grouped_decomp_by_shape`, `_batch_blocksparse_enabled`, `_koszul_sign`).
+    """
+    keep = {int(q) for q in keep}
+
+    def _keep_filtered_traced(
+        tensor,
+        left_labels,
+        right_labels,
+        max_singular_values,
+        new_bond_label,
+        normalize,
+        base_charges=None,
+    ):
+        from tenax.algorithms._ad_primitives import truncated_svd_ad
+        from tenax.algorithms._ctm_utils import _derive_charges
+
+        all_labels = tensor.labels()
+        label_to_axis = {lbl: i for i, lbl in enumerate(all_labels)}
+        left_axes = [label_to_axis[lbl] for lbl in left_labels]
+        right_axes = [label_to_axis[lbl] for lbl in right_labels]
+        left_indices = tuple(tensor.indices[i] for i in left_axes)
+        right_indices = tuple(tensor.indices[i] for i in right_axes)
+
+        grouped = _linalg._group_blocks_by_bond_charge(tensor, left_axes, right_axes)
+
+        sym = tensor.indices[0].symmetry
+        is_fermionic = sym.is_fermionic
+        decomp_perm = tuple(left_axes + right_axes)
+
+        sector_results: dict[int, tuple] = {}
+
+        for q, entries in grouped.items():
+            left_subkeys_seen: dict = {}
+            right_subkeys_seen: dict = {}
+            for lk, rk, _ in entries:
+                if lk not in left_subkeys_seen:
+                    left_subkeys_seen[lk] = len(left_subkeys_seen)
+                if rk not in right_subkeys_seen:
+                    right_subkeys_seen[rk] = len(right_subkeys_seen)
+
+            left_subkeys = list(left_subkeys_seen.keys())
+            right_subkeys = list(right_subkeys_seen.keys())
+
+            left_row_sizes: list[int] = []
+            for lk in left_subkeys:
+                size = 1
+                for leg_pos, charge_val in zip(left_axes, lk):
+                    idx = tensor.indices[leg_pos]
+                    size *= idx.multiplicity(charge_val)
+                left_row_sizes.append(size)
+
+            right_col_sizes: list[int] = []
+            for rk in right_subkeys:
+                size = 1
+                for leg_pos, charge_val in zip(right_axes, rk):
+                    idx = tensor.indices[leg_pos]
+                    size *= idx.multiplicity(charge_val)
+                right_col_sizes.append(size)
+
+            total_rows = sum(left_row_sizes)
+            total_cols = sum(right_col_sizes)
+            if total_rows == 0 or total_cols == 0:
+                continue
+
+            matrix = jnp.zeros((total_rows, total_cols), dtype=tensor.dtype)
+            for lk, rk, block in entries:
+                li = left_subkeys_seen[lk]
+                ri = right_subkeys_seen[rk]
+                row_start = sum(left_row_sizes[:li])
+                col_start = sum(right_col_sizes[:ri])
+                flat_block = block.reshape(left_row_sizes[li], right_col_sizes[ri])
+                if is_fermionic:
+                    full_key = [0] * len(tensor.indices)
+                    for ax, ch in zip(left_axes, lk):
+                        full_key[ax] = ch
+                    for ax, ch in zip(right_axes, rk):
+                        full_key[ax] = ch
+                    parities = tuple(
+                        int(sym.parity(np.array([full_key[i]]))[0])
+                        for i in range(len(full_key))
+                    )
+                    ksign = _linalg._koszul_sign(parities, decomp_perm)
+                    if ksign < 0:
+                        flat_block = -flat_block
+                matrix = matrix.at[
+                    row_start : row_start + left_row_sizes[li],
+                    col_start : col_start + right_col_sizes[ri],
+                ].set(flat_block)
+
+            available_q = min(total_rows, total_cols)
+            sector_results[q] = (
+                matrix,
+                left_subkeys,
+                right_subkeys,
+                left_row_sizes,
+                right_col_sizes,
+                available_q,
+            )
+
+        # --- Static per-sector keep allocation ---
+        if max_singular_values is None:
+            k_per_sector: dict[int, int] = {
+                q: r[5] for q, r in sector_results.items()
+            }
+        elif base_charges is not None:
+            target_charges = _derive_charges(base_charges, max_singular_values)
+            target_count: dict[int, int] = {}
+            for tq in target_charges:
+                target_count[int(tq)] = target_count.get(int(tq), 0) + 1
+            # EDIT 1: a sector q outside `keep` is dropped (k_per_sector[q] = 0).
+            k_per_sector = {
+                q: (
+                    0
+                    if int(q) not in keep
+                    else min(target_count.get(q, 0), r[5])
+                )
+                for q, r in sector_results.items()
+            }
+            remaining = max_singular_values - sum(k_per_sector.values())
+            if remaining > 0:
+                for q in sorted(
+                    sector_results.keys(),
+                    key=lambda qq: (
+                        -(sector_results[qq][5] - k_per_sector.get(qq, 0)),
+                        qq,
+                    ),
+                ):
+                    if remaining <= 0:
+                        break
+                    # EDIT 2: never backfill from a non-keep sector (the bug that
+                    # re-added the ±2 sectors at D=3 χ=12).
+                    if int(q) not in keep:
+                        continue
+                    capacity_left = sector_results[q][5] - k_per_sector.get(q, 0)
+                    take = min(remaining, capacity_left)
+                    if take > 0:
+                        k_per_sector[q] = k_per_sector.get(q, 0) + take
+                        remaining -= take
+        else:
+            total_avail = sum(r[5] for r in sector_results.values()) or 1
+            # EDIT 1 (fallback): sectors outside `keep` get 0; others proportional.
+            k_per_sector = {
+                q: (
+                    0
+                    if int(q) not in keep
+                    else max(1, round(max_singular_values * r[5] / total_avail))
+                )
+                for q, r in sector_results.items()
+            }
+            excess = sum(k_per_sector.values()) - max_singular_values
+            for q in sorted(k_per_sector.keys()):
+                if excess <= 0:
+                    break
+                take = min(excess, k_per_sector[q] - 1)
+                if take > 0:
+                    k_per_sector[q] -= take
+                    excess -= take
+            if excess > 0:
+                for q in sorted(
+                    k_per_sector.keys(),
+                    key=lambda qq: (sector_results[qq][5], qq),
+                ):
+                    if excess <= 0:
+                        break
+                    take = min(excess, k_per_sector[q])
+                    k_per_sector[q] -= take
+                    excess -= take
+
+        # Floor at >=1 total (mirrors eager n_keep = max(1, n_keep)).  Restricted
+        # to keep sectors so the floor can never re-introduce a dropped sector.
+        total_keep = sum(k_per_sector.values())
+        if total_keep == 0 and sector_results:
+            keep_candidates = [
+                q for q in sector_results.keys() if int(q) in keep
+            ] or list(sector_results.keys())
+            best_q = max(
+                keep_candidates,
+                key=lambda q: (sector_results[q][5], -q),
+            )
+            k_per_sector[best_q] = 1
+
+        # --- Per-sector AD-primitive SVD ---
+        sector_svd: dict = {}
+        _ad_mats_by_q: dict = {}
+        for q, (matrix, _, _, _, _, _) in sector_results.items():
+            k_q = k_per_sector.get(q, 0)
+            if k_q <= 0:
+                continue
+            _ad_mats_by_q[q] = matrix
+
+        if _linalg._batch_blocksparse_enabled():
+            _ad_svd_by_q = _linalg._grouped_decomp_by_shape(
+                _ad_mats_by_q,
+                truncated_svd_ad,
+                group_extra_key=lambda q: int(k_per_sector[q]),
+            )
+            for q, res in _ad_svd_by_q.items():
+                sector_svd[q] = res
+        else:
+            for q, matrix in _ad_mats_by_q.items():
+                U_q, s_q, Vh_q = truncated_svd_ad(matrix, int(k_per_sector[q]))
+                sector_svd[q] = (U_q, s_q, Vh_q)
+
+        # --- Concatenate output in canonical sector-ascending order ---
+        ordered_qs = sorted(sector_svd.keys())
+        bond_charges = np.repeat(
+            np.array(ordered_qs, dtype=np.int32),
+            np.array(
+                [sector_svd[q][1].shape[0] for q in ordered_qs], dtype=np.int32
+            ),
+        )
+        s_final = jnp.concatenate([sector_svd[q][1] for q in ordered_qs])
+
+        if normalize and s_final.shape[0] > 0:
+            s_final = s_final / jnp.sum(s_final)
+
+        bond_index_out = TensorIndex.from_charges(
+            sym, bond_charges, FlowDirection.OUT, label=new_bond_label
+        )
+        bond_index_in = TensorIndex.from_charges(
+            sym, bond_charges, FlowDirection.IN, label=new_bond_label
+        )
+
+        U_blocks: dict = {}
+        Vh_blocks: dict = {}
+        for q in ordered_qs:
+            (
+                _matrix,
+                left_subkeys,
+                right_subkeys,
+                left_row_sizes,
+                right_col_sizes,
+                _,
+            ) = sector_results[q]
+            U_q, _, Vh_q = sector_svd[q]
+            row_offset = 0
+            for li, lk in enumerate(left_subkeys):
+                n_rows = left_row_sizes[li]
+                block_rows = U_q[row_offset : row_offset + n_rows, :]
+                row_offset += n_rows
+                shape = tuple(
+                    tensor.indices[ax].multiplicity(ch)
+                    for ax, ch in zip(left_axes, lk)
+                ) + (U_q.shape[1],)
+                U_blocks[lk + (q,)] = block_rows.reshape(shape)
+            col_offset = 0
+            for ri, rk in enumerate(right_subkeys):
+                n_cols = right_col_sizes[ri]
+                block_cols = Vh_q[:, col_offset : col_offset + n_cols]
+                col_offset += n_cols
+                shape = (Vh_q.shape[0],) + tuple(
+                    tensor.indices[ax].multiplicity(ch)
+                    for ax, ch in zip(right_axes, rk)
+                )
+                Vh_blocks[(q,) + rk] = block_cols.reshape(shape)
+
+        U_indices = left_indices + (bond_index_out,)
+        Vh_indices = (bond_index_in,) + right_indices
+        U_T = SymmetricTensor._from_blocks_unchecked(U_blocks, U_indices)
+        Vh_T = SymmetricTensor._from_blocks_unchecked(Vh_blocks, Vh_indices)
+
+        return U_T, s_final, Vh_T, s_final
+
+    return _keep_filtered_traced
+
+
 @contextlib.contextmanager
-def sector_dropping_truncation(keep=frozenset({-1, 0, 1}), *, patch_traced_svd=False):
+def sector_dropping_truncation(keep=frozenset({-1, 0, 1}), *, patch_traced_svd=True):
     """Monkeypatch the CTM truncation to drop chi-bond sectors outside ``keep``.
+
+    A single ``with sector_dropping_truncation(keep={-1, 0, 1}):`` activates ALL
+    of the following patches and restores every original on exit:
+
+      1. ``_ctm_tensor_paired_moves._get_base_charges`` — keep-filter (sets the
+         truncation intent on the FORWARD single-site paired-moves path).
+      2. ``_ctm_projector._svd_projector_symmetric`` — drops non-``keep``
+         ``chi_new`` columns from the eager forward block-sparse projector.
+      3. ``_ctm_tensor_convergence._get_base_charges`` — the SAME keep-filter as
+         (1) but on the SECOND, distinct ``_get_base_charges`` that the AD
+         backward path (``_make_jit_ctm_step`` -> ``_ctm_tensor_sweep_multisite``,
+         used by the Gate-B probe AND production ``_ctm_energy_ad``) reads from.
+         Without this the traced truncation never sees the filter (Step 0(a)).
+      4. ``tenax.linalg._truncated_svd_symmetric_traced`` — replaced by a faithful
+         copy whose per-sector keep allocation (a) drops non-``keep`` sectors and
+         (b) NEVER greedy-backfills the leftover χ budget from a non-``keep``
+         sector.  Result: ``chi_new`` is the SUM of kept-sector allocations and
+         may be < ``max_singular_values`` (~10 at D=3 χ=12).  This smaller bond
+         is produced BY the truncation, so the enlarged-corner contraction
+         accepts it (Step 0(b)).
+
+    Why both (3) and (4) are needed for the BACKWARD drop
+    -----------------------------------------------------
+    The forward single-site (``ctm_tensor`` -> paired moves) and the AD backward
+    that the Gate-B/Gate-C probes profile (``_make_jit_ctm_step`` ->
+    ``_ctm_tensor_sweep_multisite`` -> 2x2 plaquette projector ->
+    ``_truncated_svd_symmetric_traced``) are DIFFERENT projector paths that read
+    ``base_charges`` from DIFFERENT ``_get_base_charges`` functions.  Filtering
+    only the paired-moves one (1) leaves the backward truncation unfiltered, and
+    even a filtered ``base_charges`` was defeated by the traced SVD's Phase-2
+    greedy backfill re-adding ±2.  Patches (3)+(4) close both gaps so the drop
+    reaches the TRACED backward as a self-consistent smaller bond (NOT a post-hoc
+    column drop — that broke the trace; see ``_drop_bond_sectors_usv``, retained
+    only for reference / the legacy forward hook).
 
     Parameters
     ----------
     keep:
         Iterable of integer charges to retain on the environment (chi) bonds.
-        Any chi-bond sector whose charge is not in ``keep`` is dropped from the
-        eager forward (block-sparse paired-moves) projector.
     patch_traced_svd:
-        Whether to ALSO patch the traced block-sparse SVD
-        (``_truncated_svd_symmetric_traced``) to drop non-``keep`` new-bond
-        sectors. Default ``False``.
-
-        IMPORTANT — read before flipping this on. The two CTM entry points use
-        different projector machinery:
-
-          * ``ctm_tensor`` (single-site forward, used by the faithfulness
-            guard) -> ``_ctm_tensor_sweep_paired`` -> ``_svd_projector_symmetric``
-            (block-sparse). The default patches (``_get_base_charges`` +
-            ``_svd_projector_symmetric``) drop sectors faithfully here.
-          * ``_make_jit_ctm_step`` / ``ctm_multisite`` (the **AD backward** path
-            that ``_optimize_gs_ad_tensor`` and the Gate-B/Gate-C probes
-            actually use) -> ``_ctm_tensor_sweep_multisite`` -> the 2x2
-            plaquette projector (``_ctm_tensor_projector_2x2``), which truncates
-            via ``tensor_svd`` -> ``_truncated_svd_symmetric_traced``.
-
-        Setting ``patch_traced_svd=True`` makes the traced SVD physically drop
-        the chi bond, but in the 2x2 plaquette path that bond feeds
-        ``_build_enlarged_corner``, whose other (un-dropped) env legs then
-        mismatch the narrowed bond -> the single-sweep VJP fails to *trace*
-        (``dot_general``/einsum size error). So the traced drop, as a post-hoc
-        bond filter, is NOT consistent with the 2x2 enlarged-corner contraction.
-        Left as an opt-in hook for the Gate-B task to investigate; the default
-        keeps the prototype trace-able so Gate-B can at least build the
-        backward jaxpr (baseline-shaped, i.e. backward NOT yet dropped).
+        Whether to apply patches (3)+(4) (the traced/backward drop).  Default
+        ``True`` (the make-or-break Gate-B behaviour).  Set ``False`` to patch
+        only the forward eager path (1)+(2), e.g. to inspect the forward env
+        drop without touching the backward jaxpr.
 
     Guards
     ------
-    * ``_get_base_charges`` returning ``None`` (dense/trivial-charge) is a
+    * Either ``_get_base_charges`` returning ``None`` (dense/trivial-charge) is a
       no-op pass-through.
-    * If filtering would remove *every* charge from ``base_charges`` or from a
-      produced bond, the original (unfiltered) value is kept so the env can
-      never collapse to an empty bond.
+    * If filtering would remove *every* charge from ``base_charges``, the
+      original (unfiltered) value is kept so the env can never collapse.
+    * The traced allocator floors at >=1 SV restricted to ``keep`` sectors, so
+      the bond can never be empty nor re-introduce a dropped sector.
     """
     keep = {int(q) for q in keep}
 
     def _patched_get_base_charges(a):
         bc = _ORIG_GET_BASE_CHARGES(a)
+        if bc is None:
+            return None
+        filt = np.array([q for q in bc if int(q) in keep], dtype=np.int32)
+        return filt if filt.size else bc
+
+    def _patched_conv_get_base_charges(a):
+        # Same keep-filter as the paired-moves one, but for the SECOND
+        # _get_base_charges that the AD backward (_ctm_tensor_sweep_multisite)
+        # reads from (Step 0(a)).
+        bc = _ORIG_CONV_GET_BASE_CHARGES(a)
         if bc is None:
             return None
         filt = np.array([q for q in bc if int(q) in keep], dtype=np.int32)
@@ -267,33 +583,17 @@ def sector_dropping_truncation(keep=frozenset({-1, 0, 1}), *, patch_traced_svd=F
         P2 = _keep_columns_of_chi_new(P2, keep)
         return P1, P2, eps
 
-    def _traced(
-        tensor,
-        left_labels,
-        right_labels,
-        max_singular_values,
-        new_bond_label,
-        normalize,
-        base_charges=None,
-    ):
-        return _patched_traced_svd(
-            tensor,
-            left_labels,
-            right_labels,
-            max_singular_values,
-            new_bond_label,
-            normalize,
-            base_charges=base_charges,
-            _keep=keep,
-        )
+    _keep_filtered_traced = _make_keep_filtered_traced_svd(keep)
 
     _pm._get_base_charges = _patched_get_base_charges
     _proj._svd_projector_symmetric = _svd_proj
     if patch_traced_svd:
-        _linalg._truncated_svd_symmetric_traced = _traced
+        _conv._get_base_charges = _patched_conv_get_base_charges
+        _linalg._truncated_svd_symmetric_traced = _keep_filtered_traced
     try:
         yield
     finally:
         _pm._get_base_charges = _ORIG_GET_BASE_CHARGES
         _proj._svd_projector_symmetric = _ORIG_SVD_PROJECTOR
+        _conv._get_base_charges = _ORIG_CONV_GET_BASE_CHARGES
         _linalg._truncated_svd_symmetric_traced = _ORIG_TRACED_SVD

--- a/examples/u1sz_defrag_prototype_610.py
+++ b/examples/u1sz_defrag_prototype_610.py
@@ -1,0 +1,299 @@
+"""THROWAWAY #610 C-lever prototype: U(1)-Sz CTM env sector-dropping.
+
+This is a branch-local, throwaway research prototype for spike #610. It is
+NEVER imported by ``src/`` and makes NO committed change to library code. It
+exists only so the spike's Gate-B / Gate-C measurements can re-profile the CTM
+backward graph and end-to-end run under a "sector-dropped" environment.
+
+What "sector dropping" means
+----------------------------
+The active CTM path for U(1)-Sz SymmetricTensors is the *paired-moves* path
+(``tenax.algorithms._ctm_tensor_paired_moves``). Each paired move derives a
+per-sector chi allocation from ``base_charges`` produced by
+``_get_base_charges(a)`` — the D^2 (u2) leg charges of the double-layer site.
+At D=3 these are ``{-2,-1,0,1,2}``. The C-lever's goal is to make the
+truncation keep ONLY the small-|Sz| chi-bond sectors (default ``{-1,0,1}``),
+dropping |Sz| > 1.
+
+Why a single ``_get_base_charges`` filter is NOT enough
+-------------------------------------------------------
+``base_charges`` flows into both the eager forward truncation
+(``_svd_projector_symmetric`` in ``_ctm_projector.py``) and the traced
+backward truncation (``_truncated_svd_symmetric_traced`` in ``linalg.py``).
+Filtering ``base_charges`` to ``{-1,0,1}`` correctly restricts the *initial*
+per-sector allocation (``target_count`` only requests ``{-1,0,1}``). BUT both
+truncation routines contain a **greedy backfill**: when the kept sectors do not
+saturate ``chi`` (at D=3 χ=12 the ``{-1,0,1}`` sectors supply only ~10 of the
+12 singular values), the remaining budget is filled from the *global*
+singular-value list, which re-introduces the ``±2`` sectors. Measured: the
+forward projector ``chi_new`` comes out ``{-2:1,-1:3,0:4,1:3,2:1}`` — the
+backfill re-adds one ``±2`` each. So the env block counts never drop.
+
+The fix: drop the sectors AND suppress the backfill
+---------------------------------------------------
+This prototype monkeypatches (restoring all on exit):
+
+  1. ``_get_base_charges`` — filter to ``keep`` (sets the truncation intent).
+  2. ``_svd_projector_symmetric`` (forward, eager block-sparse) — wrap the
+     original and drop any ``chi_new`` columns whose charge is outside ``keep``.
+     This post-filters the genuine projector output, removing whole orthonormal
+     columns for the dropped charges so each projector stays an isometry on the
+     retained sectors and the resulting env is a valid (narrower)
+     charge-conserving environment.
+  3. (OPT-IN, default OFF) ``_truncated_svd_symmetric_traced`` (the traced
+     block-sparse SVD). See ``sector_dropping_truncation``'s ``patch_traced_svd``
+     argument for why this is off by default.
+
+Two-path obstruction (key #610 finding — see ``patch_traced_svd`` docstring)
+----------------------------------------------------------------------------
+The single-site forward (``ctm_tensor`` -> paired-moves) and the AD backward
+that the Gate-B/Gate-C probes profile (``_make_jit_ctm_step`` ->
+``_ctm_tensor_sweep_multisite`` -> 2x2 plaquette projector) are DIFFERENT
+projector implementations. (2) faithfully drops the **forward** env (the
+faithfulness guard passes; corners 5->3, edges 19->9 at D=3 χ=12, matching the
+Gate-A prediction). But the backward 2x2 plaquette path truncates through
+``_truncated_svd_symmetric_traced`` and feeds the chi bond into
+``_build_enlarged_corner``; physically dropping that bond there breaks the
+enlarged-corner contraction (the un-dropped neighbour legs no longer match), so
+the single-sweep VJP cannot even be traced. The ``_get_base_charges`` filter
+alone leaves the backward bond un-dropped (its greedy backfill re-adds ``±2``),
+so the backward jaxpr is baseline-shaped. Net: a clean forward sector-drop does
+NOT carry into the traced backward via post-hoc bond filtering. The default
+config keeps Gate-B trace-able (backward not yet dropped) and leaves the traced
+drop as an opt-in hook for the Gate-B task to resolve.
+
+Usage
+-----
+    with sector_dropping_truncation(keep={-1, 0, 1}):
+        env, _ = ctm_tensor(A, chi=12, ...)
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import jax.numpy as jnp
+import numpy as np
+
+import tenax.algorithms._ctm_projector as _proj
+import tenax.algorithms._ctm_tensor_paired_moves as _pm
+import tenax.linalg as _linalg
+from tenax.core.index import TensorIndex
+from tenax.core.tensor import SymmetricTensor
+
+# Pristine originals captured once at import so repeated / nested use always
+# restores the genuine implementations.
+_ORIG_GET_BASE_CHARGES = _pm._get_base_charges
+_ORIG_SVD_PROJECTOR = _proj._svd_projector_symmetric
+_ORIG_TRACED_SVD = _linalg._truncated_svd_symmetric_traced
+
+
+def _keep_columns_of_chi_new(P: SymmetricTensor, keep: set[int]) -> SymmetricTensor:
+    """Drop ``chi_new``-axis columns whose charge is outside ``keep``.
+
+    ``P`` is a projector with indices ``(fused, chi_new)`` and blocks keyed
+    ``(fq, fq)``. Removing the whole ``(q, q)`` block for ``q not in keep``
+    deletes those orthonormal columns; the result stays an isometry on the
+    retained sectors. Rebuilds ``chi_new`` without the dropped charges.
+    """
+    if not isinstance(P, SymmetricTensor):
+        return P
+    chi_pos = P.labels().index("chi_new")
+    fused_idx = P.indices[1 - chi_pos]  # the other (fused) index
+    chi_idx = P.indices[chi_pos]
+    chi_charges = np.asarray(chi_idx.charges, dtype=np.int32)
+    if all(int(q) in keep for q in chi_charges):
+        return P  # nothing to drop
+
+    new_blocks: dict[tuple[int, ...], jnp.ndarray] = {}
+    new_chi_charges: list[int] = []
+    for key, block in P.blocks.items():
+        # chi_new charge is the entry at the chi axis position of the key
+        q_chi = int(key[chi_pos])
+        if q_chi not in keep:
+            continue
+        new_blocks[key] = block
+        new_chi_charges.extend([q_chi] * block.shape[chi_pos])
+
+    if not new_chi_charges:
+        # Degenerate: keep set removed everything — fall back to the original
+        # so we never emit an empty bond.
+        return P
+
+    new_chi_idx = TensorIndex.from_charges(
+        chi_idx.symmetry,
+        np.array(new_chi_charges, dtype=np.int32),
+        chi_idx.flow,
+        label="chi_new",
+    )
+    new_indices = (
+        (fused_idx, new_chi_idx) if chi_pos == 1 else (new_chi_idx, fused_idx)
+    )
+    return SymmetricTensor._from_blocks_unchecked(new_blocks, new_indices)
+
+
+def _drop_bond_sectors_usv(U_T, s, Vh_T, keep: set[int]):
+    """Drop new-bond sectors outside ``keep`` from a traced SVD ``(U, s, Vh)``.
+
+    ``U_T`` has the new bond as its LAST index; ``Vh_T`` as its FIRST. ``s`` is
+    a flat 1-D array in sector-ascending order matching the bond. Removing whole
+    bond sectors keeps U/Vh sub-isometric on the retained charges.
+    """
+    bond_pos_U = len(U_T.indices) - 1
+    bond_idx = U_T.indices[bond_pos_U]
+    bond_charges = np.asarray(bond_idx.charges, dtype=np.int32)
+    if all(int(q) in keep for q in bond_charges):
+        return U_T, s, Vh_T
+
+    keep_mask = np.array([int(q) in keep for q in bond_charges], dtype=bool)
+    if not keep_mask.any():
+        return U_T, s, Vh_T  # never emit an empty bond
+
+    new_bond_charges = bond_charges[keep_mask]
+    s_new = s[jnp.asarray(np.nonzero(keep_mask)[0])]
+
+    label = bond_idx.label
+    sym = bond_idx.symmetry
+    U_bond_in = U_T.indices  # for index reconstruction below
+    new_U_bond = TensorIndex.from_charges(
+        sym, new_bond_charges, bond_idx.flow, label=label
+    )
+    vh_bond_idx = Vh_T.indices[0]
+    new_Vh_bond = TensorIndex.from_charges(
+        sym, new_bond_charges, vh_bond_idx.flow, label=vh_bond_idx.label
+    )
+
+    new_U_blocks = {
+        key: blk for key, blk in U_T.blocks.items()
+        if int(key[bond_pos_U]) in keep
+    }
+    new_Vh_blocks = {
+        key: blk for key, blk in Vh_T.blocks.items()
+        if int(key[0]) in keep
+    }
+    new_U_indices = U_bond_in[:bond_pos_U] + (new_U_bond,)
+    new_Vh_indices = (new_Vh_bond,) + Vh_T.indices[1:]
+    U_out = SymmetricTensor._from_blocks_unchecked(new_U_blocks, new_U_indices)
+    Vh_out = SymmetricTensor._from_blocks_unchecked(new_Vh_blocks, new_Vh_indices)
+    return U_out, s_new, Vh_out
+
+
+def _patched_traced_svd(
+    tensor,
+    left_labels,
+    right_labels,
+    max_singular_values,
+    new_bond_label,
+    normalize,
+    base_charges=None,
+    *,
+    _keep=None,
+):
+    """Traced (backward/AD) SVD with non-``keep`` new-bond sectors dropped."""
+    U_T, s_trunc, Vh_T, s_full = _ORIG_TRACED_SVD(
+        tensor,
+        left_labels,
+        right_labels,
+        max_singular_values,
+        new_bond_label,
+        normalize,
+        base_charges=base_charges,
+    )
+    U_T, s_trunc, Vh_T = _drop_bond_sectors_usv(U_T, s_trunc, Vh_T, _keep)
+    return U_T, s_trunc, Vh_T, s_trunc
+
+
+@contextlib.contextmanager
+def sector_dropping_truncation(keep=frozenset({-1, 0, 1}), *, patch_traced_svd=False):
+    """Monkeypatch the CTM truncation to drop chi-bond sectors outside ``keep``.
+
+    Parameters
+    ----------
+    keep:
+        Iterable of integer charges to retain on the environment (chi) bonds.
+        Any chi-bond sector whose charge is not in ``keep`` is dropped from the
+        eager forward (block-sparse paired-moves) projector.
+    patch_traced_svd:
+        Whether to ALSO patch the traced block-sparse SVD
+        (``_truncated_svd_symmetric_traced``) to drop non-``keep`` new-bond
+        sectors. Default ``False``.
+
+        IMPORTANT — read before flipping this on. The two CTM entry points use
+        different projector machinery:
+
+          * ``ctm_tensor`` (single-site forward, used by the faithfulness
+            guard) -> ``_ctm_tensor_sweep_paired`` -> ``_svd_projector_symmetric``
+            (block-sparse). The default patches (``_get_base_charges`` +
+            ``_svd_projector_symmetric``) drop sectors faithfully here.
+          * ``_make_jit_ctm_step`` / ``ctm_multisite`` (the **AD backward** path
+            that ``_optimize_gs_ad_tensor`` and the Gate-B/Gate-C probes
+            actually use) -> ``_ctm_tensor_sweep_multisite`` -> the 2x2
+            plaquette projector (``_ctm_tensor_projector_2x2``), which truncates
+            via ``tensor_svd`` -> ``_truncated_svd_symmetric_traced``.
+
+        Setting ``patch_traced_svd=True`` makes the traced SVD physically drop
+        the chi bond, but in the 2x2 plaquette path that bond feeds
+        ``_build_enlarged_corner``, whose other (un-dropped) env legs then
+        mismatch the narrowed bond -> the single-sweep VJP fails to *trace*
+        (``dot_general``/einsum size error). So the traced drop, as a post-hoc
+        bond filter, is NOT consistent with the 2x2 enlarged-corner contraction.
+        Left as an opt-in hook for the Gate-B task to investigate; the default
+        keeps the prototype trace-able so Gate-B can at least build the
+        backward jaxpr (baseline-shaped, i.e. backward NOT yet dropped).
+
+    Guards
+    ------
+    * ``_get_base_charges`` returning ``None`` (dense/trivial-charge) is a
+      no-op pass-through.
+    * If filtering would remove *every* charge from ``base_charges`` or from a
+      produced bond, the original (unfiltered) value is kept so the env can
+      never collapse to an empty bond.
+    """
+    keep = {int(q) for q in keep}
+
+    def _patched_get_base_charges(a):
+        bc = _ORIG_GET_BASE_CHARGES(a)
+        if bc is None:
+            return None
+        filt = np.array([q for q in bc if int(q) in keep], dtype=np.int32)
+        return filt if filt.size else bc
+
+    def _svd_proj(C1g, C4g, chi, base_charges=None, **kw):
+        # Forward (eager) projector with non-keep chi_new columns dropped.
+        P1, P2, eps = _ORIG_SVD_PROJECTOR(
+            C1g, C4g, chi, base_charges=base_charges, **kw
+        )
+        P1 = _keep_columns_of_chi_new(P1, keep)
+        P2 = _keep_columns_of_chi_new(P2, keep)
+        return P1, P2, eps
+
+    def _traced(
+        tensor,
+        left_labels,
+        right_labels,
+        max_singular_values,
+        new_bond_label,
+        normalize,
+        base_charges=None,
+    ):
+        return _patched_traced_svd(
+            tensor,
+            left_labels,
+            right_labels,
+            max_singular_values,
+            new_bond_label,
+            normalize,
+            base_charges=base_charges,
+            _keep=keep,
+        )
+
+    _pm._get_base_charges = _patched_get_base_charges
+    _proj._svd_projector_symmetric = _svd_proj
+    if patch_traced_svd:
+        _linalg._truncated_svd_symmetric_traced = _traced
+    try:
+        yield
+    finally:
+        _pm._get_base_charges = _ORIG_GET_BASE_CHARGES
+        _proj._svd_projector_symmetric = _ORIG_SVD_PROJECTOR
+        _linalg._truncated_svd_symmetric_traced = _ORIG_TRACED_SVD

--- a/probe_u1sz_baseline_610.txt
+++ b/probe_u1sz_baseline_610.txt
@@ -1,0 +1,15 @@
+# #566 backward-VJP jaxpr op-histogram (trace-only) | x64=True
+# unit = apply_Jt = VJP of one gauge-fixed CTM sweep w.r.t. env (Neumann matvec)
+# projector_backward = auto
+
+== u1sz D=3 chi=12 blocks=32 ==
+  bucket                                 flag_off    flag_on   on/off
+  contraction                                4064       4064    1.00x
+  decomp(svd/eigh/qr)                          78         78    1.00x
+  block-pack(slice/scatter/reshape)         24515      24515    1.00x
+  transpose                                  5874       5874    1.00x
+  charge-mask / index arith                  7398       7398    1.00x
+  elementwise(add/mul/...)                  11384      11384    1.00x
+  other                                     10299      10299    1.00x
+  TOTAL                                     63612      63612    1.00x  <== TOTAL
+

--- a/probe_u1sz_defrag_610.txt
+++ b/probe_u1sz_defrag_610.txt
@@ -1,0 +1,135 @@
+# ============================================================================
+# #610 Gate B (--defrag) — TRACE DID NOT SURVIVE: NO-GO-BY-OBSTRUCTION
+# ============================================================================
+#
+# This run wraps the #566 backward-VJP trace in
+#   examples.u1sz_defrag_prototype_610.sector_dropping_truncation(keep={-1,0,1})
+# with ALL surgical patches active (Step 0 of the Gate-B task):
+#   (1) _ctm_tensor_paired_moves._get_base_charges   keep-filter (forward)
+#   (2) _ctm_projector._svd_projector_symmetric      forward chi_new column drop
+#   (3) _ctm_tensor_convergence._get_base_charges     keep-filter (BACKWARD path)
+#   (4) tenax.linalg._truncated_svd_symmetric_traced  per-sector keep allocation
+#       with the Phase-2 greedy backfill suppressed (chi_new = sum of kept
+#       sectors, ~10 at D=3 chi=12; an HONEST, truncation-emitted smaller bond,
+#       NOT a post-hoc column drop).
+#
+# RESULT: the single-sweep backward VJP cannot even be TRACED. The Gate-B
+# op-histogram below could therefore NOT be produced (the baseline histogram in
+# probe_u1sz_baseline_610.txt traces fine; the charge-mask cluster there is
+# 7398 / 63612 total ops).
+#
+# ROOT CAUSE — mixed-generation chi bonds inside one multisite 2x2 sweep
+# ----------------------------------------------------------------------
+# The traced truncation (4) now honestly emits a 3-sector {-1,0,1} chi bond on
+# the legs it refreshes. But the multisite 2x2 sweep
+# (_ctm_tensor_sweep_multisite) refreshes only the legs ALONG the current
+# absorption direction per move. env-init (initialize_ctm_tensor_env) seeds ALL
+# chi bonds at the full 5-sector {-2,-1,0,1,2} structure (dim 12). After the
+# "left" direction truncates the horizontal chi legs to {-1,0,1}, a later
+# direction's enlarged-corner build contracts a freshly-dropped leg against a
+# perpendicular leg that still carries the full 5-sector env-init bond.
+#
+# Captured at the failing contract (CT_v = contract(C_r, T_v), bottom_left):
+#   C  (corner C4): c4_r = {-1:4, 0:5, 1:3}        <- DROPPED (3 sectors)
+#                   c4_u = {-2:1,-1:3,0:4,1:3,2:1} <- FULL    (5 sectors)
+#   T_v(edge  T4):  t4_d = {-1:4, 0:5, 1:3}        <- DROPPED
+#                   t4_u = {-1:4, 0:5, 1:3}        <- DROPPED (3 sectors)
+# The shared bond c4_u(5 sectors) <-> t4_u(3 sectors) disagree ->
+#   ValueError: Size of label 'd' for operand 1 (4) does not match previous (5).
+#
+# This is DISTINCT from the prior post-hoc-bond-drop obstruction. There the
+# truncated bond mismatched its OWN paired neighbour. Here the truncation is
+# self-consistent per move, but the per-direction multisite sweep contracts
+# tensors from DIFFERENT truncation GENERATIONS (dropped absorbed legs vs the
+# un-refreshed perpendicular env-init legs) against each other mid-sweep.
+#
+# CONSEQUENCE: making the drop reach the traced backward via monkeypatch alone
+# is not possible. It would require env-init to seed 3-sector chi bonds AND the
+# multisite 2x2 sweep to refresh ALL chi legs to the same sector set before any
+# cross-leg contraction — i.e. a structural change to the CTM sweep, not a
+# runtime patch. Gate B's >=25% charge-mask reduction therefore CANNOT be
+# measured; the spike outcome is NO-GO-by-obstruction.
+#
+# Forward path is unaffected: the faithfulness test (tests/
+# test_u1sz_defrag_prototype_610.py) still passes (2 passed) — the forward
+# ctm_tensor env DOES drop (corners 5->3, edges 19->9). The wall is the
+# backward 2x2 multisite trace only.
+#
+# CAVEAT — jit cache must be cold for the patch to bite. The monkeypatch only
+# takes effect if the patched _make_jit_ctm_step unit is TRACED cold under the
+# patch. A prior un-patched trace of the same jit unit (identical input avals)
+# seeds the jax.jit compilation cache, so a later prototype-wrapped call reuses
+# the un-patched cached trace and silently produces a baseline-shaped jaxpr
+# WITHOUT raising. This `--defrag` probe runs cold (the prototype-wrapped trace
+# is the first in the process), so the failure above is the FAITHFUL result. The
+# obstruction-guard test clears jax caches (jax.clear_caches()) before the
+# prototype-wrapped call to reproduce the cold trace.
+#
+# Full captured traceback (JAX_TRACEBACK_FILTERING=off) follows.
+# ============================================================================
+# #566 backward-VJP jaxpr op-histogram (trace-only) | x64=True
+# unit = apply_Jt = VJP of one gauge-fixed CTM sweep w.r.t. env (Neumann matvec)
+# projector_backward = auto
+
+Traceback (most recent call last):
+  File "/home/yjkao/tenax/examples/probe_backward_jaxpr_566.py", line 402, in <module>
+    main()
+  File "/home/yjkao/tenax/examples/probe_backward_jaxpr_566.py", line 374, in main
+    off, off_raw = hist(A, chi, on=False)
+                   ^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/examples/probe_backward_jaxpr_566.py", line 364, in hist
+    raw = _trace(A, chi)
+          ^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/examples/probe_backward_jaxpr_566.py", line 358, in _trace
+    return count_primitives(backward_vjp_jaxpr(A, chi, pbw))
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/examples/probe_backward_jaxpr_566.py", line 181, in backward_vjp_jaxpr
+    out = gauge_fixed_sweep_from_env(env_leaves)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/examples/probe_backward_jaxpr_566.py", line 169, in gauge_fixed_sweep_from_env
+    e_out, _eps, _smin = jit_step(
+                         ^^^^^^^^^
+  File "/home/yjkao/tenax/.venv/lib/python3.11/site-packages/jax/_src/traceback_util.py", line 195, in reraise_with_filtered_traceback
+    return fun(*args, **kwargs)  # pyrefly: ignore[not-callable]
+           ^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/.venv/lib/python3.11/site-packages/jax/_src/pjit.py", line 250, in cache_miss
+    p, args_flat = _infer_params(fun, jit_info, args, kwargs)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/.venv/lib/python3.11/site-packages/jax/_src/pjit.py", line 620, in _infer_params
+    p = _trace_for_jit(fun, ji, ctx_mesh, dbg_fn(), avals, args, kwargs)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/.venv/lib/python3.11/site-packages/jax/_src/pjit.py", line 522, in _trace_for_jit
+    jaxpr, out_avals = pe.trace_to_jaxpr(fun, in_type, dbg, qdd_token)
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/.venv/lib/python3.11/site-packages/jax/_src/interpreters/partial_eval.py", line 2338, in trace_to_jaxpr
+    ans_pytree = fun(*args, **kwargs)
+                 ^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/src/tenax/algorithms/_ctm_python_loop.py", line 111, in _step
+    return _ctm_tensor_sweep_multisite(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/src/tenax/algorithms/_ctm_tensor_convergence.py", line 392, in _ctm_tensor_sweep_multisite
+    _compute_plaquette_projector_pair(
+  File "/home/yjkao/tenax/src/tenax/algorithms/_ctm_tensor_moves.py", line 436, in _compute_plaquette_projector_pair
+    Q_BL = _build_enlarged_corner(
+           ^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/src/tenax/algorithms/_ctm_tensor_projector_2x2.py", line 238, in _build_enlarged_corner
+    CT_v = contract(C_r, T_v)  # -> (c4_r, t4_d, l2)
+           ^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/src/tenax/contraction/contractor.py", line 923, in contract
+    return contract_with_subscripts(tensors, subscripts, output_indices, optimize)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/src/tenax/contraction/contractor.py", line 955, in contract_with_subscripts
+    return _contract_symmetric(list(tensors), subscripts, output_indices, optimize)  # type: ignore[arg-type]
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/src/tenax/contraction/contractor.py", line 857, in _contract_symmetric
+    expr = opt_einsum.contract_expression(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/.venv/lib/python3.11/site-packages/opt_einsum/contract.py", line 1041, in contract_expression
+    return contract(
+           ^^^^^^^^^
+  File "/home/yjkao/tenax/.venv/lib/python3.11/site-packages/opt_einsum/contract.py", line 595, in contract
+    operands, contraction_list = contract_path(  # type: ignore
+                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yjkao/tenax/.venv/lib/python3.11/site-packages/opt_einsum/contract.py", line 324, in contract_path
+    raise ValueError(
+ValueError: Size of label 'd' for operand 1 (4) does not match previous terms (5).

--- a/tests/test_u1sz_defrag_census_610.py
+++ b/tests/test_u1sz_defrag_census_610.py
@@ -1,0 +1,20 @@
+"""Static candidate-evaluation predictor for #610 Gate A."""
+from examples.census_u1sz_block_shapes_566 import predict_sectors_under_keep
+
+
+def test_drop_high_sz_sectors_reduces_block_count():
+    # block-keys: each key is a per-axis charge tuple; axes (chi_a, chi_b, d2).
+    # Keep-set {-1,0,1} on the chi axes (axes 0 and 1) drops any block whose
+    # chi charge has |q| > 1.
+    block_keys = [
+        (0, 0, 0), (1, -1, 0), (-1, 1, 0),   # all chi charges within {-1,0,1}
+        (2, 0, -2), (-2, 0, 2), (0, 2, -2),  # contain a chi charge with |q|=2
+    ]
+    kept = predict_sectors_under_keep(block_keys, chi_axes=(0, 1), keep={-1, 0, 1})
+    assert kept == 3  # only the first three survive
+
+
+def test_keep_all_is_identity():
+    block_keys = [(0, 0, 0), (2, 0, -2)]
+    kept = predict_sectors_under_keep(block_keys, chi_axes=(0, 1), keep={-2, -1, 0, 1, 2})
+    assert kept == 2

--- a/tests/test_u1sz_defrag_prototype_610.py
+++ b/tests/test_u1sz_defrag_prototype_610.py
@@ -1,0 +1,33 @@
+"""Faithfulness guard for the #610 C-lever prototype (Stage 2 prereq)."""
+import jax
+import numpy as np
+
+from examples.u1sz_defrag_prototype_610 import sector_dropping_truncation
+from tenax.algorithms._ctm_tensor import ctm_tensor
+from tenax import compute_energy_ctm_tensor
+from tenax.algorithms.ipeps import heisenberg_gate_u1sz, heisenberg_u1sz_init_pair
+
+
+def test_prototype_ctm_converges_and_energy_is_sane():
+    jax.config.update("jax_enable_x64", True)
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    with sector_dropping_truncation(keep={-1, 0, 1}):
+        env, _ = ctm_tensor(A, chi=12, max_iter=20, conv_tol=1e-7)
+        for name in env._fields:
+            t = getattr(env, name)
+            assert np.all(np.isfinite(np.asarray(t._data))), f"{name} non-finite"
+        e = float(compute_energy_ctm_tensor(A, env, heisenberg_gate_u1sz()))
+    assert np.isfinite(e), "prototype energy non-finite"
+    assert -2.0 < e < 0.0, f"prototype energy {e} outside sane Heisenberg window"
+
+
+def test_prototype_actually_drops_sectors():
+    # Under the prototype, the env block counts must drop toward the Gate-A
+    # static prediction: corners 5->3, edges 19->9 at D=3 chi=12.
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    with sector_dropping_truncation(keep={-1, 0, 1}):
+        env, _ = ctm_tensor(A, chi=12, max_iter=8, conv_tol=1e-6)
+    nblocks = {n: len(getattr(env, n)._block_keys) for n in env._fields}
+    # edges must have strictly fewer blocks than the fragmented baseline (19)
+    assert nblocks["T1"] < 19, f"edge sectors not dropped: {nblocks}"
+    assert nblocks["C1"] <= 5, f"corner sectors not dropped: {nblocks}"

--- a/tests/test_u1sz_defrag_prototype_610.py
+++ b/tests/test_u1sz_defrag_prototype_610.py
@@ -1,6 +1,10 @@
 """Faithfulness guard for the #610 C-lever prototype (Stage 2 prereq)."""
+import importlib.util
+import pathlib
+
 import jax
 import numpy as np
+import pytest
 
 from examples.u1sz_defrag_prototype_610 import sector_dropping_truncation
 from tenax.algorithms._ctm_tensor import ctm_tensor
@@ -31,3 +35,50 @@ def test_prototype_actually_drops_sectors():
     # edges must have strictly fewer blocks than the fragmented baseline (19)
     assert nblocks["T1"] < 19, f"edge sectors not dropped: {nblocks}"
     assert nblocks["C1"] <= 5, f"corner sectors not dropped: {nblocks}"
+
+
+def test_backward_trace_does_not_survive_surgical_drop():
+    """Gate-B Step-0 obstruction guard (#610): documents that the SURGICAL
+    traced-path sector drop (filtered backward base_charges + greedy-backfill-
+    suppressed traced SVD that honestly emits a smaller chi_new) STILL cannot be
+    traced through the multisite 2x2 backward.
+
+    Root cause (NO-GO-by-obstruction): the multisite sweep refreshes only the
+    legs along the current absorption direction per move, while env-init seeds
+    every chi bond at the full 5-sector {-2,-1,0,1,2} structure.  A later
+    direction's enlarged-corner build then contracts a freshly-dropped (3-sector)
+    leg against a perpendicular leg still carrying the full env-init bond ->
+    opt_einsum size mismatch.  This pins the obstruction so a future structural
+    fix (env-init + per-direction refresh emitting a uniform sector set) is
+    recognised as the thing that flips this test.
+    """
+    jax.config.update("jax_enable_x64", True)
+    spec = importlib.util.spec_from_file_location(
+        "probe_backward_jaxpr_566",
+        pathlib.Path(__file__).resolve().parents[1]
+        / "examples"
+        / "probe_backward_jaxpr_566.py",
+    )
+    probe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(probe)
+
+    A = probe.make_site("u1sz", 3)
+    chi = 12
+
+    # Baseline (no prototype) traces fine.
+    jx = probe.backward_vjp_jaxpr(A, chi, "auto")
+    assert hasattr(jx, "jaxpr") or hasattr(jx, "eqns")
+
+    # IMPORTANT: the monkeypatch only takes effect if the patched CTM-step is
+    # traced COLD under the patch. The baseline call above seeds the jax.jit
+    # compilation cache (identical input avals + same _make_jit_ctm_step
+    # closure), so without clearing it the prototype-wrapped call would reuse the
+    # un-patched cached trace and silently NOT raise. Clear caches so the patched
+    # path re-traces — mirrors the standalone `--defrag` probe, which runs cold.
+    jax.clear_caches()
+
+    # Under the surgical drop the single-sweep VJP fails to trace with the
+    # documented mixed-generation chi-bond mismatch.
+    with pytest.raises(ValueError, match="does not match previous"):
+        with sector_dropping_truncation(keep={-1, 0, 1}):
+            probe.backward_vjp_jaxpr(A, chi, "auto")

--- a/tests/test_u1sz_defrag_prototype_610.py
+++ b/tests/test_u1sz_defrag_prototype_610.py
@@ -7,8 +7,8 @@ import numpy as np
 import pytest
 
 from examples.u1sz_defrag_prototype_610 import sector_dropping_truncation
-from tenax.algorithms._ctm_tensor import ctm_tensor
 from tenax import compute_energy_ctm_tensor
+from tenax.algorithms._ctm_tensor import ctm_tensor
 from tenax.algorithms.ipeps import heisenberg_gate_u1sz, heisenberg_u1sz_init_pair
 
 


### PR DESCRIPTION
Measure-first GO/NO-GO spike per `docs/superpowers/specs/2026-06-16-u1sz-env-defrag-design.md`. Three-gate staircase, cheapest-decisive-first. **No committed `src/` change** (all prototyping via branch-local monkeypatch, mirroring #609).

## Verdict: NO-GO-by-obstruction

| Gate | Result |
|---|---|
| **A** static sector census | **PASS** — sector-drop (keep `\|Sz\|≤1`) cuts env blocks exactly 2× (96→48: corners 5→3, edges 19→9); forward prototype reproduces it, energy sane. |
| **B** backward charge-mask re-profile | **BLOCKED** — the drop can't reach the 2×2 multisite backward via monkeypatch. |
| **C** A100 end-to-end + energy | not reached. |

**Why Gate B is blocked (reproduced):** the forward drop bites the paired-moves projector, but the backward (`_make_jit_ctm_step` → `_ctm_tensor_sweep_multisite`, the 2×2 plaquette path used by production `_ctm_energy_ad`) does not. `initialize_ctm_tensor_env` seeds every chi bond at 5 sectors `{−2..+2}` while the 2×2 sweep refreshes only the current-direction legs per move, so a sweep transitioning 5→3 mid-sweep contracts a dropped 3-sector leg against an un-refreshed 5-sector perpendicular leg → `Size of label 'd' (4) != (5)` in `_build_enlarged_corner`. Three coordinated monkeypatches (both `_get_base_charges` sources + the traced χ-backfill restriction) can't cross it; honoring the drop needs a **structural** uniform-sector env-init + per-sweep refresh.

**Honest signal (inference, not measured):** forward env blocks drop 2×; #609 measured backward ops ∝ block count (~1.1/block; baseline here 63,612 ops / 7,398 charge-mask), so a faithful dropped backward would *plausibly* cut the charge-mask cluster ~40–50% (clears the 25% bar). Per cheapest-kill discipline we did **not** build on inference.

**Recommendation:** the lever is *not refuted* — it's un-measurable without the structural build it was meant to gate. Scoped follow-up issue filed for that build.

Full writeup: `docs/superpowers/handoffs/2026-06-17-u1sz-env-defrag-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)