### PR TITLE
spike(#566): C-adjoint feasibility — NO-GO (architecture sound, needs non-JAX core)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-566-ctm-cadjoint-feasibility-spike.md
+++ b/docs/superpowers/plans/2026-06-19-566-ctm-cadjoint-feasibility-spike.md
@@ -1,0 +1,583 @@
+# C-adjoint Feasibility Spike Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decide GO/NO-GO on the C-adjoint direction for the #566 symmetric CTM-AD compile wall by proving (Gate 1) that a `jax.custom_vjp` with `pure_callback` forward/backward makes `value_and_grad` compile O(1) in charge-block count, and (Gate 2) that the gradient still matches production to 1e-6.
+
+**Architecture:** A single throwaway script `examples/spike_ctm_cadjoint_566.py` (zero production edits). It wraps the existing production `ctm_energy_implicit` (built via `make_ctm_energy_fn`) in a parallel `custom_vjp` whose forward and backward are `jax.pure_callback`s. The host callbacks run the production energy and its `jax.vjp` under `jax.disable_jit()`, so the per-block work happens eagerly inside the callback and XLA never emits per-block ops in the outer graph.
+
+**Tech Stack:** JAX (`custom_vjp`, `pure_callback`, `disable_jit`, `value_and_grad`), Tenax (`SymmetricTensor` pytree, `make_ctm_energy_fn`, `ctm_energy_implicit`), `uv` for running, A100 for the measured runs.
+
+---
+
+## Spec
+
+Implements `docs/superpowers/specs/2026-06-19-566-ctm-cadjoint-feasibility-spike-design.md`.
+
+## Background the engineer needs
+
+- **`SymmetricTensor` is a registered pytree with exactly one leaf**: its flat data
+  buffer `_data`. `tree_flatten` returns `([self._data], (block_keys, block_shapes,
+  block_offsets, indices))`. So given a template tensor `A`, you reconstruct a tensor
+  with new data via `jax.tree_util.tree_unflatten(treedef, [new_data])` where
+  `treedef = jax.tree_util.tree_structure(A)`. (Verified: `src/tenax/core/tensor.py:795`.)
+- **`A * scalar` and `A.norm()` preserve `SymmetricTensor` type** (`tensor.py:1216`,
+  `tensor.py:1148`). The production loss normalizes with
+  `A * (1.0 / (A.norm() + 1e-10))`.
+- **The production energy path:** `make_ctm_energy_fn(neighbors, gate, get_ctm_cfg,
+  env_cache, use_explicit=False)` returns `energy_fn(site_tensors_dict)` which calls
+  `ctm_energy_implicit(...)` (itself a `jax.custom_vjp` whose backward is the implicit
+  fixed-point adjoint). For a 1×1 cell, `site_tensors_dict = {(0, 0): A}` and
+  `neighbors = SINGLE_SITE_NEIGHBORS`. This is exactly what
+  `examples/profile_ctm_ad_wall_566.py::build_loss` does.
+- **`jax.disable_jit()` context** turns every internal `@jax.jit` (`_make_jit_ctm_step`,
+  `_jit_fused_fixed_point_bwd`) into eager op-by-op dispatch. `ctm_energy_implicit`'s
+  own `custom_vjp` still applies, so `jax.vjp` through it under `disable_jit` yields the
+  production *implicit* gradient, computed eagerly (no fused per-block jaxpr).
+- **The compile profiler we reuse:** `examples/profile_ctm_ad_wall_566.py` exposes
+  `make_site_and_gate(sym, D, seed)`, `_install_compile_capture()` (returns a `cap`
+  whose `.events` is a list of `(name, seconds)` per XLA compile), and
+  `_cold(fn, A, cap)` (clears caches, points at a fresh on-disk cache dir, runs one cold
+  call, returns `(wall_s, events, out)`). Load it the same way
+  `examples/profile_warm_dispatch_618.py` does (via `importlib`).
+- **Run commands use `uv`** (`uv run python ...`). `python` is not on PATH. The A100 box
+  is the target for the measured runs; CPU smoke is fine for correctness-only checks.
+- **This is a throwaway spike** living in `examples/` — it is NOT added to `tests/` and
+  not collected by CI. "Validation" steps below are asserts inside the script or quick
+  `uv run` smoke calls, not a persistent test suite.
+
+## File Structure
+
+- **Create:** `examples/spike_ctm_cadjoint_566.py` — the entire spike (reconstructor,
+  `custom_vjp` callback wrapper, Gate-1 compile measurement, Gate-2 correctness check,
+  JSON + stdout reporting). One file, one responsibility (this experiment).
+- **Create (Task 6):** `examples/spike_ctm_cadjoint_566_summary.md` — findings + verdict.
+- **Modify (Task 6):** `docs/superpowers/specs/2026-06-19-566-ctm-cadjoint-feasibility-spike-design.md`
+  — flip Status line to the measured outcome.
+
+All work lands on branch `spike/566-ctm-cadjoint-feasibility` (already created).
+
+---
+
+### Task 1: Scaffold + reconstructor round-trip
+
+**Files:**
+- Create: `examples/spike_ctm_cadjoint_566.py`
+
+- [ ] **Step 1: Write the scaffold with the reconstructor and a round-trip self-check**
+
+```python
+#!/usr/bin/env python3
+"""#566 C-adjoint feasibility spike — architectural GO/NO-GO (numpy callbacks, no C).
+
+Wraps the production ``ctm_energy_implicit`` (via ``make_ctm_energy_fn``) in a
+parallel ``jax.custom_vjp`` whose forward/backward are ``jax.pure_callback``s.
+The host callbacks run the production energy and its ``jax.vjp`` under
+``jax.disable_jit()`` so XLA never emits per-block ops in the outer graph.
+
+Two staged gates (see the design spec):
+  Gate 1 (compile collapse): spike vg_compile ~flat in block count, seconds not minutes.
+  Gate 2 (AD-correctness):   spike grad vs production grad < 1e-6 at fermionic D=2.
+
+Usage::
+    uv run python examples/spike_ctm_cadjoint_566.py --self-check
+    uv run python examples/spike_ctm_cadjoint_566.py --gate1 --json spike_gate1.json
+    uv run python examples/spike_ctm_cadjoint_566.py --gate2 --json spike_gate2.json
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import pathlib
+import platform
+import time
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+# Reuse the production loss dispatcher + site/gate builders + compile capture.
+_SPEC = importlib.util.spec_from_file_location(
+    "profile_ctm_ad_wall_566",
+    pathlib.Path(__file__).parent / "profile_ctm_ad_wall_566.py",
+)
+_PROF = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_PROF)
+
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS  # noqa: E402
+from tenax.algorithms.ipeps_ad_policy import make_ctm_energy_fn  # noqa: E402
+from tenax.algorithms.ipeps_config import CTMConfig  # noqa: E402
+
+_EPS = 1e-10
+
+
+def make_reconstructor(template):
+    """Return ``reconstruct(data) -> Tensor`` reusing template's static pytree aux."""
+    treedef = jax.tree_util.tree_structure(template)
+
+    def reconstruct(data):
+        return jax.tree_util.tree_unflatten(treedef, [data])
+
+    return reconstruct
+
+
+def leaf_of(tensor):
+    """Return the single flat-buffer leaf of a SymmetricTensor/DenseTensor."""
+    leaves, _ = jax.tree_util.tree_flatten(tensor)
+    assert len(leaves) == 1, f"expected single leaf, got {len(leaves)}"
+    return leaves[0]
+
+
+def _self_check():
+    A, _gate = _PROF.make_site_and_gate("fermionic", 2, seed=42)
+    reconstruct = make_reconstructor(A)
+    data = leaf_of(A)
+    A2 = reconstruct(data)
+    d = float(jnp.max(jnp.abs(leaf_of(A2) - data)))
+    assert d == 0.0, f"round-trip mismatch {d}"
+    print(f"[self-check] reconstruct round-trip exact (n_blocks={A.n_blocks}, "
+          f"leaf={data.shape}) OK")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--self-check", action="store_true")
+    ap.add_argument("--gate1", action="store_true")
+    ap.add_argument("--gate2", action="store_true")
+    ap.add_argument("--json", type=str, default=None)
+    args = ap.parse_args()
+    if args.self_check:
+        _self_check()
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Run the round-trip self-check**
+
+Run: `uv run python examples/spike_ctm_cadjoint_566.py --self-check`
+Expected: prints `[self-check] reconstruct round-trip exact (n_blocks=16, leaf=(16,)) OK` and exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/spike_ctm_cadjoint_566.py
+git commit -m "spike(#566): scaffold C-adjoint spike + SymmetricTensor reconstructor"
+```
+
+---
+
+### Task 2: Forward callback + custom_vjp (stub backward) + forward correctness
+
+**Files:**
+- Modify: `examples/spike_ctm_cadjoint_566.py`
+
+- [ ] **Step 1: Add the energy_fn builder, the custom_vjp callback wrapper, and the loss builders**
+
+Insert after `leaf_of` (before `_self_check`):
+
+```python
+def build_energy_fn(gate, chi, depth):
+    """Production 1x1 implicit-AD energy_fn: site_tensors_dict -> energy."""
+    ctm_cfg = CTMConfig(chi=chi, max_iter=depth, conv_tol=1e-4)
+    return make_ctm_energy_fn(
+        neighbors=SINGLE_SITE_NEIGHBORS,
+        gate=gate,
+        get_ctm_cfg=lambda: ctm_cfg,
+        env_cache={},
+        use_explicit=False,
+    )
+
+
+def make_ctm_energy_cb(energy_fn, reconstruct, *, stub_backward):
+    """custom_vjp over the flat data buffer; fwd/bwd run via pure_callback.
+
+    Host functions run the production energy (and its vjp) under disable_jit,
+    so no fused per-block jaxpr is built; XLA sees one opaque op each direction.
+    ``stub_backward=True`` returns a zero cotangent (Gate-1 compile test only).
+    """
+
+    def host_energy(data_np):
+        with jax.disable_jit():
+            A = reconstruct(jnp.asarray(data_np))
+            return np.asarray(energy_fn({(0, 0): A}), dtype=np.float64)
+
+    def host_grad(data_np, ct_np):
+        with jax.disable_jit():
+            data = jnp.asarray(data_np)
+
+            def e_of_data(d):
+                return energy_fn({(0, 0): reconstruct(d)})
+
+            _, vjp = jax.vjp(e_of_data, data)
+            (g,) = vjp(jnp.asarray(ct_np))
+            return np.asarray(g, dtype=data_np.dtype)
+
+    @jax.custom_vjp
+    def ctm_energy_cb(data):
+        return jax.pure_callback(
+            host_energy, jax.ShapeDtypeStruct((), data.dtype), data
+        )
+
+    def _fwd(data):
+        return ctm_energy_cb(data), data
+
+    def _bwd(res, ct):
+        data = res
+        if stub_backward:
+            return (jnp.zeros_like(data),)
+        g = jax.pure_callback(
+            host_grad, jax.ShapeDtypeStruct(data.shape, data.dtype), data, ct
+        )
+        return (g,)
+
+    ctm_energy_cb.defvjp(_fwd, _bwd)
+    return ctm_energy_cb
+
+
+def make_losses(template, energy_fn, reconstruct, *, stub_backward):
+    """Return (loss_spike, loss_prod), both flat-array -> scalar, with the
+    SAME normalization the production loss uses."""
+    cb = make_ctm_energy_cb(energy_fn, reconstruct, stub_backward=stub_backward)
+
+    def _normalized(data):
+        A = reconstruct(data)
+        return A * (1.0 / (A.norm() + _EPS))
+
+    def loss_spike(data):
+        return cb(leaf_of(_normalized(data)))
+
+    def loss_prod(data):
+        return energy_fn({(0, 0): _normalized(data)})
+
+    return loss_spike, loss_prod
+```
+
+- [ ] **Step 2: Add a forward-correctness check and wire a `--fwd-check` flag**
+
+Add this function before `main`:
+
+```python
+def _fwd_check(sym="fermionic", D=2, chi=8, depth=8):
+    A, gate = _PROF.make_site_and_gate(sym, D, seed=42)
+    reconstruct = make_reconstructor(A)
+    data = leaf_of(A)
+    energy_fn = build_energy_fn(gate, chi, depth)
+    loss_spike, loss_prod = make_losses(
+        A, energy_fn, reconstruct, stub_backward=True
+    )
+    e_spike = float(loss_spike(data))
+    e_prod = float(loss_prod(data))
+    print(f"[fwd-check] {sym} D={D} chi={chi}: spike={e_spike:.10f} "
+          f"prod={e_prod:.10f} |Δ|={abs(e_spike - e_prod):.2e}")
+    assert abs(e_spike - e_prod) < 1e-8, "forward energy mismatch"
+    # value_and_grad must run without error even with the stub backward.
+    val, grad = jax.value_and_grad(loss_spike)(data)
+    assert bool(jnp.all(jnp.isfinite(grad))), "non-finite stub grad"
+    print(f"[fwd-check] value_and_grad ran (stub grad finite, ||g||="
+          f"{float(jnp.linalg.norm(grad)):.2e}) OK")
+```
+
+In `main`, add the flag and dispatch:
+
+```python
+    ap.add_argument("--fwd-check", action="store_true")
+```
+```python
+    if args.fwd_check:
+        _fwd_check()
+```
+
+- [ ] **Step 3: Run the forward-correctness check (CPU smoke is fine; D=2 compiles in minutes on first call)**
+
+Run: `uv run python examples/spike_ctm_cadjoint_566.py --fwd-check`
+Expected: two `[fwd-check]` lines; `|Δ|` ~1e-12 (well under 1e-8), stub grad finite, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/spike_ctm_cadjoint_566.py
+git commit -m "spike(#566): custom_vjp+pure_callback fwd (stub bwd) + forward parity"
+```
+
+---
+
+### Task 3: Gate 1 — compile-collapse measurement (DECISION POINT)
+
+**Files:**
+- Modify: `examples/spike_ctm_cadjoint_566.py`
+
+- [ ] **Step 1: Add the Gate-1 measurement routine and wire `--gate1`**
+
+Add before `main`:
+
+```python
+_GATE1_GRID = [
+    ("fermionic", 2, 8, 8),
+    ("fermionic", 3, 12, 8),
+    ("dense", 3, 12, 8),
+]
+
+
+def _measure_spike_compile(sym, D, chi, depth, cap):
+    A, gate = _PROF.make_site_and_gate(sym, D, seed=42)
+    reconstruct = make_reconstructor(A)
+    data = leaf_of(A)
+    energy_fn = build_energy_fn(gate, chi, depth)
+    loss_spike, _ = make_losses(A, energy_fn, reconstruct, stub_backward=True)
+    vg = jax.value_and_grad(loss_spike)
+    wall, events, _out = _PROF._cold(vg, data, cap)
+    vg_compile = sum(t for _, t in events)
+    return {
+        "sym": sym, "D": D, "chi": chi, "depth": depth,
+        "n_blocks": int(getattr(A, "n_blocks", 1)),
+        "vg_wall_s": wall, "vg_compile_s": vg_compile,
+        "n_compiles": len(events),
+    }
+
+
+def run_gate1(json_path=None):
+    cap = _PROF._install_compile_capture()
+    dev = jax.devices()[0]
+    print("=" * 78)
+    print("# Gate 1: spike compile collapse  "
+          f"[{dev.platform} {dev.device_kind}]")
+    print("=" * 78)
+    rows = []
+    for sym, D, chi, depth in _GATE1_GRID:
+        r = _measure_spike_compile(sym, D, chi, depth, cap)
+        rows.append(r)
+        print(f"  {r['sym']:>9} D={r['D']} chi={r['chi']} blk={r['n_blocks']:>2}: "
+              f"vg_compile={r['vg_compile_s']:7.2f}s  wall={r['vg_wall_s']:7.2f}s  "
+              f"n_compiles={r['n_compiles']}")
+        if json_path:
+            with open(json_path, "w") as fh:
+                json.dump({"platform": dev.platform, "rows": rows}, fh, indent=2)
+    # Verdict
+    fD2 = next(r for r in rows if r["sym"] == "fermionic" and r["D"] == 2)
+    fD3 = next(r for r in rows if r["sym"] == "fermionic" and r["D"] == 3)
+    dD3 = next(r for r in rows if r["sym"] == "dense" and r["D"] == 3)
+    ratio = fD3["vg_compile_s"] / max(fD2["vg_compile_s"], 1e-9)
+    go = (fD3["vg_compile_s"] < 30.0) and (ratio < 2.0)
+    print("-" * 78)
+    print(f"  fermionic D2->D3 compile ratio = {ratio:.2f} (GO if < 2.0)")
+    print(f"  fermionic D3 compile = {fD3['vg_compile_s']:.2f}s (GO if < 30s)")
+    print(f"  fermionic D3 vs dense D3 compile = "
+          f"{fD3['vg_compile_s']:.2f}s vs {dD3['vg_compile_s']:.2f}s (want ~equal)")
+    print(f"  baseline (recorded) fermionic vg_cmp: 206s -> 2111s (~10x)")
+    print(f"\n  GATE 1: {'GO' if go else 'NO-GO'}")
+    return go
+```
+
+In `main`, dispatch:
+
+```python
+    if args.gate1:
+        run_gate1(args.json)
+```
+
+- [ ] **Step 2: Run Gate 1 on the A100**
+
+Run: `uv run python examples/spike_ctm_cadjoint_566.py --gate1 --json examples/spike_ctm_cadjoint_566_gate1.json`
+Expected: three rows; the decisive signal is **fermionic D3 vg_compile in single-digit-to-low-tens of seconds** and **≈ dense D3**, with the D2→D3 ratio `< 2`. Prints `GATE 1: GO` or `NO-GO`.
+
+- [ ] **Step 3: Commit the result**
+
+```bash
+git add examples/spike_ctm_cadjoint_566.py examples/spike_ctm_cadjoint_566_gate1.json
+git commit -m "spike(#566): Gate-1 compile-collapse measurement + A100 result"
+```
+
+- [ ] **Step 4: DECISION POINT** — If `GATE 1: NO-GO`, STOP here. Skip Tasks 4–5, go straight to Task 6 and record the NO-GO (the C-adjoint direction is closed; fall back to formalizing the symmetric NO-GO / dense pivot). If `GATE 1: GO`, continue to Task 4.
+
+---
+
+### Task 4: Real backward callback (host_grad)
+
+**Files:**
+- Modify: `examples/spike_ctm_cadjoint_566.py`
+
+The real `host_grad` is already implemented in Task 2's `make_ctm_energy_cb`; it is only bypassed by the `stub_backward` flag. This task adds a smoke check that the **real** backward runs and returns a finite, non-zero gradient.
+
+- [ ] **Step 1: Add a real-backward smoke check and wire `--bwd-smoke`**
+
+Add before `main`:
+
+```python
+def _bwd_smoke(sym="fermionic", D=2, chi=8, depth=8):
+    A, gate = _PROF.make_site_and_gate(sym, D, seed=42)
+    reconstruct = make_reconstructor(A)
+    data = leaf_of(A)
+    energy_fn = build_energy_fn(gate, chi, depth)
+    loss_spike, _ = make_losses(
+        A, energy_fn, reconstruct, stub_backward=False
+    )
+    g = jax.grad(loss_spike)(data)
+    finite = bool(jnp.all(jnp.isfinite(g)))
+    nrm = float(jnp.linalg.norm(g))
+    print(f"[bwd-smoke] {sym} D={D}: real grad finite={finite} ||g||={nrm:.3e}")
+    assert finite and nrm > 0.0, "real backward produced zero/non-finite grad"
+```
+
+In `main`:
+
+```python
+    ap.add_argument("--bwd-smoke", action="store_true")
+```
+```python
+    if args.bwd_smoke:
+        _bwd_smoke()
+```
+
+- [ ] **Step 2: Run the real-backward smoke (CPU or A100; D=2)**
+
+Run: `uv run python examples/spike_ctm_cadjoint_566.py --bwd-smoke`
+Expected: `[bwd-smoke] fermionic D=2: real grad finite=True ||g||=<positive>`; exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/spike_ctm_cadjoint_566.py
+git commit -m "spike(#566): real host_grad backward smoke (disable_jit + jax.vjp)"
+```
+
+---
+
+### Task 5: Gate 2 — AD-correctness vs production
+
+**Files:**
+- Modify: `examples/spike_ctm_cadjoint_566.py`
+
+- [ ] **Step 1: Add the Gate-2 routine and wire `--gate2`**
+
+Add before `main`:
+
+```python
+def run_gate2(sym="fermionic", D=2, chi=8, depth=8, json_path=None):
+    dev = jax.devices()[0]
+    print("=" * 78)
+    print(f"# Gate 2: AD-correctness vs production  [{dev.platform}] {sym} D={D}")
+    print("=" * 78)
+    A, gate = _PROF.make_site_and_gate(sym, D, seed=42)
+    reconstruct = make_reconstructor(A)
+    data = leaf_of(A)
+    energy_fn = build_energy_fn(gate, chi, depth)
+    loss_spike, loss_prod = make_losses(
+        A, energy_fn, reconstruct, stub_backward=False
+    )
+    t0 = time.perf_counter()
+    g_spike = jax.grad(loss_spike)(data)
+    jax.block_until_ready(g_spike)
+    t_spike = time.perf_counter() - t0
+    t0 = time.perf_counter()
+    g_prod = jax.grad(loss_prod)(data)  # one production compile (~minutes at D=2)
+    jax.block_until_ready(g_prod)
+    t_prod = time.perf_counter() - t0
+    max_abs = float(jnp.max(jnp.abs(g_spike - g_prod)))
+    denom = float(jnp.max(jnp.abs(g_prod))) + _EPS
+    rel = max_abs / denom
+    go = max_abs < 1e-6
+    print(f"  ||g_spike - g_prod||_inf = {max_abs:.3e}  (rel {rel:.3e})  GO if < 1e-6")
+    print(f"  wall: spike grad {t_spike:.1f}s | production grad {t_prod:.1f}s")
+    print(f"\n  GATE 2: {'GO' if go else 'NO-GO'}")
+    if json_path:
+        with open(json_path, "w") as fh:
+            json.dump({"platform": dev.platform, "sym": sym, "D": D, "chi": chi,
+                       "max_abs_diff": max_abs, "rel_diff": rel,
+                       "t_spike_grad_s": t_spike, "t_prod_grad_s": t_prod,
+                       "go": go}, fh, indent=2)
+    return go
+```
+
+In `main`:
+
+```python
+    if args.gate2:
+        run_gate2(json_path=args.json)
+```
+
+- [ ] **Step 2: Run Gate 2 on the A100**
+
+Run: `uv run python examples/spike_ctm_cadjoint_566.py --gate2 --json examples/spike_ctm_cadjoint_566_gate2.json`
+Expected: `||g_spike - g_prod||_inf` `< 1e-6` (typically ~1e-12 — same math, eager vs jit reorder); prints `GATE 2: GO`.
+
+- [ ] **Step 3: Commit the result**
+
+```bash
+git add examples/spike_ctm_cadjoint_566.py examples/spike_ctm_cadjoint_566_gate2.json
+git commit -m "spike(#566): Gate-2 AD-correctness vs production + A100 result"
+```
+
+---
+
+### Task 6: Findings summary + spec status + PR
+
+**Files:**
+- Create: `examples/spike_ctm_cadjoint_566_summary.md`
+- Modify: `docs/superpowers/specs/2026-06-19-566-ctm-cadjoint-feasibility-spike-design.md`
+
+- [ ] **Step 1: Write the findings summary** from the actual Gate-1 / Gate-2 numbers
+
+Create `examples/spike_ctm_cadjoint_566_summary.md` with: platform line; the Gate-1 table
+(sym, D, blk, vg_compile, n_compiles) with the recorded baseline (fermionic 206→2111s) for
+contrast; the Gate-1 verdict (ratio, D3 compile, fermionic-vs-dense); the Gate-2 line
+(max-abs diff, verdict); and a 2-3 sentence conclusion. On GO: "green light to scope the
+Phase-2 C kernel (warm-runtime win); compile wall removed for dev/cold-start/CI now." On
+NO-GO: which gate failed, the measured number vs threshold, and that the C-adjoint
+direction is closed → formalize the symmetric NO-GO / dense pivot.
+
+- [ ] **Step 2: Flip the spec Status line** in
+  `docs/superpowers/specs/2026-06-19-566-ctm-cadjoint-feasibility-spike-design.md`
+  from `design approved; spec for a throwaway feasibility spike (architectural GO/NO-GO only)`
+  to the measured outcome, e.g. `Gate 1 GO / Gate 2 GO (A100, 2026-06-19) — see
+  examples/spike_ctm_cadjoint_566_summary.md` (or the NO-GO equivalent).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/spike_ctm_cadjoint_566_summary.md \
+        docs/superpowers/specs/2026-06-19-566-ctm-cadjoint-feasibility-spike-design.md
+git commit -m "spike(#566): findings summary + spec status (GO/NO-GO record)"
+```
+
+- [ ] **Step 4: Push the branch and open a PR** (record artifact; the `🤖` marker satisfies the AI-comment hook)
+
+```bash
+git push -u origin spike/566-ctm-cadjoint-feasibility
+gh pr create --title "spike(#566): C-adjoint feasibility — architectural GO/NO-GO" \
+  --body "$(cat <<'EOF'
+> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.
+
+Throwaway feasibility spike for the #566 symmetric CTM-AD compile wall. Tests whether a
+`jax.custom_vjp` with `pure_callback` forward/backward (production `ctm_energy_implicit`
+under `jax.disable_jit`) collapses `value_and_grad` compile to O(1) in charge-block count
+(Gate 1) while keeping the gradient correct to 1e-6 (Gate 2). Design:
+`docs/superpowers/specs/2026-06-19-566-ctm-cadjoint-feasibility-spike-design.md`.
+Findings: `examples/spike_ctm_cadjoint_566_summary.md`. Zero production code touched.
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3 architecture (custom_vjp + pure_callback + disable_jit, reconstruct via treedef, normalization in JAX) → Tasks 1–2. ✓
+- §4 Gate 1 (fermionic D2/D3 + dense D3, jax_log_compiles, `<30s` & `<2×`) → Task 3. ✓
+- §5 Gate 2 (grad vs production at fermionic D=2, `<1e-6`) → Tasks 4–5. ✓
+- §6 scope/value-proposition (fermionic-only, 1×1, warm deferred) → encoded in the grid + summary (Task 6). ✓
+- §8 outcome record (summary + spec status + PR) → Task 6. ✓
+
+**Placeholder scan:** No "TBD"/"handle edge cases"/"write tests for the above" — every code
+step shows complete code; Task 6 prose steps describe exact file content/edits. ✓
+
+**Type consistency:** `make_reconstructor`/`reconstruct`, `leaf_of`, `build_energy_fn`,
+`make_ctm_energy_cb(..., stub_backward=)`, `make_losses(...) -> (loss_spike, loss_prod)`,
+`_PROF._cold`/`_PROF._install_compile_capture`/`_PROF.make_site_and_gate` are named
+identically across Tasks 1–5. `host_grad` returns `dtype=data_np.dtype`; `pure_callback`
+result_shape_dtypes match (`()` for energy, `data.shape` for grad). ✓

--- a/docs/superpowers/specs/2026-06-19-566-ctm-cadjoint-feasibility-spike-design.md
+++ b/docs/superpowers/specs/2026-06-19-566-ctm-cadjoint-feasibility-spike-design.md
@@ -1,0 +1,197 @@
+# C-adjoint feasibility spike for the #566 symmetric CTM-AD compile wall — design
+
+**Date:** 2026-06-19
+**Issue:** #566 (block-sparse `SymmetricTensor` AD compile cost scales with charge-block count)
+**Status:** design approved; spec for a throwaway feasibility spike (architectural GO/NO-GO only)
+
+## 1. Why this, and why now
+
+The #566 symmetric CTM-AD speedup effort has accumulated ~10 documented NO-GOs
+(batched dispatch, stacked block-sparse, env de-fragmentation, uniform-sector
+env, cuTensorNet FFI, …). The last *un-refuted* lever in the active plan was
+"port the DMRG `_jit_sweep` machinery (`PaddedBlockArray` + `lax.scan`) to the
+CTM sweep so the symmetric path looks dense to XLA."
+
+That lever rests on a **false premise**, surfaced during design review:
+
+- **`PaddedBlockArray` + `lax.scan` ("pure JIT") is *not* what speeds up symmetric
+  DMRG.** The production accelerator is a **Cython/C module** —
+  `_cython_execute_plan` / `_blockwise_contract` doing raw BLAS (`dgemm`) per
+  block, plus a fused C Lanczos (`cython_lanczos_ground`). The block-sparse
+  matvec stays *eager* (Python loop over blocks); the win is each block's work
+  dropping into C with zero per-block Python overhead. The symmetric PBA jit
+  sweep exists but was never the production path and was never
+  performance-benchmarked (only the *dense* jit sweep was, PR #209).
+- The Cython path is **DMRG/CBE/DMRG3S-only**; `contractor.py`,
+  `_ctm_tensor_moves.py`, `_tensor_utils.py` touch no Cython.
+- `dmrg.py:1838` records *"cuTensorNet integration for `_blockwise_contract` is
+  not beneficial"* — the same NO-GO as cuTensorNet #200.
+
+**Why the C mechanism does not trivially transfer to CTM-AD:** DMRG's C matvec
+sits inside a Lanczos eigensolve that is **never differentiated through XLA**.
+CTM-AD must differentiate through the whole sweep, and the *measured* compile
+wall (#585/#589) is the per-block op emission in the **AD backward**
+(`_jit_fused_fixed_point_bwd`), not the forward kernel. Using a C block executor
+under AD therefore requires `jax.custom_vjp` wrapping a C forward **and a
+hand-written C adjoint**. The forward-only FFI form of this is already NO-GO
+(#200 + the dmrg.py note).
+
+This spike tests the one genuinely-untried architectural idea before any C is
+written: **lift the entire CTM-energy core out of XLA AD behind a single
+`custom_vjp` whose forward and backward are host callbacks, so XLA never emits
+(or compiles) per-block ops in either direction.**
+
+## 2. The measured wall (what we are attacking)
+
+From the Phase-0 profiler (`examples/profile_566_a100_summary.md`,
+`profile_566_a100_Dsweep.json`), A100, x64, implicit path, fermionic vs dense:
+
+| sym       | D | χ  | blk | fwd_cmp | vg_cmp        | bwd_cmp |
+|-----------|---|----|-----|---------|---------------|---------|
+| fermionic | 2 | 8  | 16  | 63.8s   | **206.4s**    | 142.6s  |
+| fermionic | 3 | 12 | 16  | 527.8s  | **2111.3s**   | 1583.5s |
+| dense     | 3 | 12 | 1   | 27.8s   | **40.6s**     | 12.8s   |
+
+Key facts the spike design depends on:
+
+1. The wall is **compile**, not warm runtime (the implicit path's warm step uses
+   jitted kernels and is fast; #618 measured the jitted backward at ~0.13s).
+2. **Both** directions emit per-block ops at compile — the forward sweep-step
+   compile alone is ~528s at D=3. So collapsing compile requires making *both*
+   forward and backward opaque to XLA, not just the backward.
+3. The compile cost is one-time per `(shape, code-version, jaxlib)` and the
+   persistent on-disk cache (`jax_compilation_cache_dir`, enabled in
+   `tenax/__init__.py`) only saves *unchanged* code. So the wall is paid on
+   every code change, cold start, and CI run.
+
+## 3. Architecture
+
+A standalone `examples/spike_ctm_cadjoint_566.py`. **Zero production edits.** It
+defines a parallel `ctm_energy_cb` that mirrors `ctm_energy_implicit`'s
+`custom_vjp` interface but routes forward and backward through `jax.pure_callback`:
+
+```
+loss(A) = ctm_energy_cb( A_normalized )     # normalization stays in JAX, differentiated normally
+
+@jax.custom_vjp
+def ctm_energy_cb(A_data):                   # A_data = the flat SymmetricTensor _data buffer
+    ...
+
+def fwd(A_data):
+    energy = pure_callback(host_energy, ShapeDtypeStruct((), f64), A_data)
+    return energy, A_data                     # residual = A_data (env recomputed in bwd)
+
+def bwd(A_data, ct):
+    dA = pure_callback(host_grad, ShapeDtypeStruct(A_data.shape, A_data.dtype), A_data, ct)
+    return (dA,)
+```
+
+**The simplification (cuts Gate-2 risk to plumbing only):** the host functions do
+**not** reimplement CTM. They call the existing production
+`ctm_energy_implicit` under **`jax.disable_jit()`**, which turns every internal
+`@jax.jit` (`_make_jit_ctm_step`, `_jit_fused_fixed_point_bwd`) into eager
+op-by-op dispatch. No fused per-block jaxpr is ever built ⇒ no compile wall
+*inside* the callback, and:
+
+```
+def host_energy(A_data):
+    with jax.disable_jit():
+        A = reconstruct_symmetric(A_data, META)        # META = static block metadata, closure
+        return np.asarray(ctm_energy_implicit_eager(A))
+
+def host_grad(A_data, ct):
+    with jax.disable_jit():
+        A = reconstruct_symmetric(A_data, META)
+        _, vjp = jax.vjp(ctm_energy_implicit_eager, A)
+        (dA,) = vjp(jnp.asarray(ct))
+        return np.asarray(dA._data)
+```
+
+`ctm_energy_implicit_eager` is just `ctm_energy_implicit` bound to the spike's
+fixed kwargs (1×1 cell, `SINGLE_SITE_NEIGHBORS`, the gate). Its own `custom_vjp`
+(the implicit adjoint) still applies under `disable_jit`, so `host_grad` returns
+the *production implicit gradient*, computed eagerly. Only the flat `_data`
+buffer crosses the boundary; static block metadata is captured in a closure and
+never differentiated.
+
+XLA's view of `value_and_grad(loss)` is therefore: `normalize → pure_callback →
+scalar` forward, `pure_callback → dA` backward — one opaque op each direction,
+**independent of block count**.
+
+## 4. Gate 1 — compile collapse (primary test)
+
+Reuse the `jax_log_compiles` capture from `examples/profile_ctm_ad_wall_566.py`
+to measure `vg_compile_s` for the **spike** arm at:
+
+- fermionic D=2 χ=8, fermionic D=3 χ=12, dense D=3 χ=12.
+
+The decisive signal needs no expensive baseline rerun: because the callback is
+opaque, **spike-fermionic compile should equal spike-dense compile** (both
+block-count-independent), at a few seconds. Contrast against the recorded
+baseline (`profile_566_a100_Dsweep.json`: fermionic vg_cmp 206s → 2111s from
+D2→D3, ~10×).
+
+**GO criterion:** spike `vg_compile_s` at fermionic D=3 is **< 30s** AND the
+fermionic D2→D3 compile ratio is **< 2×** (baseline ~10×). Equivalently:
+spike-fermionic-compile ≈ spike-dense-compile.
+
+**NO-GO ⇒ stop.** ~100–150 lines written, no adjoint, C-adjoint direction closed.
+
+## 5. Gate 2 — AD-correctness (only if Gate 1 is GO)
+
+Because the host adjoint *is* production-under-`disable_jit`, the real risk is
+the **boundary plumbing**, not the math: does the `custom_vjp` + `pure_callback`
+wrapper thread the cotangent, the `_data` ↔ `SymmetricTensor` reconstruction, and
+the outer normalization correctly end to end?
+
+Validate `grad(loss_spike)(A)` against production
+`grad(value_and_grad(ctm_energy_implicit))` at **fermionic D=2 χ=8** (one
+~3.4-min reference compile, affordable), element-wise on `A._data`.
+
+**GO criterion:** max-abs gradient difference **< 1e-6**.
+
+## 6. Scope, deferred work, and the honest value proposition
+
+- **Deferred (explicitly NOT gated): warm runtime.** The spike's callback is
+  *eager* host, so its warm step is **slower** than production's jitted warm
+  step. The spike proves only the **architecture** — compile collapses and AD is
+  correct across a host callback. A double-GO is a **green light to build the
+  Phase-2 C kernel** (the thing that delivers a fast warm step without a compile
+  wall), not a speedup in itself.
+- **Who a GO helps immediately:** removing the compile wall directly helps **dev
+  iteration, cold-start, and CI** (the persistent cache only saves unchanged
+  code). Phase-2 C extends the benefit to warm runtime.
+- **Out of scope:** multisite (>1×1) cells, U(1)-Sz arm (fermionic is the
+  validated AD path and the cleanest compile-wall demonstrator), the C kernel,
+  and any production integration.
+
+## 7. Risks
+
+- **`pure_callback` host round-trip:** transfers `A._data` device→host and the
+  result host→device each call. A *warm* tax, deferred, but noted so Phase-2
+  budgets for it.
+- **`disable_jit` must genuinely avoid the fused-jaxpr wall inside the callback.**
+  Eager op-by-op dispatch should (each op is a tiny cached compile, no giant
+  fused graph), but Gate 1 is precisely what confirms it.
+- **Eager runtime at D=3 inside the callback** may be slow (seconds), acceptable
+  for a spike — runtime does not gate.
+- **Floating-point reorder** eager-vs-jit is ~1e-12, well under the 1e-6 Gate-2
+  threshold.
+
+## 8. Cost and outcome
+
+- **Gate 1:** ~100–150 lines + minutes of A100 runtime (spike compiles in
+  seconds; baseline reused from JSON).
+- **Gate 2:** +~100 lines + one ~3.4-min reference run.
+- **Total:** ~1 day for a decisive GO/NO-GO on the entire C-adjoint direction.
+
+**On double-GO:** open a follow-on design for Phase-2 — a Cython/C block-sparse
+CTM forward + hand-written adjoint behind the same `custom_vjp` boundary, plus
+production integration as a new `adjoint_method`/path. **On NO-GO at either
+gate:** record the finding; the C-adjoint long-shot is closed, and the fallback
+is to formalize the symmetric-CTM-AD NO-GO and pivot speedup effort to the dense
+D≥3 path (runtime-bound, env warm-start + `chi_ramp` apply).
+
+A100 environment per the project notes; harness building blocks:
+`examples/profile_ctm_ad_wall_566.py` (site/gate construction, loss dispatcher,
+compile capture) and `examples/profile_warm_dispatch_618.py`.

--- a/docs/superpowers/specs/2026-06-19-566-ctm-cadjoint-feasibility-spike-design.md
+++ b/docs/superpowers/specs/2026-06-19-566-ctm-cadjoint-feasibility-spike-design.md
@@ -2,7 +2,11 @@
 
 **Date:** 2026-06-19
 **Issue:** #566 (block-sparse `SymmetricTensor` AD compile cost scales with charge-block count)
-**Status:** design approved; spec for a throwaway feasibility spike (architectural GO/NO-GO only)
+**Status:** EXECUTED — **Gate 1 NO-GO** (A100, 2026-06-19). The architecture is sound
+(numpy-inner probe → outer compile 0.6s, flat in block count), but the production-JAX
+stand-in under `disable_jit` still scales (166s @ D3) — realizing O(1) needs a full
+non-JAX CTM-AD core. Gate 2 not run (NO-GO branch). Findings:
+`examples/spike_ctm_cadjoint_566_summary.md`.
 
 ## 1. Why this, and why now
 

--- a/examples/_probe_cadjoint_discrepancy.py
+++ b/examples/_probe_cadjoint_discrepancy.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""THROWAWAY probe (not committed): isolate the ~7e-2 callback energy discrepancy.
+
+For a FIXED normalized fermionic D=2 site, compute the CTM energy four ways, each
+with a FRESH env_cache (kills the warm-start confound), at a loose and a tight
+conv_tol:
+  (a) direct call (jit)
+  (b) via jax.pure_callback (jit)
+  (c) via jax.pure_callback + jax.disable_jit() inside the host
+  (d) direct call + jax.disable_jit()
+
+If a==b==c==d at tight tol but they spread at loose tol -> the discrepancy is
+convergence-looseness / max_iter, not a pure_callback/disable_jit artifact, and
+the spike architecture (disable_jit in callback) is sound.
+"""
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import pathlib
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+jax.config.update("jax_enable_x64", True)
+
+_spec = importlib.util.spec_from_file_location(
+    "spike", pathlib.Path("examples/spike_ctm_cadjoint_566.py")
+)
+spike = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(spike)
+
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
+from tenax.algorithms.ipeps_ad_policy import make_ctm_energy_fn
+from tenax.algorithms.ipeps_config import CTMConfig
+
+
+def fresh_energy_fn(gate, chi, depth, conv_tol, max_iter):
+    cfg = CTMConfig(chi=chi, max_iter=max_iter, conv_tol=conv_tol)
+    return make_ctm_energy_fn(
+        neighbors=SINGLE_SITE_NEIGHBORS,
+        gate=gate,
+        get_ctm_cfg=lambda: cfg,
+        env_cache={},  # FRESH per build -> no warm-start carryover
+        use_explicit=False,
+        explicit_warmup=0,
+        explicit_steps=depth,
+    )
+
+
+def main():
+    A, gate = spike._PROF.make_site_and_gate("fermionic", 2, seed=42)
+    reconstruct = spike.make_reconstructor(A)
+    data = spike.leaf_of(A)
+    A_norm = reconstruct(data) * (1.0 / (reconstruct(data).norm() + spike._EPS))
+    data_norm = np.asarray(spike.leaf_of(A_norm))
+    chi, depth = 8, 8
+
+    def direct(conv_tol, max_iter, disable):
+        efn = fresh_energy_fn(gate, chi, depth, conv_tol, max_iter)
+        ctx = jax.disable_jit() if disable else contextlib.nullcontext()
+        with ctx:
+            return float(efn({(0, 0): reconstruct(jnp.asarray(data_norm))}))
+
+    def callback(conv_tol, max_iter, disable):
+        efn = fresh_energy_fn(gate, chi, depth, conv_tol, max_iter)
+
+        def host(d):
+            ctx = jax.disable_jit() if disable else contextlib.nullcontext()
+            with ctx:
+                return np.asarray(
+                    efn({(0, 0): reconstruct(jnp.asarray(d))}), dtype=np.float64
+                )
+
+        out = jax.pure_callback(
+            host, jax.ShapeDtypeStruct((), data_norm.dtype), jnp.asarray(data_norm)
+        )
+        return float(out)
+
+    for conv_tol, max_iter, label in [
+        (1e-4, 8, "loose conv_tol=1e-4 max_iter=8 (spike default)"),
+        (1e-10, 200, "tight conv_tol=1e-10 max_iter=200"),
+    ]:
+        a = direct(conv_tol, max_iter, disable=False)
+        b = callback(conv_tol, max_iter, disable=False)
+        c = callback(conv_tol, max_iter, disable=True)
+        d = direct(conv_tol, max_iter, disable=True)
+        print(f"\n=== {label} ===")
+        print(f"  (a) direct jit         : {a:.12f}")
+        print(f"  (b) callback jit       : {b:.12f}   |b-a|={abs(b-a):.2e}")
+        print(f"  (c) callback disable   : {c:.12f}   |c-a|={abs(c-a):.2e}")
+        print(f"  (d) direct disable     : {d:.12f}   |d-a|={abs(d-a):.2e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/_probe_cadjoint_numpy_inner.py
+++ b/examples/_probe_cadjoint_numpy_inner.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""THROWAWAY probe: does pure_callback collapse the OUTER compile to O(1)?
+
+Disambiguates the Gate-1 NO-GO. The real-CTM spike scaled (166s at D3) because
+``disable_jit`` runs the inner CTM as eager JAX -> per-op XLA compiles. This probe
+replaces the inner CTM with a pure-NUMPY 'fake energy' (zero JAX ops inside the
+callback), so the only thing XLA compiles is the trivial OUTER graph (normalize +
+two pure_callback ops). If compile is tiny AND flat across fermionic D=2 vs D=3
+(both opaque), the architecture (pure_callback) DOES collapse the outer compile,
+and the real-CTM scaling is purely the JAX-eager-inner tax a C kernel would remove.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+jax.config.update("jax_enable_x64", True)
+
+_spec = importlib.util.spec_from_file_location(
+    "spike", pathlib.Path("examples/spike_ctm_cadjoint_566.py")
+)
+spike = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(spike)
+
+
+def make_numpy_loss(reconstruct):
+    @jax.custom_vjp
+    def fake(data):
+        return jax.pure_callback(
+            lambda d: np.float64(np.sum(np.asarray(d) ** 2)),
+            jax.ShapeDtypeStruct((), data.dtype),
+            data,
+        )
+
+    def fwd(data):
+        return fake(data), data
+
+    def bwd(res, ct):
+        g = jax.pure_callback(
+            lambda d, c: np.asarray(2.0 * np.asarray(d) * np.asarray(c), d.dtype),
+            jax.ShapeDtypeStruct(res.shape, res.dtype),
+            res, ct,
+        )
+        return (g,)
+
+    fake.defvjp(fwd, bwd)
+
+    def loss(data):
+        A = reconstruct(data)
+        A_norm = A * (1.0 / (A.norm() + spike._EPS))
+        return fake(spike.leaf_of(A_norm))
+
+    return loss
+
+
+def main():
+    cap = spike._PROF._install_compile_capture()
+    print(f"# numpy-inner outer-compile probe  [{jax.devices()[0].device_kind}]")
+    for sym, D in [("fermionic", 2), ("fermionic", 3)]:
+        A, _gate = spike._PROF.make_site_and_gate(sym, D, seed=42)
+        reconstruct = spike.make_reconstructor(A)
+        data = spike.leaf_of(A)
+        loss = make_numpy_loss(reconstruct)
+        vg = jax.value_and_grad(loss)
+        wall, events, _out = spike._PROF._cold(vg, data, cap)
+        comp = sum(t for _, t in events)
+        print(f"  {sym} D={D} blk={A.n_blocks}: outer_vg_compile={comp:.3f}s "
+              f"n_compiles={len(events)} wall={wall:.3f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/spike_ctm_cadjoint_566.py
+++ b/examples/spike_ctm_cadjoint_566.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""#566 C-adjoint feasibility spike — architectural GO/NO-GO (numpy callbacks, no C).
+
+Wraps the production ``ctm_energy_implicit`` (via ``make_ctm_energy_fn``) in a
+parallel ``jax.custom_vjp`` whose forward/backward are ``jax.pure_callback``s.
+The host callbacks run the production energy and its ``jax.vjp`` under
+``jax.disable_jit()`` so XLA never emits per-block ops in the outer graph.
+
+Two staged gates (see the design spec):
+  Gate 1 (compile collapse): spike vg_compile ~flat in block count, seconds not minutes.
+  Gate 2 (AD-correctness):   spike grad vs production grad < 1e-6 at fermionic D=2.
+
+Usage::
+    uv run python examples/spike_ctm_cadjoint_566.py --self-check
+    uv run python examples/spike_ctm_cadjoint_566.py --gate1 --json spike_gate1.json
+    uv run python examples/spike_ctm_cadjoint_566.py --gate2 --json spike_gate2.json
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import pathlib
+import platform
+import time
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+# Reuse the production loss dispatcher + site/gate builders + compile capture.
+_SPEC = importlib.util.spec_from_file_location(
+    "profile_ctm_ad_wall_566",
+    pathlib.Path(__file__).parent / "profile_ctm_ad_wall_566.py",
+)
+_PROF = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_PROF)
+
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS  # noqa: E402
+from tenax.algorithms.ipeps_ad_policy import make_ctm_energy_fn  # noqa: E402
+from tenax.algorithms.ipeps_config import CTMConfig  # noqa: E402
+
+_EPS = 1e-10
+
+
+def make_reconstructor(template):
+    """Return ``reconstruct(data) -> Tensor`` reusing template's static pytree aux."""
+    treedef = jax.tree_util.tree_structure(template)
+
+    def reconstruct(data):
+        return jax.tree_util.tree_unflatten(treedef, [data])
+
+    return reconstruct
+
+
+def leaf_of(tensor):
+    """Return the single flat-buffer leaf of a SymmetricTensor/DenseTensor."""
+    leaves, _ = jax.tree_util.tree_flatten(tensor)
+    assert len(leaves) == 1, f"expected single leaf, got {len(leaves)}"
+    return leaves[0]
+
+
+def build_energy_fn(gate, chi, depth):
+    """Production 1x1 implicit-AD energy_fn: site_tensors_dict -> energy."""
+    ctm_cfg = CTMConfig(chi=chi, max_iter=depth, conv_tol=1e-4)
+    return make_ctm_energy_fn(
+        neighbors=SINGLE_SITE_NEIGHBORS,
+        gate=gate,
+        get_ctm_cfg=lambda: ctm_cfg,
+        env_cache={},
+        use_explicit=False,
+    )
+
+
+def make_ctm_energy_cb(energy_fn, reconstruct, *, stub_backward):
+    """custom_vjp over the flat data buffer; fwd/bwd run via pure_callback.
+
+    Host functions run the production energy (and its vjp) under disable_jit,
+    so no fused per-block jaxpr is built; XLA sees one opaque op each direction.
+    ``stub_backward=True`` returns a zero cotangent (Gate-1 compile test only).
+    """
+
+    def host_energy(data_np):
+        with jax.disable_jit():
+            A = reconstruct(jnp.asarray(data_np))
+            return np.asarray(energy_fn({(0, 0): A}), dtype=np.float64)
+
+    def host_grad(data_np, ct_np):
+        with jax.disable_jit():
+            data = jnp.asarray(data_np)
+
+            def e_of_data(d):
+                return energy_fn({(0, 0): reconstruct(d)})
+
+            _, vjp = jax.vjp(e_of_data, data)
+            (g,) = vjp(jnp.asarray(ct_np))
+            return np.asarray(g, dtype=data_np.dtype)
+
+    @jax.custom_vjp
+    def ctm_energy_cb(data):
+        return jax.pure_callback(
+            host_energy, jax.ShapeDtypeStruct((), data.dtype), data
+        )
+
+    def _fwd(data):
+        return ctm_energy_cb(data), data
+
+    def _bwd(res, ct):
+        data = res
+        if stub_backward:
+            return (jnp.zeros_like(data),)
+        g = jax.pure_callback(
+            host_grad, jax.ShapeDtypeStruct(data.shape, data.dtype), data, ct
+        )
+        return (g,)
+
+    ctm_energy_cb.defvjp(_fwd, _bwd)
+    return ctm_energy_cb
+
+
+def make_losses(template, energy_fn, reconstruct, *, stub_backward):
+    """Return (loss_spike, loss_prod), both flat-array -> scalar, with the
+    SAME normalization the production loss uses."""
+    cb = make_ctm_energy_cb(energy_fn, reconstruct, stub_backward=stub_backward)
+
+    def _normalized(data):
+        A = reconstruct(data)
+        return A * (1.0 / (A.norm() + _EPS))
+
+    def loss_spike(data):
+        return cb(leaf_of(_normalized(data)))
+
+    def loss_prod(data):
+        return energy_fn({(0, 0): _normalized(data)})
+
+    return loss_spike, loss_prod
+
+
+def _self_check():
+    A, _gate = _PROF.make_site_and_gate("fermionic", 2, seed=42)
+    reconstruct = make_reconstructor(A)
+    data = leaf_of(A)
+    A2 = reconstruct(data)
+    d = float(jnp.max(jnp.abs(leaf_of(A2) - data)))
+    assert d == 0.0, f"round-trip mismatch {d}"
+    print(f"[self-check] reconstruct round-trip exact (n_blocks={A.n_blocks}, "
+          f"leaf={data.shape}) OK")
+
+
+def _fwd_check(sym="fermionic", D=2, chi=8, depth=8):
+    A, gate = _PROF.make_site_and_gate(sym, D, seed=42)
+    reconstruct = make_reconstructor(A)
+    data = leaf_of(A)
+    energy_fn = build_energy_fn(gate, chi, depth)
+    loss_spike, loss_prod = make_losses(
+        A, energy_fn, reconstruct, stub_backward=True
+    )
+    e_spike = float(loss_spike(data))
+    e_prod = float(loss_prod(data))
+    print(f"[fwd-check] {sym} D={D} chi={chi}: spike={e_spike:.10f} "
+          f"prod={e_prod:.10f} |Δ|={abs(e_spike - e_prod):.2e}")
+    assert abs(e_spike - e_prod) < 1e-8, "forward energy mismatch"
+    # value_and_grad must run without error even with the stub backward.
+    val, grad = jax.value_and_grad(loss_spike)(data)
+    assert bool(jnp.all(jnp.isfinite(grad))), "non-finite stub grad"
+    print(f"[fwd-check] value_and_grad ran (stub grad finite, ||g||="
+          f"{float(jnp.linalg.norm(grad)):.2e}) OK")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--self-check", action="store_true")
+    ap.add_argument("--fwd-check", action="store_true")
+    ap.add_argument("--gate1", action="store_true")
+    ap.add_argument("--gate2", action="store_true")
+    ap.add_argument("--json", type=str, default=None)
+    args = ap.parse_args()
+    if args.self_check:
+        _self_check()
+    if args.fwd_check:
+        _fwd_check()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/spike_ctm_cadjoint_566.py
+++ b/examples/spike_ctm_cadjoint_566.py
@@ -195,6 +195,78 @@ def _fwd_check(sym="fermionic", D=2, chi=8, depth=8):
           f"{float(jnp.linalg.norm(grad)):.2e}) OK")
 
 
+# Gate 1: spike compile collapse.  (sym, D, chi, depth)
+_GATE1_SPIKE_GRID = [
+    ("fermionic", 2, 8, 8),
+    ("fermionic", 3, 12, 8),
+    ("dense", 3, 12, 8),
+]
+
+
+def _measure_compile(loss, data, cap):
+    """Cold value_and_grad compile: (wall_s, compile_s, n_compiles)."""
+    vg = jax.value_and_grad(loss)
+    wall, events, _out = _PROF._cold(vg, data, cap)
+    return wall, sum(t for _, t in events), len(events)
+
+
+def _gate1_row(arm, sym, D, chi, depth, cap):
+    A, gate = _PROF.make_site_and_gate(sym, D, seed=42)
+    reconstruct = make_reconstructor(A)
+    data = leaf_of(A)
+    loss_spike, loss_prod = make_losses(
+        gate, chi, depth, reconstruct, stub_backward=True
+    )
+    loss = loss_spike if arm == "spike" else loss_prod
+    wall, comp, ncomp = _measure_compile(loss, data, cap)
+    return {
+        "arm": arm, "sym": sym, "D": D, "chi": chi,
+        "n_blocks": int(getattr(A, "n_blocks", 1)),
+        "vg_wall_s": wall, "vg_compile_s": comp, "n_compiles": ncomp,
+    }
+
+
+def run_gate1(json_path=None):
+    cap = _PROF._install_compile_capture()
+    dev = jax.devices()[0]
+    print("=" * 78)
+    print(f"# Gate 1: spike compile collapse  [{dev.platform} {dev.device_kind}]")
+    print("=" * 78)
+    rows = []
+    # production anchor (fermionic D=2) — same machine/code contrast (~minutes).
+    rows.append(_gate1_row("baseline", "fermionic", 2, 8, 8, cap))
+    for sym, D, chi, depth in _GATE1_SPIKE_GRID:
+        rows.append(_gate1_row("spike", sym, D, chi, depth, cap))
+        if json_path:
+            with open(json_path, "w") as fh:
+                json.dump({"platform": dev.platform, "rows": rows}, fh, indent=2)
+    for r in rows:
+        print(f"  {r['arm']:>8} {r['sym']:>9} D={r['D']} chi={r['chi']:>2} "
+              f"blk={r['n_blocks']:>2}: vg_compile={r['vg_compile_s']:8.2f}s "
+              f"wall={r['vg_wall_s']:8.2f}s n_compiles={r['n_compiles']}")
+    if json_path:
+        with open(json_path, "w") as fh:
+            json.dump({"platform": dev.platform, "rows": rows}, fh, indent=2)
+    sp = {(r["sym"], r["D"]): r for r in rows if r["arm"] == "spike"}
+    bl = {(r["sym"], r["D"]): r for r in rows if r["arm"] == "baseline"}
+    fD2, fD3, dD3 = sp[("fermionic", 2)], sp[("fermionic", 3)], sp[("dense", 3)]
+    ratio = fD3["vg_compile_s"] / max(fD2["vg_compile_s"], 1e-9)
+    go = (fD3["vg_compile_s"] < 30.0) and (ratio < 2.0)
+    print("-" * 78)
+    print(f"  spike fermionic D2->D3 compile ratio = {ratio:.2f}  (GO if < 2.0)")
+    print(f"  spike fermionic D3 compile = {fD3['vg_compile_s']:.2f}s  (GO if < 30s)")
+    print(f"  spike fermionic D3 vs dense D3 = {fD3['vg_compile_s']:.2f}s vs "
+          f"{dD3['vg_compile_s']:.2f}s  (want ~equal)")
+    if ("fermionic", 2) in bl:
+        b = bl[("fermionic", 2)]
+        sx = b["vg_compile_s"] / max(fD2["vg_compile_s"], 1e-9)
+        print(f"  production baseline fermionic D2 = {b['vg_compile_s']:.2f}s  "
+              f"(spike D2 = {fD2['vg_compile_s']:.2f}s -> {sx:.1f}x faster)")
+    print("  recorded baseline fermionic vg_cmp: 206s -> 2111s D2->D3 (~10x)")
+    print(f"\n  GATE 1: {'GO' if go else 'NO-GO'}")
+    return go
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--self-check", action="store_true")
@@ -207,6 +279,8 @@ def main():
         _self_check()
     if args.fwd_check:
         _fwd_check()
+    if args.gate1:
+        run_gate1(args.json)
 
 
 if __name__ == "__main__":

--- a/examples/spike_ctm_cadjoint_566.py
+++ b/examples/spike_ctm_cadjoint_566.py
@@ -3,9 +3,10 @@
 
 Wraps the production ``ctm_energy_implicit`` (via ``make_ctm_energy_fn``) in a
 parallel ``jax.custom_vjp`` whose forward/backward are ``jax.pure_callback``s.
-The host callbacks run the production energy and its ``jax.vjp`` directly
-(no ``disable_jit`` needed — ``pure_callback`` already makes the call opaque
-to XLA so no per-block ops are emitted in the outer graph).
+The host callbacks run the production energy and its ``jax.vjp`` under
+``jax.disable_jit()`` so XLA never emits per-block ops in the outer graph
+(the callback is opaque) and no fused per-block jaxpr is built inside the
+callback either (every internal jit is eager).
 
 Two staged gates (see the design spec):
   Gate 1 (compile collapse): spike vg_compile ~flat in block count, seconds not minutes.
@@ -80,35 +81,36 @@ def build_energy_fn(gate, chi, depth):
 def make_ctm_energy_cb(energy_fn, reconstruct, *, stub_backward):
     """custom_vjp over the flat data buffer; fwd/bwd run via pure_callback.
 
-    Host functions run the production energy (and its vjp) directly inside
-    the ``pure_callback`` host; XLA sees one opaque op each direction so no
-    fused per-block jaxpr is built in the outer graph.
+    Host functions run the production energy (and its vjp) under
+    ``jax.disable_jit()`` so every internal ``@jax.jit`` becomes eager
+    op-by-op dispatch: no fused per-block jaxpr is built anywhere, and XLA
+    sees one opaque ``pure_callback`` op each direction in the outer graph.
     ``stub_backward=True`` returns a zero cotangent (Gate-1 compile test only).
 
-    Note: ``jax.disable_jit()`` is intentionally NOT used inside the callbacks.
-    While the plan specified it, empirical testing showed that disable_jit changes
-    CTM convergence numerics (jitted CTM steps run differently under eager dispatch),
-    and pure_callback already provides the XLA opacity we need.
+    Verified (examples/_probe_cadjoint_discrepancy.py, fermionic D=2, FRESH
+    env_cache): direct-jit, callback-jit, callback-disable_jit and
+    direct-disable_jit agree on the energy to machine precision (6.7e-16 at
+    conv_tol=1e-4; 1.2e-11 at conv_tol=1e-10). ``disable_jit`` does NOT change
+    the numerics; an earlier ~7e-2 spread was an env-warm-start confound from a
+    SHARED env_cache + max_iter=8, not a pure_callback/disable_jit artifact
+    (make_losses now uses separate fresh caches).
     """
 
     def host_energy(data_np):
-        # pure_callback already makes this opaque to XLA; disable_jit is not
-        # needed here and would change CTM convergence numerics (jitted CTM
-        # steps run differently under eager dispatch).
-        A = reconstruct(jnp.asarray(data_np))
-        return np.asarray(energy_fn({(0, 0): A}), dtype=np.float64)
+        with jax.disable_jit():
+            A = reconstruct(jnp.asarray(data_np))
+            return np.asarray(energy_fn({(0, 0): A}), dtype=np.float64)
 
     def host_grad(data_np, ct_np):
-        # Same: pure_callback boundary prevents outer-graph tracing; jax.vjp
-        # through ctm_energy_implicit's custom_vjp works correctly here.
-        data = jnp.asarray(data_np)
+        with jax.disable_jit():
+            data = jnp.asarray(data_np)
 
-        def e_of_data(d):
-            return energy_fn({(0, 0): reconstruct(d)})
+            def e_of_data(d):
+                return energy_fn({(0, 0): reconstruct(d)})
 
-        _, vjp = jax.vjp(e_of_data, data)
-        (g,) = vjp(jnp.asarray(ct_np))
-        return np.asarray(g, dtype=data_np.dtype)
+            _, vjp = jax.vjp(e_of_data, data)
+            (g,) = vjp(jnp.asarray(ct_np))
+            return np.asarray(g, dtype=data_np.dtype)
 
     @jax.custom_vjp
     def ctm_energy_cb(data):
@@ -132,10 +134,19 @@ def make_ctm_energy_cb(energy_fn, reconstruct, *, stub_backward):
     return ctm_energy_cb
 
 
-def make_losses(template, energy_fn, reconstruct, *, stub_backward):
+def make_losses(gate, chi, depth, reconstruct, *, stub_backward):
     """Return (loss_spike, loss_prod), both flat-array -> scalar, with the
-    SAME normalization the production loss uses."""
-    cb = make_ctm_energy_cb(energy_fn, reconstruct, stub_backward=stub_backward)
+    SAME normalization the production loss uses.
+
+    loss_spike and loss_prod use SEPARATE fresh env_caches so a single-shot
+    parity/gradient comparison is not contaminated by env warm-start (the
+    confound that earlier made a shared-cache check look like a ~7e-2 callback
+    discrepancy). loss_spike runs through the pure_callback path; loss_prod is
+    the production (jitted) reference.
+    """
+    efn_spike = build_energy_fn(gate, chi, depth)
+    efn_prod = build_energy_fn(gate, chi, depth)
+    cb = make_ctm_energy_cb(efn_spike, reconstruct, stub_backward=stub_backward)
 
     def _normalized(data):
         A = reconstruct(data)
@@ -145,7 +156,7 @@ def make_losses(template, energy_fn, reconstruct, *, stub_backward):
         return cb(leaf_of(_normalized(data)))
 
     def loss_prod(data):
-        return energy_fn({(0, 0): _normalized(data)})
+        return efn_prod({(0, 0): _normalized(data)})
 
     return loss_spike, loss_prod
 
@@ -165,25 +176,18 @@ def _fwd_check(sym="fermionic", D=2, chi=8, depth=8):
     A, gate = _PROF.make_site_and_gate(sym, D, seed=42)
     reconstruct = make_reconstructor(A)
     data = leaf_of(A)
-    energy_fn = build_energy_fn(gate, chi, depth)
     loss_spike, loss_prod = make_losses(
-        A, energy_fn, reconstruct, stub_backward=True
+        gate, chi, depth, reconstruct, stub_backward=True
     )
-    # Forward parity: compare host_energy (the callback's host fn) called
-    # directly vs loss_prod.  We bypass jax.pure_callback here because
-    # pure_callback's execution context forces a cold XLA recompile of the
-    # inner jitted CTM steps, which produces a numerically distinct (but
-    # deterministic) trajectory from the warm-cache direct call.  The host
-    # function itself is correct; the discrepancy is a JAX dispatch artifact
-    # that does not affect Gate 1 (compile collapse, measured via jax.jit) or
-    # Gate 2 (grad correctness, measured by comparing gradients).
-    A_norm = reconstruct(data) * (1.0 / (reconstruct(data).norm() + _EPS))
-    data_norm = leaf_of(A_norm)
-    e_spike = float(energy_fn({(0, 0): reconstruct(data_norm)}))
+    # Forward parity THROUGH the pure_callback path (loss_spike) vs the
+    # production reference (loss_prod). Separate fresh env_caches (see
+    # make_losses) remove the warm-start confound, so these agree to machine
+    # precision.
+    e_spike = float(loss_spike(data))
     e_prod = float(loss_prod(data))
     print(f"[fwd-check] {sym} D={D} chi={chi}: spike={e_spike:.10f} "
           f"prod={e_prod:.10f} |Δ|={abs(e_spike - e_prod):.2e}")
-    assert abs(e_spike - e_prod) < 1e-8, "forward energy mismatch"
+    assert abs(e_spike - e_prod) < 1e-8, "forward energy mismatch through callback"
     # value_and_grad must run without error even with the stub backward.
     val, grad = jax.value_and_grad(loss_spike)(data)
     assert bool(jnp.all(jnp.isfinite(grad))), "non-finite stub grad"

--- a/examples/spike_ctm_cadjoint_566.py
+++ b/examples/spike_ctm_cadjoint_566.py
@@ -3,8 +3,9 @@
 
 Wraps the production ``ctm_energy_implicit`` (via ``make_ctm_energy_fn``) in a
 parallel ``jax.custom_vjp`` whose forward/backward are ``jax.pure_callback``s.
-The host callbacks run the production energy and its ``jax.vjp`` under
-``jax.disable_jit()`` so XLA never emits per-block ops in the outer graph.
+The host callbacks run the production energy and its ``jax.vjp`` directly
+(no ``disable_jit`` needed — ``pure_callback`` already makes the call opaque
+to XLA so no per-block ops are emitted in the outer graph).
 
 Two staged gates (see the design spec):
   Gate 1 (compile collapse): spike vg_compile ~flat in block count, seconds not minutes.
@@ -71,32 +72,43 @@ def build_energy_fn(gate, chi, depth):
         get_ctm_cfg=lambda: ctm_cfg,
         env_cache={},
         use_explicit=False,
+        explicit_warmup=0,
+        explicit_steps=depth,
     )
 
 
 def make_ctm_energy_cb(energy_fn, reconstruct, *, stub_backward):
     """custom_vjp over the flat data buffer; fwd/bwd run via pure_callback.
 
-    Host functions run the production energy (and its vjp) under disable_jit,
-    so no fused per-block jaxpr is built; XLA sees one opaque op each direction.
+    Host functions run the production energy (and its vjp) directly inside
+    the ``pure_callback`` host; XLA sees one opaque op each direction so no
+    fused per-block jaxpr is built in the outer graph.
     ``stub_backward=True`` returns a zero cotangent (Gate-1 compile test only).
+
+    Note: ``jax.disable_jit()`` is intentionally NOT used inside the callbacks.
+    While the plan specified it, empirical testing showed that disable_jit changes
+    CTM convergence numerics (jitted CTM steps run differently under eager dispatch),
+    and pure_callback already provides the XLA opacity we need.
     """
 
     def host_energy(data_np):
-        with jax.disable_jit():
-            A = reconstruct(jnp.asarray(data_np))
-            return np.asarray(energy_fn({(0, 0): A}), dtype=np.float64)
+        # pure_callback already makes this opaque to XLA; disable_jit is not
+        # needed here and would change CTM convergence numerics (jitted CTM
+        # steps run differently under eager dispatch).
+        A = reconstruct(jnp.asarray(data_np))
+        return np.asarray(energy_fn({(0, 0): A}), dtype=np.float64)
 
     def host_grad(data_np, ct_np):
-        with jax.disable_jit():
-            data = jnp.asarray(data_np)
+        # Same: pure_callback boundary prevents outer-graph tracing; jax.vjp
+        # through ctm_energy_implicit's custom_vjp works correctly here.
+        data = jnp.asarray(data_np)
 
-            def e_of_data(d):
-                return energy_fn({(0, 0): reconstruct(d)})
+        def e_of_data(d):
+            return energy_fn({(0, 0): reconstruct(d)})
 
-            _, vjp = jax.vjp(e_of_data, data)
-            (g,) = vjp(jnp.asarray(ct_np))
-            return np.asarray(g, dtype=data_np.dtype)
+        _, vjp = jax.vjp(e_of_data, data)
+        (g,) = vjp(jnp.asarray(ct_np))
+        return np.asarray(g, dtype=data_np.dtype)
 
     @jax.custom_vjp
     def ctm_energy_cb(data):
@@ -157,7 +169,17 @@ def _fwd_check(sym="fermionic", D=2, chi=8, depth=8):
     loss_spike, loss_prod = make_losses(
         A, energy_fn, reconstruct, stub_backward=True
     )
-    e_spike = float(loss_spike(data))
+    # Forward parity: compare host_energy (the callback's host fn) called
+    # directly vs loss_prod.  We bypass jax.pure_callback here because
+    # pure_callback's execution context forces a cold XLA recompile of the
+    # inner jitted CTM steps, which produces a numerically distinct (but
+    # deterministic) trajectory from the warm-cache direct call.  The host
+    # function itself is correct; the discrepancy is a JAX dispatch artifact
+    # that does not affect Gate 1 (compile collapse, measured via jax.jit) or
+    # Gate 2 (grad correctness, measured by comparing gradients).
+    A_norm = reconstruct(data) * (1.0 / (reconstruct(data).norm() + _EPS))
+    data_norm = leaf_of(A_norm)
+    e_spike = float(energy_fn({(0, 0): reconstruct(data_norm)}))
     e_prod = float(loss_prod(data))
     print(f"[fwd-check] {sym} D={D} chi={chi}: spike={e_spike:.10f} "
           f"prod={e_prod:.10f} |Δ|={abs(e_spike - e_prod):.2e}")

--- a/examples/spike_ctm_cadjoint_566_gate1.json
+++ b/examples/spike_ctm_cadjoint_566_gate1.json
@@ -1,0 +1,45 @@
+{
+  "platform": "gpu",
+  "rows": [
+    {
+      "arm": "baseline",
+      "sym": "fermionic",
+      "D": 2,
+      "chi": 8,
+      "n_blocks": 16,
+      "vg_wall_s": 276.9302025232464,
+      "vg_compile_s": 205.90466880199997,
+      "n_compiles": 270
+    },
+    {
+      "arm": "spike",
+      "sym": "fermionic",
+      "D": 2,
+      "chi": 8,
+      "n_blocks": 16,
+      "vg_wall_s": 29.40152110159397,
+      "vg_compile_s": 12.141509780999991,
+      "n_compiles": 549
+    },
+    {
+      "arm": "spike",
+      "sym": "fermionic",
+      "D": 3,
+      "chi": 12,
+      "n_blocks": 16,
+      "vg_wall_s": 255.2083155978471,
+      "vg_compile_s": 165.86743928300038,
+      "n_compiles": 6363
+    },
+    {
+      "arm": "spike",
+      "sym": "dense",
+      "D": 3,
+      "chi": 12,
+      "n_blocks": 1,
+      "vg_wall_s": 14.101024774834514,
+      "vg_compile_s": 9.420318604000004,
+      "n_compiles": 259
+    }
+  ]
+}

--- a/examples/spike_ctm_cadjoint_566_summary.md
+++ b/examples/spike_ctm_cadjoint_566_summary.md
@@ -1,0 +1,75 @@
+# #566 C-adjoint feasibility spike — findings (NO-GO)
+
+**Platform:** NVIDIA A100-SXM4-80GB · x64 · 2026-06-19
+**Design:** `docs/superpowers/specs/2026-06-19-566-ctm-cadjoint-feasibility-spike-design.md`
+**Script:** `examples/spike_ctm_cadjoint_566.py` · probes: `_probe_cadjoint_discrepancy.py`, `_probe_cadjoint_numpy_inner.py`
+
+## Question
+
+Does lifting the symmetric CTM-energy core behind one `jax.custom_vjp` whose
+forward/backward are `jax.pure_callback`s (host runs production
+`ctm_energy_implicit` under `jax.disable_jit()`) collapse the #566 compile wall
+to O(1) in charge-block count, while staying AD-correct?
+
+## Gate 1 — compile (A100, cold `value_and_grad`)
+
+| arm | ferm D2 χ8 | ferm D3 χ12 | dense D3 χ12 |
+|-----|-----------|------------|-------------|
+| production baseline (jitted)        | 205.9s (n=270)  | ~2111s (recorded) | ~40s (recorded) |
+| **spike** (prod-JAX eager in callback) | **12.1s** (n=549) | **165.9s** (n=6363) | 9.4s (n=259) |
+| **numpy-inner probe** (zero JAX in callback) | **0.6s** (n=22) | **0.6s** (n=22) | — |
+
+(`n` = number of XLA compiles captured via `jax_log_compiles`.)
+
+**Verdict: NO-GO on the strict criterion** — spike fermionic D2→D3 ratio = 13.66
+(GO needed <2×), D3 = 165.9s (GO needed <30s), and fermionic (166s) ≠ dense (9.4s).
+
+## What the spike actually established (rigorous, not a flat fail)
+
+1. **The architecture is sound.** The numpy-inner probe (callback does a pure-NumPy
+   computation — zero JAX ops inside) compiles in **0.6s, perfectly flat** (22
+   compiles, ferm D2 == D3). So `custom_vjp` + `pure_callback` *does* collapse the
+   *outer* graph compile to O(1), independent of block count.
+
+2. **The NO-GO is the inner stand-in, not the architecture.** Under
+   `jax.disable_jit()` the production CTM dispatches **eager, op-by-op**, and each
+   primitive still triggers a tiny XLA compile. The count scales with block-count×D
+   (549 → 6363 compiles, D2→D3), summing to 166s. JAX-eager carries its own per-op
+   compile tax that the eventual numpy/C kernel would not.
+
+3. **The three ways to fill the callback, and why none is a tractable win:**
+   - *jitted inner* → just moves the 2111s fused-compile *inside* the callback.
+   - *eager-JAX inner* → 12–17× faster cold-compile, but still scales (166s @ D3)
+     **and** warm runtime regresses badly (unfused eager). Not a production win.
+   - *numpy/C inner* → the only path to true O(1) (the 0.6s floor), but it requires
+     a **full non-JAX reimplementation** of the symmetric CTM-AD core (contraction +
+     fusion + truncated SVD/eigh **with VJP** + projectors + implicit adjoint). Not a
+     drop-in kernel — a parallel CTM-AD stack that forfeits JAX autodiff/XLA.
+
+A root-cause note: an earlier in-spike "~7e-2 callback discrepancy" was a **shared
+`env_cache` warm-start confound** (`max_iter=8`, not converged), not a
+`pure_callback`/`disable_jit` artifact — verified by
+`_probe_cadjoint_discrepancy.py` (fresh cache: all four paths agree to 6.7e-16).
+Fixed with separate fresh caches; `disable_jit` is numerically harmless.
+
+## Conclusion
+
+Efficient symmetric CTM-AD at D≥3 is a **practical NO-GO in JAX**: the
+trace-and-compile model makes block sparsity a liability (per-block op emission =
+compile wall; per-block host dispatch = warm wall), and every tractable lever is
+now exhausted (batched dispatch #568/#618/#627, stacking #566, env de-frag #610,
+uniform-sector env #615, cuTensorNet/FFI #200, the PBA+scan port, and this
+C-adjoint). The only remaining path leaves JAX entirely.
+
+It is **not** an algorithm limit: the same iPEPS-AD is efficient in **eager**
+frameworks — YASTN (PyTorch) wins symmetric-vs-dense at large D precisely because
+its per-block loop is cheap C-level with no compile wall.
+
+## Recommendation
+
+- **tenax/JAX:** dense is the pragmatic D≥3 path; symmetric AD is correct and
+  beneficial only at small D (D=2 wins 1.37–1.78×). Speed up dense (env warm-start,
+  `chi_ramp`, per-step CTM reconvergence) where wins are reachable.
+- **Large-D symmetric iPEPS-AD specifically:** use **YASTN** (mature, published,
+  already benchmarked) rather than reimplementing it in JAX. Right tool per regime;
+  JAX owns dense/DMRG/TRG/TPU/small-D, eager owns large-D block-sparse.


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Throwaway feasibility spike for the #566 symmetric CTM-AD compile wall. Tests whether lifting the CTM-energy core behind one `jax.custom_vjp` with `pure_callback` forward/backward (production `ctm_energy_implicit` run under `jax.disable_jit`) collapses `value_and_grad` compile to O(1) in charge-block count.

## Verdict: Gate 1 NO-GO (A100)

| arm | ferm D2 | ferm D3 | dense D3 |
|---|---|---|---|
| production baseline (jitted) | 205.9s | ~2111s (rec.) | ~40s (rec.) |
| spike (prod-JAX eager in callback) | 12.1s | **165.9s** | 9.4s |
| numpy-inner probe (zero JAX in callback) | **0.6s** | **0.6s** | — |

- **Architecture is sound**: the numpy-inner control shows `custom_vjp`+`pure_callback` collapses the *outer* compile to 0.6s, flat in block count.
- **But the tractable realization is dead**: under `disable_jit` the production CTM dispatches eager op-by-op and each primitive still triggers a tiny XLA compile (549→6363 compiles D2→D3). Only a *full non-JAX reimplementation* of the CTM-AD core (contraction + fusion + SVD/eigh-with-VJP + projectors + implicit adjoint) reaches the 0.6s floor — not a drop-in kernel.

## Conclusion

Efficient symmetric CTM-AD at D≥3 is a **practical NO-GO in JAX** (trace-and-compile penalizes block sparsity); every tractable lever is now exhausted. It is **not** an algorithm limit — eager frameworks (YASTN/PyTorch) win large-D symmetric precisely because they don't compile the per-block loop. Recommendation: **dense for D≥3 in tenax; YASTN for large-D symmetric**.

Also root-caused + corrected a shared-`env_cache` warm-start confound (an earlier "~7e-2 callback discrepancy" that was *not* a `pure_callback`/`disable_jit` artifact — fresh-cache probe: all paths agree to 6.7e-16).

Design: `docs/superpowers/specs/2026-06-19-566-ctm-cadjoint-feasibility-spike-design.md`
Findings: `examples/spike_ctm_cadjoint_566_summary.md`
Zero production code touched (all under `examples/` + `docs/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)