### PR TITLE
docs(#618): NO-GO findings — batched dispatch can't close D≥3 U(1)-Sz CTM-AD warm wall

### DIFF
--- a/docs/superpowers/handoffs/2026-06-18-618-u1sz-batched-dispatch-findings.md
+++ b/docs/superpowers/handoffs/2026-06-18-618-u1sz-batched-dispatch-findings.md
@@ -1,0 +1,156 @@
+# #618 — Batched block-sparse dispatch to close the D≥3 U(1)-Sz CTM-AD warm wall — Findings
+
+**Date:** 2026-06-18
+**Parent:** #566 (block-sparse AD cost scales with charge-block count). **Motivated by:** #615.
+**Verdict:** **NO-GO (measured, not inferred).** The lever #618 proposes — "batch same-shape blocks
+so eager cost goes O(n_blocks) → O(n_distinct_shapes)" — is (a) **already implemented** for the
+contraction path and gated by the same `TENAX_BATCH_BLOCKSPARSE` flag step 1 measured, and (b)
+**structurally incapable** of closing the 24× warm gap. The warm wall is **host-bound eager per-block
+dispatch dominated by the fuse** (`_fuse_indices_symmetric`, 8 eager forward sweeps, ~19 s) — *not*
+the contraction or the device. Batching the fuse = the #566 stacked-fuse lever (already NO-GO, within
+1% noise); batching the contraction = the gate (already measured +14% warm). Both cap at the U(1)-Sz
+same-shape collapse ceiling ~1.9× against a 24× gap. No `src/` change.
+
+## Question (issue #618, steps 2–4)
+
+After step 1 (existing `TENAX_BATCH_BLOCKSPARSE=1` helps compile ~21%, **hurts** warm ~14% at D=3
+χ=12), step 2 asks: where does the u1sz warm-step eager time go (block-pack vs contraction vs
+decomp)? Step 3: prototype batched contraction/block-pack dispatch. Step 4: does it cut the warm gap
+materially toward dense?
+
+## Answer: the premise is wrong, and the measured ceiling kills the lever.
+
+### Premise correction (load-bearing): contraction IS already batched.
+
+The issue states "Batching today covers decompositions; the CTM-AD warm-step hot path (eager
+contraction + block-pack assembly) appears **not** to be batched." **This is false.** The same
+`TENAX_BATCH_BLOCKSPARSE` flag routes symmetric contraction through `_contract_symmetric_batched`
+(`src/tenax/contraction/contractor.py:785`), which groups surviving block-combos by input
+block-shape signature, `jnp.stack`s same-shape blocks on a fresh batch axis, runs **one batched
+`jnp.einsum` per shape group**, and `jax.ops.segment_sum`s combos sharing an output key
+(`contractor.py:241–371`). That is *exactly* the step-3 lever ("O(n_blocks) → O(n_distinct_shapes)").
+So step 3 is not a new build — it exists, and step 1 already measured it end-to-end.
+
+**Tooling caveat that hid this:** `examples/probe_backward_jaxpr_566.py` compares gate off vs on
+**in one process**. `jax.make_jaxpr` reuses the first (gate-off) trace for the second (gate-on) call
+when avals are identical — the same `jax.jit`-cache contamination the #610 handoff flagged — so the
+in-process probe reports a spurious **1.00× identical** histogram. The gate's effect is only visible
+with **separate processes per gate value** (or `jax.clear_caches()` between). Verified directly: with
+a cold trace and the gate on, `_contract_symmetric_batched` fires (call-counted = 1) and emits
+`segment_sum`/batched einsum; with the contaminated in-process re-trace it does not.
+
+### Step 2 — where the warm time goes (clean separate-process backward op histogram)
+
+Full fused backward VJP (env-sweep + params-sweep), u1sz D=3 χ=12, 32 blocks, trace-only, **one
+process per gate** (`/tmp/trace618.py`):
+
+| bucket | gate OFF (per-block) | gate ON (batched) | ratio |
+|---|---:|---:|---:|
+| contraction (`dot_general`) | 8,890 | **2,807** | **0.32×** ✓ batched einsum collapses it |
+| transpose | 13,112 | **4,210** | 0.32× ✓ |
+| decomp (svd/eigh/qr) | 156 | 90 | 0.58× ✓ |
+| **block-pack (slice/scatter/reshape)** | **58,656** | **66,871** | **1.14×** ✗ grows |
+| broadcast_in_dim | 29,808 | 36,457 | 1.22× ✗ grows |
+| charge-mask / index arith | 21,717 | 20,993 | 0.97× ~flat |
+| elementwise | 31,014 | 31,984 | 1.03× ~flat |
+| other | 37,899 | 59,328 | 1.57× ✗ grows |
+| **TOTAL** | **171,444** | **186,283** | **1.087× — MORE ops** |
+
+**Reading:** block-pack (slice/scatter/reshape) is the dominant cluster (34% of all ops), ≫
+contraction (5%) ≫ decomp (0.1%). Batching the contraction *works* (it collapses contraction 3.2×
+and transpose 3.1×), but contraction is only 5% of the graph, and the batching **machinery** (stack
+into a batch axis, `segment_sum` scatter, broadcasts) **adds ~15k ops** to the dominant block-pack /
+broadcast / "other" clusters. Net op count goes **up +8.7%** → more device work → the measured **+14%
+slower warm** (step 1). The batchable cluster is minor; the dominant cluster grows.
+
+### Step 2 — the warm wall is HOST-bound eager per-block dispatch, dominated by the FUSE
+
+A100, D=3 χ=12 depth=8, implicit fixed-point AD, `examples/profile_warm_dispatch_618.py`:
+
+| arm | n_blocks | warm_med | dispatch (host return) | sync | pipeline ×4 speedup |
+|---|---:|---:|---:|---:|---:|
+| dense | 1 | 778.9 ms | 775.1 ms (99.5%) | ~0 ms | 1.01× |
+| u1sz | 32 | **18,482.6 ms** (~24× dense) | 18,498 ms (100.1%) | ~0 ms | 1.00× |
+
+`value_and_grad` returns only after the work is essentially done (`dispatch ≈ warm`, `sync ≈ 0`,
+pipeline ≈ 1×) — and the cProfile shows **why**: the forward CTM sweep runs **eagerly in Python**, not
+as one compiled unit. The warm `value_and_grad` cProfile (tottime / cumtime, u1sz):
+
+| frame | ncalls | tottime | cumtime |
+|---|---:|---:|---:|
+| `_tensor_utils.py:231 _fuse_indices_symmetric` | **8** | 0.245 s | **19.159 s** |
+| `_ctm_loop_core.py:116 _run_ctm_loop_with_bump` | 1 | 0.457 s | 5.673 s |
+| `jax .../lax.py _convert_element_type` | **73,748** | 0.359 s | 2.695 s |
+| `jax .../array_constructors.py array` | **32,820** | 0.338 s | 2.408 s |
+| `jax .../indexing.py _parse_indices` | **17,567** | 0.288 s | 0.596 s |
+| `jax .../core.py __new__` | **62,392** | 0.211 s | — |
+| `_ctm_energy_ad.py:1281 f_bwd` (jitted backward) | 1 | 0.132 s | **0.134 s** |
+
+**Reading:** the dominant warm cost is `_fuse_indices_symmetric` — **cumtime 19.16 s across 8 eager
+sweeps** (one per `max_iter`), driving **tens of thousands** of Python-dispatched JAX micro-ops
+(73,748 `convert_element_type`, 32,820 array constructions, 62,392 aval `__new__`). The **fuse /
+block-pack** path — slicing the flat buffer per block, transposing/reshaping, scattering into fused
+output blocks — runs **per block, eagerly, in Python, every sweep**. By contrast the jitted
+fixed-point backward (`f_bwd`) is **0.134 s** — the backward *is* compiled and fast; it is the
+**eager forward** that is the 18.5 s wall. This is **host-bound eager per-block dispatch**, exactly
+the mechanism #618 names — but the dominant cluster is the **fuse**, not contraction, and `dispatch
+≈ warm / sync ≈ 0 / pipeline 1×` is the host running the eager loop synchronously (not a device-sync
+artifact). The per-op count scales ~linearly with block count, so dense (1 block) pays ~nothing and
+u1sz (32 blocks) pays ~24×.
+
+### Why batching cannot close the gap (the measured ceiling) — and the fuse lever is already a NO-GO
+
+The dominant warm cost is `_fuse_indices_symmetric`. **Batching the fuse is precisely the #566
+stacking spike's primary lever** ("a single targeted lever (default: stacked-aware `fuse`)") — which
+was already measured **NO-GO**: stacked-fuse on/off was within **1% noise** at D=3 because the
+same-shape collapse ceiling on the env tensors that the fuse touches is only ~1.9×.
+
+The #566 stacking census **measured** that ceiling (`n_blocks / n_distinct_shapes`) for U(1)-Sz at
+D=3: site 32× (one shape) but **env corners 1.67×, edges 1.9×, median 1.90×**. The fuse + contraction
+work is dominated by the *env* tensors (C/T), so any same-shape batching of that work caps at
+**~1.9×**. The warm gap to close is **~24–28×** — batching is off by **more than an order of
+magnitude**. A perfect fuse-batching would cut warm ~18.5 s → ~10 s (still ~13× dense); and per the
+contraction histogram above, for fragmented U(1)-Sz the stacking fixed cost (stack + segment_sum +
+broadcast) isn't even amortized, so on the contraction cluster the net is **negative** (the measured
++14%). This is the same wall as the #566 stacking NO-GO and the #615 de-frag NO-GO, now confirmed
+from the warm-step / eager-dispatch angle.
+
+The only structural escape — jit the **whole forward sweep** as one unit so warm = 1 dispatch instead
+of 8 eager sweeps × tens-of-thousands of micro-ops — is not a batching lever; it re-opens the #566
+**compile** wall (the per-block emission that makes the symmetric forward compile minutes-long;
+fwd_n_compiles ≈ 1362 today). That trade is #566's scan-fusion question, not #618's.
+
+## Recommendation / next lever
+
+**Close #618 NO-GO.** The warm wall is host-bound eager per-block dispatch dominated by the
+**fuse** (`_fuse_indices_symmetric`, 8 eager sweeps, ~19 s). Batching the fuse = the #566 stacked-fuse
+lever = already NO-GO (within 1% noise; ceiling ~1.9×). Batching the contraction = the existing
+`TENAX_BATCH_BLOCKSPARSE` path = measured **+14% warm** (it *grows* the dominant block-pack/broadcast
+clusters). Both are capped at ~1.9× against a 24× gap. Do not fund a fuse/block-pack-batching build:
+the ceiling is **measured, not inferred**.
+
+The compile win is the only real benefit of the flag (−21%, from batched **decomp**); it could be
+worth wiring `TENAX_BATCH_BLOCKSPARSE` as a **compile-only** default for D≥3 U(1)-Sz if/when the
+compile face of #566 is the binding cost — but that belongs to #566, not #618, and must NOT be the
+warm-step default (it regresses warm +14%).
+
+**For D≥3 U(1)-Sz today, dense remains pragmatic** (memory `u1sz-perf-study-d3-findings`,
+`615-u1sz-uniform-sector-env`). The binding wall is #566 eager per-block dispatch of a graph whose
+block count cannot be collapsed (fragmentation), not anything #618's batching can move.
+
+## Artifacts (branch-local; no `src/` touched)
+
+- `examples/profile_warm_dispatch_618.py` — warm-step host-vs-device attribution (dispatch/sync
+  split, pipelining probe, cProfile).
+- `profile_warm_dispatch_618_gateoff.json` — the warm-step run above.
+- `examples/trace_op_histogram_618.py` — separate-process backward op histogram (the clean gate
+  off/on comparison; one gate per process to avoid make_jaxpr trace-cache contamination).
+- `profile_d3chi12_batch_618.json` — step-1 artifact (existing-gate warm/compile, prior session).
+
+## Risks / caveats recorded
+
+- **Probe in-process gate comparison is contaminated** (make_jaxpr trace reuse) → reports 1.00×.
+  Always compare `TENAX_BATCH_BLOCKSPARSE` off/on in **separate processes**. (New caveat; generalizes
+  the #610 cold-trace warning to the gate dimension.)
+- Verdict scope: NO-GO is for batched *dispatch* as a **warm-step** lever. The batched **decomp**
+  compile win (−21%) is real and orthogonal (a #566 compile-face knob).

--- a/examples/profile_warm_dispatch_618.py
+++ b/examples/profile_warm_dispatch_618.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""#618 step 2: attribute the U(1)-Sz CTM-AD WARM-step wall (host dispatch vs device).
+
+Step 1 (issue #618) showed ``TENAX_BATCH_BLOCKSPARSE=1`` helps the #566 *compile*
+wall ~21% but HURTS the *warm* step ~14% -> the warm wall is NOT in the (batched)
+decompositions.  This script attributes ONE warm ``value_and_grad`` step to decide
+WHERE the ~24x u1sz/dense warm gap lives:
+
+  (A) HOST / eager per-block dispatch  -- Python orchestration of the forward
+      python-loop CTM steps: pytree flatten/unflatten over O(n_blocks) leaves,
+      per-block SymmetricTensor assembly/disassembly, argument handling.  A
+      Python-level batching of same-shape blocks would shrink this.
+  (B) DEVICE  -- the COMPILED graph is a huge pile of tiny ops (block-pack
+      slice/scatter/reshape + per-block dot_general); warm time is the GPU
+      executing ~30k tiny kernels.  Only a graph-level change (vmap/batched
+      einsum over the block axis -> fewer, bigger kernels) helps; Python
+      batching does nothing.
+
+Decisive split
+--------------
+* cold-compile vg(A) once (warmup, block_until_ready).
+* **dispatch-vs-sync:** ``t_dispatch`` = wall to RETURN from ``vg(A)`` (all jit
+  units issued async, not synced); ``t_sync`` = extra wall for
+  ``block_until_ready``.  Large ``t_dispatch`` => HOST/dispatch bound (A);
+  small ``t_dispatch`` with large ``t_sync`` => DEVICE bound (B).
+* **pipelining probe:** K calls blocking only once at the end vs K x single
+  blocked.  If batched << K x single, the host runs ahead of the device
+  (device-bound); if ~=, each call fully serializes (host- or saturation-bound).
+* **cProfile** one warm call -> top funcs by tottime (host CPU) and cumtime.
+  Heavy *tottime* in tenax Python (contraction / block iteration / pytree) =>
+  HOST; cumtime concentrated in a ``block_until_ready`` / xla-execute C-frame
+  with thin tenax tottime => DEVICE.
+
+Usage
+-----
+    uv run python examples/profile_warm_dispatch_618.py \
+        --sym dense u1sz --D 3 --chi 12 --depth 8 --reps 5 \
+        --json profile_warm_dispatch_618.json
+
+Set ``--gate`` to run under ``TENAX_BATCH_BLOCKSPARSE=1`` (step-1 arm).
+"""
+
+from __future__ import annotations
+
+import argparse
+import cProfile
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import platform
+import pstats
+import statistics
+import time
+
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+# Reuse make_site_and_gate / build_loss from the shared #566 profiler so site
+# construction + the production loss dispatcher are a single source of truth.
+_prof_spec = importlib.util.spec_from_file_location(
+    "profile_ctm_ad_wall_566",
+    pathlib.Path(__file__).parent / "profile_ctm_ad_wall_566.py",
+)
+_PROF = importlib.util.module_from_spec(_prof_spec)
+_prof_spec.loader.exec_module(_PROF)
+
+FLAG = "TENAX_BATCH_BLOCKSPARSE"
+
+
+def _median(xs):
+    return statistics.median(xs) if xs else float("nan")
+
+
+def profile_sym(sym, D, chi, depth, reps, *, pipeline_k=4):
+    """Cold-compile then attribute one warm value_and_grad step for `sym`."""
+    A, gate = _PROF.make_site_and_gate(sym, D, seed=42)
+    n_blocks = getattr(A, "n_blocks", 1)
+    loss_fn = _PROF.build_loss(gate, chi, depth, explicit=False, warmup=3)
+    vg = jax.value_and_grad(loss_fn)
+
+    # --- cold compile (warmup) -------------------------------------------- #
+    t0 = time.perf_counter()
+    out = vg(A)
+    jax.block_until_ready(out)
+    compile_wall = time.perf_counter() - t0
+    E0 = float(out[0])
+
+    # --- uninstrumented warm wall (median of reps blocked calls) ---------- #
+    warm = []
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        out = vg(A)
+        jax.block_until_ready(out)
+        warm.append(time.perf_counter() - t0)
+
+    # --- dispatch-vs-sync split ------------------------------------------- #
+    disp, sync = [], []
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        out = vg(A)  # returns once all jit units are dispatched (async)
+        t1 = time.perf_counter()
+        jax.block_until_ready(out)
+        t2 = time.perf_counter()
+        disp.append(t1 - t0)
+        sync.append(t2 - t1)
+
+    # --- pipelining probe ------------------------------------------------- #
+    # K calls, block only at the very end: if the host can run ahead of the
+    # device, wall/K < single blocked warm (device-bound).
+    t0 = time.perf_counter()
+    last = None
+    for _ in range(pipeline_k):
+        last = vg(A)
+    jax.block_until_ready(last)
+    pipe_wall = time.perf_counter() - t0
+
+    # --- cProfile one warm call ------------------------------------------- #
+    pr = cProfile.Profile()
+    pr.enable()
+    out = vg(A)
+    jax.block_until_ready(out)
+    pr.disable()
+
+    s = io.StringIO()
+    ps = pstats.Stats(pr, stream=s).sort_stats("tottime")
+    ps.print_stats(30)
+    tottime_dump = s.getvalue()
+
+    s2 = io.StringIO()
+    ps2 = pstats.Stats(pr, stream=s2).sort_stats("cumulative")
+    ps2.print_stats(30)
+    cumtime_dump = s2.getvalue()
+
+    # Programmatic extraction of the largest tottime frames for the JSON.
+    top_tottime = []
+    stats_dict = ps.stats  # {(file,line,name): (cc, nc, tt, ct, callers)}
+    rows = sorted(stats_dict.items(), key=lambda kv: kv[1][2], reverse=True)
+    for (fn_file, fn_line, fn_name), (cc, nc, tt, ct, _callers) in rows[:25]:
+        short = f"{pathlib.Path(fn_file).name}:{fn_line}({fn_name})"
+        top_tottime.append({"func": short, "ncalls": nc, "tottime": tt, "cumtime": ct})
+
+    warm_med = _median(warm)
+    disp_med = _median(disp)
+    sync_med = _median(sync)
+
+    result = {
+        "sym": sym,
+        "D": D,
+        "chi": chi,
+        "depth": depth,
+        "n_blocks": int(n_blocks),
+        "gate": os.environ.get(FLAG, "0"),
+        "energy": E0,
+        "compile_wall_s": compile_wall,
+        "warm_med_s": warm_med,
+        "warm_all_s": warm,
+        "dispatch_med_s": disp_med,
+        "sync_med_s": sync_med,
+        "dispatch_frac": (disp_med / warm_med) if warm_med else float("nan"),
+        "pipeline_k": pipeline_k,
+        "pipeline_wall_s": pipe_wall,
+        "pipeline_per_call_s": pipe_wall / pipeline_k,
+        "pipeline_speedup_vs_serial": (warm_med * pipeline_k / pipe_wall)
+        if pipe_wall
+        else float("nan"),
+        "top_tottime": top_tottime,
+    }
+    return result, tottime_dump, cumtime_dump
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sym", nargs="+", default=["dense", "u1sz"])
+    ap.add_argument("--D", type=int, default=3)
+    ap.add_argument("--chi", type=int, default=12)
+    ap.add_argument("--depth", type=int, default=8)
+    ap.add_argument("--reps", type=int, default=5)
+    ap.add_argument("--pipeline-k", type=int, default=4)
+    ap.add_argument("--gate", action="store_true", help="Run under TENAX_BATCH_BLOCKSPARSE=1.")
+    ap.add_argument("--json", type=str, default=None)
+    args = ap.parse_args()
+
+    os.environ[FLAG] = "1" if args.gate else "0"
+
+    dev = jax.devices()[0]
+    print("=" * 92)
+    print("# #618 step-2: warm-step host-vs-device attribution")
+    print(f"# platform : {dev.platform}  device0={dev.device_kind}")
+    print(f"# host     : {platform.platform()}")
+    print(f"# x64={jax.config.read('jax_enable_x64')}  {FLAG}={os.environ[FLAG]}")
+    print(f"# D={args.D} chi={args.chi} depth={args.depth} reps={args.reps}")
+    print("=" * 92)
+
+    meta = {
+        "platform": dev.platform,
+        "device_kind": dev.device_kind,
+        "x64": bool(jax.config.read("jax_enable_x64")),
+        "gate": os.environ[FLAG],
+        "D": args.D,
+        "chi": args.chi,
+        "depth": args.depth,
+        "reps": args.reps,
+    }
+    rows = []
+    for sym in args.sym:
+        print(f"\n### {sym} (D={args.D} chi={args.chi}) ###", flush=True)
+        try:
+            r, tot, cum = profile_sym(
+                sym, args.D, args.chi, args.depth, args.reps, pipeline_k=args.pipeline_k
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"  !! {type(exc).__name__}: {exc}")
+            rows.append({"sym": sym, "error": f"{type(exc).__name__}: {exc}"})
+            if args.json:
+                with open(args.json, "w") as fh:
+                    json.dump({**meta, "rows": rows}, fh, indent=2)
+            continue
+        print(
+            f"  n_blocks={r['n_blocks']}  E={r['energy']:.6f}  "
+            f"compile={r['compile_wall_s']:.1f}s"
+        )
+        print(
+            f"  warm_med={r['warm_med_s'] * 1e3:.1f} ms  "
+            f"dispatch={r['dispatch_med_s'] * 1e3:.1f} ms "
+            f"({100 * r['dispatch_frac']:.1f}% of warm)  "
+            f"sync={r['sync_med_s'] * 1e3:.1f} ms"
+        )
+        print(
+            f"  pipeline x{r['pipeline_k']}: per_call={r['pipeline_per_call_s'] * 1e3:.1f} ms  "
+            f"speedup_vs_serial={r['pipeline_speedup_vs_serial']:.2f}x  "
+            f"(>1 => device-bound, host runs ahead)"
+        )
+        print("  -- top tottime (host CPU) --")
+        for t in r["top_tottime"][:12]:
+            print(
+                f"    {t['tottime']:>8.3f}s  ncalls={t['ncalls']:>9}  {t['func']}"
+            )
+        print("\n  ===== cProfile tottime (top 30) =====")
+        print(tot)
+        rows.append(r)
+        if args.json:
+            with open(args.json, "w") as fh:
+                json.dump({**meta, "rows": rows}, fh, indent=2)
+
+    # Summary verdict heuristic
+    print("\n" + "=" * 92)
+    print("# READING: dispatch_frac high (>~50%) => HOST/eager-dispatch bound "
+          "(Python batching can help).")
+    print("#          dispatch_frac low + pipeline speedup >1 => DEVICE bound "
+          "(need graph-level batching: fewer/bigger kernels).")
+    if args.json:
+        print(f"\nJSON -> {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/trace_op_histogram_618.py
+++ b/examples/trace_op_histogram_618.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""#618 step 2: clean separate-process backward op histogram for the U(1)-Sz
+CTM-AD warm wall.
+
+Run ONE gate value per process so jax.make_jaxpr trace-caching cannot reuse the
+gate-OFF trace for the gate-ON call (the contamination that makes the in-process
+probe_backward_jaxpr_566.py gate comparison report a spurious 1.00x identical).
+
+Usage::
+
+    JAX_PLATFORMS=cpu uv run python examples/trace_op_histogram_618.py 0   # gate OFF
+    JAX_PLATFORMS=cpu uv run python examples/trace_op_histogram_618.py 1   # gate ON
+"""
+
+import os, sys, collections, importlib.util, pathlib, jax
+jax.config.update("jax_enable_x64", True)
+spec = importlib.util.spec_from_file_location("p", "examples/probe_backward_jaxpr_566.py")
+P = importlib.util.module_from_spec(spec); spec.loader.exec_module(P)
+gate = sys.argv[1]
+os.environ["TENAX_BATCH_BLOCKSPARSE"] = gate
+A = P.make_site("u1sz", 3)
+jx = P.backward_vjp_jaxpr(A, 12, "auto", full=True)
+env_jx, par_jx = jx
+c = P._combine(P.count_primitives(env_jx), P.count_primitives(par_jx))
+b = P.bucketize(c)
+print(f"GATE={gate} blocks={A.n_blocks} TOTAL={b['TOTAL']}")
+for k in ["contraction","decomp(svd/eigh/qr)","block-pack(slice/scatter/reshape)","transpose","charge-mask / index arith","elementwise(add/mul/...)","other"]:
+    print(f"  {k:<40} {b[k]:>8}")
+for extra in ["segment_sum","broadcast_in_dim"]:
+    print(f"  [raw] {extra:<34} {c.get(extra,0):>8}")

--- a/profile_d3chi12_batch_618.json
+++ b/profile_d3chi12_batch_618.json
@@ -1,0 +1,59 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "syms": [
+    "dense",
+    "u1sz"
+  ],
+  "depths": [
+    8
+  ],
+  "explicit": false,
+  "backward_steps": null,
+  "defrag": false,
+  "rows": [
+    {
+      "sym": "dense",
+      "D": 3,
+      "chi": 12,
+      "depth": 8,
+      "path": "implicit",
+      "backward_steps": null,
+      "n_blocks": 1,
+      "fwd_wall_s": 17.31213726848364,
+      "fwd_compile_s": 15.358115200000006,
+      "fwd_n_compiles": 101,
+      "vg_wall_s": 23.71375324204564,
+      "vg_compile_s": 19.975527763000002,
+      "vg_n_compiles": 112,
+      "bwd_compile_s_est": 4.617412562999997,
+      "top_compile_name": "jit(_jit_fused_fixed_point_bwd)",
+      "top_compile_s": 8.971446753,
+      "warm_step_s": 0.7621061149984598,
+      "energy": -0.0039617707236439675,
+      "grad_finite": true
+    },
+    {
+      "sym": "u1sz",
+      "D": 3,
+      "chi": 12,
+      "depth": 8,
+      "path": "implicit",
+      "backward_steps": null,
+      "n_blocks": 32,
+      "fwd_wall_s": 151.48242536373436,
+      "fwd_compile_s": 97.74343825300005,
+      "fwd_n_compiles": 1362,
+      "vg_wall_s": 1329.3501584492624,
+      "vg_compile_s": 995.1626048080002,
+      "vg_n_compiles": 1406,
+      "bwd_compile_s_est": 897.4191665550002,
+      "top_compile_name": "jit(_jit_fused_fixed_point_bwd)",
+      "top_compile_s": 365.847779751,
+      "warm_step_s": 21.287916829809546,
+      "energy": -0.013387147559968747,
+      "grad_finite": true
+    }
+  ]
+}

--- a/profile_warm_dispatch_618_gateoff.json
+++ b/profile_warm_dispatch_618_gateoff.json
@@ -1,0 +1,366 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "gate": "0",
+  "D": 3,
+  "chi": 12,
+  "depth": 8,
+  "reps": 5,
+  "rows": [
+    {
+      "sym": "dense",
+      "D": 3,
+      "chi": 12,
+      "depth": 8,
+      "n_blocks": 1,
+      "gate": "0",
+      "energy": -0.0039617707236439675,
+      "compile_wall_s": 8.51032380387187,
+      "warm_med_s": 0.7789001185446978,
+      "warm_all_s": [
+        0.7926023062318563,
+        0.7781757153570652,
+        0.7789001185446978,
+        0.7791546955704689,
+        0.7770726531744003
+      ],
+      "dispatch_med_s": 0.7751356437802315,
+      "sync_med_s": 2.20518559217453e-05,
+      "dispatch_frac": 0.9951669351758479,
+      "pipeline_k": 4,
+      "pipeline_wall_s": 3.0947988722473383,
+      "pipeline_per_call_s": 0.7736997180618346,
+      "pipeline_speedup_vs_serial": 1.0067214713427717,
+      "top_tottime": [
+        {
+          "func": "_ctm_loop_core.py:116(_run_ctm_loop_with_bump)",
+          "ncalls": 1,
+          "tottime": 0.553395669,
+          "cumtime": 0.679742048
+        },
+        {
+          "func": "_ctm_energy_ad.py:1281(f_bwd)",
+          "ncalls": 1,
+          "tottime": 0.081315933,
+          "cumtime": 0.082353005
+        },
+        {
+          "func": "dispatch.py:82(apply_primitive)",
+          "ncalls": 431,
+          "tottime": 0.032246996,
+          "cumtime": 0.033511185
+        },
+        {
+          "func": "ufunc_api.py:175(__call__)",
+          "ncalls": 329,
+          "tottime": 0.026825426000000003,
+          "cumtime": 0.030192377000000003
+        },
+        {
+          "func": "ad_utils.py:442(_frob_phase_fix)",
+          "ncalls": 64,
+          "tottime": 0.010629707,
+          "cumtime": 0.11672328600000001
+        },
+        {
+          "func": "array_methods.py:795(_operator_truediv)",
+          "ncalls": 130,
+          "tottime": 0.0072539430000000005,
+          "cumtime": 0.007449217
+        },
+        {
+          "func": "array_methods.py:695(_operator_lt)",
+          "ncalls": 64,
+          "tottime": 0.006253456,
+          "cumtime": 0.006294635000000001
+        },
+        {
+          "func": "array.py:606(_value)",
+          "ncalls": 19,
+          "tottime": 0.005063563,
+          "cumtime": 0.005164467000000001
+        },
+        {
+          "func": "~:0(<built-in method builtins.isinstance>)",
+          "ncalls": 15966,
+          "tottime": 0.0036119980000000004,
+          "cumtime": 0.003882485
+        },
+        {
+          "func": "array_methods.py:719(_operator_ge)",
+          "ncalls": 64,
+          "tottime": 0.0034386150000000003,
+          "cumtime": 0.003562813
+        },
+        {
+          "func": "array_methods.py:262(_flatten)",
+          "ncalls": 65,
+          "tottime": 0.003308997,
+          "cumtime": 0.0039858260000000005
+        },
+        {
+          "func": "lax_numpy.py:8178(argmax)",
+          "ncalls": 64,
+          "tottime": 0.0033063570000000002,
+          "cumtime": 0.0038649630000000003
+        },
+        {
+          "func": "ufuncs.py:3351(conj)",
+          "ncalls": 68,
+          "tottime": 0.003203694,
+          "cumtime": 0.003203694
+        },
+        {
+          "func": "reductions.py:408(max)",
+          "ncalls": 64,
+          "tottime": 0.003086936,
+          "cumtime": 0.003272446
+        },
+        {
+          "func": "core.py:627(bind)",
+          "ncalls": 514,
+          "tottime": 0.003057447,
+          "cumtime": 0.729467894
+        },
+        {
+          "func": "util.py:270(wrapper)",
+          "ncalls": 1514,
+          "tottime": 0.002913871,
+          "cumtime": 0.005066811
+        },
+        {
+          "func": "ad_utils.py:424(_phase_fix_ctm_tensor)",
+          "ncalls": 8,
+          "tottime": 0.001956619,
+          "cumtime": 0.120293854
+        },
+        {
+          "func": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)",
+          "ncalls": 629,
+          "tottime": 0.0015301210000000002,
+          "cumtime": 0.0015301210000000002
+        },
+        {
+          "func": "lax.py:1643(_convert_element_type)",
+          "ncalls": 224,
+          "tottime": 0.0014968120000000001,
+          "cumtime": 0.017752153
+        },
+        {
+          "func": "core.py:1212(process_primitive)",
+          "ncalls": 502,
+          "tottime": 0.001161008,
+          "cumtime": 0.037211763
+        },
+        {
+          "func": "core.py:1851(typeof)",
+          "ncalls": 1152,
+          "tottime": 0.001080103,
+          "cumtime": 0.0067505510000000005
+        },
+        {
+          "func": "array_constructors.py:106(array)",
+          "ncalls": 92,
+          "tottime": 0.0010737700000000001,
+          "cumtime": 0.005425846000000001
+        },
+        {
+          "func": "core.py:2111(canonicalize_value)",
+          "ncalls": 799,
+          "tottime": 0.0010706930000000002,
+          "cumtime": 0.002573536
+        },
+        {
+          "func": "slicing.py:3403(_dynamic_slice_indices)",
+          "ncalls": 64,
+          "tottime": 0.001025343,
+          "cumtime": 0.030465119000000002
+        },
+        {
+          "func": "array.py:1092(_get_aval_array)",
+          "ncalls": 993,
+          "tottime": 0.001019982,
+          "cumtime": 0.005180606
+        }
+      ]
+    },
+    {
+      "sym": "u1sz",
+      "D": 3,
+      "chi": 12,
+      "depth": 8,
+      "n_blocks": 32,
+      "gate": "0",
+      "energy": -0.013387147559970634,
+      "compile_wall_s": 1525.8242038600147,
+      "warm_med_s": 18.482632379978895,
+      "warm_all_s": [
+        18.670215716585517,
+        18.39398686774075,
+        18.34451510384679,
+        18.63091461919248,
+        18.482632379978895
+      ],
+      "dispatch_med_s": 18.49798772856593,
+      "sync_med_s": 2.7805566787719727e-05,
+      "dispatch_frac": 1.0008307987883625,
+      "pipeline_k": 4,
+      "pipeline_wall_s": 73.90780301205814,
+      "pipeline_per_call_s": 18.476950753014535,
+      "pipeline_speedup_vs_serial": 1.0003074980845221,
+      "top_tottime": [
+        {
+          "func": "dispatch.py:82(apply_primitive)",
+          "ncalls": 105814,
+          "tottime": 9.334403537,
+          "cumtime": 9.823501742000001
+        },
+        {
+          "func": "indexing.py:1280(_index_to_gather)",
+          "ncalls": 8302,
+          "tottime": 1.042379084,
+          "cumtime": 11.486321176
+        },
+        {
+          "func": "array_methods.py:695(_operator_lt)",
+          "ncalls": 6692,
+          "tottime": 0.9664950050000001,
+          "cumtime": 0.969393724
+        },
+        {
+          "func": "~:0(<built-in method builtins.isinstance>)",
+          "ncalls": 4197950,
+          "tottime": 0.6868989400000001,
+          "cumtime": 0.725645873
+        },
+        {
+          "func": "core.py:627(bind)",
+          "ncalls": 105906,
+          "tottime": 0.66616578,
+          "cumtime": 27.470209632000003
+        },
+        {
+          "func": "util.py:270(wrapper)",
+          "ncalls": 335610,
+          "tottime": 0.6660428930000001,
+          "cumtime": 1.041335275
+        },
+        {
+          "func": "_ctm_loop_core.py:116(_run_ctm_loop_with_bump)",
+          "ncalls": 1,
+          "tottime": 0.45680547000000005,
+          "cumtime": 5.673137963
+        },
+        {
+          "func": "lax_numpy.py:2269(squeeze)",
+          "ncalls": 7422,
+          "tottime": 0.45403885200000005,
+          "cumtime": 0.530606149
+        },
+        {
+          "func": "array_methods.py:262(_flatten)",
+          "ncalls": 8428,
+          "tottime": 0.442354342,
+          "cumtime": 0.44239817400000003
+        },
+        {
+          "func": "lax.py:1643(_convert_element_type)",
+          "ncalls": 73748,
+          "tottime": 0.358851014,
+          "cumtime": 2.6948000800000003
+        },
+        {
+          "func": "array_constructors.py:106(array)",
+          "ncalls": 32820,
+          "tottime": 0.33777052300000004,
+          "cumtime": 2.407737252
+        },
+        {
+          "func": "indexing.py:118(_parse_indices)",
+          "ncalls": 17567,
+          "tottime": 0.287504009,
+          "cumtime": 0.596378406
+        },
+        {
+          "func": "core.py:1212(process_primitive)",
+          "ncalls": 105886,
+          "tottime": 0.255306745,
+          "cumtime": 10.437052268
+        },
+        {
+          "func": "_tensor_utils.py:231(_fuse_indices_symmetric)",
+          "ncalls": 8,
+          "tottime": 0.24494790300000002,
+          "cumtime": 19.159168663000003
+        },
+        {
+          "func": "indexing.py:330(normalize_indices)",
+          "ncalls": 8302,
+          "tottime": 0.23498364600000002,
+          "cumtime": 5.7232806830000005
+        },
+        {
+          "func": "core.py:2111(canonicalize_value)",
+          "ncalls": 167272,
+          "tottime": 0.22258886800000002,
+          "cumtime": 0.6271169830000001
+        },
+        {
+          "func": "core.py:2391(__new__)",
+          "ncalls": 62392,
+          "tottime": 0.21051106700000002,
+          "cumtime": 0.422595604
+        },
+        {
+          "func": "core.py:2047(canonicalize_shape)",
+          "ncalls": 112923,
+          "tottime": 0.20981312100000002,
+          "cumtime": 0.400584732
+        },
+        {
+          "func": "core.py:1851(typeof)",
+          "ncalls": 220314,
+          "tottime": 0.20807197300000002,
+          "cumtime": 1.5508661920000002
+        },
+        {
+          "func": "dtypes.py:975(dtype)",
+          "ncalls": 157478,
+          "tottime": 0.20668507500000002,
+          "cumtime": 0.35656987
+        },
+        {
+          "func": "core.py:645(bind_with_trace)",
+          "ncalls": 99268,
+          "tottime": 0.181027464,
+          "cumtime": 9.633490735
+        },
+        {
+          "func": "array.py:1092(_get_aval_array)",
+          "ncalls": 178429,
+          "tottime": 0.18038910800000002,
+          "cumtime": 0.9108258410000001
+        },
+        {
+          "func": "core.py:1365(set_trace)",
+          "ncalls": 211870,
+          "tottime": 0.169896983,
+          "cumtime": 0.169896983
+        },
+        {
+          "func": "contextlib.py:78(inner)",
+          "ncalls": 2050,
+          "tottime": 0.156385939,
+          "cumtime": 0.171687734
+        },
+        {
+          "func": "core.py:2104(canonicalize_value_dtype)",
+          "ncalls": 167272,
+          "tottime": 0.14327673000000002,
+          "cumtime": 0.345367136
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Resolves the measure-first spike for #618 (steps 2–4). **Verdict: NO-GO (measured, not inferred).** No `src/` change — handoff doc + throwaway profiling tooling only.

## What was asked (#618)
After step 1 found the existing `TENAX_BATCH_BLOCKSPARSE=1` gate helps compile ~21% but **hurts** warm ~14%, steps 2–4 asked: profile where the u1sz warm-step eager time goes, prototype batched contraction/block-pack dispatch, and gate on whether it closes the ~24× warm gap.

## What was found

**1. The issue's premise is factually wrong.** The contraction path **is** already batched: `TENAX_BATCH_BLOCKSPARSE` routes symmetric contraction through `_contract_symmetric_batched` (`contractor.py:785`) — stack same-shape blocks → one batched `jnp.einsum` → `segment_sum`, which is *exactly* the proposed step-3 lever. So step 1 already measured it end-to-end. Verified the path fires with a cold trace + call-counter.

**2. Tooling caveat (generalizes the #610 cold-trace warning).** `probe_backward_jaxpr_566.py` compares gate off/on **in one process**; `jax.make_jaxpr` reuses the gate-OFF trace for the gate-ON call (identical avals) → spurious **1.00× identical** histogram. Must compare gates in **separate processes** (`examples/trace_op_histogram_618.py`). Clean histogram: gate ON collapses contraction 3.2× but *grows* the dominant block-pack/broadcast clusters → **+8.7% more total ops**, explaining step-1's +14% warm.

**3. Mechanism (measured — corrects an earlier device-bound assumption).** The warm wall is **host-bound eager per-block dispatch in the FORWARD**, dominated by `_fuse_indices_symmetric` — cProfile cumtime **~19 s of the 18.5 s warm step** across **8 eager sweeps** (73,748 `convert_element_type`, 32,820 array constructions). The jitted fixed-point backward (`f_bwd`) is **0.134 s** — backward is compiled & fast; the eager forward fuse is the wall.

**4. Why no batching lever closes it.** Batching the fuse = the #566 "stacked-aware fuse" lever (already NO-GO, within 1% noise). Both fuse- and contraction-batching cap at the U(1)-Sz same-shape collapse ceiling **~1.9×** (env corners 1.67×, edges 1.9×) against a **24× gap** — off by >10×. The flag's only real benefit is the **compile** −21% (batched decomp), a potential #566 compile-only knob, never a warm-step default.

Full detail + tables: `docs/superpowers/handoffs/2026-06-18-618-u1sz-batched-dispatch-findings.md`.

## Recommendation
Close #618 NO-GO. For D≥3 U(1)-Sz, dense remains pragmatic; the binding wall is #566 eager per-block dispatch of a graph whose block count can't be collapsed (fragmentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)