### PR TITLE
study(#615): U(1)-Sz uniform-sector env — NO-GO record (DO NOT MERGE)

### DIFF
--- a/docs/superpowers/handoffs/2026-06-18-u1sz-uniform-sector-env-findings.md
+++ b/docs/superpowers/handoffs/2026-06-18-u1sz-uniform-sector-env-findings.md
@@ -1,0 +1,65 @@
+# U(1)-Sz uniform-sector env — flag-gated Gate-B measurement findings (#615)
+
+**Date:** 2026-06-18
+**Branch:** `feat/615-u1sz-uniform-sector-env` (off `origin/main` post-#614)
+**Tracking issue:** #615 · **Parent:** #566 · **Predecessor spike:** #610 (PR #614, NO-GO-by-obstruction)
+**Spec:** `docs/superpowers/specs/2026-06-17-u1sz-uniform-sector-env-measurement-design.md`
+**Plan:** `docs/superpowers/plans/2026-06-17-u1sz-uniform-sector-env-measurement.md`
+**Verdict:** **NO-GO.** The mechanism works — the #610 cold-backward obstruction is *structurally solved for one sweep* — but the measured charge-mask reduction (21.63%, flat in χ) misses the 25% Gate-B bar, the load-bearing #609 premise is **refuted**, and an A100 runtime check shows the lever is irrelevant against a ~24× #566 dispatch wall (and the full implicit-AD path doesn't even run under keep). Do **not** merge the flag to `main`; do **not** fund the full feature. The branch preserves the proven single-sweep mechanism for the record.
+
+---
+
+## What was built (opt-in, default-off; branch-local)
+
+A `keep_sectors: frozenset[int] | None = None` flag (default `None` ⇒ byte-identical) realized as a **process-local context** read at trace time (`tenax.algorithms._ctm_uniform_sector`), mirroring the codebase's existing module toggles. Under `keep_sectors={-1,0,1}`:
+- **Env-init** seeds every chi bond uniformly to `{-1:3, 0:4, 1:3}` (dim 10), D² legs preserved (`_ctm_tensor_init.py`).
+- **Projector truncation** drops non-keep sectors at all four allocation sites (`linalg._truncated_svd_symmetric_traced`, `_ctm_projector._eigh/_svd_projector_symmetric`, `_ctm_tensor_projector_2x2._retruncate_by_base_charges`).
+- **A-consistency (the key to making the backward trace):** the backward/multisite `_get_base_charges` returns the FULL D² pattern (tile-then-restrict, matching env-init) while the forward paired-moves `_get_base_charges` keeps restrict-then-tile (the two sweep paths need *opposite* policies — documented in-code), and the χ-backfill is **suppressed under keep** so `chi_new` = keep-target sum (=10), identical to env-init. This makes every chi bond (init and truncated) `{-1:3,0:4,1:3}`, so the 2×2 sweep's mixed-generation contractions pair equal per-sector dims.
+
+Default-off is proven byte-identical: the flag-off backward op-histogram is unchanged (TOTAL 63612 / charge-mask 7398) and the core suite (977 passed) is unaffected.
+
+## The three-gate result
+
+### Gate A — sector census (PASS, as in #610)
+Under keep the converged forward env drops corners 5→3, edges 19→9 (env blocks ~96→48, 2×), energy finite/sane. Reproduced exactly. (Faithfulness guard passes at D=3 χ=12.)
+
+### Mechanism gate — cold backward VJP builds (PASS — the #610 obstruction is solved for one sweep)
+The #610 spike could not even trace the 2×2 multisite backward under the drop (`ValueError: Size of label 'd' (4)!=(5)` in `_build_enlarged_corner`). Under the structural flag the **cold** backward VJP (`backward_vjp_jaxpr`, `jax.clear_caches()` first) **builds** (3506 eqns vs 6610 flag-off). Locked as a regression test (`test_cold_backward_vjp_builds_under_keep`). This is the structural advance #615 set out to make.
+
+### Gate B — backward charge-mask re-profile (FAIL: 21.63% < 25%, and flat in χ)
+
+| metric (D=3 χ=12, flag-off → keep) | flag-off | keep | reduction |
+|---|---|---|---|
+| **charge-mask / index-arith** | 7398 | 5798 | **21.63%** |
+| TOTAL backward ops | 63612 | 45664 | 28.21% |
+
+- **Below the 25% charge-mask bar.** The χ-sweep shows χ=12 and χ=16 are **byte-identical** (op count is fixed by the D=3 sector structure, independent of χ) ⇒ the reduction is **flat at 21.63%** and will not cross 25% at larger χ. (χ≥24 can't be measured: the *baseline* flag-off backward fails at χ=24 — a pre-existing D=3 large-χ fragility, unrelated to this work.)
+- **The #609 premise is REFUTED.** Every bucket shrinks roughly uniformly (~0.59–0.87×, ~0.72× overall) — the charge-mask cluster is *not* a disproportionately-reducible "third"; it falls in proportion with the broad sector drop. #610's *inferred* ~40–50% was optimistic by ~2×.
+
+### Gate C proxy — A100 warm-step runtime (decisive NO-GO)
+
+| arm (D=3 χ=12, depth 8, warm step) | warm_ms |
+|---|---|
+| dense | **776** |
+| u1sz fragmented (keep off) | **18,643** (~24× slower than dense) |
+| u1sz keep {-1,0,1} | **errored** — `ValueError: ... float64[36] vs float64[34]` in the implicit-AD VJP |
+
+- u1sz is **~24× slower than dense** at warm-step — the bottleneck is the **#566 eager per-block dispatch** (32 blocks), not the backward op count. A 28% op cut (or 21.6% charge-mask) is irrelevant against a 24× wall; it cannot approach dense parity.
+- **The keep flag's full implicit fixed-point AD does not run.** Tactic A makes the *single-sweep* VJP trace, but the full `ctm_energy_implicit` value_and_grad needs the env pytree shape to be a **fixed-point invariant** under keep (the forward fixed-point and the adjoint must agree); under keep an env leaf comes out `[34]` where `[36]` is expected. End-to-end runtime under keep would need a *further* structural change (a fixed-point-invariant keep env), beyond the single-sweep mechanism built here.
+
+## Verdict and recommendation
+
+**NO-GO.** The de-fragmentation lever is real and the #610 single-sweep obstruction is structurally solved, but: (1) the measured charge-mask reduction is 21.63% — below the 25% bar and flat in χ; (2) the premise that charge-mask is disproportionately reducible is refuted; (3) the runtime gap to dense is ~24× and dominated by #566 eager dispatch, which a ~28% op cut cannot close; and (4) the full implicit-AD path isn't even runnable under keep without further structural work. Funding the full feature (Gate C / accuracy spine / tactic B sweep rewrite) is not justified on this evidence.
+
+**Disposition:** the opt-in, default-off flag stays **branch-local** (not merged to `main`), preserving the proven single-sweep uniform-sector mechanism and the measurement tooling for the record. For D≥3 U(1)-Sz today, the **dense** path remains pragmatic (memory `u1sz-perf-study-d3-findings`). The binding wall for D≥3 U(1)-Sz is **#566 eager per-block dispatch** (the ~24× warm-step gap), not the backward charge-mask cluster — any future effort should target that, not env de-fragmentation.
+
+## Artifacts (all on the branch)
+
+- `src/` flag (branch-local, default-off): `_ctm_uniform_sector.py` (context), `_ctm_tensor_init.py` (env-init seed), `linalg.py` + `_ctm_projector.py` + `_ctm_tensor_projector_2x2.py` (truncation), `_ctm_tensor_convergence.py` + `_ctm_tensor_paired_moves.py` (split base_charges policy), `_ctm_energy_ad.py` (param + VJP-cache key).
+- `tests/test_u1sz_uniform_sector_615.py` — identity (default-off), env-init keep-seed, forward block-count drop, **cold backward VJP builds**, faithfulness guard.
+- `examples/probe_backward_jaxpr_566.py` (`--defrag` → real flag), `probe_u1sz_off_615.txt`, `probe_u1sz_on_615.txt`.
+- `examples/profile_ctm_ad_wall_566.py` (`--defrag`), `profile_d3chi12_baseline_615.json`, `/tmp/timing_615.txt` (warm-step arms).
+
+## Risks / caveats recorded
+- **`E` from `compute_energy_ctm_tensor` is a random-init scale** (≈ −0.06, not a ground state); the faithfulness window (−2, 0) is a sanity gate, not an accuracy claim. (Moot — Gate C accuracy not reached.)
+- **Verdict scope:** NO-GO is for env de-fragmentation as a runtime lever for D≥3 U(1)-Sz; the single-sweep mechanism is sound and preserved. The dominant wall is #566, surfaced cleanly by the ~24× warm-step gap.

--- a/docs/superpowers/plans/2026-06-17-u1sz-uniform-sector-env-measurement.md
+++ b/docs/superpowers/plans/2026-06-17-u1sz-uniform-sector-env-measurement.md
@@ -1,0 +1,676 @@
+# U(1)-Sz uniform-sector env — flag-gated Gate-B measurement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the minimal opt-in (default-off) structural change that makes the 2×2 multisite U(1)-Sz CTM carry a uniform chi-bond sector set, so the AD backward becomes cold-traceable under the `|Sz|≤1` sector drop — then measure Gate B (charge-mask op reduction) and emit a documented GO/NO-GO finding.
+
+**Architecture:** A `keep_sectors` knob, **off by default**. The public entry points (`ctm_tensor`, `ctm_energy_implicit`) expose a `keep_sectors: frozenset[int] | None = None` parameter and, internally, activate a **process-local context** (`keep_sectors_context`) — read at *trace time* — that the symmetric env-init and the projector truncation consult. This avoids threading the flag through ~8 projector layers and mirrors the codebase's existing module-toggle pattern (`set_implicit_ad_norm_diagnostics`, `_batch_blocksparse_enabled()`). When the context is inactive (`None`), every touched function takes its original path verbatim. Tactic **A** (uniform-by-construction: env-init seeds `keep` + truncation outputs `keep`); tactic **C** (conform at the `_build_enlarged_corner` boundary) is the scoped fallback if per-sector multiplicities mismatch; tactic **B** (sweep rewrite) is deferred to the full feature.
+
+**Tech Stack:** Python, JAX (x64), pytest, the Tenax block-sparse `SymmetricTensor` CTM-AD path. Reuses the #610 assets (merged via #614): `examples/probe_backward_jaxpr_566.py` (`--defrag`), `examples/u1sz_defrag_prototype_610.py` (the truncation reference — `_make_keep_filtered_traced_svd`), `tests/test_profiler_u1sz_arm.py`.
+
+**Research-spike note (read before executing):** Tasks 0–3, 5–7 are deterministic and get full TDD. **Task 4 is the make-or-break gate** — whether tactic A alone makes the cold backward VJP *build*. Its acceptance is crisp (the cold VJP traces without `ValueError`), but the *mechanism* may need one or two iterations (A-consistency → tactic C). **Honor the gate:** if Task 4 cannot reach a building trace via A-consistency or tactic C cheaply, STOP, record "uniform-by-construction insufficient; needs tactic B sweep rewrite" as the finding (Task 7), and skip Tasks 5–6. The src change merges to `main` **only if Gate B (Task 6) passes** — until then it stays branch-local.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-u1sz-uniform-sector-env-measurement-design.md`
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility |
+|---|---|---|
+| `src/tenax/algorithms/_ctm_uniform_sector.py` | **Create** | The process-local `keep_sectors` context: `keep_sectors_context(keep)` (sets/restores) + `current_keep_sectors()` (trace-time reader) + `restrict_charges_to_keep(charges, keep)` helper. Default state `None`. |
+| `src/tenax/algorithms/_ctm_tensor_init.py` | Modify | Env-init seed: in `_init_symmetric_standard_corner` and `_init_symmetric_standard_edge`, restrict chi-bond charges to the active keep set before `_grouped_chi_perm`. |
+| `src/tenax/algorithms/_ctm_tensor_paired_moves.py` | Modify | `_get_base_charges`: filter extracted charges to the active keep set. |
+| `src/tenax/algorithms/_ctm_tensor_convergence.py` | Modify | `_get_base_charges`: same keep-filter. `ctm_tensor`: add `keep_sectors` param wrapping the body in `keep_sectors_context`. |
+| `src/tenax/algorithms/_ctm_energy_ad.py` | Modify | `ctm_energy_implicit` (+ its dispatch): add `keep_sectors` param wrapping the body in `keep_sectors_context`, so the implicit-AD backward honors the drop. |
+| `src/tenax/linalg.py` | Modify | `_truncated_svd_symmetric_traced`: when keep is active, drop non-keep sectors in Phase-1 allocation and suppress the Phase-2 χ-backfill (promote the prototype's `_make_keep_filtered_traced_svd` logic into a guarded branch). |
+| `src/tenax/algorithms/_ctm_tensor_projector_2x2.py` | Modify | `_retruncate_by_base_charges`: mirror the keep-restriction (eager forward path). |
+| `tests/test_u1sz_uniform_sector_615.py` | **Create** | Default-off identity test, env-init keep-seed test, faithfulness guard, and the cold-trace-builds regression lock. |
+| `examples/probe_backward_jaxpr_566.py` | Modify | Repoint `--defrag` from the monkeypatch to `keep_sectors_context` (Gate B). |
+| `docs/superpowers/handoffs/2026-06-17-u1sz-uniform-sector-env-findings.md` | **Create (last task)** | The Gate-B measured number + GO/NO-GO finding. |
+
+**Note on line anchors:** the `src/` files are unchanged by #610, so all `src/` line numbers below are valid on the current branch. The `examples/probe_backward_jaxpr_566.py --defrag` flag and `examples/u1sz_defrag_prototype_610.py` arrive via #614; Task 0 merges them in.
+
+---
+
+## Task 0: Sync the branch and lock the baseline
+
+Bring in the #610 artifacts (probe `--defrag`, prototype reference, docs) once #614 lands, and confirm the D=3 χ=12 backward traces (flag-off) so later deltas are attributable.
+
+**Files:** none modified (sync + smoke only).
+
+- [ ] **Step 1: Merge `origin/main` once #614 has merged**
+
+```bash
+cd /home/yjkao/tenax
+gh pr view 614 --json state -q .state    # expect: MERGED
+git fetch origin
+git merge origin/main
+```
+Expected: clean merge (this branch only adds a new spec doc; #614 adds `examples/`+`tests/`+`docs/`). If `gh` shows `OPEN`, wait for the merge queue and retry — do not proceed.
+
+- [ ] **Step 2: Confirm the D=3 χ=12 U(1)-Sz forward runs (flag-off prerequisite)**
+
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_profiler_u1sz_arm.py::test_u1sz_ctm_forward_runs -v
+```
+Expected: PASS for the `[3-8]` case. If it fails, STOP — the prerequisite is broken; record and report.
+
+- [ ] **Step 3: Confirm the flag-off backward traces and record the anchor**
+
+```bash
+JAX_PLATFORMS=cpu uv run python examples/probe_backward_jaxpr_566.py --sym u1sz --D 3 --chi-factor 4 > /tmp/probe_baseline_615.txt
+tail -20 /tmp/probe_baseline_615.txt
+```
+Expected: the bucketized histogram prints; total ≈ **63,612** ops, charge-mask ≈ **7,398** (the #610 anchor). Record both. No commit (no file changed).
+
+---
+
+## Task 1: The `keep_sectors` context + flag plumbing (default-off firewall)
+
+Create the process-local context and wire `keep_sectors` onto the public entry points. With `keep_sectors=None`, behavior is byte-identical — proven by an identity test.
+
+**Files:**
+- Create: `src/tenax/algorithms/_ctm_uniform_sector.py`
+- Modify: `src/tenax/algorithms/_ctm_tensor_convergence.py` (`ctm_tensor`, ~line 571), `src/tenax/algorithms/_ctm_energy_ad.py` (`ctm_energy_implicit`, ~line 337; `_ctm_energy_implicit_dispatch`, ~line 723)
+- Test: `tests/test_u1sz_uniform_sector_615.py`
+
+- [ ] **Step 1: Write the failing identity test**
+
+Create `tests/test_u1sz_uniform_sector_615.py`:
+```python
+"""#615 uniform-sector env: flag-gated Gate-B measurement scaffold."""
+import jax
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_tensor import ctm_tensor
+from tenax.algorithms.ipeps import heisenberg_u1sz_init_pair
+
+
+def _env_block_signature(env):
+    """A structural fingerprint: per-tensor sorted (block-key, shape) list."""
+    sig = {}
+    for name in env._fields:
+        t = getattr(env, name)
+        sig[name] = sorted(
+            (tuple(int(q) for q in k), tuple(int(s) for s in b.shape))
+            for k, b in t.blocks.items()
+        )
+    return sig
+
+
+def test_keep_sectors_none_is_identity():
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    env_a, e_a = ctm_tensor(A, chi=12, max_iter=4, conv_tol=1e-4)
+    env_b, e_b = ctm_tensor(A, chi=12, max_iter=4, conv_tol=1e-4, keep_sectors=None)
+    assert _env_block_signature(env_a) == _env_block_signature(env_b)
+    assert float(e_a) == float(e_b)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_u1sz_uniform_sector_615.py::test_keep_sectors_none_is_identity -v
+```
+Expected: FAIL with `TypeError: ctm_tensor() got an unexpected keyword argument 'keep_sectors'`.
+
+- [ ] **Step 3: Create the context module**
+
+Create `src/tenax/algorithms/_ctm_uniform_sector.py`:
+```python
+"""Process-local "keep sectors" context for the U(1)-Sz uniform-sector env (#615).
+
+Default OFF. When a keep set is active, the symmetric CTM env-init and the
+projector truncation restrict chi-bond charges to the keep set, so the 2x2
+multisite backward carries a *uniform* sector set and becomes traceable under
+the sector drop (#610 NO-GO-by-obstruction).
+
+The keep set is a STATIC, structural choice (it changes block sectors/shapes),
+so it is read at TRACE time as a plain Python value via ``current_keep_sectors``
+— never threaded as a traced array. Mirrors the codebase's existing module-level
+toggles (``set_implicit_ad_norm_diagnostics``, ``_batch_blocksparse_enabled``).
+"""
+from __future__ import annotations
+
+import contextlib
+
+import numpy as np
+
+_KEEP_SECTORS: frozenset[int] | None = None
+
+
+def current_keep_sectors() -> frozenset[int] | None:
+    """The active keep set, or ``None`` (default: no restriction)."""
+    return _KEEP_SECTORS
+
+
+@contextlib.contextmanager
+def keep_sectors_context(keep):
+    """Activate a keep set for the duration of the ``with`` block.
+
+    ``keep=None`` is a no-op pass-through (restores the default path), so callers
+    can wrap unconditionally: ``with keep_sectors_context(keep_sectors): ...``.
+    """
+    global _KEEP_SECTORS
+    prev = _KEEP_SECTORS
+    _KEEP_SECTORS = None if keep is None else frozenset(int(q) for q in keep)
+    try:
+        yield
+    finally:
+        _KEEP_SECTORS = prev
+
+
+def restrict_charges_to_keep(charges, keep) -> np.ndarray:
+    """Return ``charges`` with entries outside ``keep`` removed.
+
+    Degenerate guard: if filtering would empty the array, return the original
+    (an env bond / SVD sector list must never be empty).
+    """
+    arr = np.asarray(charges, dtype=np.int32)
+    if keep is None:
+        return arr
+    mask = np.array([int(q) in keep for q in arr], dtype=bool)
+    return arr[mask] if mask.any() else arr
+```
+
+- [ ] **Step 4: Add the `keep_sectors` param to `ctm_tensor`**
+
+In `src/tenax/algorithms/_ctm_tensor_convergence.py`, add the import near the other algorithm imports:
+```python
+from tenax.algorithms._ctm_uniform_sector import keep_sectors_context
+```
+Change the `ctm_tensor` signature (~line 571) to add the parameter (keep all existing params; append the new one):
+```python
+def ctm_tensor(
+    A: Tensor,
+    chi: int,
+    max_iter: int = 100,
+    conv_tol: float = 1e-8,
+    renormalize: bool = True,
+    projector_method: str = "svd",
+    qr_warmup_steps: int = 3,
+    projector_backward: str = "auto",
+    keep_sectors: frozenset[int] | None = None,
+) -> tuple[CTMTensorEnv, float]:
+```
+Wrap the existing function body in the context. Concretely, immediately after the docstring, open the context and indent the existing body one level:
+```python
+    with keep_sectors_context(keep_sectors):
+        # ... existing body unchanged (env-init, sweep loop, return) ...
+```
+(If indenting the whole body is unwieldy, instead set it explicitly at the top and restore in a `finally` — but the context manager is preferred and matches the test.)
+
+- [ ] **Step 5: Run the identity test to verify it passes**
+
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_u1sz_uniform_sector_615.py::test_keep_sectors_none_is_identity -v
+```
+Expected: PASS (with `keep_sectors=None` the context is a no-op, so nothing downstream changes).
+
+- [ ] **Step 6: Thread `keep_sectors` onto the implicit-AD entry**
+
+In `src/tenax/algorithms/_ctm_energy_ad.py`, add the import:
+```python
+from tenax.algorithms._ctm_uniform_sector import keep_sectors_context
+```
+Add `keep_sectors: frozenset[int] | None = None` to the signatures of `ctm_energy_implicit` (~line 337) and `_ctm_energy_implicit_dispatch` (~line 723), and wrap each function body in `with keep_sectors_context(keep_sectors):` (so the forward env-init **and** the `jit_step_bwd` backward sweep both run under the active keep set). Pass `keep_sectors` from `ctm_energy_implicit` down to `_ctm_energy_implicit_dispatch` at its call site.
+
+- [ ] **Step 7: Verify default-off across the core suite (no regression)**
+
+```bash
+JAX_PLATFORMS=cpu uv run pytest -m core -q
+JAX_PLATFORMS=cpu uv run pytest tests/test_profiler_u1sz_arm.py -q
+```
+Expected: PASS (the new param defaults to `None`; no existing call changes).
+
+- [ ] **Step 8: Lint + commit**
+
+```bash
+uv run ruff check src/ tests/
+git add src/tenax/algorithms/_ctm_uniform_sector.py \
+        src/tenax/algorithms/_ctm_tensor_convergence.py \
+        src/tenax/algorithms/_ctm_energy_ad.py \
+        tests/test_u1sz_uniform_sector_615.py
+git commit -m "feat(#615): keep_sectors context + default-off flag plumbing"
+```
+
+---
+
+## Task 2: Env-init seeds only the keep sectors
+
+When a keep set is active, the freshly-initialized env chi bonds carry only `keep` charges. This is half of tactic A (the other half is Task 3).
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_tensor_init.py` (`_init_symmetric_standard_corner` ~line 390; `_init_symmetric_standard_edge` ~lines 334–337)
+- Test: `tests/test_u1sz_uniform_sector_615.py`
+
+- [ ] **Step 1: Write the failing env-init keep-seed test**
+
+Append to `tests/test_u1sz_uniform_sector_615.py`:
+```python
+from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env
+from tenax.algorithms._ctm_uniform_sector import keep_sectors_context
+
+
+def _chi_sectors(t):
+    """Set of charges appearing on any 'chi'-labelled leg of tensor ``t``."""
+    out = set()
+    for ix in t.indices:
+        if ix.label.lower().startswith("chi"):
+            out |= {int(q) for q in ix.charges}
+    return out
+
+
+def test_env_init_seeds_only_keep_sectors():
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    # Baseline: chi legs carry the full {-2..+2}.
+    env0 = initialize_ctm_tensor_env(A, chi=12)
+    base = set().union(*(_chi_sectors(getattr(env0, n)) for n in env0._fields))
+    assert 2 in base or -2 in base, "baseline should carry |Sz|=2 chi sectors"
+    # Under keep={-1,0,1}, no chi leg may carry |Sz|=2.
+    with keep_sectors_context({-1, 0, 1}):
+        env = initialize_ctm_tensor_env(A, chi=12)
+    for n in env._fields:
+        assert _chi_sectors(getattr(env, n)) <= {-1, 0, 1}, f"{n} kept |Sz|=2"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_u1sz_uniform_sector_615.py::test_env_init_seeds_only_keep_sectors -v
+```
+Expected: FAIL — the second assertion trips (env still carries `±2`).
+
+- [ ] **Step 3: Restrict chi charges in the corner init**
+
+In `src/tenax/algorithms/_ctm_tensor_init.py`, add at the top of the module:
+```python
+from tenax.algorithms._ctm_uniform_sector import (
+    current_keep_sectors,
+    restrict_charges_to_keep,
+)
+```
+In `_init_symmetric_standard_corner`, replace the permutation block (currently lines ~390–391):
+```python
+    perm = _grouped_chi_perm(chi_charges)
+    chi_charges = np.asarray(chi_charges)[perm]
+```
+with a keep-restriction *before* the perm, and apply the perm to the (possibly smaller) charge array. Because the corner data is rank-1 (`C_dense[0,0]=1`), the dense array must be re-sized to the kept length:
+```python
+    chi_charges = restrict_charges_to_keep(chi_charges, current_keep_sectors())
+    chi_len = len(chi_charges)
+    perm = _grouped_chi_perm(chi_charges)
+    chi_charges = np.asarray(chi_charges)[perm]
+```
+and change the dense construction (currently lines ~397–399) to use `chi_len`:
+```python
+    idx_a = TensorIndex.from_charges(sym, chi_charges.copy(), flow_a, label=label_a)
+    idx_b = TensorIndex.from_charges(sym, chi_charges.copy(), flow_b, label=label_b)
+    C_dense = jnp.zeros((chi_len, chi_len), dtype=A.dtype).at[0, 0].set(1.0)
+    C_dense = C_dense[perm][:, perm]
+```
+
+- [ ] **Step 4: Restrict chi charges in the edge init**
+
+In `_init_symmetric_standard_edge`, replace the perm block (currently lines ~334–337):
+```python
+    perm1 = _grouped_chi_perm(chi1_charges)
+    perm2 = _grouped_chi_perm(chi2_charges)
+    chi1_charges = np.asarray(chi1_charges)[perm1]
+    chi2_charges = np.asarray(chi2_charges)[perm2]
+```
+with a keep-restriction first, tracking the kept lengths for the dense δ-pattern:
+```python
+    keep = current_keep_sectors()
+    chi1_charges = restrict_charges_to_keep(chi1_charges, keep)
+    chi2_charges = restrict_charges_to_keep(chi2_charges, keep)
+    chi1_len = len(chi1_charges)
+    chi2_len = len(chi2_charges)
+    perm1 = _grouped_chi_perm(chi1_charges)
+    perm2 = _grouped_chi_perm(chi2_charges)
+    chi1_charges = np.asarray(chi1_charges)[perm1]
+    chi2_charges = np.asarray(chi2_charges)[perm2]
+```
+and change the dense δ-pattern construction (currently lines ~348–352) to use the kept lengths:
+```python
+    diag_idx = np.arange(D, dtype=np.int32) * (D + 1)
+    T = jnp.zeros((chi1_len, D2, chi2_len), dtype=A.dtype)
+    T = T.at[0, diag_idx, 0].set(jnp.ones(D, dtype=A.dtype))
+    T = T[perm1][:, :, perm2]
+```
+(The `[0, ..., 0]` δ-write requires `chi1_len ≥ 1` and `chi2_len ≥ 1`, guaranteed by `restrict_charges_to_keep`'s never-empty guard, since charge `0` is always in `keep`.)
+
+- [ ] **Step 5: Run the env-init test to verify it passes**
+
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_u1sz_uniform_sector_615.py::test_env_init_seeds_only_keep_sectors -v
+```
+Expected: PASS. Also re-run the identity test (Step from Task 1) to confirm default-off is still byte-identical:
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_u1sz_uniform_sector_615.py::test_keep_sectors_none_is_identity -v
+```
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+uv run ruff check src/ tests/
+git add src/tenax/algorithms/_ctm_tensor_init.py tests/test_u1sz_uniform_sector_615.py
+git commit -m "feat(#615): env-init seeds only keep sectors under active context"
+```
+
+---
+
+## Task 3: Truncation outputs only the keep sectors (traced + eager) + base_charges filter
+
+The other half of tactic A: every projector truncation produces a `keep`-only chi bond — dropping non-keep sectors and **never** backfilling χ from a non-keep sector. This is the prototype's patch (4)/(3)/(1) promoted into guarded branches.
+
+**Files:**
+- Modify: `src/tenax/linalg.py` (`_truncated_svd_symmetric_traced`, ~lines 583–864; backfill ~732–747)
+- Modify: `src/tenax/algorithms/_ctm_tensor_projector_2x2.py` (`_retruncate_by_base_charges`, ~lines 709–801)
+- Modify: `src/tenax/algorithms/_ctm_tensor_paired_moves.py` (`_get_base_charges`, ~line 38) and `src/tenax/algorithms/_ctm_tensor_convergence.py` (`_get_base_charges`, ~line 239)
+
+- [ ] **Step 1: Filter both `_get_base_charges` to the active keep set**
+
+In **both** `_ctm_tensor_paired_moves.py` and `_ctm_tensor_convergence.py`, import the reader and apply the filter just before each `_get_base_charges` returns `charges`:
+```python
+from tenax.algorithms._ctm_uniform_sector import current_keep_sectors, restrict_charges_to_keep
+...
+    # (existing: charges = np.asarray(a.indices[u2_pos].charges, dtype=np.int32))
+    if np.all(charges == 0):
+        return None
+    keep = current_keep_sectors()
+    if keep is not None:
+        charges = restrict_charges_to_keep(charges, keep)
+    return charges
+```
+This sets the per-sector allocation *intent* to keep-only on both the forward paired-moves path and the multisite/backward path.
+
+- [ ] **Step 2: Constrain the traced SVD (the backward truncation)**
+
+In `src/tenax/linalg.py`, in `_truncated_svd_symmetric_traced`, import the reader at module scope and apply two guarded edits inside the `base_charges is not None` allocation block (~lines 714–747), exactly mirroring `examples/u1sz_defrag_prototype_610.py::_make_keep_filtered_traced_svd` (the proven reference):
+```python
+from tenax.algorithms._ctm_uniform_sector import current_keep_sectors
+...
+        target_charges = _derive_charges(base_charges, max_singular_values)
+        target_count = {}
+        for tq in target_charges:
+            target_count[int(tq)] = target_count.get(int(tq), 0) + 1
+        _keep = current_keep_sectors()           # None ⇒ original behaviour
+        k_per_sector = {
+            q: (0 if (_keep is not None and int(q) not in _keep)
+                else min(target_count.get(q, 0), r[5]))
+            for q, r in sector_results.items()
+        }
+        remaining = max_singular_values - sum(k_per_sector.values())
+        if remaining > 0:
+            for q in sorted(sector_results.keys(),
+                            key=lambda qq: (-(sector_results[qq][5] - k_per_sector.get(qq, 0)), qq)):
+                if remaining <= 0:
+                    break
+                if _keep is not None and int(q) not in _keep:   # never backfill non-keep
+                    continue
+                capacity_left = sector_results[q][5] - k_per_sector.get(q, 0)
+                take = min(remaining, capacity_left)
+                if take > 0:
+                    k_per_sector[q] = k_per_sector.get(q, 0) + take
+                    remaining -= take
+```
+Consequence: with keep active, `chi_new` is the sum of kept-sector allocations and may be `< max_singular_values` (~10 at D=3 χ=12). With keep `None`, this is byte-identical to the current code. **Do not** change the concatenation / block-rebuild logic below — only the `k_per_sector` allocation.
+
+- [ ] **Step 3: Mirror the restriction in the eager retruncation**
+
+In `src/tenax/algorithms/_ctm_tensor_projector_2x2.py`, `_retruncate_by_base_charges` (~lines 709–801): import `current_keep_sectors`, and in its greedy fill, apply the same two rules — a sector outside the active keep set gets `0`, and the leftover-budget refill skips non-keep sectors. (Match the exact local variable names in that function; the logic is identical to Step 2.)
+
+- [ ] **Step 4: Write the failing "truncation drops sectors" test**
+
+Append to `tests/test_u1sz_uniform_sector_615.py`:
+```python
+def test_forward_env_block_counts_drop_under_keep():
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    env0, _ = ctm_tensor(A, chi=12, max_iter=8, conv_tol=1e-6)
+    n0 = {n: len(getattr(env0, n).blocks) for n in env0._fields}
+    env1, _ = ctm_tensor(A, chi=12, max_iter=8, conv_tol=1e-6, keep_sectors={-1, 0, 1})
+    n1 = {n: len(getattr(env1, n).blocks) for n in env1._fields}
+    # #610 Gate-A: corners 5->3, edges 19->9; assert a real drop on every tensor.
+    for name in n0:
+        assert n1[name] < n0[name], f"{name}: {n1[name]} !< {n0[name]}"
+    # And no chi leg carries |Sz|=2 in the converged env.
+    for name in env1._fields:
+        assert _chi_sectors(getattr(env1, name)) <= {-1, 0, 1}
+```
+
+- [ ] **Step 5: Run it (and the identity test) to verify pass**
+
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_u1sz_uniform_sector_615.py -v
+```
+Expected: `test_forward_env_block_counts_drop_under_keep` PASS, `test_keep_sectors_none_is_identity` still PASS, `test_env_init_seeds_only_keep_sectors` still PASS. If the forward energy is NaN/non-finite under keep, that's a faithfulness problem — debug before continuing (the converged env must be valid).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+uv run ruff check src/ tests/
+git add src/tenax/linalg.py \
+        src/tenax/algorithms/_ctm_tensor_projector_2x2.py \
+        src/tenax/algorithms/_ctm_tensor_paired_moves.py \
+        src/tenax/algorithms/_ctm_tensor_convergence.py \
+        tests/test_u1sz_uniform_sector_615.py
+git commit -m "feat(#615): keep-restricted projector truncation (traced + eager) + base_charges filter"
+```
+
+---
+
+## Task 4: The make-or-break — cold backward VJP builds under the flag
+
+The decisive structural gate: does tactic A (Tasks 2+3) make the 2×2 multisite **backward** trace without `ValueError`? This is the #610 obstruction test, inverted to PASS.
+
+**Files:**
+- Test: `tests/test_u1sz_uniform_sector_615.py`
+- (Iteration only, if needed) `src/tenax/algorithms/_ctm_tensor_init.py`, `src/tenax/algorithms/_ctm_tensor_projector_2x2.py`
+
+- [ ] **Step 1: Write the cold-trace-builds test**
+
+Append to `tests/test_u1sz_uniform_sector_615.py`. Use the probe's backward tracer (the same unit the #610 obstruction hit):
+```python
+from examples.probe_backward_jaxpr_566 import backward_vjp_jaxpr  # from #614
+
+
+def test_cold_backward_vjp_builds_under_keep():
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    # COLD trace is load-bearing: a prior flag-off trace of the same jit unit
+    # (identical avals) would be reused, masking the structural change (#610).
+    jax.clear_caches()
+    with keep_sectors_context({-1, 0, 1}):
+        counts = backward_vjp_jaxpr(A, chi=12, on=True)  # raised ValueError pre-#615
+    assert counts is not None and counts.get("total", 0) > 0
+```
+(If `backward_vjp_jaxpr`'s signature differs after #614, match its actual call — it returns the bucketized op counts and traces the 2×2 multisite VJP internally.)
+
+- [ ] **Step 2: Run it — this is the gate**
+
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_u1sz_uniform_sector_615.py::test_cold_backward_vjp_builds_under_keep -v
+```
+- **PASS** → tactic A is sufficient. Go to Step 4.
+- **FAIL with `ValueError: Size of label ... (X) != (Y)`** → per-sector **multiplicity** mismatch (uniform sector *set* but unequal per-sector dims between an init-seeded leg and a truncated leg). Go to Step 3.
+
+- [ ] **Step 3 (only if Step 2 mismatched): A-consistency, then tactic C**
+
+Apply in order; re-run Step 2 after each; STOP at the first that makes the trace build:
+
+- **A-consistency (preferred — stays in tactic A):** make env-init seed the SAME per-keep-sector multiplicities the truncation targets. Both already tile the D²-charge pattern; align them by deriving the corner/edge chi charges from `_derive_charges(restrict_charges_to_keep(base, keep), chi)` using the *identical* base-charge ordering the truncation consumes (the double-layer `u2` charges), so the `[:chi]` truncation picks the same per-sector counts. Edit in `_ctm_tensor_init.py`.
+- **Tactic C (scoped fallback):** if multiplicities still diverge (data-availability under-fills a keep sector below the seeded count), conform the perpendicular legs to the truncated allocation **only at the `_build_enlarged_corner` boundary** in `_ctm_tensor_projector_2x2.py` (project/pad the un-refreshed leg to the contracted leg's per-sector dims). Smallest delta that closes the specific gap.
+- **Escalation (record, do not build):** if neither builds the trace within ~2 iterations, STOP. Record in the Task-7 findings: *"uniform-by-construction (tactic A) + boundary-conform (tactic C) insufficient; the measurement requires tactic B (all-legs-per-sweep refresh)"* — a documented escalation, not silent scope growth. Skip Tasks 5–6.
+
+- [ ] **Step 4: Confirm default-off backward is unchanged (regression)**
+
+```bash
+JAX_PLATFORMS=cpu uv run python examples/probe_backward_jaxpr_566.py --sym u1sz --D 3 --chi-factor 4 > /tmp/probe_offcheck_615.txt
+diff <(tail -20 /tmp/probe_baseline_615.txt) <(tail -20 /tmp/probe_offcheck_615.txt) && echo "FLAG-OFF UNCHANGED ✓"
+```
+Expected: identical (flag-off backward must match the Task-0 anchor).
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run ruff check src/ tests/
+git add tests/test_u1sz_uniform_sector_615.py src/tenax/algorithms/_ctm_tensor_init.py src/tenax/algorithms/_ctm_tensor_projector_2x2.py
+git commit -m "feat(#615): cold backward VJP builds under keep (tactic A; +C fallback if needed)"
+```
+
+---
+
+## Task 5: Faithfulness guard under the real flag
+
+Before trusting Gate-B op counts, prove the keep-active CTM produces a *valid* env: converges, finite, energy sane at D=3 χ=12.
+
+**Files:** Test: `tests/test_u1sz_uniform_sector_615.py`
+
+- [ ] **Step 1: Write the faithfulness-guard test**
+
+Append to `tests/test_u1sz_uniform_sector_615.py`:
+```python
+from tenax import compute_energy_ctm_tensor
+from tenax.algorithms.ipeps import heisenberg_gate_u1sz
+
+
+def test_keep_env_is_faithful_at_d3_chi12():
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    env, _ = ctm_tensor(A, chi=12, max_iter=20, conv_tol=1e-7, keep_sectors={-1, 0, 1})
+    for name in env._fields:
+        assert np.all(np.isfinite(np.asarray(getattr(env, name)._data))), f"{name} non-finite"
+    e = float(compute_energy_ctm_tensor(A, env, heisenberg_gate_u1sz()))
+    assert np.isfinite(e) and -2.0 < e < 0.0, f"energy {e} outside sane Heisenberg window"
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_u1sz_uniform_sector_615.py::test_keep_env_is_faithful_at_d3_chi12 -v
+```
+Expected: PASS. If energy is out of window or non-finite, the truncation is producing an invalid charge-conserving env — debug (likely a degenerate keep allocation) before Gate B.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_u1sz_uniform_sector_615.py
+git commit -m "test(#615): faithfulness guard — keep-active env converges, energy sane"
+```
+
+---
+
+## Task 6: Gate B — measure the charge-mask reduction, then decide
+
+Repoint the probe's `--defrag` to the real flag (no monkeypatch), measure flag-off vs flag-on at D=3 χ=12 with **cold** traces, and apply the Gate-B criterion.
+
+**Files:** Modify: `examples/probe_backward_jaxpr_566.py`
+
+- [ ] **Step 1: Repoint `--defrag` to the real context**
+
+In `examples/probe_backward_jaxpr_566.py`, replace the `--defrag` monkeypatch wrapper (added in #610) with the real context, and clear caches so the on-trace is cold:
+```python
+import contextlib, jax
+from tenax.algorithms._ctm_uniform_sector import keep_sectors_context
+
+ctx = contextlib.nullcontext()
+if args.defrag:
+    jax.clear_caches()                      # cold-trace: do NOT reuse the flag-off jaxpr
+    ctx = keep_sectors_context({-1, 0, 1})
+with ctx:
+    counts = backward_vjp_jaxpr(A, chi, on=on)   # match the existing call site
+```
+
+- [ ] **Step 2: Capture flag-off and flag-on histograms**
+
+```bash
+JAX_PLATFORMS=cpu uv run python examples/probe_backward_jaxpr_566.py --sym u1sz --D 3 --chi-factor 4 > probe_u1sz_off_615.txt
+JAX_PLATFORMS=cpu uv run python examples/probe_backward_jaxpr_566.py --sym u1sz --D 3 --chi-factor 4 --defrag > probe_u1sz_on_615.txt
+```
+Expected: the flag-on run **traces** (no `ValueError`) and shows fewer charge-mask ops. Record the charge-mask cluster count and total for each.
+
+- [ ] **Step 3: Compute the reduction**
+
+Compute `charge_mask_reduction = 1 - charge_mask_on / charge_mask_off` and `total_reduction = 1 - total_on / total_off`. (Anchor: off ≈ 7,398 / 63,612.) Record both.
+
+- [ ] **Step 4: GATE B decision**
+
+**Pass criterion:** `charge_mask_reduction ≥ 0.25` (well beyond #609's ~1% noise), with `total_reduction` commensurate.
+- **≥25% → GO.** Proceed to Task 7 GO branch (PR to main + follow-up issue).
+- **<25% → NO-GO.** Proceed to Task 7 NO-GO branch (document the measured number; do not merge to main).
+
+- [ ] **Step 5: Commit the measurement artifacts**
+
+```bash
+uv run ruff check src/ tests/
+git add examples/probe_backward_jaxpr_566.py probe_u1sz_off_615.txt probe_u1sz_on_615.txt
+git commit -m "study(#615): Gate B — keep-active backward charge-mask re-profile"
+```
+
+---
+
+## Task 7: Findings, memory, and the decision (always run)
+
+Reached on any terminal outcome (GO, NO-GO, or Task-4 escalation). Record the *measured* number — this is the deliverable that converts #610's inference.
+
+**Files:**
+- Create: `docs/superpowers/handoffs/2026-06-17-u1sz-uniform-sector-env-findings.md`
+- Modify: `/home/yjkao/.claude/projects/-home-yjkao-tenax/memory/` (new memory + `MEMORY.md` pointer)
+
+- [ ] **Step 1: Write the findings handoff**
+
+Create `docs/superpowers/handoffs/2026-06-17-u1sz-uniform-sector-env-findings.md` with: the verdict (GO / NO-GO / escalation), the binding outcome (cold-trace built? via tactic A or C?), the measured numbers (flag-off vs flag-on charge-mask + total; the reduction %), the faithfulness energy, and the recommendation. Mirror the #610 findings structure.
+
+- [ ] **Step 2: Memory + MEMORY.md pointer**
+
+Create `/home/yjkao/.claude/projects/-home-yjkao-tenax/memory/615-u1sz-uniform-sector-env.md` (type `project`): the verdict, the measured charge-mask reduction, and whether tactic A alone sufficed (the non-obvious takeaway). Link `[[610-u1sz-env-defrag]]`, `[[566-u1sz-stacking-nogo]]`, `[[u1sz-perf-study-d3-findings]]`. Add a one-line pointer to `MEMORY.md`.
+
+- [ ] **Step 3a: If GO — open the follow-up full-feature issue**
+
+```bash
+gh issue create --title "feat(#566): productionize U(1)-Sz uniform-sector env (Gate C + accuracy spine + tactic B)" \
+  --body "Spike #615 GO: keep-active backward cut the charge-mask cluster by <X>% at D=3 chi=12 (cold trace builds via tactic <A|C>). Productionize: Gate C (A100 end-to-end + |E_uniform-E_frag|/|E_frag|<=1% on an OPTIMIZED state), accuracy spine, and tactic B (all-legs sweep refresh). See docs/superpowers/handoffs/2026-06-17-u1sz-uniform-sector-env-findings.md."
+```
+
+- [ ] **Step 3b: If NO-GO — record and do NOT merge src/ to main**
+
+Note in the findings that the measured charge-mask reduction (<25%) does not clear the bar; the flag-gated `src/` change stays branch-local for the record. (No `gh issue`; no PR to main.)
+
+- [ ] **Step 4: Commit the findings + memory pointer**
+
+```bash
+git add docs/superpowers/handoffs/2026-06-17-u1sz-uniform-sector-env-findings.md
+git commit -m "docs(#615): U(1)-Sz uniform-sector env — Gate-B <GO|NO-GO> finding"
+```
+
+- [ ] **Step 5: If GO — open the PR to main**
+
+```bash
+git push -u origin feat/615-u1sz-uniform-sector-env
+gh pr create --title "feat(#615): U(1)-Sz uniform-sector env (default-off) — Gate-B GO" \
+  --body "Opt-in (default-off) keep_sectors flag makes the 2x2 multisite CTM carry a uniform chi-bond sector set; the AD backward is now cold-traceable under the |Sz|<=1 drop. Gate B measured a <X>% charge-mask reduction at D=3 chi=12. Default path byte-identical (identity test). See docs/superpowers/specs/2026-06-17-u1sz-uniform-sector-env-measurement-design.md. 🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+If NO-GO, skip — the branch documents the finding without merging.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3 flag (default-off, `keep_sectors`) → Task 1 (context + public param + identity test). ✓
+- §4 tactic A injection points: env-init seed → Task 2; truncation constraint (traced+eager) + base_charges filter → Task 3. ✓
+- §4 make-or-break cold-trace + A-consistency/tactic-C fallback + tactic-B escalation → Task 4. ✓
+- §5 faithfulness guard → Task 5. ✓
+- §6 Gate B (repoint probe, cold trace, ≥25%) → Task 6. ✓
+- §7 verification: default-off identity (Task 1), flag-on faithfulness (Task 5), cold-trace-builds lock (Task 4), flag-off backward unchanged (Task 4 Step 4). ✓
+- §8 merge discipline (GO→PR+issue; NO-GO→no merge) → Task 6 Step 4 + Task 7. ✓
+- §9 deliverables (src change, tests, Gate-B numbers, findings, memory, follow-up) → Tasks 1–7. ✓
+
+**Placeholder scan:** No TBD/TODO. `<X>%` and `<A|C>`/`<GO|NO-GO>` in Task 7 are intentional fill-from-measurement values in human-authored issue/PR prose, not code placeholders. Line anchors marked `~` are flagged in the File Structure note as re-confirm-at-execution (src unchanged by #610, so they are current).
+
+**Type/name consistency:** `keep_sectors_context(keep)` / `current_keep_sectors()` / `restrict_charges_to_keep(charges, keep)` defined in Task 1 Step 3, used identically in Tasks 2, 3, 6. `keep_sectors: frozenset[int] | None = None` param defined in Task 1 Steps 4/6, used in tests in Tasks 1/3/5. `backward_vjp_jaxpr(A, chi, on=...)` (from #609/#614) used in Tasks 4/6. `_env_block_signature`/`_chi_sectors` test helpers defined once (Tasks 1/2) and reused.
+
+**Scope check:** single coherent measurement build (one plan); Gate C / accuracy spine / tactic B explicitly deferred to the GO follow-up issue.

--- a/docs/superpowers/plans/2026-06-17-u1sz-uniform-sector-env-measurement.md
+++ b/docs/superpowers/plans/2026-06-17-u1sz-uniform-sector-env-measurement.md
@@ -24,7 +24,8 @@
 | `src/tenax/algorithms/_ctm_tensor_convergence.py` | Modify | `_get_base_charges`: same keep-filter. `ctm_tensor`: add `keep_sectors` param wrapping the body in `keep_sectors_context`. |
 | `src/tenax/algorithms/_ctm_energy_ad.py` | Modify | `ctm_energy_implicit` (+ its dispatch): add `keep_sectors` param wrapping the body in `keep_sectors_context`, so the implicit-AD backward honors the drop. |
 | `src/tenax/linalg.py` | Modify | `_truncated_svd_symmetric_traced`: when keep is active, drop non-keep sectors in Phase-1 allocation and suppress the Phase-2 χ-backfill (promote the prototype's `_make_keep_filtered_traced_svd` logic into a guarded branch). |
-| `src/tenax/algorithms/_ctm_tensor_projector_2x2.py` | Modify | `_retruncate_by_base_charges`: mirror the keep-restriction (eager forward path). |
+| `src/tenax/algorithms/_ctm_projector.py` | Modify | `_svd_projector_symmetric`: keep-restrict the paired-moves forward eager projector allocation (the path `ctm_tensor` uses for U(1)-Sz). |
+| `src/tenax/algorithms/_ctm_tensor_projector_2x2.py` | Modify | `_retruncate_by_base_charges`: mirror the keep-restriction (2×2 multisite eager path). |
 | `tests/test_u1sz_uniform_sector_615.py` | **Create** | Default-off identity test, env-init keep-seed test, faithfulness guard, and the cold-trace-builds regression lock. |
 | `examples/probe_backward_jaxpr_566.py` | Modify | Repoint `--defrag` from the monkeypatch to `keep_sectors_context` (Gate B). |
 | `docs/superpowers/handoffs/2026-06-17-u1sz-uniform-sector-env-findings.md` | **Create (last task)** | The Gate-B measured number + GO/NO-GO finding. |
@@ -368,10 +369,11 @@ git commit -m "feat(#615): env-init seeds only keep sectors under active context
 
 The other half of tactic A: every projector truncation produces a `keep`-only chi bond — dropping non-keep sectors and **never** backfilling χ from a non-keep sector. This is the prototype's patch (4)/(3)/(1) promoted into guarded branches.
 
-**Files:**
-- Modify: `src/tenax/linalg.py` (`_truncated_svd_symmetric_traced`, ~lines 583–864; backfill ~732–747)
-- Modify: `src/tenax/algorithms/_ctm_tensor_projector_2x2.py` (`_retruncate_by_base_charges`, ~lines 709–801)
-- Modify: `src/tenax/algorithms/_ctm_tensor_paired_moves.py` (`_get_base_charges`, ~line 38) and `src/tenax/algorithms/_ctm_tensor_convergence.py` (`_get_base_charges`, ~line 239)
+**Files (THREE truncation allocation sites — one per active CTM path — plus both base_charges sources):**
+- Modify: `src/tenax/linalg.py` (`_truncated_svd_symmetric_traced`, allocation ~lines 714–747) — the **traced / backward** SVD (the make-or-break path).
+- Modify: `src/tenax/algorithms/_ctm_projector.py` (`_svd_projector_symmetric`, allocation ~lines 382–434) — the **paired-moves forward eager** projector that `ctm_tensor` uses for U(1)-Sz (this is what the Step-4 forward-block-count test exercises; it has its own greedy backfill AND an "absent sector seed" path that both must be keep-gated). *(Added vs. original plan: the forward `ctm_tensor` path goes through here, not `_retruncate_by_base_charges`.)*
+- Modify: `src/tenax/algorithms/_ctm_tensor_projector_2x2.py` (`_retruncate_by_base_charges`, ~lines 709–801) — the **2×2 multisite eager** retruncation.
+- Modify: `src/tenax/algorithms/_ctm_tensor_paired_moves.py` (`_get_base_charges`, ~line 38) and `src/tenax/algorithms/_ctm_tensor_convergence.py` (`_get_base_charges`, ~line 239).
 
 - [ ] **Step 1: Filter both `_get_base_charges` to the active keep set**
 
@@ -421,9 +423,13 @@ from tenax.algorithms._ctm_uniform_sector import current_keep_sectors
 ```
 Consequence: with keep active, `chi_new` is the sum of kept-sector allocations and may be `< max_singular_values` (~10 at D=3 χ=12). With keep `None`, this is byte-identical to the current code. **Do not** change the concatenation / block-rebuild logic below — only the `k_per_sector` allocation.
 
-- [ ] **Step 3: Mirror the restriction in the eager retruncation**
+- [ ] **Step 3: Constrain the paired-moves forward eager projector**
 
-In `src/tenax/algorithms/_ctm_tensor_projector_2x2.py`, `_retruncate_by_base_charges` (~lines 709–801): import `current_keep_sectors`, and in its greedy fill, apply the same two rules — a sector outside the active keep set gets `0`, and the leftover-budget refill skips non-keep sectors. (Match the exact local variable names in that function; the logic is identical to Step 2.)
+In `src/tenax/algorithms/_ctm_projector.py`, `_svd_projector_symmetric` (allocation ~lines 382–434): import `current_keep_sectors`, read `_keep = current_keep_sectors()` once, and apply the keep-gate at THREE points in the `base_charges is not None` block: (a) after building `target_count` (~line 391), drop non-keep sectors: `if _keep is not None: target_count = {q: c for q, c in target_count.items() if q in _keep}` — this also prevents the "absent sector seed" loop (~lines 405–414) from creating ±2 seed eigenvectors; (b) in the redistribution backfill loop (~lines 428–434), skip non-keep: `if _keep is not None and fq not in _keep: continue` before `sector_keep.setdefault(...)`. With keep None, byte-identical.
+
+- [ ] **Step 3b: Mirror the restriction in the 2×2 eager retruncation**
+
+In `src/tenax/algorithms/_ctm_tensor_projector_2x2.py`, `_retruncate_by_base_charges` (~lines 729–755): import `current_keep_sectors`, read `_keep = current_keep_sectors()` once, then (a) after `target_count` is built (~line 732), drop non-keep: `if _keep is not None: target_count = {q: c for q, c in target_count.items() if q in _keep}`; (b) in the global leftover-budget refill (~lines 745–755), skip indices whose charge is non-keep: `if _keep is not None and int(bond_charges_full[j]) not in _keep: continue` before appending `j`. With keep None, byte-identical.
 
 - [ ] **Step 4: Write the failing "truncation drops sectors" test**
 

--- a/docs/superpowers/specs/2026-06-17-u1sz-uniform-sector-env-measurement-design.md
+++ b/docs/superpowers/specs/2026-06-17-u1sz-uniform-sector-env-measurement-design.md
@@ -64,10 +64,16 @@ keep_sectors: frozenset[int] | None = None
 - `keep_sectors=frozenset({-1, 0, 1})` (the documented C-lever, |Sz| ≤ 1) → uniform-sector path
   active end-to-end.
 
-Threaded as a dedicated parameter (not folded into the existing `recipe` string) so default-off is
-trivial to assert and the Gate-B probe can pass it explicitly. Flow:
-`ctm_tensor(...)` → `initialize_ctm_tensor_env(...)` → corner/edge init helpers; and the AD entry
-(`_ctm_energy_ad` / `_make_jit_ctm_step`) → `_ctm_tensor_sweep_multisite` → projector truncation.
+Surfaced as a dedicated parameter on the public entry points (`ctm_tensor`, `ctm_energy_implicit`) —
+not folded into the existing `recipe` string — so default-off is trivial to assert and the Gate-B
+probe can pass it explicitly. Internally it is realized as a **process-local context** set by those
+entry points (`with keep_sectors_context(keep_sectors):`) and read at **trace time** by env-init and
+the projector truncation via `current_keep_sectors()`. This avoids threading the flag through the ~8
+projector layers between `_make_jit_ctm_step`/`_ctm_tensor_sweep_multisite` and
+`linalg._truncated_svd_symmetric_traced`, and mirrors the codebase's existing module-level toggles
+(`set_implicit_ad_norm_diagnostics`, `_batch_blocksparse_enabled()`). `keep_sectors` is a *static
+structural choice* (it changes block sectors/shapes), so reading it as a trace-time Python value — not
+a traced array — is correct; the jit-cache implication is exactly the §6 cold-trace caveat.
 
 ## 4. Mechanism — uniform-by-construction (tactic A), with a scoped fallback
 

--- a/docs/superpowers/specs/2026-06-17-u1sz-uniform-sector-env-measurement-design.md
+++ b/docs/superpowers/specs/2026-06-17-u1sz-uniform-sector-env-measurement-design.md
@@ -1,0 +1,195 @@
+# U(1)-Sz CTM uniform-sector env — flag-gated Gate-B measurement (#615)
+
+**Date:** 2026-06-17
+**Tracking issue:** #615 · **Parent:** #566 · **Predecessor spike:** #610 (PR #614) — NO-GO-by-obstruction
+**Branch:** `feat/615-u1sz-uniform-sector-env` (off `origin/main`; merge `origin/main` after #614 lands to pick up the #610 artifacts this spec references)
+**Spec lineage:** `docs/superpowers/specs/2026-06-16-u1sz-env-defrag-design.md` (the #610 measure-first spike), `docs/superpowers/handoffs/2026-06-17-u1sz-env-defrag-findings.md` (the obstruction finding).
+**Status:** design, pending implementation plan.
+
+---
+
+## 1. Objective & the one question
+
+#610 proved the U(1)-Sz CTM env sector-drop ("C-lever": keep `|Sz| ≤ 1` on the chi bonds) is
+**constructible and exact in the forward** path (env block counts 96 → 48, exactly 2×, at D=3 χ=12;
+energy finite/sane) but could **not measure** the make-or-break backward charge-mask benefit (Gate
+B), because the drop cannot be injected into the 2×2 multisite backward via a runtime monkeypatch.
+
+This work builds the **minimal, opt-in, default-off** structural change that makes the 2×2 multisite
+CTM carry a **uniform chi-bond sector set**, so the AD backward becomes **cold-traceable under the
+drop**. With the backward finally traceable, run **Gate B** to convert #610's *inferred* ~40–50%
+charge-mask reduction into a *measured* number, then decide GO/NO-GO on funding the full feature.
+
+**Output:** a measured Gate-B charge-mask reduction at D=3 χ=12 and a documented GO/NO-GO finding —
+**not** a shipped feature. The flag-gated `src/` change exists to make the measurement *possible*;
+whether it merges to `main` is itself gated on Gate B (see §8).
+
+## 2. Fixed facts (established by #610 — do NOT re-derive)
+
+From `docs/superpowers/handoffs/2026-06-17-u1sz-env-defrag-findings.md` and
+`examples/u1sz_defrag_prototype_610.py`:
+
+1. **The forward drop is real.** Under the prototype, the converged forward `ctm_tensor` env has
+   block counts `{C: 3, T: 9}` (from `{C: 5, T: 19}`), energy finite/sane. The representation change
+   is faithful in the forward paired-moves path.
+2. **The truncation problem is already solved.** The prototype's traced-SVD copy
+   (`_make_keep_filtered_traced_svd`) drops non-`keep` sectors in the Phase-1 allocation **and
+   suppresses the Phase-2 greedy χ-backfill** that otherwise re-adds `±2` to saturate χ. It produces
+   an honest smaller bond (~10 SVs at D=3 χ=12). This is the reference for the truncation constraint;
+   we promote it into a flag-gated branch — we do **not** need to re-invent it.
+3. **The obstruction is a `5 → 3` sector *transition* mid-sweep, not the truncation.** Even with the
+   truncation fixed, the cold backward VJP raises
+   `ValueError: Size of label 'd' (4) != (5)` in `_build_enlarged_corner -> contract(C_r, T_v)`
+   (`_ctm_tensor_projector_2x2.py`). Root cause: `initialize_ctm_tensor_env` seeds **every** chi bond
+   at the full 5-sector `{−2..+2}`, while `_ctm_tensor_sweep_multisite` refreshes **only** the legs
+   along the *current* absorption direction per move. A sweep transitioning 5→3 sectors then contracts
+   a freshly-dropped 3-sector leg against an un-refreshed 5-sector perpendicular corner leg.
+4. **A monkeypatch cannot reach it.** Making the backward honor the drop requires env-init to seed a
+   uniform sector set *and* the chi-bond sector set to stay uniform across the sweep — a structural
+   change to real `src/` functions. This is the entire reason #610 ended NO-GO-by-obstruction.
+5. **Baseline backward op counts (D=3 χ=12, `probe_u1sz_baseline_610.txt`):** **63,612** total ops,
+   **7,398** charge-mask / index-arith ops. #609 measured backward op count ≈ linear in block count
+   (~1.1 ops/block). These are the Gate-B comparison anchors.
+
+## 3. The flag (API surface)
+
+A single optional knob threaded top-down, **off by default**:
+
+```python
+keep_sectors: frozenset[int] | None = None
+```
+
+- `keep_sectors=None` (default) → **byte-identical to today.** This is the blast-radius firewall:
+  every touched function takes the new path only inside `if keep_sectors is not None:`.
+- `keep_sectors=frozenset({-1, 0, 1})` (the documented C-lever, |Sz| ≤ 1) → uniform-sector path
+  active end-to-end.
+
+Threaded as a dedicated parameter (not folded into the existing `recipe` string) so default-off is
+trivial to assert and the Gate-B probe can pass it explicitly. Flow:
+`ctm_tensor(...)` → `initialize_ctm_tensor_env(...)` → corner/edge init helpers; and the AD entry
+(`_ctm_energy_ad` / `_make_jit_ctm_step`) → `_ctm_tensor_sweep_multisite` → projector truncation.
+
+## 4. Mechanism — uniform-by-construction (tactic A), with a scoped fallback
+
+**Hypothesis (tactic A):** if every chi bond is **born `keep`** and **every truncation outputs
+`keep`**, the sector set is a *uniform invariant* — there is never a 5→3 transition, so the
+per-direction sweep refresh never produces a mixed-generation contraction. This avoids rewriting the
+hot `_ctm_tensor_sweep_multisite` move loop.
+
+Three injection points, each guarded by `keep_sectors is not None` (file:line from the current
+tree — re-confirm after merging #614):
+
+1. **Env-init seed** — `_init_symmetric_standard_corner` (`_ctm_tensor_init.py:~378`) and
+   `_init_symmetric_standard_edge` (`~322–325`): filter the fused chi-bond charges to `keep` **before**
+   `_grouped_chi_perm`. Chi bonds are born with only `keep` sectors.
+2. **Truncation constraint** — `_truncated_svd_symmetric_traced` (`linalg.py:~732–747`, the traced /
+   backward path): flag-gated branch that drops non-`keep` sectors in the Phase-1 `base_charges`
+   allocation and **never backfills the leftover χ from a non-`keep` sector**. Mirror the same
+   constraint in the eager `_retruncate_by_base_charges` (`_ctm_tensor_projector_2x2.py:~709`). This is
+   the prototype's patch (4) promoted to a real branch.
+3. **base_charges filter** — both `_get_base_charges` (in `_ctm_tensor_convergence.py:~239` and
+   `_ctm_tensor_paired_moves.py:~38`): filter the extracted charges to `keep` so the allocation intent
+   is consistent across forward and backward.
+
+**Make-or-break check for the mechanism:** the **cold** backward VJP traces **without `ValueError`**
+(`jax.clear_caches()` first — see §6 cold-trace caveat). This is the crisp, cheap acceptance gate for
+tactic A.
+
+**Risk — per-sector *multiplicities*, not just the sector set.** The `_build_enlarged_corner`
+contraction matches legs on sector set **and** per-sector dim. Tactic A only guarantees a uniform
+sector *set*; if the env-init seed allocation and the truncation allocation distribute `keep` over
+different per-sector multiplicities, the cold trace can still mismatch on dims. Two mitigations, in
+order:
+- **A-consistency:** make env-init seed and truncation use the *same* per-`keep`-sector allocation
+  rule (so multiplicities coincide by construction). Preferred — stays within tactic A.
+- **Tactic C (scoped fallback):** if the cold trace still mismatches, conform the perpendicular legs
+  to the uniform allocation **only at the `_build_enlarged_corner` boundary** — the smallest delta
+  that closes the specific gap, short of a sweep rewrite.
+
+**Tactic B (full all-legs-per-sweep refresh) is explicitly deferred** to the full-feature follow-up
+(if Gate B passes); it is the heaviest change to the hottest path and is not needed to *measure*.
+
+## 5. Faithfulness guard (mandatory before Gate B)
+
+Reuse the #610 guard, repointed from the monkeypatch to the real flag: under
+`keep_sectors={-1,0,1}`, the CTM **converges**, all env tensors are finite, and `E_uniform` is finite
+and in the sane Heisenberg window at D=3 χ=12. An invalid charge-conserving env makes the Gate-B
+op-histogram meaningless, so the guard runs **before** the re-profile.
+
+## 6. Measurement (Gate B — the make-or-break, Tier 1)
+
+Repoint `examples/probe_backward_jaxpr_566.py --defrag` from the prototype monkeypatch to the **real
+flag** (`keep_sectors={-1,0,1}`). Trace-only, CPU, no XLA compile:
+
+1. Baseline (flag-off) backward op-histogram at D=3 χ=12 → charge-mask cluster + total (anchor: 7,398
+   / 63,612 from #610).
+2. Flag-on backward op-histogram at D=3 χ=12 → charge-mask cluster + total.
+3. Reduction = `1 − (charge_mask_on / charge_mask_off)` and the total-op reduction.
+
+**Cold-trace caveat (load-bearing).** The flag-on backward must be traced **cold**
+(`jax.clear_caches()` before the flag-on trace). A prior flag-off trace of the same jit unit with
+identical avals seeds the `jax.jit` cache; a later flag-on call silently reuses the flag-off trace —
+neither erroring nor dropping. Any "it traced" or measured-drop claim must verify cold tracing, or it
+is re-measuring the baseline. The probe must clear caches between the off and on traces.
+
+**Gate B pass criterion:** charge-mask cluster op count drops **≥ 25%** (well beyond #609's ~1%
+noise), with total backward ops dropping commensurately.
+
+## 7. Verification & blast radius
+
+- **Default-off regression (the firewall):** with `keep_sectors=None`, existing CTM behavior is
+  byte-identical. Run `uv run pytest -m core` and the U(1)-Sz arm
+  (`tests/test_profiler_u1sz_arm.py`) flag-off; assert no diff in env block structure / energy vs
+  `origin/main` on a D=3 χ=12 smoke.
+- **Flag-on faithfulness guard (§5):** new test — CTM converges, env finite, energy sane under the
+  flag.
+- **Cold-trace-builds unit test:** the #610 obstruction test
+  (`test_backward_trace_does_not_survive_surgical_drop`) **inverted to PASS** — under the real flag,
+  the cold backward VJP of the 2×2 multisite step **builds** (no `ValueError`). This is the
+  regression lock for the structural fix.
+- **Blast radius:** flag-on touches env-init + traced/eager projector truncation + the multisite
+  sweep's `base_charges` threading — the most-used symmetric CTM paths. Confined entirely behind
+  `keep_sectors is not None`; default-off leaves them untouched.
+
+## 8. Decision & merge discipline (gated on Gate B)
+
+| Gate-B result | Action |
+|---|---|
+| **≥ 25% charge-mask drop** | **GO.** Open PR to `main` with the default-off flag. Open a follow-up issue for the full feature: Gate C (A100 end-to-end + `\|E_uniform − E_frag\|/\|E_frag\| ≤ 1%`, on an **optimized** state — not the random init), accuracy spine, and tactic B (all-legs sweep refresh). |
+| **< 25% charge-mask drop** | **NO-GO.** The structural change finally *measured* the lever (converting #610's inference). Write findings + memory recording the measured number; **do not merge** the `src/` change to `main`. The branch preserves it for the record. |
+
+The flag-gated `src/` change lives on the branch to make the measurement possible; **it merges to
+`main` only if Gate B passes** — honoring the project's measure-first / don't-fund-on-inference
+discipline (mirrors #609/#610).
+
+## 9. Deliverables
+
+- Flag-gated `src/` change (branch-local until Gate B; §3–§4).
+- Faithfulness guard test + cold-trace-builds unit test + default-off regression assertion (§7).
+- Gate-B op-histogram numbers (flag-off vs flag-on) at D=3 χ=12.
+- A findings handoff (`docs/superpowers/handoffs/2026-06-17-u1sz-uniform-sector-env-findings.md`)
+  recording the measured charge-mask drop and the GO/NO-GO decision.
+- A memory update; link `[[610-u1sz-env-defrag]]`, `[[566-u1sz-stacking-nogo]]`,
+  `[[u1sz-perf-study-d3-findings]]`.
+- **If GO:** the follow-up full-feature issue (Gate C / accuracy spine / tactic B).
+
+## 10. Risks / kill-switches
+
+- **Multiplicity mismatch defeats tactic A** — caught cheaply by the cold-trace-builds check; mitigated
+  by A-consistency then tactic C (§4). If tactic C also fails to build cheaply, the finding is
+  "uniform-by-construction insufficient; needs tactic B sweep rewrite" — a documented escalation, not a
+  silent expansion of scope.
+- **Charge-mask partly irreducible** — Gate B catches it (trace-only) before any A100 spend; a <25%
+  measured drop is a clean NO-GO with a real number.
+- **Cold-trace cache trap** — §6; the probe clears caches between off/on traces.
+- **Blast radius on the hot paths** — confined behind the default-off flag; the default-off regression
+  test is the guard.
+
+## 11. Non-goals
+
+- No Gate C / A100 / end-to-end runtime work this round (gated on Gate B passing).
+- No accuracy spine / golden infrastructure (belongs to the full-feature follow-up if GO).
+- No tactic B (all-legs sweep refresh) this round — deferred to the full feature.
+- Not chasing D=2 (symmetry already wins) or D≥4 (note headroom only); the binding case is D=3 χ=12.
+- The flag is **not** advertised as public API in this round (no README/`__init__` export) — it is a
+  measurement-enabling internal knob until the full feature ships.

--- a/examples/probe_backward_jaxpr_566.py
+++ b/examples/probe_backward_jaxpr_566.py
@@ -338,16 +338,15 @@ def main() -> None:
     # drops |Sz|>1 chi-bond sectors. Mirrors backward_vjp_jaxpr's call signature
     # exactly; the only change is the surrounding sector_dropping_truncation().
     if args.defrag:
-        import importlib.util as _ilu
-        import pathlib as _pl
+        import jax as _jax
 
-        _spec = _ilu.spec_from_file_location(
-            "u1sz_defrag_prototype_610",
-            _pl.Path(__file__).parent / "u1sz_defrag_prototype_610.py",
-        )
-        _defrag_mod = _ilu.module_from_spec(_spec)
-        _spec.loader.exec_module(_defrag_mod)
-        _sector_drop = _defrag_mod.sector_dropping_truncation
+        from tenax.algorithms._ctm_uniform_sector import keep_sectors_context
+
+        # #615 Gate B: cold-trace under the REAL keep flag (not the #610
+        # monkeypatch). clear_caches so the keep trace is not masked by a prior
+        # flag-off jaxpr of the same jit unit (cold-trace caveat).
+        _jax.clear_caches()
+        _sector_drop = lambda: keep_sectors_context({-1, 0, 1})  # noqa: E731
     else:
         _sector_drop = None
 

--- a/examples/profile_ctm_ad_wall_566.py
+++ b/examples/profile_ctm_ad_wall_566.py
@@ -70,6 +70,7 @@ from __future__ import annotations
 
 import argparse
 import atexit
+import contextlib
 import json
 import logging
 import platform
@@ -348,11 +349,28 @@ def main() -> None:
         "Implies the explicit path; use to measure the truncated-backprop RUNTIME "
         "lever (warm-step vs implicit). Default None = full backprop.",
     )
+    ap.add_argument(
+        "--defrag",
+        action="store_true",
+        help="Run each cell inside keep_sectors_context({-1,0,1}) (#615 keep "
+        "flag): the U(1)-Sz uniform-sector env de-fragmentation. Forces a cold "
+        "compile (jax.clear_caches) under the keep set so env-init + truncation "
+        "restrict chi-bond charges. Measures keep vs fragmented-sym warm-step.",
+    )
     ap.add_argument("--json", type=str, default=None)
     args = ap.parse_args()
     # --backward-steps only affects the explicit path; auto-enable it.
     if args.backward_steps is not None:
         args.explicit = True
+
+    def _maybe_keep():
+        """Activate the #615 keep set for the cell measurement when --defrag."""
+        if args.defrag:
+            from tenax.algorithms._ctm_uniform_sector import keep_sectors_context
+
+            jax.clear_caches()
+            return keep_sectors_context({-1, 0, 1})
+        return contextlib.nullcontext()
 
     cap = _install_compile_capture()
     dev = jax.devices()[0]
@@ -375,6 +393,7 @@ def main() -> None:
         "depths": args.depth,
         "explicit": args.explicit,
         "backward_steps": args.backward_steps,
+        "defrag": args.defrag,
     }
 
     # Build the (sym, D, chi, depth, path) grid.
@@ -404,17 +423,18 @@ def main() -> None:
     rows = []
     for sym, D, chi, depth, explicit in configs:
         try:
-            r = profile_config(
-                sym,
-                D,
-                chi,
-                depth,
-                explicit=explicit,
-                warmup=args.warmup,
-                reps=args.reps,
-                cap=cap,
-                backward_steps=args.backward_steps if explicit else None,
-            )
+            with _maybe_keep():
+                r = profile_config(
+                    sym,
+                    D,
+                    chi,
+                    depth,
+                    explicit=explicit,
+                    warmup=args.warmup,
+                    reps=args.reps,
+                    cap=cap,
+                    backward_steps=args.backward_steps if explicit else None,
+                )
         except Exception as exc:  # noqa: BLE001 - record + continue the sweep
             print(
                 f"{sym:>9} {D:>2} {chi:>4} {depth:>4} "

--- a/probe_u1sz_off_615.txt
+++ b/probe_u1sz_off_615.txt
@@ -1,0 +1,15 @@
+# #566 backward-VJP jaxpr op-histogram (trace-only) | x64=True
+# unit = apply_Jt = VJP of one gauge-fixed CTM sweep w.r.t. env (Neumann matvec)
+# projector_backward = auto
+
+== u1sz D=3 chi=12 blocks=32 ==
+  bucket                                 flag_off    flag_on   on/off
+  contraction                                4064       4064    1.00x
+  decomp(svd/eigh/qr)                          78         78    1.00x
+  block-pack(slice/scatter/reshape)         24515      24515    1.00x
+  transpose                                  5874       5874    1.00x
+  charge-mask / index arith                  7398       7398    1.00x
+  elementwise(add/mul/...)                  11384      11384    1.00x
+  other                                     10299      10299    1.00x
+  TOTAL                                     63612      63612    1.00x  <== TOTAL
+

--- a/probe_u1sz_on_615.txt
+++ b/probe_u1sz_on_615.txt
@@ -1,0 +1,15 @@
+# #566 backward-VJP jaxpr op-histogram (trace-only) | x64=True
+# unit = apply_Jt = VJP of one gauge-fixed CTM sweep w.r.t. env (Neumann matvec)
+# projector_backward = auto
+
+== u1sz D=3 chi=12 blocks=32 ==
+  bucket                                 flag_off    flag_on   on/off
+  contraction                                2386       2386    1.00x
+  decomp(svd/eigh/qr)                          68         68    1.00x
+  block-pack(slice/scatter/reshape)         17671      17671    1.00x
+  transpose                                  3972       3972    1.00x
+  charge-mask / index arith                  5798       5798    1.00x
+  elementwise(add/mul/...)                   8428       8428    1.00x
+  other                                      7341       7341    1.00x
+  TOTAL                                     45664      45664    1.00x  <== TOTAL
+

--- a/profile_d3chi12_baseline_615.json
+++ b/profile_d3chi12_baseline_615.json
@@ -1,0 +1,38 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "syms": [
+    "dense",
+    "u1sz"
+  ],
+  "depths": [
+    8
+  ],
+  "explicit": false,
+  "backward_steps": null,
+  "defrag": false,
+  "rows": [
+    {
+      "sym": "dense",
+      "D": 3,
+      "chi": 12,
+      "depth": 8,
+      "path": "implicit",
+      "backward_steps": null,
+      "n_blocks": 1,
+      "fwd_wall_s": 17.188620429486036,
+      "fwd_compile_s": 15.234135626000008,
+      "fwd_n_compiles": 101,
+      "vg_wall_s": 23.77550066821277,
+      "vg_compile_s": 20.075071101000002,
+      "vg_n_compiles": 112,
+      "bwd_compile_s_est": 4.840935474999995,
+      "top_compile_name": "jit(_jit_fused_fixed_point_bwd)",
+      "top_compile_s": 9.134130478,
+      "warm_step_s": 0.775690233334899,
+      "energy": -0.0039617707236439675,
+      "grad_finite": true
+    }
+  ]
+}

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -33,6 +33,7 @@ from tenax.algorithms._ctm_tensor_init import (
     CTMTensorEnv,
     initialize_ctm_tensor_env,
 )
+from tenax.algorithms._ctm_uniform_sector import keep_sectors_context
 from tenax.algorithms._gmres_lax import gmres_pytree, gmres_pytree_jax
 from tenax.algorithms.ad_utils import CTMRGGradientError, _phase_fix_ctm_tensor
 from tenax.contraction.contractor import contract
@@ -363,6 +364,7 @@ def ctm_energy_implicit(
     ctmrg_heuristic_increase_chi_step_size: int = 2,
     chi_max: int | None = None,
     recipe: str = "2x2",
+    keep_sectors: frozenset[int] | None = None,
 ) -> jnp.ndarray:
     """Compute iPEPS energy with implicit-differentiation backward (GMRES).
 
@@ -450,71 +452,73 @@ def ctm_energy_implicit(
     Returns:
         Scalar energy per site.
     """
-    # Reject ``ctmrg_heuristic_increase_chi`` + ``chi_ramp`` at the
-    # ctm_energy_implicit boundary.  Without this guard, the chi_ramp
-    # branch inside ``_run_forward`` silently drops the bump kwargs
-    # (``_python_loop_chi_ramp`` doesn't accept them), so a caller
-    # passing both would get a bump-off run with no error.  Mirrors
-    # ``python_loop_ctm_converge``'s identical check (#514 Task 5
-    # review follow-up).
-    if ctmrg_heuristic_increase_chi and chi_ramp is not None:
-        raise ValueError(
-            "ctmrg_heuristic_increase_chi and chi_ramp are mutually "
-            "exclusive: chi_ramp is a deterministic schedule applied "
-            "across stages, while ctmrg_heuristic_increase_chi is reactive "
-            "inside a single CTM convergence call."
+    with keep_sectors_context(keep_sectors):
+        # Reject ``ctmrg_heuristic_increase_chi`` + ``chi_ramp`` at the
+        # ctm_energy_implicit boundary.  Without this guard, the chi_ramp
+        # branch inside ``_run_forward`` silently drops the bump kwargs
+        # (``_python_loop_chi_ramp`` doesn't accept them), so a caller
+        # passing both would get a bump-off run with no error.  Mirrors
+        # ``python_loop_ctm_converge``'s identical check (#514 Task 5
+        # review follow-up).
+        if ctmrg_heuristic_increase_chi and chi_ramp is not None:
+            raise ValueError(
+                "ctmrg_heuristic_increase_chi and chi_ramp are mutually "
+                "exclusive: chi_ramp is a deterministic schedule applied "
+                "across stages, while ctmrg_heuristic_increase_chi is reactive "
+                "inside a single CTM convergence call."
+            )
+
+        # Mirror the bump-kwarg validation from ``_sigma_gauged_ctm_converge`` at
+        # the public boundary so kwarg-validation tests (chi_max=None,
+        # step_size<=0, env_init above chi_max) surface their specific
+        # ValueError at the entry point, before dispatch hands off to the
+        # custom_vjp factory.  Chi-lock (#516) lifted the prior
+        # NotImplementedError raise that this block historically preceded.
+        _validate_chi_bump_args(
+            chi=chi,
+            chi_max=chi_max,
+            env_init=env_init,
+            bump_enabled=ctmrg_heuristic_increase_chi,
+            bump_step_size=ctmrg_heuristic_increase_chi_step_size,
         )
 
-    # Mirror the bump-kwarg validation from ``_sigma_gauged_ctm_converge`` at
-    # the public boundary so kwarg-validation tests (chi_max=None,
-    # step_size<=0, env_init above chi_max) surface their specific
-    # ValueError at the entry point, before dispatch hands off to the
-    # custom_vjp factory.  Chi-lock (#516) lifted the prior
-    # NotImplementedError raise that this block historically preceded.
-    _validate_chi_bump_args(
-        chi=chi,
-        chi_max=chi_max,
-        env_init=env_init,
-        bump_enabled=ctmrg_heuristic_increase_chi,
-        bump_step_size=ctmrg_heuristic_increase_chi_step_size,
-    )
+        coords = sorted(site_tensors.keys())
+        # Pass Tensor objects directly through custom_vjp boundary.
+        # Both DenseTensor and SymmetricTensor are registered JAX pytrees,
+        # so JAX can differentiate through them without densifying.
+        params_data = tuple(site_tensors[c] for c in coords)
 
-    coords = sorted(site_tensors.keys())
-    # Pass Tensor objects directly through custom_vjp boundary.
-    # Both DenseTensor and SymmetricTensor are registered JAX pytrees,
-    # so JAX can differentiate through them without densifying.
-    params_data = tuple(site_tensors[c] for c in coords)
-
-    return _ctm_energy_implicit_dispatch(
-        params_data,
-        coords,
-        neighbors,
-        gate,
-        chi,
-        max_iter,
-        conv_tol,
-        projector_method,
-        renormalize,
-        projector_backward,
-        qr_warmup_steps,
-        chi_ramp,
-        env_init,
-        forward_gauge,
-        conv_method,
-        min_iter,
-        gmres_tol,
-        gmres_maxiter,
-        gmres_restart,
-        energy_fn,
-        arnoldi_precheck,
-        adjoint_method,
-        plateau_patience,
-        ctmrg_heuristic_increase_chi,
-        ctmrg_heuristic_increase_chi_threshold,
-        ctmrg_heuristic_increase_chi_step_size,
-        chi_max,
-        recipe,
-    )
+        return _ctm_energy_implicit_dispatch(
+            params_data,
+            coords,
+            neighbors,
+            gate,
+            chi,
+            max_iter,
+            conv_tol,
+            projector_method,
+            renormalize,
+            projector_backward,
+            qr_warmup_steps,
+            chi_ramp,
+            env_init,
+            forward_gauge,
+            conv_method,
+            min_iter,
+            gmres_tol,
+            gmres_maxiter,
+            gmres_restart,
+            energy_fn,
+            arnoldi_precheck,
+            adjoint_method,
+            plateau_patience,
+            ctmrg_heuristic_increase_chi,
+            ctmrg_heuristic_increase_chi_threshold,
+            ctmrg_heuristic_increase_chi_step_size,
+            chi_max,
+            recipe,
+            keep_sectors,
+        )
 
 
 def _sigma_gauged_ctm_converge(
@@ -749,6 +753,7 @@ def _ctm_energy_implicit_dispatch(
     ctmrg_heuristic_increase_chi_step_size,
     chi_max,
     recipe="2x2",
+    keep_sectors=None,
 ):
     """Dispatch to custom_vjp-decorated function with caching.
 
@@ -756,82 +761,83 @@ def _ctm_energy_implicit_dispatch(
     We cache it on a key derived from the static configuration so that
     optimizer loops reuse the compiled backward across steps.
     """
-    # Build a hashable key from the static configuration.
-    # Gate and energy_fn must be in the key because the JIT backward
-    # captures them at trace time as compile-time constants.
-    cache_key = (
-        tuple(coords),
-        chi,
-        max_iter,
-        conv_tol,
-        projector_method,
-        renormalize,
-        projector_backward,
-        qr_warmup_steps,
-        forward_gauge,
-        conv_method,
-        min_iter,
-        gmres_tol,
-        gmres_maxiter,
-        gmres_restart,
-        id(neighbors),  # same dict object across optimizer steps
-        id(gate),  # different Hamiltonian → different backward
-        id(energy_fn),  # different energy callback → different backward
-        arnoldi_precheck,
-        adjoint_method,
-        plateau_patience,
-        ctmrg_heuristic_increase_chi,
-        ctmrg_heuristic_increase_chi_threshold,
-        ctmrg_heuristic_increase_chi_step_size,
-        chi_max,
-        recipe,  # distinct sweep recipe → distinct cached forward+backward
-    )
+    with keep_sectors_context(keep_sectors):
+        # Build a hashable key from the static configuration.
+        # Gate and energy_fn must be in the key because the JIT backward
+        # captures them at trace time as compile-time constants.
+        cache_key = (
+            tuple(coords),
+            chi,
+            max_iter,
+            conv_tol,
+            projector_method,
+            renormalize,
+            projector_backward,
+            qr_warmup_steps,
+            forward_gauge,
+            conv_method,
+            min_iter,
+            gmres_tol,
+            gmres_maxiter,
+            gmres_restart,
+            id(neighbors),  # same dict object across optimizer steps
+            id(gate),  # different Hamiltonian → different backward
+            id(energy_fn),  # different energy callback → different backward
+            arnoldi_precheck,
+            adjoint_method,
+            plateau_patience,
+            ctmrg_heuristic_increase_chi,
+            ctmrg_heuristic_increase_chi_threshold,
+            ctmrg_heuristic_increase_chi_step_size,
+            chi_max,
+            recipe,  # distinct sweep recipe → distinct cached forward+backward
+        )
 
-    entry = _VJP_CACHE.get(cache_key)
-    if entry is not None:
-        f, mutables = entry
-        # Update per-call mutable state
-        mutables["gate"] = gate
-        mutables["chi_ramp"] = chi_ramp
-        mutables["env_init"] = env_init
-        mutables["energy_fn"] = energy_fn
+        entry = _VJP_CACHE.get(cache_key)
+        if entry is not None:
+            f, mutables = entry
+            # Update per-call mutable state
+            mutables["gate"] = gate
+            mutables["chi_ramp"] = chi_ramp
+            mutables["env_init"] = env_init
+            mutables["energy_fn"] = energy_fn
+            return f(params_data_tuple)
+
+        # First call with this config — build and cache
+        mutables = {
+            "gate": gate,
+            "chi_ramp": chi_ramp,
+            "env_init": env_init,
+            "energy_fn": energy_fn,
+        }
+        f = _make_implicit_vjp_fn(
+            coords=coords,
+            mutables=mutables,
+            neighbors=neighbors,
+            chi=chi,
+            max_iter=max_iter,
+            conv_tol=conv_tol,
+            projector_method=projector_method,
+            renormalize=renormalize,
+            projector_backward=projector_backward,
+            qr_warmup_steps=qr_warmup_steps,
+            forward_gauge=forward_gauge,
+            conv_method=conv_method,
+            min_iter=min_iter,
+            gmres_tol=gmres_tol,
+            gmres_maxiter=gmres_maxiter,
+            gmres_restart=gmres_restart,
+            arnoldi_precheck=arnoldi_precheck,
+            adjoint_method=adjoint_method,
+            plateau_patience=plateau_patience,
+            ctmrg_heuristic_increase_chi=ctmrg_heuristic_increase_chi,
+            ctmrg_heuristic_increase_chi_threshold=ctmrg_heuristic_increase_chi_threshold,
+            ctmrg_heuristic_increase_chi_step_size=ctmrg_heuristic_increase_chi_step_size,
+            chi_max=chi_max,
+            recipe=recipe,
+        )
+        _VJP_CACHE[cache_key] = (f, mutables)
         return f(params_data_tuple)
-
-    # First call with this config — build and cache
-    mutables = {
-        "gate": gate,
-        "chi_ramp": chi_ramp,
-        "env_init": env_init,
-        "energy_fn": energy_fn,
-    }
-    f = _make_implicit_vjp_fn(
-        coords=coords,
-        mutables=mutables,
-        neighbors=neighbors,
-        chi=chi,
-        max_iter=max_iter,
-        conv_tol=conv_tol,
-        projector_method=projector_method,
-        renormalize=renormalize,
-        projector_backward=projector_backward,
-        qr_warmup_steps=qr_warmup_steps,
-        forward_gauge=forward_gauge,
-        conv_method=conv_method,
-        min_iter=min_iter,
-        gmres_tol=gmres_tol,
-        gmres_maxiter=gmres_maxiter,
-        gmres_restart=gmres_restart,
-        arnoldi_precheck=arnoldi_precheck,
-        adjoint_method=adjoint_method,
-        plateau_patience=plateau_patience,
-        ctmrg_heuristic_increase_chi=ctmrg_heuristic_increase_chi,
-        ctmrg_heuristic_increase_chi_threshold=ctmrg_heuristic_increase_chi_threshold,
-        ctmrg_heuristic_increase_chi_step_size=ctmrg_heuristic_increase_chi_step_size,
-        chi_max=chi_max,
-        recipe=recipe,
-    )
-    _VJP_CACHE[cache_key] = (f, mutables)
-    return f(params_data_tuple)
 
 
 def _make_implicit_vjp_fn(

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -791,6 +791,7 @@ def _ctm_energy_implicit_dispatch(
             ctmrg_heuristic_increase_chi_step_size,
             chi_max,
             recipe,  # distinct sweep recipe → distinct cached forward+backward
+            keep_sectors,  # sector-restricted backward graph differs from unrestricted
         )
 
         entry = _VJP_CACHE.get(cache_key)

--- a/src/tenax/algorithms/_ctm_projector.py
+++ b/src/tenax/algorithms/_ctm_projector.py
@@ -44,6 +44,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from tenax.algorithms._ctm_truncation_error import compute_truncation_error
+from tenax.algorithms._ctm_uniform_sector import current_keep_sectors
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
 
@@ -385,10 +386,17 @@ def _eigh_projector_symmetric(
         # by ensuring every charge from A's bond is represented.
         from tenax.algorithms._ctm_utils import _derive_charges
 
+        # Keep-restriction (#615): read once; guarded — None => byte-identical.
+        _keep = current_keep_sectors()
+
         target_charges = _derive_charges(base_charges, n_keep)
         target_count: dict[int, int] = {}
         for q in target_charges:
             target_count[int(q)] = target_count.get(int(q), 0) + 1
+        # Drop non-keep sectors before allocation so neither the per-sector
+        # take nor the absent-sector identity seed creates non-keep vectors.
+        if _keep is not None:
+            target_count = {q: c for q, c in target_count.items() if q in _keep}
 
         # Allocate per sector: take top eigenvalues within each sector.
         # For sectors absent from the data, create identity-like seed
@@ -428,6 +436,8 @@ def _eigh_projector_symmetric(
             for _, fq, idx in all_eig_pairs:
                 if remaining <= 0:
                     break
+                if _keep is not None and int(fq) not in _keep:
+                    continue
                 if (fq, idx) not in reserved:
                     sector_keep.setdefault(fq, []).append(idx)
                     reserved.add((fq, idx))

--- a/src/tenax/algorithms/_ctm_projector.py
+++ b/src/tenax/algorithms/_ctm_projector.py
@@ -435,7 +435,7 @@ def _eigh_projector_symmetric(
         # tile-then-restrict distribution). Default-off path keeps full backfill.
         used = sum(len(v) for v in sector_keep.values())
         remaining = n_keep - used
-        if remaining > 0 and _keep is None:
+        if remaining > 0 and _keep is None:  # under keep: no backfill — chi_new shrinks to the keep-target sum (matches env-init)
             reserved = {(fq, idx) for fq, idxs in sector_keep.items() for idx in idxs}
             for _, fq, idx in all_eig_pairs:
                 if remaining <= 0:
@@ -769,7 +769,7 @@ def _svd_projector_symmetric(
         # tile-then-restrict distribution). Default-off path keeps full backfill.
         used = sum(len(v) for v in sector_keep.values())
         remaining = n_keep - used
-        if remaining > 0 and _keep is None:
+        if remaining > 0 and _keep is None:  # under keep: no backfill — chi_new shrinks to the keep-target sum (matches env-init)
             reserved = {(fq, idx) for fq, idxs in sector_keep.items() for idx in idxs}
             for _, fq, idx in all_sv_pairs:
                 if remaining <= 0:

--- a/src/tenax/algorithms/_ctm_projector.py
+++ b/src/tenax/algorithms/_ctm_projector.py
@@ -739,6 +739,13 @@ def _svd_projector_symmetric(
         for q in target_charges:
             target_count[int(q)] = target_count.get(int(q), 0) + 1
 
+        # #615 keep-restriction: drop non-keep sectors so this forward
+        # projector cannot allocate (nor backfill) |Sz|>1 chi-bond sectors.
+        # No-op when no keep set is active.
+        _keep = current_keep_sectors()
+        if _keep is not None:
+            target_count = {q: c for q, c in target_count.items() if q in _keep}
+
         for fq in sorted(target_count.keys()):
             n_want = target_count[fq]
             if fq in sector_results:
@@ -755,6 +762,8 @@ def _svd_projector_symmetric(
             for _, fq, idx in all_sv_pairs:
                 if remaining <= 0:
                     break
+                if _keep is not None and int(fq) not in _keep:
+                    continue
                 if (fq, idx) not in reserved:
                     sector_keep.setdefault(fq, []).append(idx)
                     reserved.add((fq, idx))

--- a/src/tenax/algorithms/_ctm_projector.py
+++ b/src/tenax/algorithms/_ctm_projector.py
@@ -430,9 +430,12 @@ def _eigh_projector_symmetric(
                 all_eig_pairs.append((float(val), fq, i))
         all_eig_pairs.sort(key=lambda x: (-x[0], -x[2]))
 
+        # #615: under an active keep set, suppress backfill entirely so the
+        # retained bond shrinks to the keep-sector targets (matching env-init's
+        # tile-then-restrict distribution). Default-off path keeps full backfill.
         used = sum(len(v) for v in sector_keep.values())
         remaining = n_keep - used
-        if remaining > 0:
+        if remaining > 0 and _keep is None:
             reserved = {(fq, idx) for fq, idxs in sector_keep.items() for idx in idxs}
             for _, fq, idx in all_eig_pairs:
                 if remaining <= 0:
@@ -761,9 +764,12 @@ def _svd_projector_symmetric(
                 top_indices = list(np.argsort(sv_arr)[-n_take:][::-1])
                 sector_keep[fq] = top_indices
 
+        # #615: under an active keep set, suppress backfill entirely so the
+        # retained bond shrinks to the keep-sector targets (matching env-init's
+        # tile-then-restrict distribution). Default-off path keeps full backfill.
         used = sum(len(v) for v in sector_keep.values())
         remaining = n_keep - used
-        if remaining > 0:
+        if remaining > 0 and _keep is None:
             reserved = {(fq, idx) for fq, idxs in sector_keep.items() for idx in idxs}
             for _, fq, idx in all_sv_pairs:
                 if remaining <= 0:

--- a/src/tenax/algorithms/_ctm_projector.py
+++ b/src/tenax/algorithms/_ctm_projector.py
@@ -380,14 +380,15 @@ def _eigh_projector_symmetric(
 
     sector_keep: dict[int, list[int]] = {}
 
+    # Keep-restriction (#615): read once per call regardless of branch; a cheap
+    # no-op (returns None) when no keep set is active — byte-identical default.
+    _keep = current_keep_sectors()
+
     if base_charges is not None:
         # Per-sector allocation matching _derive_charges distribution.
         # This prevents cascading charge-sector loss across CTM sweeps
         # by ensuring every charge from A's bond is represented.
         from tenax.algorithms._ctm_utils import _derive_charges
-
-        # Keep-restriction (#615): read once; guarded — None => byte-identical.
-        _keep = current_keep_sectors()
 
         target_charges = _derive_charges(base_charges, n_keep)
         target_count: dict[int, int] = {}
@@ -443,6 +444,8 @@ def _eigh_projector_symmetric(
                     reserved.add((fq, idx))
                     remaining -= 1
     else:
+        # No base_charges (DenseTensor / trivial charges) → no sector
+        # structure to keep-restrict; _keep intentionally unused here.
         # Pure global truncation (no base_charges)
         for _, fq, idx in all_eig_pairs[:n_keep]:
             sector_keep.setdefault(fq, []).append(idx)
@@ -731,6 +734,10 @@ def _svd_projector_symmetric(
 
     sector_keep: dict[int, list[int]] = {}
 
+    # Keep-restriction (#615): read once per call regardless of branch; a cheap
+    # no-op (returns None) when no keep set is active — byte-identical default.
+    _keep = current_keep_sectors()
+
     if base_charges is not None:
         from tenax.algorithms._ctm_utils import _derive_charges
 
@@ -739,10 +746,9 @@ def _svd_projector_symmetric(
         for q in target_charges:
             target_count[int(q)] = target_count.get(int(q), 0) + 1
 
-        # #615 keep-restriction: drop non-keep sectors so this forward
+        # Keep-restriction (#615): drop non-keep sectors so this forward
         # projector cannot allocate (nor backfill) |Sz|>1 chi-bond sectors.
         # No-op when no keep set is active.
-        _keep = current_keep_sectors()
         if _keep is not None:
             target_count = {q: c for q, c in target_count.items() if q in _keep}
 
@@ -769,6 +775,8 @@ def _svd_projector_symmetric(
                     reserved.add((fq, idx))
                     remaining -= 1
     else:
+        # No base_charges (DenseTensor / trivial charges) → no sector
+        # structure to keep-restrict; _keep intentionally unused here.
         for _, fq, idx in all_sv_pairs[:n_keep]:
             sector_keep.setdefault(fq, []).append(idx)
 

--- a/src/tenax/algorithms/_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_ctm_tensor_convergence.py
@@ -49,6 +49,7 @@ from tenax.algorithms._ctm_tensor_paired_moves import (
     _ctm_tensor_move_horizontal,
     _ctm_tensor_move_vertical,
 )
+from tenax.algorithms._ctm_uniform_sector import keep_sectors_context
 from tenax.core import EPS
 from tenax.core.lattice import Lattice
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
@@ -577,6 +578,7 @@ def ctm_tensor(
     projector_method: str = "svd",
     qr_warmup_steps: int = 3,
     projector_backward: str = "auto",
+    keep_sectors: frozenset[int] | None = None,
 ) -> tuple[CTMTensorEnv, float]:
     """Run standard CTM to convergence using the Tensor protocol.
 
@@ -609,67 +611,70 @@ def ctm_tensor(
         is a v2 follow-up), or when the SVD runs inside a JAX tracer (AD
         backward pass).
     """
-    # Determine sweep function: use paired moves for SymmetricTensors
-    # with non-trivial virtual charges (fixes charge-sector mismatch
-    # from independent projectors in standard 4-move CTM).  When virtual
-    # charges are asymmetric (e.g. after simple update truncation),
-    # fall back to DenseTensor since the D^2 leg charges change per
-    # direction.
-    use_paired = False
-    if isinstance(A, SymmetricTensor):
-        import numpy as _np
+    with keep_sectors_context(keep_sectors):
+        # Determine sweep function: use paired moves for SymmetricTensors
+        # with non-trivial virtual charges (fixes charge-sector mismatch
+        # from independent projectors in standard 4-move CTM).  When virtual
+        # charges are asymmetric (e.g. after simple update truncation),
+        # fall back to DenseTensor since the D^2 leg charges change per
+        # direction.
+        use_paired = False
+        if isinstance(A, SymmetricTensor):
+            import numpy as _np
 
-        virtual_indices = [A.indices[i] for i in range(4)]
-        has_nontrivial = any(
-            not (_np.array_equal(vi.sectors, [0]) and vi.n_sectors == 1)
-            for vi in virtual_indices
-        )
-        idx0 = virtual_indices[0]
-        all_same = all(
-            _np.array_equal(idx0.sectors, virtual_indices[i].sectors)
-            and _np.array_equal(idx0.multiplicities, virtual_indices[i].multiplicities)
-            for i in range(1, 4)
-        )
-        if has_nontrivial and all_same:
-            use_paired = True
-        elif has_nontrivial and not all_same:
-            # Asymmetric virtual charges: densify for compatibility
-            A = DenseTensor(A.todense(), A.indices)
-
-    sweep_fn = _ctm_tensor_sweep_paired if use_paired else _ctm_tensor_sweep
-
-    a = _build_double_layer_tensor(A)
-    env = initialize_ctm_tensor_env(A, chi)
-
-    # QR warm-up: run a few eigh iterations before switching to QR
-    if projector_method == "qr" and qr_warmup_steps > 0:
-        warmup = min(qr_warmup_steps, max_iter)
-        for _ in range(warmup):
-            env, _ = sweep_fn(
-                env, a, chi, renormalize, "eigh", projector_backward=projector_backward
+            virtual_indices = [A.indices[i] for i in range(4)]
+            has_nontrivial = any(
+                not (_np.array_equal(vi.sectors, [0]) and vi.n_sectors == 1)
+                for vi in virtual_indices
             )
-        max_iter = max_iter - warmup
+            idx0 = virtual_indices[0]
+            all_same = all(
+                _np.array_equal(idx0.sectors, virtual_indices[i].sectors)
+                and _np.array_equal(
+                    idx0.multiplicities, virtual_indices[i].multiplicities
+                )
+                for i in range(1, 4)
+            )
+            if has_nontrivial and all_same:
+                use_paired = True
+            elif has_nontrivial and not all_same:
+                # Asymmetric virtual charges: densify for compatibility
+                A = DenseTensor(A.todense(), A.indices)
 
-    last_max_eps: float = 0.0
-    prev_sv = None
-    for _ in range(max_iter):
-        env, last_max_eps = sweep_fn(
-            env,
-            a,
-            chi,
-            renormalize,
-            projector_method,
-            projector_backward=projector_backward,
-        )
+        sweep_fn = _ctm_tensor_sweep_paired if use_paired else _ctm_tensor_sweep
 
-        current_sv = _corner_singular_values(env.C1)
-        if prev_sv is not None:
-            diff = _ctm_sv_diff(current_sv, prev_sv)
-            if float(diff) < conv_tol:
-                break
-        prev_sv = current_sv
+        a = _build_double_layer_tensor(A)
+        env = initialize_ctm_tensor_env(A, chi)
 
-    return env, last_max_eps
+        # QR warm-up: run a few eigh iterations before switching to QR
+        if projector_method == "qr" and qr_warmup_steps > 0:
+            warmup = min(qr_warmup_steps, max_iter)
+            for _ in range(warmup):
+                env, _ = sweep_fn(
+                    env, a, chi, renormalize, "eigh", projector_backward=projector_backward
+                )
+            max_iter = max_iter - warmup
+
+        last_max_eps: float = 0.0
+        prev_sv = None
+        for _ in range(max_iter):
+            env, last_max_eps = sweep_fn(
+                env,
+                a,
+                chi,
+                renormalize,
+                projector_method,
+                projector_backward=projector_backward,
+            )
+
+            current_sv = _corner_singular_values(env.C1)
+            if prev_sv is not None:
+                diff = _ctm_sv_diff(current_sv, prev_sv)
+                if float(diff) < conv_tol:
+                    break
+            prev_sv = current_sv
+
+        return env, last_max_eps
 
 
 def _ctm_tensor_multisite(

--- a/src/tenax/algorithms/_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_ctm_tensor_convergence.py
@@ -249,6 +249,13 @@ def _get_base_charges(a: Tensor):
     charges = _np.asarray(a.indices[u2_pos].charges, dtype=_np.int32)
     if _np.all(charges == 0):
         return None
+    # #615: deliberately NOT keep-filtered (unlike the forward paired path's
+    # _ctm_tensor_paired_moves._get_base_charges). The 2x2 multisite/backward
+    # path must tile the FULL D² charge pattern and let the truncation drop
+    # non-keep sectors (tile-then-restrict), so freshly-truncated chi bonds
+    # match env-init's per-sector dims and the mixed-generation enlarged-corner
+    # contractions pair equal sizes. Re-adding a keep-filter here reintroduces
+    # the #610 cold-backward ValueError (only fails under the keep flag).
     return charges
 
 

--- a/src/tenax/algorithms/_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_ctm_tensor_convergence.py
@@ -50,9 +50,7 @@ from tenax.algorithms._ctm_tensor_paired_moves import (
     _ctm_tensor_move_vertical,
 )
 from tenax.algorithms._ctm_uniform_sector import (
-    current_keep_sectors,
     keep_sectors_context,
-    restrict_charges_to_keep,
 )
 from tenax.core import EPS
 from tenax.core.lattice import Lattice
@@ -251,9 +249,6 @@ def _get_base_charges(a: Tensor):
     charges = _np.asarray(a.indices[u2_pos].charges, dtype=_np.int32)
     if _np.all(charges == 0):
         return None
-    keep = current_keep_sectors()
-    if keep is not None:
-        charges = restrict_charges_to_keep(charges, keep)
     return charges
 
 

--- a/src/tenax/algorithms/_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_ctm_tensor_convergence.py
@@ -49,7 +49,11 @@ from tenax.algorithms._ctm_tensor_paired_moves import (
     _ctm_tensor_move_horizontal,
     _ctm_tensor_move_vertical,
 )
-from tenax.algorithms._ctm_uniform_sector import keep_sectors_context
+from tenax.algorithms._ctm_uniform_sector import (
+    current_keep_sectors,
+    keep_sectors_context,
+    restrict_charges_to_keep,
+)
 from tenax.core import EPS
 from tenax.core.lattice import Lattice
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
@@ -247,6 +251,9 @@ def _get_base_charges(a: Tensor):
     charges = _np.asarray(a.indices[u2_pos].charges, dtype=_np.int32)
     if _np.all(charges == 0):
         return None
+    keep = current_keep_sectors()
+    if keep is not None:
+        charges = restrict_charges_to_keep(charges, keep)
     return charges
 
 

--- a/src/tenax/algorithms/_ctm_tensor_init.py
+++ b/src/tenax/algorithms/_ctm_tensor_init.py
@@ -399,7 +399,8 @@ def _init_symmetric_standard_corner(
     # Keep-sector restriction: drop charges outside the active keep set so the
     # seeded chi bond carries only the allowed sectors (tactic A, #615).
     # When no keep set is active this is a no-op and chi_len == chi.
-    chi_charges = restrict_charges_to_keep(chi_charges, current_keep_sectors())
+    keep = current_keep_sectors()
+    chi_charges = restrict_charges_to_keep(chi_charges, keep)
     chi_len = len(chi_charges)
     # Canonicalize chi-bond order to match the block-sparse SVD's grouped
     # bond order (#602).  Both corner legs share the same chi charges, so the

--- a/src/tenax/algorithms/_ctm_tensor_init.py
+++ b/src/tenax/algorithms/_ctm_tensor_init.py
@@ -22,6 +22,10 @@ from typing import NamedTuple
 import jax.numpy as jnp
 import numpy as np
 
+from tenax.algorithms._ctm_uniform_sector import (
+    current_keep_sectors,
+    restrict_charges_to_keep,
+)
 from tenax.algorithms._ctm_utils import (
     _CORNER_SPECS,
 )
@@ -328,6 +332,14 @@ def _init_symmetric_standard_edge(
     idx_bra = idx_ket.flip_flow()  # bar() flips flow
     D2_charges = _compute_fused_charges(idx_ket, idx_bra, flow_D2, sym)
 
+    # Keep-sector restriction: drop charges outside the active keep set so the
+    # seeded chi bonds carry only the allowed sectors (tactic A, #615).
+    # When no keep set is active this is a no-op and chi1_len/chi2_len == chi.
+    keep = current_keep_sectors()
+    chi1_charges = restrict_charges_to_keep(chi1_charges, keep)
+    chi2_charges = restrict_charges_to_keep(chi2_charges, keep)
+    chi1_len = len(chi1_charges)
+    chi2_len = len(chi2_charges)
     # Canonicalize chi-bond order to match the block-sparse SVD's grouped
     # bond order (#602); the D² leg is left as-is (it is matched against the
     # double-layer tensor's identically-fused D² leg, not the SVD bond).
@@ -346,7 +358,7 @@ def _init_symmetric_standard_edge(
     # previous diag-pattern across i ∈ 0..min(chi,D)-1 traps CTM at a
     # degenerate fixed point on generic complex iPEPS).
     diag_idx = np.arange(D, dtype=np.int32) * (D + 1)
-    T = jnp.zeros((chi, D2, chi), dtype=A.dtype)
+    T = jnp.zeros((chi1_len, D2, chi2_len), dtype=A.dtype)
     T = T.at[0, diag_idx, 0].set(jnp.ones(D, dtype=A.dtype))
     # Faithful reorder of the chi axes into the grouped order chosen above.
     T = T[perm1][:, :, perm2]
@@ -384,6 +396,11 @@ def _init_symmetric_standard_corner(
         reps = chi // len(base_D2_charges) + 1
         chi_charges = np.asarray(np.tile(base_D2_charges, reps)[:chi], dtype=np.int32)
 
+    # Keep-sector restriction: drop charges outside the active keep set so the
+    # seeded chi bond carries only the allowed sectors (tactic A, #615).
+    # When no keep set is active this is a no-op and chi_len == chi.
+    chi_charges = restrict_charges_to_keep(chi_charges, current_keep_sectors())
+    chi_len = len(chi_charges)
     # Canonicalize chi-bond order to match the block-sparse SVD's grouped
     # bond order (#602).  Both corner legs share the same chi charges, so the
     # same permutation applies to both axes.
@@ -394,7 +411,7 @@ def _init_symmetric_standard_corner(
     idx_b = TensorIndex.from_charges(sym, chi_charges.copy(), flow_b, label=label_b)
     # variPEPS chi_init=1: rank-1 corner — only the leading (0, 0) entry
     # is non-zero. Subsequent absorptions grow chi via SVD truncation.
-    C_dense = jnp.zeros((chi, chi), dtype=A.dtype).at[0, 0].set(1.0)
+    C_dense = jnp.zeros((chi_len, chi_len), dtype=A.dtype).at[0, 0].set(1.0)
     # Faithful reorder of both chi axes into the grouped order chosen above.
     C_dense = C_dense[perm][:, perm]
     return SymmetricTensor.from_dense(

--- a/src/tenax/algorithms/_ctm_tensor_paired_moves.py
+++ b/src/tenax/algorithms/_ctm_tensor_paired_moves.py
@@ -45,6 +45,15 @@ def _get_base_charges(a: Tensor) -> np.ndarray | None:
     For SymmetricTensor with non-trivial charges, returns the charges
     of one of the D^2 legs.  For DenseTensor, returns None (no charge
     stabilization needed).
+
+    #615: the FORWARD paired-moves sweep is applied one direction at a time, so
+    a freshly-truncated chi leg is contracted against still-init legs on the
+    same tensor.  Keep-filtering the base charges here (restrict-then-tile) is
+    what keeps the paired path self-consistent under ``keep_sectors``.  The
+    2x2 multisite sweep (``_ctm_tensor_convergence._get_base_charges``)
+    deliberately does NOT filter — it tiles the FULL pattern then lets the
+    truncation drop non-keep (tile-then-restrict), which matches env-init for
+    the mixed-generation contractions in the cold backward VJP (the #615 gate).
     """
     if not isinstance(a, SymmetricTensor):
         return None

--- a/src/tenax/algorithms/_ctm_tensor_paired_moves.py
+++ b/src/tenax/algorithms/_ctm_tensor_paired_moves.py
@@ -31,6 +31,10 @@ from tenax.algorithms._ctm_tensor_moves import (
     _flip_leg_flow,
     _normalize_tensor,
 )
+from tenax.algorithms._ctm_uniform_sector import (
+    current_keep_sectors,
+    restrict_charges_to_keep,
+)
 from tenax.contraction.contractor import contract
 from tenax.core.tensor import SymmetricTensor, Tensor
 
@@ -50,6 +54,9 @@ def _get_base_charges(a: Tensor) -> np.ndarray | None:
     # Only stabilize if charges are non-trivial
     if np.all(charges == 0):
         return None
+    keep = current_keep_sectors()
+    if keep is not None:
+        charges = restrict_charges_to_keep(charges, keep)
     return charges
 
 

--- a/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
+++ b/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
@@ -749,8 +749,11 @@ def _retruncate_by_base_charges(
         keep_global.extend(slots[:take])
 
     # Fill any remaining budget greedily from any unused entry (global SV order).
+    # #615: under an active keep set, suppress backfill entirely so the retained
+    # bond shrinks to the keep-sector targets (matching env-init's
+    # tile-then-restrict distribution). Default-off path keeps full backfill.
     remaining = chi - len(keep_global)
-    if remaining > 0:
+    if remaining > 0 and _keep is None:
         used_set = set(keep_global)
         for j in range(len(bond_charges_full)):
             if remaining <= 0:

--- a/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
+++ b/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
@@ -753,7 +753,7 @@ def _retruncate_by_base_charges(
     # bond shrinks to the keep-sector targets (matching env-init's
     # tile-then-restrict distribution). Default-off path keeps full backfill.
     remaining = chi - len(keep_global)
-    if remaining > 0 and _keep is None:
+    if remaining > 0 and _keep is None:  # under keep: no backfill — chi_new shrinks to the keep-target sum (matches env-init)
         used_set = set(keep_global)
         for j in range(len(bond_charges_full)):
             if remaining <= 0:

--- a/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
+++ b/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
@@ -15,6 +15,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from tenax.algorithms._ctm_uniform_sector import current_keep_sectors
 from tenax.contraction.contractor import contract
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.symmetry import U1Symmetry
@@ -725,11 +726,16 @@ def _retruncate_by_base_charges(
     """
     from tenax.algorithms._ctm_utils import _derive_charges
 
+    # Keep-restriction (#615): read once; guarded — None => byte-identical.
+    _keep = current_keep_sectors()
+
     bond_charges_full = np.asarray(U_T.indices[-1].charges, dtype=np.int32)
     target_charges = _derive_charges(base_charges, chi)
     target_count: dict[int, int] = {}
     for q in target_charges:
         target_count[int(q)] = target_count.get(int(q), 0) + 1
+    if _keep is not None:
+        target_count = {q: c for q, c in target_count.items() if q in _keep}
 
     in_sector_idx_of: dict[int, list[int]] = {}
     for j, q in enumerate(bond_charges_full):
@@ -749,6 +755,8 @@ def _retruncate_by_base_charges(
         for j in range(len(bond_charges_full)):
             if remaining <= 0:
                 break
+            if _keep is not None and int(bond_charges_full[j]) not in _keep:
+                continue
             if j not in used_set:
                 keep_global.append(j)
                 used_set.add(j)

--- a/src/tenax/algorithms/_ctm_uniform_sector.py
+++ b/src/tenax/algorithms/_ctm_uniform_sector.py
@@ -13,6 +13,7 @@ toggles (``set_implicit_ad_norm_diagnostics``, ``_batch_blocksparse_enabled``).
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Iterable
 
 import numpy as np
 
@@ -25,7 +26,7 @@ def current_keep_sectors() -> frozenset[int] | None:
 
 
 @contextlib.contextmanager
-def keep_sectors_context(keep):
+def keep_sectors_context(keep: frozenset[int] | Iterable[int] | None):
     """Activate a keep set for the duration of the ``with`` block.
 
     ``keep=None`` is a no-op pass-through (restores the default path), so callers
@@ -40,7 +41,7 @@ def keep_sectors_context(keep):
         _KEEP_SECTORS = prev
 
 
-def restrict_charges_to_keep(charges, keep) -> np.ndarray:
+def restrict_charges_to_keep(charges, keep: frozenset[int] | None) -> np.ndarray:
     """Return ``charges`` with entries outside ``keep`` removed.
 
     Degenerate guard: if filtering would empty the array, return the original

--- a/src/tenax/algorithms/_ctm_uniform_sector.py
+++ b/src/tenax/algorithms/_ctm_uniform_sector.py
@@ -1,0 +1,53 @@
+"""Process-local "keep sectors" context for the U(1)-Sz uniform-sector env (#615).
+
+Default OFF. When a keep set is active, the symmetric CTM env-init and the
+projector truncation restrict chi-bond charges to the keep set, so the 2x2
+multisite backward carries a *uniform* sector set and becomes traceable under
+the sector drop (#610 NO-GO-by-obstruction).
+
+The keep set is a STATIC, structural choice (it changes block sectors/shapes),
+so it is read at TRACE time as a plain Python value via ``current_keep_sectors``
+— never threaded as a traced array. Mirrors the codebase's existing module-level
+toggles (``set_implicit_ad_norm_diagnostics``, ``_batch_blocksparse_enabled``).
+"""
+from __future__ import annotations
+
+import contextlib
+
+import numpy as np
+
+_KEEP_SECTORS: frozenset[int] | None = None
+
+
+def current_keep_sectors() -> frozenset[int] | None:
+    """The active keep set, or ``None`` (default: no restriction)."""
+    return _KEEP_SECTORS
+
+
+@contextlib.contextmanager
+def keep_sectors_context(keep):
+    """Activate a keep set for the duration of the ``with`` block.
+
+    ``keep=None`` is a no-op pass-through (restores the default path), so callers
+    can wrap unconditionally: ``with keep_sectors_context(keep_sectors): ...``.
+    """
+    global _KEEP_SECTORS
+    prev = _KEEP_SECTORS
+    _KEEP_SECTORS = None if keep is None else frozenset(int(q) for q in keep)
+    try:
+        yield
+    finally:
+        _KEEP_SECTORS = prev
+
+
+def restrict_charges_to_keep(charges, keep) -> np.ndarray:
+    """Return ``charges`` with entries outside ``keep`` removed.
+
+    Degenerate guard: if filtering would empty the array, return the original
+    (an env bond / SVD sector list must never be empty).
+    """
+    arr = np.asarray(charges, dtype=np.int32)
+    if keep is None:
+        return arr
+    mask = np.array([int(q) in keep for q in arr], dtype=bool)
+    return arr[mask] if mask.any() else arr

--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -742,8 +742,12 @@ def _truncated_svd_symmetric_traced(
         # eager path under AD (codex P2 review on PR #440 / comment 3223755136).
         # Order: largest unused capacity first, ties broken by smallest q for
         # determinism.
+        # #615: under an active keep set, suppress backfill entirely so
+        # ``chi_new`` shrinks to the sum of keep-sector targets (matching
+        # env-init's tile-then-restrict distribution). Default-off path
+        # (_keep is None) keeps the full backfill, byte-identical to before.
         remaining = max_singular_values - sum(k_per_sector.values())
-        if remaining > 0:
+        if remaining > 0 and _keep is None:
             for q in sorted(
                 sector_results.keys(),
                 key=lambda qq: (

--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -747,7 +747,7 @@ def _truncated_svd_symmetric_traced(
         # env-init's tile-then-restrict distribution). Default-off path
         # (_keep is None) keeps the full backfill, byte-identical to before.
         remaining = max_singular_values - sum(k_per_sector.values())
-        if remaining > 0 and _keep is None:
+        if remaining > 0 and _keep is None:  # under keep: no backfill — chi_new shrinks to the keep-target sum (matches env-init)
             for q in sorted(
                 sector_results.keys(),
                 key=lambda qq: (

--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -20,6 +20,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from tenax.algorithms._ctm_uniform_sector import current_keep_sectors
 from tenax.core.index import FlowDirection, Label, TensorIndex
 from tenax.core.tensor import (
     BlockKey,
@@ -719,8 +720,18 @@ def _truncated_svd_symmetric_traced(
         target_count: dict[int, int] = {}
         for tq in target_charges:
             target_count[int(tq)] = target_count.get(int(tq), 0) + 1
+        # Keep-restriction (#615): when a keep set is active, force k=0 for
+        # any sector outside keep and never backfill leftover budget into a
+        # non-keep sector, so the truncated chi bond is keep-only. Guarded by
+        # ``_keep is not None`` — byte-identical to the prior path when off.
+        _keep = current_keep_sectors()
         k_per_sector = {
-            q: min(target_count.get(q, 0), r[5]) for q, r in sector_results.items()
+            q: (
+                0
+                if (_keep is not None and int(q) not in _keep)
+                else min(target_count.get(q, 0), r[5])
+            )
+            for q, r in sector_results.items()
         }
         # Greedy fill: if base_charges over-allocates a sector (target_count[q]
         # > available_q), distribute the unused budget to sectors with
@@ -740,6 +751,8 @@ def _truncated_svd_symmetric_traced(
             ):
                 if remaining <= 0:
                     break
+                if _keep is not None and int(q) not in _keep:
+                    continue
                 capacity_left = sector_results[q][5] - k_per_sector.get(q, 0)
                 take = min(remaining, capacity_left)
                 if take > 0:

--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -713,6 +713,8 @@ def _truncated_svd_symmetric_traced(
         )
 
     # --- Static per-sector keep allocation ---
+    # Full spectrum per sector (no chi budget) → keep restriction is not
+    # meaningful in no-truncation mode and is intentionally not applied here.
     if max_singular_values is None:
         k_per_sector: dict[int, int] = {q: r[5] for q, r in sector_results.items()}
     elif base_charges is not None:

--- a/tests/test_u1sz_uniform_sector_615.py
+++ b/tests/test_u1sz_uniform_sector_615.py
@@ -24,12 +24,10 @@ def _env_block_signature(env):
 
 
 def _chi_sectors(t):
-    """Set of charges appearing on chi-bond legs of tensor ``t``.
+    """Charges on the chi-bond legs of ``t``.
 
-    Corners: all legs are chi-bond legs (labels like c1_d, c1_r).
-    Edges: chi legs are the first and last; the D² middle leg has a label
-    ending in '2' (u2, r2, d2, l2).  We identify chi legs as those whose
-    label does NOT end with '2'.
+    D² legs are labelled with a trailing '2' (u2/d2/l2/r2); every other leg
+    is a chi bond. So a chi leg is any leg whose label does not end in '2'.
     """
     out = set()
     for ix in t.indices:

--- a/tests/test_u1sz_uniform_sector_615.py
+++ b/tests/test_u1sz_uniform_sector_615.py
@@ -5,6 +5,7 @@ import pytest
 
 jax.config.update("jax_enable_x64", True)
 
+from examples.probe_backward_jaxpr_566 import backward_vjp_jaxpr
 from tenax.algorithms._ctm_tensor import ctm_tensor
 from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env
 from tenax.algorithms._ctm_uniform_sector import keep_sectors_context
@@ -67,3 +68,16 @@ def test_forward_env_block_counts_drop_under_keep():
         assert n1[name] < n0[name], f"{name}: {n1[name]} !< {n0[name]}"
     for name in env1._fields:
         assert _chi_sectors(getattr(env1, name)) <= {-1, 0, 1}
+
+
+def test_cold_backward_vjp_builds_under_keep():
+    """#615 make-or-break: the 2x2 multisite backward VJP — which raised
+    ValueError('Size of label d ...') in the #610 spike — now traces cold under
+    the sector drop. This is the structural gate the whole issue exists to clear.
+    """
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    jax.clear_caches()  # COLD: do not reuse a flag-off jaxpr (cold-trace caveat)
+    with keep_sectors_context({-1, 0, 1}):
+        jaxpr = backward_vjp_jaxpr(A, chi=12)
+    assert jaxpr is not None
+    assert len(jaxpr.eqns) > 0

--- a/tests/test_u1sz_uniform_sector_615.py
+++ b/tests/test_u1sz_uniform_sector_615.py
@@ -1,0 +1,29 @@
+"""#615 uniform-sector env: flag-gated Gate-B measurement scaffold."""
+import jax
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_tensor import ctm_tensor
+from tenax.algorithms.ipeps import heisenberg_u1sz_init_pair
+
+
+def _env_block_signature(env):
+    """A structural fingerprint: per-tensor sorted (block-key, shape) list."""
+    sig = {}
+    for name in env._fields:
+        t = getattr(env, name)
+        sig[name] = sorted(
+            (tuple(int(q) for q in k), tuple(int(s) for s in b.shape))
+            for k, b in t.blocks.items()
+        )
+    return sig
+
+
+def test_keep_sectors_none_is_identity():
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    env_a, e_a = ctm_tensor(A, chi=12, max_iter=4, conv_tol=1e-4)
+    env_b, e_b = ctm_tensor(A, chi=12, max_iter=4, conv_tol=1e-4, keep_sectors=None)
+    assert _env_block_signature(env_a) == _env_block_signature(env_b)
+    assert float(e_a) == float(e_b)

--- a/tests/test_u1sz_uniform_sector_615.py
+++ b/tests/test_u1sz_uniform_sector_615.py
@@ -55,3 +55,15 @@ def test_env_init_seeds_only_keep_sectors():
         env = initialize_ctm_tensor_env(A, chi=12)
     for n in env._fields:
         assert _chi_sectors(getattr(env, n)) <= {-1, 0, 1}, f"{n} kept |Sz|=2"
+
+
+def test_forward_env_block_counts_drop_under_keep():
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    env0, _ = ctm_tensor(A, chi=12, max_iter=8, conv_tol=1e-6)
+    n0 = {n: len(getattr(env0, n).blocks) for n in env0._fields}
+    env1, _ = ctm_tensor(A, chi=12, max_iter=8, conv_tol=1e-6, keep_sectors={-1, 0, 1})
+    n1 = {n: len(getattr(env1, n).blocks) for n in env1._fields}
+    for name in n0:
+        assert n1[name] < n0[name], f"{name}: {n1[name]} !< {n0[name]}"
+    for name in env1._fields:
+        assert _chi_sectors(getattr(env1, name)) <= {-1, 0, 1}

--- a/tests/test_u1sz_uniform_sector_615.py
+++ b/tests/test_u1sz_uniform_sector_615.py
@@ -6,10 +6,11 @@ import pytest
 jax.config.update("jax_enable_x64", True)
 
 from examples.probe_backward_jaxpr_566 import backward_vjp_jaxpr
+from tenax import compute_energy_ctm_tensor
 from tenax.algorithms._ctm_tensor import ctm_tensor
 from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env
 from tenax.algorithms._ctm_uniform_sector import keep_sectors_context
-from tenax.algorithms.ipeps import heisenberg_u1sz_init_pair
+from tenax.algorithms.ipeps import heisenberg_gate_u1sz, heisenberg_u1sz_init_pair
 
 
 def _env_block_signature(env):
@@ -81,3 +82,16 @@ def test_cold_backward_vjp_builds_under_keep():
         jaxpr = backward_vjp_jaxpr(A, chi=12)
     assert jaxpr is not None
     assert len(jaxpr.eqns) > 0
+
+
+def test_keep_env_is_faithful_at_d3_chi12():
+    """#615 faithfulness guard: the keep-active CTM env must be VALID before the
+    Gate-B op-count measurement is trustworthy — it must converge, be finite, and
+    give a sane (random-init, not ground-state) Heisenberg energy."""
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    env, _ = ctm_tensor(A, chi=12, max_iter=20, conv_tol=1e-7, keep_sectors={-1, 0, 1})
+    for name in env._fields:
+        assert np.all(np.isfinite(np.asarray(getattr(env, name)._data))), f"{name} non-finite"
+    e = float(compute_energy_ctm_tensor(A, env, heisenberg_gate_u1sz()))
+    assert np.isfinite(e), f"energy {e} non-finite"
+    assert -2.0 < e < 0.0, f"energy {e} outside sane Heisenberg window (-2, 0)"

--- a/tests/test_u1sz_uniform_sector_615.py
+++ b/tests/test_u1sz_uniform_sector_615.py
@@ -6,6 +6,8 @@ import pytest
 jax.config.update("jax_enable_x64", True)
 
 from tenax.algorithms._ctm_tensor import ctm_tensor
+from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env
+from tenax.algorithms._ctm_uniform_sector import keep_sectors_context
 from tenax.algorithms.ipeps import heisenberg_u1sz_init_pair
 
 
@@ -21,9 +23,37 @@ def _env_block_signature(env):
     return sig
 
 
+def _chi_sectors(t):
+    """Set of charges appearing on chi-bond legs of tensor ``t``.
+
+    Corners: all legs are chi-bond legs (labels like c1_d, c1_r).
+    Edges: chi legs are the first and last; the D² middle leg has a label
+    ending in '2' (u2, r2, d2, l2).  We identify chi legs as those whose
+    label does NOT end with '2'.
+    """
+    out = set()
+    for ix in t.indices:
+        if not ix.label.lower().endswith("2"):
+            out |= {int(q) for q in ix.charges}
+    return out
+
+
 def test_keep_sectors_none_is_identity():
     A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
     env_a, e_a = ctm_tensor(A, chi=12, max_iter=4, conv_tol=1e-4)
     env_b, e_b = ctm_tensor(A, chi=12, max_iter=4, conv_tol=1e-4, keep_sectors=None)
     assert _env_block_signature(env_a) == _env_block_signature(env_b)
     assert float(e_a) == float(e_b)
+
+
+def test_env_init_seeds_only_keep_sectors():
+    A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
+    # Baseline: chi legs carry the full {-2..+2}.
+    env0 = initialize_ctm_tensor_env(A, chi=12)
+    base = set().union(*(_chi_sectors(getattr(env0, n)) for n in env0._fields))
+    assert 2 in base or -2 in base, "baseline should carry |Sz|=2 chi sectors"
+    # Under keep={-1,0,1}, no chi leg may carry |Sz|=2.
+    with keep_sectors_context({-1, 0, 1}):
+        env = initialize_ctm_tensor_env(A, chi=12)
+    for n in env._fields:
+        assert _chi_sectors(getattr(env, n)) <= {-1, 0, 1}, f"{n} kept |Sz|=2"

--- a/timing_d3chi12_615.txt
+++ b/timing_d3chi12_615.txt
@@ -1,0 +1,36 @@
+######## DENSE ########
+
+Reading the table (the Phase-0 gate):
+  * implicit vg_cmp ~FLAT across depth  -> compile wall is NOT unroll;
+    scan-fusion buys runtime (eager dispatch), not compile, for the default path.
+  * explicit vg_cmp grows with depth     -> unroll wall (a), explicit-only.
+  * fermionic vg_cmp >> dense at same D/chi -> per-block emission (b) = #566 core.
+  * vg_cmp grows steeply with chi        -> large-chi SVD/eigh VJP (c) -> pivot #570.
+  * bwd_cmp (= vg_cmp - fwd_cmp) large   -> implicit-diff backward (d) dominates.
+######## U1SZ FRAGMENTED (keep off) ########
+      sym  D  chi  dep      path  blk  fwd_cmp   vg_cmp  bwd_cmp   vg_wall  warm_ms            top(name:s)
+----------------------------------------------------------------------------------------------------------
+     u1sz  3   12    8  implicit   32   83.06s 1265.54s 1182.48s  1576.70s 18643.1 jit(_jit_fused_f:523.5
+----------------------------------------------------------------------------------------------------------
+
+Reading the table (the Phase-0 gate):
+  * implicit vg_cmp ~FLAT across depth  -> compile wall is NOT unroll;
+    scan-fusion buys runtime (eager dispatch), not compile, for the default path.
+  * explicit vg_cmp grows with depth     -> unroll wall (a), explicit-only.
+  * fermionic vg_cmp >> dense at same D/chi -> per-block emission (b) = #566 core.
+  * vg_cmp grows steeply with chi        -> large-chi SVD/eigh VJP (c) -> pivot #570.
+  * bwd_cmp (= vg_cmp - fwd_cmp) large   -> implicit-diff backward (d) dominates.
+######## U1SZ KEEP {-1,0,1} (--defrag) ########
+      sym  D  chi  dep      path  blk  fwd_cmp   vg_cmp  bwd_cmp   vg_wall  warm_ms            top(name:s)
+----------------------------------------------------------------------------------------------------------
+     u1sz  3   12    8  implicit  !! ValueError: unexpected JAX type (e.g. shape/dtype) for argument to VJP function: got float64[36], but expected float64[34] because the corresponding output of the differentiated function had JAX type float64[34]
+----------------------------------------------------------------------------------------------------------
+
+Reading the table (the Phase-0 gate):
+  * implicit vg_cmp ~FLAT across depth  -> compile wall is NOT unroll;
+    scan-fusion buys runtime (eager dispatch), not compile, for the default path.
+  * explicit vg_cmp grows with depth     -> unroll wall (a), explicit-only.
+  * fermionic vg_cmp >> dense at same D/chi -> per-block emission (b) = #566 core.
+  * vg_cmp grows steeply with chi        -> large-chi SVD/eigh VJP (c) -> pivot #570.
+  * bwd_cmp (= vg_cmp - fwd_cmp) large   -> implicit-diff backward (d) dominates.
+######## DONE ########


### PR DESCRIPTION
**DRAFT / record only — do NOT merge.** The opt-in, default-off `keep_sectors` flag in this branch is a measure-to-decide spike artifact; per the NO-GO finding it stays branch-local and must not land on `main`.

## Verdict: NO-GO (measured)

Builds the structural uniform-sector CTM env that **solves #610's single-sweep cold-backward obstruction** (the cold 2×2-multisite backward VJP now traces — locked as a regression test). But the measurement kills funding the full feature:

- **Gate B charge-mask reduction = 21.63%** (7398→5798), below the 25% bar and **flat in χ** (χ=12 ≡ χ=16). Total backward ops −28.21%.
- **#609 premise refuted**: uniform ~0.72× shrink across all op buckets, not a charge-mask-concentrated collapse.
- **A100 warm-step (D=3 χ=12): u1sz ~24× slower than dense** (18,643 ms vs 776 ms) — the wall is **#566 eager per-block dispatch**, not the backward op count. The keep flag's full implicit-AD `value_and_grad` doesn't even run (`float64[36]≠[34]`; env shape not fixed-point-invariant under keep).

**Takeaway:** env de-fragmentation is not the lever for D≥3 U(1)-Sz; #566 eager dispatch is the binding wall. Dense stays pragmatic.

Default-off is byte-identical (flag-off backward 63612/7398 unchanged; core suite 977 passed). Findings: `docs/superpowers/handoffs/2026-06-18-u1sz-uniform-sector-env-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)