### PR TITLE
docs(itebd): correct Hastings attribution in stable-iTEBD comments (#583)

### DIFF
--- a/examples/minimal_fpeps.py
+++ b/examples/minimal_fpeps.py
@@ -17,8 +17,10 @@ IMPORTANT — this is NOT simple update being broken in general. Two things:
     identically, so it's not a Koszul/#392 sign bug.
   * The collapse is a numerical λ⁻¹ instability in the SU canonical-form
     bookkeeping that bites when a Schmidt sector legitimately vanishes (as a
-    non-area-law state forces). The principled fix is a numerically stable
-    iTEBD canonical form (Hastings, arXiv:0903.3253).
+    non-area-law state forces). The principled fix is an inversion-free
+    canonical update that never forms λ⁻¹ (Hastings, arXiv:0903.3253); the
+    current code instead regularizes the inverse (``safe_inv_lambda``), and a
+    true Hastings update lacks a 2D canonical-form analogue.
 For free fermions specifically, optimize via AD.
 
 Model: H = -t (c†_i c_j + h.c.) on the 2D square lattice (V=0 free fermions).

--- a/src/tenax/algorithms/_tensor_utils.py
+++ b/src/tenax/algorithms/_tensor_utils.py
@@ -28,9 +28,10 @@ def safe_inv_lambda(lam: jax.Array, rel_tol: float = 1e-12) -> jax.Array:
     Schmidt sector to ~``1/EPS``; under the absorb-then-remove round-trip plus a
     global re-normalization that flips sector dominance and degenerates the whole
     bond (all weights -> 0, or NaN). Dropping dead sectors keeps the update
-    numerically stable -- the gauge-restoration analogue of orthogonalizing
-    against the environment instead of dividing by singular values (cf. the
-    stable iTEBD of Hastings, arXiv:0903.3253). Mirrors ``pess._safe_inv``.
+    numerically stable. This is a regularized/thresholded inverse, NOT the
+    inversion-free canonical update of Hastings (arXiv:0903.3253), which avoids
+    forming ``lambda^-1`` altogether and uses no pseudo-inverse. Mirrors
+    ``pess._safe_inv``.
     """
     lam = jnp.asarray(lam)
     cutoff = rel_tol * jnp.max(lam)

--- a/src/tenax/algorithms/itebd.py
+++ b/src/tenax/algorithms/itebd.py
@@ -5,11 +5,17 @@ unit cell, in the Vidal ``Gamma-lambda`` canonical form. The one numerically
 delicate step of the original Vidal iTEBD is the explicit inversion of the bond
 weights (``lambda^-1``) when restoring the canonical form after a gate+SVD: a
 vanishing Schmidt value amplifies to ``1/eps`` and, after re-normalization,
-degenerates the whole bond (see ``fermionic_ipeps._safe_inv``). Following the
-spirit of Hastings' stable iTEBD (arXiv:0903.3253) we never let that blow up:
-the ``lambda^-1`` is taken as a *pseudo-inverse* that drops dead Schmidt sectors
-(``_safe_inv``), which is the gauge-restoration analogue of orthogonalizing
-against the environment instead of dividing by singular values.
+degenerates the whole bond (see ``fermionic_ipeps._safe_inv``). We guard that
+step by taking ``lambda^-1`` as a regularized *pseudo-inverse* that drops dead
+Schmidt sectors (``_safe_inv``) instead of dividing by ~0.
+
+Note: this is the standard Vidal ``Gamma-lambda`` iTEBD with a regularized
+inverse -- it is NOT the inversion-free canonical update of Hastings
+(arXiv:0903.3253). Hastings' trick avoids forming ``lambda^-1`` entirely: it
+applies the gate to a left-/right-canonical 2-site block and re-orthogonalizes
+via SVD, and never uses a pseudo-inverse. A genuine Hastings update could
+replace the inversion step here but is not implemented (and lacks a 2D
+canonical-form analogue for the PEPS simple-update path).
 
 Validated against iDMRG: the spin-1/2 Heisenberg chain converges to
 ``e_0 = 1/4 - ln 2 ~= -0.4431`` per site.


### PR DESCRIPTION
## Summary

Addresses @ianmccul's review comment on PR #583: the iTEBD comments mis-attributed the thresholded **pseudo-inverse** of the bond weights to **Hastings' stable iTEBD** (arXiv:0903.3253).

As Ian pointed out, the implemented algorithm is **standard Vidal Γ-λ iTEBD** with a *regularized* `λ⁻¹`. Hastings' trick is the opposite idea: it **avoids forming `λ⁻¹` entirely** — apply the gate to a left/right-canonical 2-site block and re-orthogonalize via SVD — and **uses no pseudo-inverse**. The paper does not mention pseudo-inverses at all.

## Changes (comment-only)

Three comments corrected to describe the pseudo-inverse honestly and cite Hastings only as the inversion-free alternative that is **not** implemented here (and which lacks a 2D canonical-form analogue for the PEPS simple-update path):

- `src/tenax/algorithms/itebd.py` — module docstring
- `src/tenax/algorithms/_tensor_utils.py` — `safe_inv_lambda` docstring (dropped the misleading "orthogonalizing against the environment instead of dividing by singular values" framing; the code *does* divide, with a cutoff)
- `examples/minimal_fpeps.py` — header note

## Verification

`uv run pytest tests/test_itebd.py` → **3 passed** (170s). No code paths changed.

## Not addressed here

Ian also noted the `_safe_inv` helper is duplicated across `itebd.py`, `_tensor_utils.safe_inv_lambda`, and `pess._safe_inv`. That's a separate de-duplication concern; left for a follow-up rather than folded into this attribution fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)