### PR TITLE
bench(#566): A100 batched-dispatch D-sweep (D=2..8) — no large-D crossover

### DIFF
--- a/examples/bench_566_a100_D3.json
+++ b/examples/bench_566_a100_D3.json
@@ -1,0 +1,31 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "symmetry": "FermionParity",
+  "chi_desc": "3*D",
+  "max_iter": 12,
+  "reps": 2,
+  "crossover_step_D": null,
+  "crossover_first_D": null,
+  "all_grads_finite": true,
+  "results": [
+    {
+      "D": 3,
+      "chi": 9,
+      "n_blocks": 16,
+      "first_off_s": 1172.8822302408516,
+      "first_on_s": 2053.244447182864,
+      "first_speedup": 0.5712336063297745,
+      "step_off_s": 1432.990422484465,
+      "step_on_s": 2535.2941150264814,
+      "step_min_off_s": 1395.9031586553901,
+      "step_min_on_s": 2434.692671349272,
+      "step_speedup": 0.5652166405432993,
+      "energy_off": -0.01937774507272392,
+      "energy_on": -0.02055510345665746,
+      "grad_finite_off": true,
+      "grad_finite_on": true
+    }
+  ]
+}

--- a/examples/bench_566_a100_D4.json
+++ b/examples/bench_566_a100_D4.json
@@ -1,0 +1,31 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "symmetry": "FermionParity",
+  "chi_desc": "3*D",
+  "max_iter": 12,
+  "reps": 2,
+  "crossover_step_D": null,
+  "crossover_first_D": null,
+  "all_grads_finite": true,
+  "results": [
+    {
+      "D": 4,
+      "chi": 12,
+      "n_blocks": 16,
+      "first_off_s": 167.92967950738966,
+      "first_on_s": 227.36036651581526,
+      "first_speedup": 0.7386057740881959,
+      "step_off_s": 62.780657639726996,
+      "step_on_s": 70.38304505310953,
+      "step_min_off_s": 62.39515362307429,
+      "step_min_on_s": 70.01088921539485,
+      "step_speedup": 0.8919855285083796,
+      "energy_off": -0.02814433621911581,
+      "energy_on": -0.026201506882680643,
+      "grad_finite_off": true,
+      "grad_finite_on": true
+    }
+  ]
+}

--- a/examples/bench_566_a100_D6.json
+++ b/examples/bench_566_a100_D6.json
@@ -1,0 +1,31 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "symmetry": "FermionParity",
+  "chi_desc": "3*D",
+  "max_iter": 12,
+  "reps": 2,
+  "crossover_step_D": null,
+  "crossover_first_D": null,
+  "all_grads_finite": true,
+  "results": [
+    {
+      "D": 6,
+      "chi": 18,
+      "n_blocks": 16,
+      "first_off_s": 188.05600945465267,
+      "first_on_s": 271.60751996561885,
+      "first_speedup": 0.692381453497523,
+      "step_off_s": 72.0540268830955,
+      "step_on_s": 79.22185901552439,
+      "step_min_off_s": 71.44643181562424,
+      "step_min_on_s": 79.19366146810353,
+      "step_speedup": 0.9095220407409996,
+      "energy_off": 0.001246691201999182,
+      "energy_on": 0.0012069408760078018,
+      "grad_finite_off": true,
+      "grad_finite_on": true
+    }
+  ]
+}

--- a/examples/bench_566_a100_D8chi16.json
+++ b/examples/bench_566_a100_D8chi16.json
@@ -1,0 +1,31 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "symmetry": "FermionParity",
+  "chi_desc": "16",
+  "max_iter": 12,
+  "reps": 2,
+  "crossover_step_D": null,
+  "crossover_first_D": null,
+  "all_grads_finite": true,
+  "results": [
+    {
+      "D": 8,
+      "chi": 16,
+      "n_blocks": 16,
+      "first_off_s": 208.51331266015768,
+      "first_on_s": 278.21373735927045,
+      "first_speedup": 0.7494716639059942,
+      "step_off_s": 77.90663244854659,
+      "step_on_s": 84.70503445807844,
+      "step_min_off_s": 77.59124185703695,
+      "step_min_on_s": 84.34090905822814,
+      "step_speedup": 0.9197402839981552,
+      "energy_off": -0.0003969067184796573,
+      "energy_on": -0.000396905920483679,
+      "grad_finite_off": true,
+      "grad_finite_on": true
+    }
+  ]
+}

