### PR TITLE
docs(itebd): clarify B_new is intentionally not left-canonical (Hastings inversion-free)

### DIFF
--- a/src/tenax/algorithms/itebd.py
+++ b/src/tenax/algorithms/itebd.py
@@ -123,9 +123,23 @@ def _update_bond_hastings(A, B, l_right, gate, chi_max):
 
     ``A``, ``B`` are left-canonical ``(chiL, d, chiR)`` tensors sharing the bond
     to be updated; ``l_right`` is the Schmidt weight on the bond to the *right*
-    of the ``B`` tensor. Applies ``gate`` across the A-B bond and returns updated
-    left-canonical ``(A_new, l_AB_new, B_new)``. No ``lambda^-1`` is ever formed:
-    ``B_new = X^dagger . Theta`` contracts the *unweighted* gated block.
+    of the ``B`` tensor. Applies ``gate`` across the A-B bond and returns
+    ``(A_new, l_AB_new, B_new)``.
+
+    ``A_new`` is an exact left-canonical isometry. ``B_new = X^dagger . Theta``
+    is the inversion-free right-partner and is **intentionally NOT left-canonical**
+    under truncation: its left Gram is ``Theta^dagger P_X Theta`` (``P_X = X X^dagger``,
+    the rank-k projector), equivalently ``B_new = S . Yh . lambda_right^-1`` — it
+    carries the implicit ``lambda^-1`` *without ever forming it*, which is the whole
+    point of the Hastings scheme. The asymmetry is self-correcting and does not need
+    re-orthogonalizing: the next sweep's SVD re-establishes the isometry from whatever
+    gauge ``B`` is in, and ``_bond_energy_left`` normalizes explicitly
+    (``<theta|H|theta>/<theta|theta>``), so a non-canonical ``B`` is absorbed, not
+    propagated. Verified: ``itebd_groundstate_hastings`` matches the Vidal
+    ``_safe_inv`` path (``itebd_groundstate``) bit-for-bit across the truncation
+    regime (chi=2..32), converging to ``e0 = 1/4 - ln 2``. Do NOT "fix" ``B_new`` to
+    be left-canonical — that reintroduces the normalization/inverse step the scheme
+    exists to avoid (see PR #619 review thread).
     """
     chiL, d, _ = A.shape
     _, _, chiR = B.shape
@@ -139,7 +153,9 @@ def _update_bond_hastings(A, B, l_right, gate, chi_max):
     X, S = X[:, :k], S[:k]
     S = S / (np.linalg.norm(S) + 1e-300)
     A_new = X.reshape(chiL, d, k)  # exact isometry (left-canonical)
-    # B_new = X^dagger . theta  (uses unweighted theta -> no l_right^-1)
+    # B_new = X^dagger . theta: inversion-free right-partner (= S.Yh.l_right^-1
+    # computed without forming l_right^-1). Intentionally NOT left-canonical under
+    # truncation; re-orthogonalized by the next sweep's SVD. See docstring.
     B_new = np.einsum("aiK,aijc->Kjc", A_new.conj(), theta)
     return A_new, S, B_new
 


### PR DESCRIPTION
Follow-up to a code-review comment on #619 (the Hastings inversion-free iTEBD reference).

The Codex review flagged that, after truncation, `_update_bond_hastings` returns a `B_new = X†·θ` that is **not** left-canonical (left Gram `θ† P_X θ`), and worried that the driver + `_bond_energy_left` assume left-canonical tensors. The algebra is correct, **but** the implication (wrong evolution/measurement) does not hold: I verified `itebd_groundstate_hastings` matches the known-good Vidal `_safe_inv` path (`itebd_groundstate`) **bit-for-bit across the truncation regime** (χ=2…32), both converging to the exact `e₀ = ¼ − ln2 = −0.443147`.

It's correct because (1) `_bond_energy_left` is an explicit Rayleigh quotient `⟨θ|H|θ⟩/⟨θ|θ⟩` — it doesn't rely on an implicit identity right-environment, only on `A` being left-canonical (it is); and (2) the next sweep's SVD re-establishes the isometry from whatever gauge `B` is in, so a non-canonical `B` is absorbed, not propagated. `B_new = S·Yh·λ_right⁻¹` is precisely the inversion-free right-partner — carrying the implicit `λ⁻¹` *without forming it*, which is the point of the Hastings scheme.

This PR only updates the `_update_bond_hastings` docstring + inline comment so the gauge is documented (the old docstring incorrectly said it returns *left-canonical* `B_new`) and nobody "fixes" it by re-orthogonalizing — which would reintroduce the normalization/inverse step the scheme exists to avoid.

**Comment/docstring-only — no behavior change.** Ruff clean; `itebd_groundstate_hastings` smoke run unchanged. See the #619 review thread for the verification table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)