### PR TITLE
fix(auto_mpo): charge-aware MPO compression for symmetric=True (#620)

### DIFF
--- a/src/tenax/algorithms/auto_mpo.py
+++ b/src/tenax/algorithms/auto_mpo.py
@@ -263,6 +263,79 @@ def _compress_mpo_bond(
     return w_left_new, w_right_new
 
 
+def _compress_mpo_bond_symmetric(
+    w_left: np.ndarray,
+    w_right: np.ndarray,
+    mid_charges: np.ndarray,
+    tol: float = 1e-12,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Charge-preserving SVD compression of one symmetric MPO bond.
+
+    Like :func:`_compress_mpo_bond`, but block-diagonal in the U(1) charge of
+    the shared (mid) bond: that bond is grouped by charge and each sector is
+    compressed independently.  A plain dense SVD would mix bond states of
+    different charge -- the retained singular vectors would carry no definite
+    charge, so the compressed bond could not be a valid symmetric leg, and the
+    bond-charge array would no longer match the W-matrix shape (issue #620).
+    Doing it per sector keeps every retained bond state at a definite charge and
+    returns the updated ``new_mid_charges`` consistent with the compressed shape.
+
+    Because the charge-conserving W-matrix, reshaped to ``(D_l*d*d, D_mid)``, is
+    block-diagonal w.r.t. (row charge, mid charge), the per-sector SVD is exact
+    -- it equals the dense SVD restricted to each block.
+
+    Args:
+        w_left:      Shape ``(D_l, d, d, D_mid)``.
+        w_right:     Shape ``(D_mid, d, d, D_r)``.
+        mid_charges: Length-``D_mid`` int charge array for the shared bond.
+        tol:         Relative truncation threshold (against the global largest
+                     singular value, matching :func:`_compress_mpo_bond`).
+
+    Returns:
+        ``(w_left_new, w_right_new, new_mid_charges)`` with the compressed bond.
+    """
+    D_l, d, _, _ = w_left.shape
+    flat = w_left.reshape(D_l * d * d, -1)
+
+    # Per-sector SVD (block-diagonal in the mid-bond charge).
+    sectors: list[tuple[int, np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = []
+    s_max = 0.0
+    for q in np.unique(mid_charges):
+        cols = np.nonzero(mid_charges == q)[0]
+        U_q, s_q, Vt_q = np.linalg.svd(flat[:, cols], full_matrices=False)
+        sectors.append((int(q), cols, U_q, s_q, Vt_q))
+        if s_q.size and s_q[0] > s_max:
+            s_max = float(s_q[0])
+
+    threshold = tol * s_max if s_max > 0.0 else tol
+
+    left_blocks: list[np.ndarray] = []
+    right_blocks: list[np.ndarray] = []
+    charge_blocks: list[np.ndarray] = []
+    for q, cols, U_q, s_q, Vt_q in sectors:
+        rank = int(np.sum(s_q > threshold))
+        if rank == 0:
+            continue
+        left_blocks.append(U_q[:, :rank] * s_q[:rank])
+        right_blocks.append(np.einsum("rm,mabn->rabn", Vt_q[:rank, :], w_right[cols]))
+        charge_blocks.append(np.full(rank, q, dtype=mid_charges.dtype))
+
+    if not left_blocks:
+        # Degenerate (all singular values below threshold): keep the single
+        # largest vector so the bond stays non-empty.
+        q, cols, U_q, s_q, Vt_q = max(
+            sectors, key=lambda t: float(t[3][0]) if t[3].size else -1.0
+        )
+        left_blocks.append(U_q[:, :1] * s_q[:1])
+        right_blocks.append(np.einsum("rm,mabn->rabn", Vt_q[:1, :], w_right[cols]))
+        charge_blocks.append(np.full(1, q, dtype=mid_charges.dtype))
+
+    w_left_new = np.concatenate(left_blocks, axis=1).reshape(D_l, d, d, -1)
+    w_right_new = np.concatenate(right_blocks, axis=0)
+    new_mid_charges = np.concatenate(charge_blocks)
+    return w_left_new, w_right_new, new_mid_charges
+
+
 def _compute_operator_charge(op: np.ndarray, phys_charges: np.ndarray) -> int:
     """Determine the U(1) charge transfer of a single-site operator.
 
@@ -683,12 +756,6 @@ class AutoMPO:
         bond_states = _assign_bond_states(self._terms, self.L)
         w_mats = _build_w_matrices(self._terms, bond_states, self.L, self.d, identity)
 
-        if compress and self.L > 1:
-            for j in range(self.L - 1):
-                w_mats[j], w_mats[j + 1] = _compress_mpo_bond(
-                    w_mats[j], w_mats[j + 1], tol=compress_tol
-                )
-
         if symmetric:
             if phys_charges is None:
                 if self.d == 2:
@@ -705,6 +772,19 @@ class AutoMPO:
             bond_charges = _compute_bond_charges(
                 self._terms, bond_states, self.L, phys_charges
             )
+            if compress and self.L > 1:
+                # Charge-aware compression: a plain dense SVD would mix charge
+                # sectors and leave bond_charges out of sync with the compressed
+                # W-matrix shape (issue #620).  Compress each charge sector
+                # separately so bond_charges stays consistent by construction.
+                for j in range(self.L - 1):
+                    (
+                        w_mats[j],
+                        w_mats[j + 1],
+                        bond_charges[j],
+                    ) = _compress_mpo_bond_symmetric(
+                        w_mats[j], w_mats[j + 1], bond_charges[j], tol=compress_tol
+                    )
             return _w_matrices_to_symmetric_mpo(
                 w_mats,
                 self.d,
@@ -712,6 +792,12 @@ class AutoMPO:
                 bond_charges,
                 dtype=dtype,
             )
+
+        if compress and self.L > 1:
+            for j in range(self.L - 1):
+                w_mats[j], w_mats[j + 1] = _compress_mpo_bond(
+                    w_mats[j], w_mats[j + 1], tol=compress_tol
+                )
 
         return _w_matrices_to_mpo(w_mats, self.d, dtype=dtype)
 

--- a/tests/test_auto_mpo.py
+++ b/tests/test_auto_mpo.py
@@ -79,6 +79,23 @@ def _build_heisenberg_matrix(L: int, Jz: float = 1.0, Jxy: float = 1.0) -> np.nd
     return H
 
 
+def _mpo_operator_matrix(mpo: TensorNetwork, L: int) -> np.ndarray:
+    """Contract an MPO into its full ``(2**L, 2**L)`` operator.
+
+    Site tensors are ``(left, top, bot, right)`` with dim-1 boundary bonds;
+    rows are the ``top`` (output) indices, columns the ``bot`` (input) indices.
+    Works on dense or symmetric MPOs (``todense`` per site).
+    """
+    op = None
+    for i in range(L):
+        T = np.asarray(mpo.get_tensor(i).todense())  # (Dl, d, d, Dr)
+        op = T if op is None else np.einsum("...r,rtbR->...tbR", op, T)
+    op = np.squeeze(op, axis=(0, op.ndim - 1))  # (t0, b0, t1, b1, ...)
+    tops = list(range(0, 2 * L, 2))
+    bots = list(range(1, 2 * L, 2))
+    return np.transpose(op, tops + bots).reshape(2**L, 2**L)
+
+
 # ---------------------------------------------------------------------------
 # TestSpinOps
 # ---------------------------------------------------------------------------
@@ -584,6 +601,40 @@ class TestBuildAutoMPOFunctional:
 
 class TestAutoMPOSymmetric:
     """Tests for symmetric (SymmetricTensor-based) MPO construction."""
+
+    def test_symmetric_compress_builds(self):
+        """Regression for #620: ``symmetric=True`` + ``compress=True`` must not
+        raise (stale bond charges previously crashed ``from_dense``) and must
+        actually shrink at least one virtual bond."""
+        L = 6
+        terms = _heisenberg_terms(L)
+        mpo_unc = build_auto_mpo(terms, L=L, symmetric=True)
+        mpo_cmp = build_auto_mpo(
+            terms, L=L, symmetric=True, compress=True, compress_tol=1e-10
+        )
+        assert mpo_cmp.n_nodes() == L
+        unc_bonds = [mpo_unc.get_tensor(i).todense().shape[3] for i in range(L)]
+        cmp_bonds = [mpo_cmp.get_tensor(i).todense().shape[3] for i in range(L)]
+        for i in range(L):
+            assert np.all(np.isfinite(np.asarray(mpo_cmp.get_tensor(i).todense())))
+        assert any(c < u for c, u in zip(cmp_bonds, unc_bonds)), (
+            f"no bond compressed: unc={unc_bonds} cmp={cmp_bonds}"
+        )
+
+    def test_symmetric_compress_preserves_operator(self):
+        """Charge-aware compression must preserve the Hamiltonian: the
+        compressed symmetric MPO contracts to the exact Heisenberg operator
+        (compression is approximate but ~machine-exact at tol=1e-10)."""
+        L = 4
+        terms = _heisenberg_terms(L)
+        mpo_cmp = build_auto_mpo(
+            terms, L=L, symmetric=True, compress=True, compress_tol=1e-10
+        )
+        M = _mpo_operator_matrix(mpo_cmp, L)
+        H = _build_heisenberg_matrix(L)
+        np.testing.assert_allclose(
+            M, H, atol=1e-9, err_msg="compressed symmetric MPO != Heisenberg H"
+        )
 
     def test_symmetric_mpo_todense_matches_dense(self):
         """The dense representation of a symmetric MPO should match a dense MPO."""


### PR DESCRIPTION
Fixes #620.

## Problem

`build_auto_mpo(..., symmetric=True, compress=True)` raised `ValueError: data.shape (1, 2, 2, 4) does not match index dims (1, 2, 2, 5)` from `SymmetricTensor.from_dense`. Each flag alone worked; only the combination crashed. Reproduces on a plain spin-½ Heisenberg chain (not fermion-specific).

## Root cause (confirmed by reproduction)

Two coupled problems:
1. **Stale length** — the SVD compression pass shrinks the MPO virtual bonds, but `bond_charges` is computed from the *uncompressed* `bond_states`, so its length no longer matches the compressed W-matrix.
2. **Broken symmetry** — even with the length fixed, a plain dense SVD (`_compress_mpo_bond`) mixes virtual-bond states of *different* U(1) charge, so the compressed bond carries no definite charge and cannot be a valid symmetric leg.

## Fix

Add `_compress_mpo_bond_symmetric`, which compresses **each charge sector of the shared bond independently** and returns the updated bond charges. Because the charge-conserving W-matrix is block-diagonal in the bond charge when reshaped to `(D_l·d·d, D_mid)`, the per-sector SVD is *exact* (equal to the dense SVD restricted to each block) and assigns every retained bond state a definite charge by construction. `to_mpo` runs this charge-aware pass in the symmetric branch; the non-symmetric path keeps the original `_compress_mpo_bond` unchanged.

This lives in the host-side numpy MPO-builder layer (no `SymmetricTensor`s exist until the final conversion), so it stays consistent with the repo's block-sparse coding rule — there is no `todense()` on a `SymmetricTensor`.

## Verification

- **Operator-exact:** the compressed symmetric MPO contracts to the *exact* Heisenberg Hamiltonian (`|M − H|` ~ 1e-16 at `tol=1e-10`).
- Reproducer now passes (case C); also verified spin-1 (`d=3`) and spinless fermions.
- New tests: `test_symmetric_compress_builds` (regression guard + confirms a bond actually shrinks) and `test_symmetric_compress_preserves_operator` (operator equivalence to exact H).
- Full `tests/test_auto_mpo.py`: **48 passed** (46 existing + 2 new); non-symmetric compression path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)