### PR TITLE
examples: salvaged 2x2 Heisenberg iPEPS-AD v6–v8 benchmark scripts

### DIFF
--- a/docs/plans/chi-lock-issue-draft.md
+++ b/docs/plans/chi-lock-issue-draft.md
@@ -1,0 +1,100 @@
+# [Draft] feat(ipeps-ad): chi-lock for `ctm_energy_implicit` so implicit AD can opt into in-CTM χ-bump
+
+**Status:** Draft for filing after PR #515 lands.
+
+**Title (for `gh issue create --title`):**
+> chi-lock for `ctm_energy_implicit` — unblock implicit AD + in-CTM χ-bump (#514 follow-up)
+
+**Labels:** `area/ipeps`, `area/ctm`, `kind/feature`, `priority/high`
+
+---
+
+## Summary
+
+PR #515 (Phase 2 of #492 / #514) wired the variPEPS-style in-CTM χ-bump into the explicit-AD warmup path, but left `ctm_energy_implicit` defensively raising `NotImplementedError` whenever `ctmrg_heuristic_increase_chi=True`. This issue tracks lifting that raise.
+
+**Motivation is wall-clock, not correctness.** Fixed χ with χ-extrapolation remains the community-standard reporting protocol, and the variational property `E(χ) ≥ E_exact` holds at any fixed χ. The bump is a variPEPS-style optimization heuristic to avoid wasting L-BFGS steps at small χ early in optimization, then growing to a final χ_max once truncation error matters. This issue makes that heuristic *available* on the implicit-AD path; production benchmarks may still prefer fixed χ.
+
+## The bug (why the raise exists)
+
+`_make_implicit_vjp_fn` (`src/tenax/algorithms/_ctm_energy_ad.py:714-737`) is a factory that closes over `chi` as a Python int and uses it inside three `@jax.jit`'d backward helpers:
+
+- `_jit_apply_Jt` — `_ctm_energy_ad.py:895` → `jit_step_bwd(..., chi=chi, ...)`
+- `_jit_chain_rule` — `_ctm_energy_ad.py:931` → `jit_step_bwd(..., chi=chi, ...)`
+- `_jit_fused_fixed_point_bwd` — `_ctm_energy_ad.py:1000` → `jit_step_bwd(..., chi=chi, ...)`
+
+`jit_step_bwd = _make_jit_ctm_step(neighbors)` (`:838`) uses that `chi` as the truncation rank of the renormalization step's SVD projector.
+
+When `ctmrg_heuristic_increase_chi=True`, the forward CTM may grow the env's first-dim from e.g. χ=9 → 18 mid-convergence. `f_fwd` then hands `env_leaves` of shape `(18, D², 18)` to `f_bwd` as residuals, but the closure-captured `chi` is still 9. Two failure modes:
+
+1. **Silent retrace.** JAX retraces because abstract shapes changed, but `chi=9` still goes into `jit_step_bwd` inside the new trace. The backward CTM step truncates the env back to χ=9.
+2. **Wrong VJP.** The adjoint `(I − J^T)λ = ∂E/∂env` solves with `J^T` of "step with χ=9 projector applied to a χ=18 env" — not the Jacobian of the actual forward step at χ=18. The chain-rule term `J_params^T λ` (`:931`, `:1000`) is similarly broken. The optimizer descends against a fictitious objective — same flavour of pathology as the v8b ghost-minimum (`feedback_drop_chi_schedule_protocol`) but baked into every L-BFGS step.
+
+Defensive raise: `_ctm_energy_ad.py:441-450`.
+
+## The cache layer
+
+`_VJP_CACHE` (`:595`) keys on the static config including `chi`, `ctmrg_heuristic_increase_chi`, `chi_max`, etc. (`:641-666`). The cache is keyed by *build-time* chi, so a forward-side bump within a single call doesn't refresh the closure.
+
+## Proposed approaches
+
+### Option A — cache invalidation on `final_chi` change *(recommended first cut)*
+
+After forward, read `final_chi` from the warmup result. If it differs from the closure's `chi_at_build`, evict the `_VJP_CACHE` entry and rebuild `_make_implicit_vjp_fn(..., chi=final_chi, ...)`. Backward then operates at the new chi.
+
+- **Pros:** small diff, mechanical, easy to test, doesn't touch JIT internals.
+- **Cons:** loses JIT trace reuse across L-BFGS steps that trigger bumps. Once χ stabilises at χ_max, reuse resumes.
+- **Effort:** ~few hundred LoC + tests. 3–5 days.
+- **Risk:** low. Worst case: extra compile time on bump steps.
+
+### Option B — promote chi to a runtime arg
+
+Drop `chi=chi` from the JIT'd helpers' static config; pass it as a runtime arg, or infer from `env_leaves[0].shape[0]`.
+
+- **Pros:** variPEPS-correct fix. One closure handles every χ in `[chi_initial, chi_max]`. No recompile on bump.
+- **Cons:** requires auditing `_make_jit_ctm_step` to confirm `chi` is not a true XLA-static knob (it goes into the SVD projector which **does** want a static truncation rank). May force splitting the projector into trace-static rank vs runtime-shape branches.
+- **Effort:** ~1–2 weeks + careful tests. Touches the projector path.
+- **Risk:** medium-high. Subtle bugs in the SVD projector's static-vs-runtime split could land silently.
+
+### Option C — pre-build closures for every reachable χ
+
+For `chi_max=24` and step size 2 starting from χ=9: build closures at χ∈{9,11,13,…,23,24}. Dispatch by `final_chi` lookup.
+
+- **Pros:** preserves trace reuse without runtime-chi audit.
+- **Cons:** multiplies compile cost by chi-step count (~8× here). Awkward when `chi_max` is large or step size small.
+- **Effort:** lower than B, higher than A. Tests need to assert every closure is reachable.
+- **Risk:** medium (cache-explosion footgun if defaults change).
+
+**Recommendation:** Ship A first to unblock v9b benchmarks; revisit B as a perf follow-up if A's recompile cost dominates wall-clock at large `chi_max`.
+
+## Acceptance criteria
+
+1. `ctmrg_heuristic_increase_chi=True` no longer raises in `ctm_energy_implicit`.
+2. Forward CTM grows χ when `norm_smallest_S > eps`; backward operates at the post-forward χ.
+3. Gradient correctness test: FD-vs-AD parity on a small probe (D=2, χ_initial=4, χ_max=8) where bump is forced to trigger.
+4. Sigma-gauge path remains correct (regression test mirroring `test_ctm_loop_core.py` sigma-gauge regression added in #515).
+5. v9b benchmark (D=3, 2-site bipartite, implicit AD, `chi_initial=9`, `chi_max=24`, no schedule) runs to convergence with wall-clock **at or below** the equivalent fixed-χ=24 run from v7b (8h52m). This is the *wall-clock* gate: bump should save cycles at early L-BFGS steps without producing a worse fixed-point at the same χ_max. Energy should land within numerical tolerance of fixed-χ=24 v7b (~−0.6225); **not** a QMC-parity gate.
+6. `_F3_LAST_DIAGNOSTICS` / `tenax.ctm.gmres` debug logger emits a "chi-rebuild" event when invalidation fires, so wall-clock-perf regression can be diagnosed.
+
+## Test plan
+
+- **Unit:** Add `test_ctm_energy_implicit_chi_bump.py`. Force a bump during forward, assert (a) no raise, (b) `f_bwd`'s captured chi matches `final_chi`, (c) AD gradient matches FD to 1e-5 at D=2 χ=4→8.
+- **Cache:** Assert `_VJP_CACHE` entry evicted/rebuilt when forward chi changes; existing entries at fixed chi unchanged.
+- **Regression:** Existing 856 `-m core` tests still pass; existing defensive-raise tests in `test_ctm_energy_implicit.py` are updated to reflect the new behaviour (raise should no longer fire).
+- **Benchmark gate:** v9b reaches within tolerance of QMC, or we file a follow-up explaining the residual gap.
+
+## Not in scope
+
+- Lifting the bump prohibition for the explicit-`chi_ramp` path (`chi_ramp + ctmrg_heuristic_increase_chi` mutex stays).
+- Multisite / 3-site PESS paths (covered by #411).
+- Deleting `chi_ramp` entirely (covered by #512).
+
+## Related
+
+- #492 — original in-CTM bump feature request
+- #513 — Phase 1 (env-cache warm-start path)
+- #514 / PR #515 — Phase 2 (AD paths; explicit-AD enabled, implicit-AD raises)
+- #512 — deprecate scheduled chi-ramp + end-of-step bump
+- #328 — explicit-AD non-variational drift (separate; not affected by this issue)
+- `feedback_drop_chi_schedule_protocol.md` — why scheduled chi-ramp is the wrong alternative
+- `project_v7_fixed_chi_results.md` — fixed-χ=24 baseline (wall-clock 8h52m on the v5 protocol)

--- a/examples/heisenberg_ipeps_ad_2x2_v6_compose.py
+++ b/examples/heisenberg_ipeps_ad_2x2_v6_compose.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""v6: heisenberg_ipeps_ad_2x2 + reactive ε_T auto-bump composed with the
+v5 chi-schedule (#455 follow-up benchmark, 2026-05-15).
+
+Identical to ``heisenberg_ipeps_ad_2x2.py`` except for:
+    - ``chi_auto_bump=True``
+    - ``chi_auto_bump_eps=1e-5`` (variPEPS §2.8.2 default)
+    - ``chi_auto_bump_step=2`` (default)
+    - ``chi=8`` start in CTMConfig (matches v5 first stage)
+
+Goal: test whether reactive ε_T-driven bumps fire *earlier* than the
+scheduled stage budget, advancing chi=8→16→24 before the
+``[(8,30),(16,30),(24,20)]`` schedule's nominal step boundaries. The
+compose order in ``_optimize_gs_ad_tensor_2site`` is reactive first
+(``_maybe_bump_chi``), scheduled second (``_advance_chi_stage_if_due``),
+so reactive can pre-empt the schedule but not vice-versa. Schedule
+serves as an upper bound.
+
+Comparison target:
+    - v5 (#455-baseline): chi-schedule only — E=-0.66422809 in 8h52m,
+      chi=24 stalled without improvement over chi=16.
+    - variPEPS bipartite (pure reactive auto-bump): documented in
+      ``project_chi_schedule_v5_validated.md``.
+
+PR #481 (#474) makes ε_T real on the 2x2 plaquette path; before that
+patch, eps_T was identically 0.0 and reactive bumps could never fire.
+
+PR #484 adds INFO-level log lines to ``_maybe_bump_chi`` so reactive
+bump events are visible in stdout; this script sets the logger to INFO.
+
+QMC reference: E/site ≈ −0.6694.
+
+Usage::
+
+    JAX_PLATFORMS=cpu uv run python examples/heisenberg_ipeps_ad_2x2_v6_compose.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+# PR #484 observability: surface _maybe_bump_chi INFO log lines so we can see
+# when reactive bumps fire vs schedule-only advances. Set DEBUG to also see
+# per-step (chi, eps_T, threshold) trace useful for retuning chi_auto_bump_eps.
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+from tenax import (  # noqa: E402
+    CTMConfig,
+    aligned_ctm_schedules,
+    heisenberg_gate,
+    iPEPSConfig,
+    optimize_gs_ad_chi_schedule,
+)
+
+
+def main():
+    print("iPEPS-AD v6: chi_schedule + chi_auto_bump compose (#455 follow-up)")
+    print("H = J sum_<ij> S_i . S_j,   J = 1")
+    print("QMC reference: E/site ~ -0.6694\n")
+
+    H = heisenberg_gate()
+
+    conv_tol_schedule, patience_schedule = aligned_ctm_schedules(
+        [(0.0, 1e-5, 20), (0.7, 1e-7, None)]
+    )
+
+    D = 3
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        num_imaginary_steps=300,
+        dt=0.05,
+        unit_cell="2site",
+        ctm=CTMConfig(
+            chi=8,  # start small; schedule + auto-bump ramps to chi_max
+            max_iter=75,
+            min_iter=10,
+            conv_tol=1e-5,
+            projector_method="svd",
+            forward_gauge="phase",
+            adjoint_method="fixed_point",
+            gmres_tol=1e-7,
+            gmres_maxiter=75,
+            # v6: enable reactive ε_T auto-bump (variPEPS §2.8.2)
+            chi_auto_bump=True,
+            chi_auto_bump_eps=1e-5,
+            chi_auto_bump_step=2,
+        ),
+        gs_c4v=True,
+        gs_optimizer="lbfgs",
+        gs_line_search_method="hager_zhang",
+        gs_line_search_max_steps=40,
+        gs_metric_precond=True,
+        metric_gmres_maxiter=3,
+        gs_ctm_conv_tol_schedule=conv_tol_schedule,
+        gs_plateau_patience_schedule=patience_schedule,
+        gs_conv_tol=1e-5,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-5,
+        gs_stall_recovery="reset",
+        gs_noise_amplitude=1e-4,
+        gs_noise_recovery_retries=5,
+        su_init=True,
+        gs_verbose=True,
+        gs_log_interval=5,
+    )
+
+    # Same v5 schedule — auto-bump may pre-empt some stage advances.
+    chi_schedule = [(8, 30), (16, 30), (24, 20)]
+
+    t0 = time.perf_counter()
+    (A_opt, B_opt), envs, E_gs = optimize_gs_ad_chi_schedule(
+        H, None, config, chi_schedule
+    )
+    dt = time.perf_counter() - t0
+
+    print(f"\n  D       = {D}")
+    print(f"  E/site  = {E_gs:.8f}")
+    print(f"  time    = {dt:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/heisenberg_ipeps_ad_2x2_v6b_bipartite.py
+++ b/examples/heisenberg_ipeps_ad_2x2_v6b_bipartite.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""v6b: v6 compose benchmark with gs_c4v=False (bipartite 2-site).
+
+Identical to ``heisenberg_ipeps_ad_2x2_v6_compose.py`` except for
+``gs_c4v=False`` — A and B are two independent site tensors, not B
+derived from A via sublattice rotation. Same implicit-AD path
+(``adjoint_method='fixed_point'`` + default ``gs_implicit_ad=True``).
+
+Goal: apples-to-apples vs variPEPS bipartite reference (D=3, χ=24,
+E=-0.668168 from 2026-05-13). v6 C4v reached E=-0.66498121 — variPEPS
+is 3.2×10⁻³ lower. This run isolates whether the gap is from the C4v
+constraint or from optimizer/stall handling (v6 hit 5/5 stalls; variPEPS
+ran 68+ steps stall-free).
+
+QMC reference: E/site ≈ −0.6694.
+
+Usage::
+
+    CUDA_VISIBLE_DEVICES=0 uv run python examples/heisenberg_ipeps_ad_2x2_v6b_bipartite.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+from tenax import (  # noqa: E402
+    CTMConfig,
+    aligned_ctm_schedules,
+    heisenberg_gate,
+    iPEPSConfig,
+    optimize_gs_ad_chi_schedule,
+)
+
+
+def main():
+    print("iPEPS-AD v6b: bipartite (gs_c4v=False) compose")
+    print("H = J sum_<ij> S_i . S_j,   J = 1")
+    print("QMC reference: E/site ~ -0.6694\n")
+
+    H = heisenberg_gate()
+
+    conv_tol_schedule, patience_schedule = aligned_ctm_schedules(
+        [(0.0, 1e-5, 20), (0.7, 1e-7, None)]
+    )
+
+    D = 3
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        num_imaginary_steps=300,
+        dt=0.05,
+        unit_cell="2site",
+        ctm=CTMConfig(
+            chi=16,  # start at chi=16: bipartite drifts below QMC at chi<16
+            max_iter=75,
+            min_iter=10,
+            conv_tol=1e-5,
+            projector_method="svd",
+            forward_gauge="phase",
+            adjoint_method="fixed_point",
+            gmres_tol=1e-7,
+            gmres_maxiter=75,
+            chi_auto_bump=True,
+            chi_auto_bump_eps=1e-5,
+            chi_auto_bump_step=2,
+        ),
+        gs_c4v=False,  # v6b: bipartite — A and B independent
+        gs_optimizer="lbfgs",
+        gs_line_search_method="hager_zhang",
+        gs_line_search_max_steps=40,
+        gs_metric_precond=True,
+        metric_gmres_maxiter=3,
+        gs_ctm_conv_tol_schedule=conv_tol_schedule,
+        gs_plateau_patience_schedule=patience_schedule,
+        gs_conv_tol=1e-5,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-5,
+        gs_stall_recovery="reset",
+        gs_noise_amplitude=1e-4,
+        gs_noise_recovery_retries=5,
+        su_init=True,
+        gs_verbose=True,
+        gs_log_interval=5,
+    )
+
+    # Skip the chi=8 stage: bipartite implicit AD is non-variational below
+    # chi=16 (warning at ipeps_optimize.py:2089), and the v6b/v6c chi=8
+    # probe at 2026-05-16 21:50 showed the optimizer pushes E to -0.85 by
+    # step 5 — already in the drift basin before reactive bumps can catch up.
+    chi_schedule = [(16, 30), (24, 30)]
+
+    t0 = time.perf_counter()
+    (A_opt, B_opt), envs, E_gs = optimize_gs_ad_chi_schedule(
+        H, None, config, chi_schedule
+    )
+    dt = time.perf_counter() - t0
+
+    print(f"\n  D       = {D}")
+    print(f"  E/site  = {E_gs:.8f}")
+    print(f"  time    = {dt:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/heisenberg_ipeps_ad_2x2_v6c_explicit.py
+++ b/examples/heisenberg_ipeps_ad_2x2_v6c_explicit.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""v6c: 2-site bipartite explicit AD with the new chi_auto_bump stack.
+
+Same as v6b (gs_c4v=False, bipartite) but with gs_implicit_ad=False —
+explicit AD through the unrolled CTM. The 2-site explicit AD path is
+known non-variational at finite χ (issue #328, ipeps_optimize.py:2079
+warning): the optimizer drifts below QMC E=-0.6694 to ~-0.566 because
+truncation bias at the projector level lets it "cheat".
+
+Goal: test whether the post-#481 / #484 toolkit rescues this:
+    - #481: real ε_T on the 2x2 plaquette projector (was 0.0 prior).
+    - #484: INFO logging of ε_T per step and reactive bump events.
+    - #472/#473: chi_auto_bump on the 2-site AD path — dynamically
+      raises χ when ε_T exceeds threshold, forcing the optimizer back
+      into the variational regime.
+    - stop_gradient on projector outputs (#481): blocks "cheating"
+      through projector gradients on the 2x2 path.
+
+If chi_auto_bump=True + chi_auto_bump_eps=1e-5 keeps E above the QMC
+floor, the drift was finite-χ truncation bias and the explicit AD path
+is reusable. If E still drifts, the bug is in the backward pass itself.
+
+QMC reference: E/site ≈ −0.6694 (drift if E goes below).
+
+Usage::
+
+    CUDA_VISIBLE_DEVICES=1 uv run python examples/heisenberg_ipeps_ad_2x2_v6c_explicit.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+from tenax import (  # noqa: E402
+    CTMConfig,
+    aligned_ctm_schedules,
+    heisenberg_gate,
+    iPEPSConfig,
+    optimize_gs_ad_chi_schedule,
+)
+
+
+def main():
+    print("iPEPS-AD v6c: bipartite explicit AD with chi_auto_bump (issue #328 probe)")
+    print("H = J sum_<ij> S_i . S_j,   J = 1")
+    print("QMC reference: E/site ~ -0.6694 (drift signature: E < -0.6694)\n")
+
+    H = heisenberg_gate()
+
+    conv_tol_schedule, patience_schedule = aligned_ctm_schedules(
+        [(0.0, 1e-5, 20), (0.7, 1e-7, None)]
+    )
+
+    D = 3
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        num_imaginary_steps=300,
+        dt=0.05,
+        unit_cell="2site",
+        ctm=CTMConfig(
+            chi=16,  # start at chi=16: bipartite drifts below QMC at chi<16
+            max_iter=75,
+            min_iter=10,
+            conv_tol=1e-5,
+            projector_method="svd",
+            forward_gauge="phase",
+            adjoint_method="fixed_point",
+            gmres_tol=1e-7,
+            gmres_maxiter=75,
+            chi_auto_bump=True,
+            chi_auto_bump_eps=1e-5,
+            chi_auto_bump_step=2,
+        ),
+        gs_c4v=False,  # bipartite
+        gs_implicit_ad=False,  # v6c: explicit AD through unrolled CTM
+        gs_optimizer="lbfgs",
+        gs_line_search_method="hager_zhang",
+        gs_line_search_max_steps=40,
+        gs_metric_precond=True,
+        metric_gmres_maxiter=3,
+        gs_ctm_conv_tol_schedule=conv_tol_schedule,
+        gs_plateau_patience_schedule=patience_schedule,
+        gs_conv_tol=1e-5,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-5,
+        gs_stall_recovery="reset",
+        gs_noise_amplitude=1e-4,
+        gs_noise_recovery_retries=5,
+        su_init=True,
+        gs_verbose=True,
+        gs_log_interval=5,
+    )
+
+    # Skip chi=8 stage — see v6b for rationale.
+    chi_schedule = [(16, 30), (24, 30)]
+
+    t0 = time.perf_counter()
+    (A_opt, B_opt), envs, E_gs = optimize_gs_ad_chi_schedule(
+        H, None, config, chi_schedule
+    )
+    dt = time.perf_counter() - t0
+
+    print(f"\n  D       = {D}")
+    print(f"  E/site  = {E_gs:.8f}")
+    print(f"  time    = {dt:.1f}s")
+    print(f"  drift   = {'YES (E < QMC)' if E_gs < -0.6694 else 'NO (E >= QMC)'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/heisenberg_ipeps_ad_2x2_v7a_c4v_fixed.py
+++ b/examples/heisenberg_ipeps_ad_2x2_v7a_c4v_fixed.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""v7a: 2-site C4v at fixed chi=24 (peps-torch / YASTN pattern).
+
+No chi_schedule, no chi_auto_bump — fixed chi=24 from step 1. Compares
+to v6 (C4v + chi_schedule + auto_bump, E=-0.66498121) to isolate the
+cost of the chi=8 warm-up stage on the C4v ansatz.
+
+QMC reference: E/site ≈ −0.6694.
+
+Usage::
+
+    CUDA_VISIBLE_DEVICES=0 uv run python examples/heisenberg_ipeps_ad_2x2_v7a_c4v_fixed.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+from tenax import (  # noqa: E402
+    CTMConfig,
+    aligned_ctm_schedules,
+    heisenberg_gate,
+    iPEPSConfig,
+    optimize_gs_ad,
+)
+
+
+def main():
+    print("iPEPS-AD v7a: C4v fixed chi=24 (no schedule, no auto-bump)")
+    print("H = J sum_<ij> S_i . S_j,   J = 1")
+    print("QMC reference: E/site ~ -0.6694\n")
+
+    H = heisenberg_gate()
+
+    conv_tol_schedule, patience_schedule = aligned_ctm_schedules(
+        [(0.0, 1e-5, 20), (0.7, 1e-7, None)]
+    )
+
+    D = 3
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        num_imaginary_steps=300,
+        dt=0.05,
+        unit_cell="2site",
+        gs_num_steps=80,
+        ctm=CTMConfig(
+            chi=24,  # fixed chi
+            max_iter=75,
+            min_iter=10,
+            conv_tol=1e-5,
+            projector_method="svd",
+            forward_gauge="phase",
+            adjoint_method="fixed_point",
+            gmres_tol=1e-7,
+            gmres_maxiter=75,
+            chi_auto_bump=False,  # off — fixed-chi pattern
+        ),
+        gs_c4v=True,
+        gs_optimizer="lbfgs",
+        gs_line_search_method="hager_zhang",
+        gs_line_search_max_steps=40,
+        gs_metric_precond=True,
+        metric_gmres_maxiter=3,
+        gs_ctm_conv_tol_schedule=conv_tol_schedule,
+        gs_plateau_patience_schedule=patience_schedule,
+        gs_conv_tol=1e-5,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-5,
+        gs_stall_recovery="reset",
+        gs_noise_amplitude=1e-4,
+        gs_noise_recovery_retries=5,
+        su_init=True,
+        gs_verbose=True,
+        gs_log_interval=5,
+    )
+
+    t0 = time.perf_counter()
+    (A_opt, B_opt), envs, E_gs = optimize_gs_ad(H, None, config)
+    dt = time.perf_counter() - t0
+
+    print(f"\n  D       = {D}")
+    print("  chi     = 24 (fixed)")
+    print(f"  E/site  = {E_gs:.8f}")
+    print(f"  time    = {dt:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/heisenberg_ipeps_ad_2x2_v7b_bipartite_fixed.py
+++ b/examples/heisenberg_ipeps_ad_2x2_v7b_bipartite_fixed.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""v7b: 2-site bipartite implicit AD at fixed chi=24.
+
+Apples-to-apples vs variPEPS bipartite reference (D=3, chi=24,
+E=-0.668168). No chi_schedule, no chi_auto_bump — peps-torch / YASTN
+fixed-chi pattern.
+
+QMC reference: E/site ≈ −0.6694.
+
+Usage::
+
+    CUDA_VISIBLE_DEVICES=1 uv run python examples/heisenberg_ipeps_ad_2x2_v7b_bipartite_fixed.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+from tenax import (  # noqa: E402
+    CTMConfig,
+    aligned_ctm_schedules,
+    heisenberg_gate,
+    iPEPSConfig,
+    optimize_gs_ad,
+)
+
+
+def main():
+    print("iPEPS-AD v7b: bipartite implicit AD fixed chi=24 (variPEPS-style)")
+    print("H = J sum_<ij> S_i . S_j,   J = 1")
+    print("QMC reference: E/site ~ -0.6694\n")
+
+    H = heisenberg_gate()
+
+    conv_tol_schedule, patience_schedule = aligned_ctm_schedules(
+        [(0.0, 1e-5, 20), (0.7, 1e-7, None)]
+    )
+
+    D = 3
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        num_imaginary_steps=300,
+        dt=0.05,
+        unit_cell="2site",
+        gs_num_steps=80,
+        ctm=CTMConfig(
+            chi=24,
+            max_iter=75,
+            min_iter=10,
+            conv_tol=1e-5,
+            projector_method="svd",
+            forward_gauge="phase",
+            adjoint_method="fixed_point",
+            gmres_tol=1e-7,
+            gmres_maxiter=75,
+            chi_auto_bump=False,
+        ),
+        gs_c4v=False,  # bipartite
+        gs_optimizer="lbfgs",
+        gs_line_search_method="hager_zhang",
+        gs_line_search_max_steps=40,
+        gs_metric_precond=True,
+        metric_gmres_maxiter=3,
+        gs_ctm_conv_tol_schedule=conv_tol_schedule,
+        gs_plateau_patience_schedule=patience_schedule,
+        gs_conv_tol=1e-5,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-5,
+        gs_stall_recovery="reset",
+        gs_noise_amplitude=1e-4,
+        gs_noise_recovery_retries=5,
+        su_init=True,
+        gs_verbose=True,
+        gs_log_interval=5,
+    )
+
+    t0 = time.perf_counter()
+    (A_opt, B_opt), envs, E_gs = optimize_gs_ad(H, None, config)
+    dt = time.perf_counter() - t0
+
+    print(f"\n  D       = {D}")
+    print("  chi     = 24 (fixed)")
+    print(f"  E/site  = {E_gs:.8f}")
+    print(f"  time    = {dt:.1f}s")
+    print("  variPEPS ref: -0.668168")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/heisenberg_ipeps_ad_2x2_v7c_explicit_fixed.py
+++ b/examples/heisenberg_ipeps_ad_2x2_v7c_explicit_fixed.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""v7c: 2-site bipartite explicit AD at fixed chi=24 (#328 probe).
+
+No schedule, no auto-bump. Tests whether the bipartite-explicit-AD drift
+(issue #328) is purely an intermediate-chi effect (would be rescued
+here because chi is always 24, never below) or whether explicit AD
+drifts even at chi=24.
+
+If E stays above QMC (-0.6694): drift was intermediate-chi, fix is to
+start at variational chi (or in-CTM auto-bump per #492).
+If E still drifts below QMC: bug is in the explicit backward pass.
+
+QMC reference: E/site ≈ −0.6694.
+
+Usage::
+
+    CUDA_VISIBLE_DEVICES=0 uv run python examples/heisenberg_ipeps_ad_2x2_v7c_explicit_fixed.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+from tenax import (  # noqa: E402
+    CTMConfig,
+    aligned_ctm_schedules,
+    heisenberg_gate,
+    iPEPSConfig,
+    optimize_gs_ad,
+)
+
+
+def main():
+    print("iPEPS-AD v7c: bipartite explicit AD fixed chi=24 (#328 probe)")
+    print("H = J sum_<ij> S_i . S_j,   J = 1")
+    print("QMC reference: E/site ~ -0.6694 (drift signature: E < -0.6694)\n")
+
+    H = heisenberg_gate()
+
+    conv_tol_schedule, patience_schedule = aligned_ctm_schedules(
+        [(0.0, 1e-5, 20), (0.7, 1e-7, None)]
+    )
+
+    D = 3
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        num_imaginary_steps=300,
+        dt=0.05,
+        unit_cell="2site",
+        gs_num_steps=80,
+        ctm=CTMConfig(
+            chi=24,
+            max_iter=75,
+            min_iter=10,
+            conv_tol=1e-5,
+            projector_method="svd",
+            forward_gauge="phase",
+            adjoint_method="fixed_point",
+            gmres_tol=1e-7,
+            gmres_maxiter=75,
+            chi_auto_bump=False,
+        ),
+        gs_c4v=False,
+        gs_implicit_ad=False,  # explicit AD through unrolled CTM
+        gs_optimizer="lbfgs",
+        gs_line_search_method="hager_zhang",
+        gs_line_search_max_steps=40,
+        gs_metric_precond=True,
+        metric_gmres_maxiter=3,
+        gs_ctm_conv_tol_schedule=conv_tol_schedule,
+        gs_plateau_patience_schedule=patience_schedule,
+        gs_conv_tol=1e-5,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-5,
+        gs_stall_recovery="reset",
+        gs_noise_amplitude=1e-4,
+        gs_noise_recovery_retries=5,
+        su_init=True,
+        gs_verbose=True,
+        gs_log_interval=5,
+    )
+
+    t0 = time.perf_counter()
+    (A_opt, B_opt), envs, E_gs = optimize_gs_ad(H, None, config)
+    dt = time.perf_counter() - t0
+
+    print(f"\n  D       = {D}")
+    print("  chi     = 24 (fixed)")
+    print(f"  E/site  = {E_gs:.8f}")
+    print(f"  time    = {dt:.1f}s")
+    print(f"  drift   = {'YES (E < QMC)' if E_gs < -0.6694 else 'NO'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/heisenberg_ipeps_ad_2x2_v8b_bipartite_ramp.py
+++ b/examples/heisenberg_ipeps_ad_2x2_v8b_bipartite_ramp.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""v8b: bipartite implicit AD with 9→12→16→18 chi ramp on the #493-fixed branch.
+
+Configuration: ``gs_c4v=False`` + ``gs_implicit_ad=True`` (implicit AD via
+fixed-point adjoint), ``chi_schedule=[(9,20),(12,20),(16,20),(18,20)]``,
+``chi_auto_bump=False`` (explicit ramp only, no auto-bump noise).
+
+The schedule deliberately caps at χ=18 (well below variPEPS's canonical
+χ=24) to keep wall-clock manageable while still probing all chi-bump
+transitions on the #494-fixed energy.
+
+Verdict logic:
+- v7b (fixed χ=24, post-fix) stayed above QMC through step 35.
+- If v8b also stays above QMC across all four chi stages, then the
+  implicit-AD path remains variational under chi-ramping, which is
+  the production code path users will hit.
+
+QMC reference: E/site ≈ −0.6694.  variPEPS bipartite ref: -0.668168.
+
+Usage::
+
+    CUDA_VISIBLE_DEVICES=0 uv run python examples/heisenberg_ipeps_ad_2x2_v8b_bipartite_ramp.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+from tenax import (  # noqa: E402
+    CTMConfig,
+    aligned_ctm_schedules,
+    heisenberg_gate,
+    iPEPSConfig,
+    optimize_gs_ad_chi_schedule,
+)
+
+
+def main():
+    print("iPEPS-AD v8b: bipartite implicit AD + chi-ramp (post-#493 fix)")
+    print("H = J sum_<ij> S_i . S_j,   J = 1")
+    print("QMC reference: E/site ~ -0.6694 (drift signature: E < -0.6694)\n")
+
+    H = heisenberg_gate()
+
+    conv_tol_schedule, patience_schedule = aligned_ctm_schedules(
+        [(0.0, 1e-5, 20), (0.7, 1e-7, None)]
+    )
+
+    D = 3
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        num_imaginary_steps=300,
+        dt=0.05,
+        unit_cell="2site",
+        ctm=CTMConfig(
+            chi=9,
+            max_iter=75,
+            min_iter=10,
+            conv_tol=1e-5,
+            projector_method="svd",
+            forward_gauge="phase",
+            adjoint_method="fixed_point",
+            gmres_tol=1e-7,
+            gmres_maxiter=75,
+            chi_auto_bump=False,
+        ),
+        gs_c4v=False,
+        gs_optimizer="lbfgs",
+        gs_line_search_method="hager_zhang",
+        gs_line_search_max_steps=40,
+        gs_metric_precond=True,
+        metric_gmres_maxiter=3,
+        gs_ctm_conv_tol_schedule=conv_tol_schedule,
+        gs_plateau_patience_schedule=patience_schedule,
+        gs_conv_tol=1e-5,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-5,
+        gs_stall_recovery="reset",
+        gs_noise_amplitude=1e-4,
+        gs_noise_recovery_retries=5,
+        su_init=True,
+        gs_verbose=True,
+        gs_log_interval=5,
+    )
+
+    chi_schedule = [(9, 20), (12, 20), (16, 20), (18, 20)]
+
+    t0 = time.perf_counter()
+    (A_opt, B_opt), envs, E_gs = optimize_gs_ad_chi_schedule(
+        H, None, config, chi_schedule
+    )
+    dt = time.perf_counter() - t0
+
+    print(f"\n  D       = {D}")
+    print(f"  E/site  = {E_gs:.8f}")
+    print(f"  time    = {dt:.1f}s")
+    print(f"  drift   = {'YES (E < QMC)' if E_gs < -0.6694 else 'NO (E >= QMC)'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/heisenberg_ipeps_ad_2x2_v8c_explicit_ramp.py
+++ b/examples/heisenberg_ipeps_ad_2x2_v8c_explicit_ramp.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""v8c: bipartite explicit AD with 9→12→16→18 chi ramp on the #493-fixed branch.
+
+Configuration: ``gs_c4v=False`` + ``gs_implicit_ad=False`` (explicit AD
+through unrolled CTM), ``chi_schedule=[(9,20),(12,20),(16,20),(18,20)]``,
+``chi_auto_bump=False`` (explicit ramp only).
+
+Purpose has shifted from "verdict on #328" to **perf-signal collection
+for the explicit-AD speedup backlog** (#505 checkpointing, #506 TBPTT,
+#507 late-stage CTM cap). v7c already established that post-#494-fix
+explicit AD drifts below QMC at fixed χ=24, so #328's warning stays.
+v8c instead collects the CTM-iteration and chi-bump trajectory data on
+the correct-energy chi-ramped path — exactly what's needed to design
+TBPTT tape lengths and CTM-cap policies for the production path.
+
+QMC reference: E/site ≈ −0.6694 (this run is NOT a variational probe;
+descent below QMC is expected per #328).
+
+Usage::
+
+    CUDA_VISIBLE_DEVICES=1 uv run python examples/heisenberg_ipeps_ad_2x2_v8c_explicit_ramp.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+from tenax import (  # noqa: E402
+    CTMConfig,
+    aligned_ctm_schedules,
+    heisenberg_gate,
+    iPEPSConfig,
+    optimize_gs_ad_chi_schedule,
+)
+
+
+def main():
+    print("iPEPS-AD v8c: bipartite explicit AD + chi-ramp (post-#493 fix)")
+    print("H = J sum_<ij> S_i . S_j,   J = 1")
+    print("QMC reference: E/site ~ -0.6694 (drift signature: E < -0.6694)\n")
+
+    H = heisenberg_gate()
+
+    conv_tol_schedule, patience_schedule = aligned_ctm_schedules(
+        [(0.0, 1e-5, 20), (0.7, 1e-7, None)]
+    )
+
+    D = 3
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        num_imaginary_steps=300,
+        dt=0.05,
+        unit_cell="2site",
+        ctm=CTMConfig(
+            chi=9,
+            max_iter=75,
+            min_iter=10,
+            conv_tol=1e-5,
+            projector_method="svd",
+            forward_gauge="phase",
+            adjoint_method="fixed_point",
+            gmres_tol=1e-7,
+            gmres_maxiter=75,
+            chi_auto_bump=False,
+        ),
+        gs_c4v=False,
+        gs_implicit_ad=False,  # explicit AD through unrolled CTM
+        gs_optimizer="lbfgs",
+        gs_line_search_method="hager_zhang",
+        gs_line_search_max_steps=40,
+        gs_metric_precond=True,
+        metric_gmres_maxiter=3,
+        gs_ctm_conv_tol_schedule=conv_tol_schedule,
+        gs_plateau_patience_schedule=patience_schedule,
+        gs_conv_tol=1e-5,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-5,
+        gs_stall_recovery="reset",
+        gs_noise_amplitude=1e-4,
+        gs_noise_recovery_retries=5,
+        su_init=True,
+        gs_verbose=True,
+        gs_log_interval=5,
+    )
+
+    chi_schedule = [(9, 20), (12, 20), (16, 20), (18, 20)]
+
+    t0 = time.perf_counter()
+    (A_opt, B_opt), envs, E_gs = optimize_gs_ad_chi_schedule(
+        H, None, config, chi_schedule
+    )
+    dt = time.perf_counter() - t0
+
+    print(f"\n  D       = {D}")
+    print(f"  E/site  = {E_gs:.8f}")
+    print(f"  time    = {dt:.1f}s")
+    print(f"  drift   = {'YES (E < QMC)' if E_gs < -0.6694 else 'NO (E >= QMC)'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Commits 8 benchmark scripts + 1 draft note that were recovered from a stale (merged) worktree during a branch/worktree cleanup, so they live in version control instead of as loose untracked files.

## Contents
- `examples/heisenberg_ipeps_ad_2x2_v6{,b,c}_*.py`, `v7{a,b,c}_*.py`, `v8{b,c}_*.py` — the v6/v7/v8 variants (compose / bipartite / explicit / c4v-fixed / ramp) of the 2×2 Heisenberg iPEPS-AD benchmark ladder (cf. the v6–v9 benchmark summary).
- `docs/plans/chi-lock-issue-draft.md` — draft note for the chi-lock issue.

Throwaway/benchmark tooling only; no `src/` change. ruff auto-fixed 4 lint nits + reformatted one file on commit.

If you'd rather not keep the draft note in-tree, I can drop it from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)