--- a/examples/bench_566_a100_dispatch_summary.md
+++ b/examples/bench_566_a100_dispatch_summary.md
@@ -1,0 +1,66 @@
+# #566 batched-dispatch D-sweep — A100 record (2026-06-18)
+
+Does the live batched-dispatch gate `TENAX_BATCH_BLOCKSPARSE` (off→on) speed up a
+real symmetric/fermionic iPEPS CTM-AD step, and does it cross over to a *win* at
+large bond dimension D the way YASTN's abelian-symmetric iPEPS does at D≈8?
+
+Harness: `examples/bench_symmetric_ad_batching_566.py` — production
+`jax.value_and_grad` path on a **FermionParity** 16-block iPEPS site tensor
+(`_build_initial_fpeps_tensor`), default `ad_backward_method="vjp"` (iterative
+Neumann backward), x64, on one NVIDIA A100-SXM4-80GB. χ=3D unless noted.
+
+## Result — decisive NO-GO, no crossover
+
+| D | χ | blocks | compile off→on | warm step off→on | warm ratio | notes |
+|---|----|--------|----------------|------------------|-----------|-------|
+| 2 | 6  | 16 | 159→219s (0.73×) | 60.0→67.0s | **0.90×** | clean (run alone) |
+| 3 | 9  | 16 | 1173→2053s (0.57×) | 1433→2535s | 0.57× | **contaminated** — seed-dependent slow Neumann backward (see below) |
+| 4 | 12 | 16 | 168→227s (0.74×) | 62.8→70.4s | **0.89×** | clean |
+| 6 | 18 | 16 | 188→272s (0.69×) | 72.1→79.2s | **0.91×** | clean |
+| 8 | 16 | 16 | 209→278s (0.75×) | 77.9→84.7s | **0.92×** | clean; χ=2D because χ=3D=24 OOMs 80 GB |
+
+`speedup > 1.0` ⇒ batching faster. **It is < 1.0 at every D, on both axes.**
+
+Raw JSON: `bench_566_a100_stackedfwd.json` (D=2), `bench_566_a100_D{3,4,6}.json`,
+`bench_566_a100_D8chi16.json`.
+
+## Reading
+
+* **No crossover through D=8.** The warm off/on ratio is flat at ~0.90× — batched
+  dispatch is consistently ~8–11% *slower*, never faster, and trends nowhere near a
+  win. Compile is also always slower under batching (0.69–0.75×).
+* **The warm step is host-orchestration-bound, not kernel-bound.** During warm
+  steps the **GPU sits at 0% util**; warm time grows only 60→78s from D=2→8 while
+  the block count is *fixed* at 16 (FermionParity is structural — only block *size*
+  grows with D). The cost is the eager CTM-convergence Python loop + eager
+  `_fuse_indices_symmetric` + the Neumann vjp backward Python loop. Batching the
+  *contraction* collapses only the in-jit contraction primitives, adding
+  stack/segment overhead with nothing on the GPU to offset.
+* **Why this differs from YASTN.** YASTN's per-block loop *is* the cheap C-level
+  (NumPy/PyTorch) inner loop, so collapsing it into batched kernels pays by D=8.
+  Here the equivalent cost is host Python orchestration, which batched contraction
+  kernels don't touch. The eager↔batched dial is the wrong axis; the lever is the
+  *cost of one block's unit of work*.
+* **Memory wall.** D=8 at χ=3D=24 OOMs on 80 GB with the Neumann backward (2138
+  allocator-retry dumps); only χ=2D=16 fits. Echoes YASTN needing its ~30× memory
+  gain to reach large D.
+
+## Caveats
+
+* **D=3 row is contaminated and kept only for the record.** Both seed 42 and seed
+  123 produced ~24-min warm steps at D=3 — a seed-dependent *slow-converging
+  Neumann backward* (data-dependent iteration count; the harness disables the
+  Arnoldi precheck). This is a backward-iteration-count artifact, **not** a
+  dispatch property. The true D=3 warm step is bracketed by D=2/D=4 (~60–63s); the
+  ratio direction (batching slower) still holds.
+* This is the **deprecated** `ctm_tensor_converge` + vjp-Neumann path. The modern
+  `ctm_energy_implicit` (CTM fixed-point implicit differentiation) + env warm-start
+  is the faster production path; this benchmark isolates the *dispatch* question on
+  the multi-block path that runs end-to-end.
+
+## Bottom line
+
+Batched dispatch never wins the warm step on this path; dense stays pragmatic for
+D≥3. The only lever that addresses the measured (host-orchestration) wall is making
+the symmetric CTM sweep fully jittable as one graph — the `PaddedBlockArray` +
+`lax.scan` approach already proven in `_jit_sweep.py` for DMRG, ported to CTM.

--- a/examples/bench_566_a100_stackedfwd.json
+++ b/examples/bench_566_a100_stackedfwd.json
@@ -1,0 +1,31 @@
+{
+  "platform": "gpu",
+  "device_kind": "NVIDIA A100-SXM4-80GB",
+  "x64": true,
+  "symmetry": "FermionParity",
+  "chi_desc": "3*D",
+  "max_iter": 12,
+  "reps": 5,
+  "crossover_step_D": null,
+  "crossover_first_D": null,
+  "all_grads_finite": true,
+  "results": [
+    {
+      "D": 2,
+      "chi": 6,
+      "n_blocks": 16,
+      "first_off_s": 159.3904197383672,
+      "first_on_s": 218.6503681372851,
+      "first_speedup": 0.7289739372324767,
+      "step_off_s": 60.02814699523151,
+      "step_on_s": 66.95203666388988,
+      "step_min_off_s": 59.59115514717996,
+      "step_min_on_s": 66.76339039579034,
+      "step_speedup": 0.896584330908148,
+      "energy_off": 0.1655922846937031,
+      "energy_on": 0.16143482630089248,
+      "grad_finite_off": true,
+      "grad_finite_on": true
+    }
+  ]
+}


### PR DESCRIPTION
## What

Records an A100-80GB sweep measuring the live `TENAX_BATCH_BLOCKSPARSE` batched block-sparse dispatch gate (off vs on) on the production **fermionic** FermionParity iPEPS CTM-AD `value_and_grad` path, across **D = 2, 3, 4, 6, 8**. The question: does batched dispatch ever *win* the warm step at large D the way YASTN's abelian-symmetric iPEPS crosses over at D≈8?

## Result — decisive NO-GO, no crossover

| D | χ | compile off→on | warm step off→on | warm ratio |
|---|----|----------------|------------------|-----------|
| 2 | 6  | 0.73× | 60.0→67.0s | **0.90×** |
| 4 | 12 | 0.74× | 62.8→70.4s | **0.89×** |
| 6 | 18 | 0.69× | 72.1→79.2s | **0.91×** |
| 8 | 16 | 0.75× | 77.9→84.7s | **0.92×** |

Batching is ~8–11% **slower** on the warm step at every D, and slower to compile — flat, no trend toward a win.

## Why (measured, not inferred)

The warm step is **host-orchestration-bound**: GPU at **0% util**, warm time grows only 60→78s from D=2→8 while the block count is *fixed* at 16 (FermionParity is structural). The cost is the eager CTM-convergence Python loop + eager `_fuse_indices_symmetric` + the Neumann vjp backward — none of which contraction-batching touches. Unlike YASTN (whose per-block loop *is* the cheap C-level inner loop), collapsing tenax's in-jit contraction primitives adds stack/segment overhead with nothing on the GPU to offset.

D=8 at χ=3D=24 **OOMs** 80 GB with the Neumann backward; only χ=2D=16 fits.

## Caveats

- **D=3 row contaminated** (kept for the record, flagged in the summary): a seed-dependent slow-converging Neumann backward (~24-min warm steps at both seed 42 and 123) — a backward-iteration artifact, not a dispatch property. True D=3 is bracketed by D=2/D=4.
- Uses the deprecated `ctm_tensor_converge` + vjp-Neumann path to isolate the dispatch question on the multi-block path that runs end-to-end.

## Contents

Doc/data only, no `src/` change: `examples/bench_566_a100_dispatch_summary.md` + raw per-D JSON.

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.