### PR TITLE
docs(#632): multi-GPU dense CTM findings + well-conditioned sharding parity test

### DIFF
--- a/docs/superpowers/handoffs/2026-06-21-632-multigpu-dense-ctm-findings.md
+++ b/docs/superpowers/handoffs/2026-06-21-632-multigpu-dense-ctm-findings.md
@@ -1,0 +1,164 @@
+# #632 rung-1 — Multi-GPU GSPMD-sharded dense forward CTM at large D — Findings
+
+**Date:** 2026-06-21
+**Parent:** #566 (large-D iPEPS is a tenax/JAX wall). **Implements:** the rung-1 plan's
+**Task 7** (GPU memory-feasibility benchmark, never run on real hardware until now).
+**Spec:** `docs/superpowers/specs/2026-06-19-gspmd-sharded-dense-ctm-large-d-design.md`.
+**Hardware:** single node, 4× A100-SXM4-80GB (NVLink) + 1 DGX-Display GPU (excluded).
+**Verdict:** **GO on correctness, WEAK as a large-D lever (measured).** GSPMD sharding of
+the dense forward CTM is numerically correct and does fit a D that OOMs on one GPU onto
+four — but the per-device memory reduction is only **~1.6×** (not ~4×), and dense-CTM
+memory scales as **~D⁶**, so N GPUs buy only **N^(1/6)** in D. Net: 4 GPUs lift the forward
+ceiling from **D=10 → D=12** (χ=24), i.e. **+2 in D**. Per-step throughput is unchanged.
+This is not a route to the genuinely large-D regime, and it does not change the
+[fermionic-large-D] strategic picture (eager/YASTN for large D).
+
+## Question
+
+Does single-node multi-GPU (GSPMD D²-axis sharding, #632 rung-1) "really scale" the dense
+iPEPS forward CTM to large D? Concretely: (1) does a D that OOMs on one A100-80GB fit on
+2–4? (2) by how much does per-device memory drop? (3) is the sharded result correct on real
+GPUs? (4) what is the throughput cost?
+
+## Setup
+
+Dense forward CTM + energy, **f64** (tenax enables x64 on import — all numbers are
+double-precision), 1-site Heisenberg probe (`tests/_ctm_sharding_probe.py`), GSPMD per-move
+D²-axis resharding (corners + projector SVD replicated). Benchmark
+`examples/bench_ctm_sharding_memory.py`; I added a `--max-iter` passthrough + wall-time
+(peak memory is reached in CTM sweep 1, so `max_iter=2` measures the true peak cheaply).
+`peak_bytes_in_use` from `jax.Device.memory_stats()`, `XLA_PYTHON_CLIENT_PREALLOCATE=false`
+so OOM and peak are real. **Device note:** CUDA enumerates the DGX-Display as device 4 (not
+nvidia-smi's index 3); use `CUDA_VISIBLE_DEVICES=0,1,2,3` for the four A100s — `0,1,2,4`
+wrongly includes the 4 GB display and the executable fails to launch.
+
+## Answer
+
+### 1. Memory: the OOM crossover is real (the headline) — but the reduction is only ~1.6×
+
+Cleanest single-config measurements (each D in its own process; 4-GPU peak is reproducible
+to the byte across runs, single-GPU peak has ~25% allocator/autotune variance):
+
+| D (χ=24, f64) | 1 GPU peak | 4-GPU per-device | reduction | outcome |
+|---|---:|---:|---|---|
+| 8  | 6.7 GB | 2.2 GB | — (small-D, replicated floor dominates) | both fit |
+| 10 | **20.3 GB** | **12.8 GB** (stable ×3) | **1.6×** | both fit |
+| 12 | **OOM** (>80 GB; +45 GiB alloc failed) | **55 GB → FITS** | — | ✅ **crossover** |
+| 14 | autotuner failure (see §5) | ~143 GB (est.) → OOM | — | fails on both |
+
+- **Single-GPU forward ceiling (χ=24) = D=10.** D=12 OOMs.
+- **4-GPU forward ceiling (χ=24) = D=12.** Net reach gain **+2 in D**.
+- The per-device reduction is **~1.6×, far below the ideal 4×.** Peak memory is pinned by
+  **partially-replicated intermediates** — the projector-SVD all-gather is replicated *by
+  design* (spec §"sharding scheme"), plus per-move `a` reshard buffers and unsharded
+  reductions — not by the cleanly-sharded χ²D⁶ term. So 4 GPUs do **not** give a 4×
+  memory headroom.
+
+> ⚠️ **Correction to the in-session interim table.** An earlier sweep reported reductions
+> "2.1× → 2.8× → 3.1× rising with D" from a *multi-D loop* (D=4,6,8 in one process). That was
+> **single-GPU allocator high-water inflation** (the loop's peak carries fragmentation from
+> earlier D's), which oversold the win. The controlled single-config number is **1.6×** and is
+> the one to trust.
+
+### 2. Throughput: unchanged (not slower, not faster)
+
+Compile-subtracted per-CTM-iteration at D=10 χ=24 (two `max_iter` points, difference out the
+one-time compile):
+
+| | wall @ mi=2 | wall @ mi=5 | per-iter | 
+|---|---:|---:|---:|
+| 1 GPU | 16.1 s | 39.6 s | **7.83 s/iter** |
+| 4 GPU | 17.1 s | 40.2 s | **7.70 s/iter** |
+
+Per-step compute is **essentially equal** (4-GPU 1.7% faster = noise). The spec feared the
+replicated-SVD all-gathers would make it slower; they don't, but the sharded D⁶ compute
+doesn't make it faster either. **Multi-GPU here is a pure memory play.** (An in-session
+"16× faster" observation was a single cold-compile outlier — a fresh-process first compile of
+D=10 took 116 s once but 16 s on repeat; debunked by the compile-subtracted numbers above.)
+
+### 3. Correctness: SETTLED — sharded == single to machine precision on well-conditioned states
+
+The benchmark's *random* probe states showed sharded-vs-single energy gaps of ~1e-4, larger
+than CI's <1e-8 parity claim. I traced this to **floating-point reassociation of the sharded
+contraction axis, NOT a logic bug.** Two decisive diagnostics (fake CPU devices so no GPU FP
+confound):
+
+| state (D=4 χ=8) | 2 devices | 4 devices |
+|---|---:|---:|
+| random (ill-conditioned CTM fixed point) | Δ = 2.7e-5 | Δ = 5.6e-5 |
+| well-conditioned (near-product) | Δ = **6.9e-18** | Δ = **4.9e-17** |
+
+The discrepancy **scales with device count** (more shards → more partial-sum regrouping →
+different rounding) and **collapses to machine epsilon when the fixed point is
+well-conditioned.** That is the exact signature of non-associative floating-point summation,
+amplified by the κ of a *random* iPEPS CTM fixed point. Real optimization targets
+well-conditioned (physical) states, where the sharded CTM equals single-device to ~1e-17.
+
+**Two regimes of bit-exactness.** (i) At D=2, D²=4 → 1 element/device, so the contracted sum
+is never regrouped → bit-exact for *any* state (CPU 2-dev and 4-dev both Δ~1e-17).
+(ii) At D=4/χ=4 with N=4 (4 elements/device), the sum *is* regrouped, yet the random probe is
+still Δ~1.4e-17 — because the small-χ fixed point happens to be well-conditioned. Push the same
+random state to χ=8 and it diverges to ~1e-4. So bit-exactness at D≥4 is **conditioning-, not
+structure-, dependent**: the reassociation always happens; whether it shows depends on κ.
+
+### 4. Why it does NOT reach truly large D
+
+1. **D⁶ memory scaling ⇒ N^(1/6) gain in D.** 4 GPUs = 4^(1/6) ≈ 1.26× → +2 in D. Reaching
+   D≈16 would need ~64 GPUs; D≈20, ~4000. Structural, not tunable.
+2. **Sharding efficiency ~1.6×, not 4×** (replicated SVD + reshard buffers, §1). The realized
+   headroom is even smaller than the device count suggests.
+
+### 5. Scope caveats
+
+- **Forward CTM only.** Full `optimize_gs_ad` at large D still needs **rung-2 AD-backward
+  sharding (UNBUILT)**. Backward memory is ~2–4× forward, so the *optimization* ceiling is
+  **below D=12** until rung 2 lands.
+- **The spec's premise was wrong for forward-only f64.** "D=6–8 χ=24 OOMs on 1 GPU" is false —
+  D=8 is 6.65 GB and fits one A100 comfortably. Multi-GPU only matters at **D≥11**.
+- **D=14 hits a separate XLA failure on BOTH single and multi-GPU:** `INTERNAL: Failed to get
+  configs for: 6 out of 30 instructions` (cuDNN/cuBLAS autotuner cannot allocate workspace at
+  that size). This is an XLA-autotuner issue distinct from the sharding and would gate D≥14
+  regardless of device count.
+
+## Recommendation
+
+**Land rung-1 as correct, but record it as a weak large-D lever; do not over-promise.** The
+mechanism works and is numerically sound, and the D=12 crossover is genuine — but +2 in D per
+4× GPUs against a D⁶ wall means multi-GPU dense in tenax/JAX is **not** the path to the
+large-D regime where symmetric/eager frameworks matter. For genuinely large D, the
+[fermionic-large-D] verdict stands (YASTN/peps-torch eager).
+
+**If rung-2 is pursued anyway** (to make the win usable for actual optimization, not just
+forward energy), weigh it against this ceiling first: even a perfect rung-2 inherits the
+~1.6×-per-4-GPU / N^(1/6) economics, so the optimization ceiling lands around D=11–12 on 4
+GPUs — a marginal gain over the D=10 single-GPU forward ceiling.
+
+**CI parity gap (closed in this PR).** `tests/_ctm_sharding_parity.py` covers D=2 (N=2) and
+D=4/χ=4 (N=4). Both pass bit-exact — but only D=4/χ=4 even reassociates, and it stays bit-exact
+*because its small-χ random fixed point happens to be well-conditioned*, not by construction. No
+case exercised a larger-χ regime where a random state diverges (~1e-4) but a physical one stays
+tight. This PR adds `test_sharded_well_conditioned_tight_parity` (D=4/χ=8, N=4, near-product
+state, asserts <1e-10) — verified meaningful: the *random* state at the same (D,χ) fails 1e-10,
+the well-conditioned one passes. This guards the property that matters: sharding is exact up to
+FP reassociation, which stays at machine precision on physical (well-conditioned) states.
+
+## Artifacts (this PR, off `main`)
+
+- `docs/.../2026-06-21-632-multigpu-dense-ctm-findings.md` — this doc.
+- `tests/test_ctm_sharding_parity.py` — new well-conditioned tight-parity case (the CI gap fix).
+- `tests/_ctm_sharding_probe.py` — added `max_iter` kwarg (default 20, backward-compatible) and a
+  `well_conditioned` near-product option (used by the new parity case + the bench).
+- `tests/_ctm_sharding_parity_subproc.py` — accepts `well_conditioned` + threshold args.
+- `examples/bench_ctm_sharding_memory.py` — added `--max-iter`, wall-time, x64-in-header; removed
+  a misleading `reset_peak()` no-op and documented the cumulative-peak / one-D-per-process caveat.
+
+## Risks / caveats recorded
+
+- **`peak_bytes_in_use` is a cumulative high-water mark** — JAX has no reset API, so multi-D
+  sweeps report the running max (inflating single-GPU peaks with earlier-D fragmentation; the
+  bench's old `reset_peak()` was a silent no-op, now removed). **Run one D per process** for
+  trustworthy per-config memory (as the headline numbers above do).
+- **`CUDA_VISIBLE_DEVICES` ordering ≠ nvidia-smi ordering** — the DGX-Display is CUDA index 4;
+  use `0,1,2,3` for the four A100s.
+- The D=12 4-GPU peak (55 GB) is close to the 80 GB ceiling, so D=12 is near the 4-GPU forward
+  limit at χ=24 — there is little headroom for rung-2 backward at that D.

--- a/examples/bench_ctm_sharding_memory.py
+++ b/examples/bench_ctm_sharding_memory.py
@@ -1,13 +1,24 @@
 """Memory feasibility: dense CTM at large D, single-GPU vs N-GPU GSPMD mesh.
 
 Usage (real GPUs):
-    # 1) find the single-GPU OOM ceiling:
-    CUDA_VISIBLE_DEVICES=0 uv run python examples/bench_ctm_sharding_memory.py --D 6 8 --chi 24
+    # 1) find the single-GPU OOM ceiling (one D per process for a clean peak):
+    CUDA_VISIBLE_DEVICES=0 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        uv run python examples/bench_ctm_sharding_memory.py --D 12 --chi 24
     # 2) show it fits on N GPUs:
-    CUDA_VISIBLE_DEVICES=0,1,2,3 uv run python examples/bench_ctm_sharding_memory.py --D 6 8 --chi 24 --shard
+    CUDA_VISIBLE_DEVICES=0,1,2,3 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        uv run python examples/bench_ctm_sharding_memory.py --D 12 --chi 24 --shard
+
+NB on device ordering: CUDA enumerates by a different order than nvidia-smi — on
+a mixed box (e.g. A100s + a display GPU), confirm ``jax.devices()`` lists only the
+compute GPUs you want before trusting CUDA_VISIBLE_DEVICES indices.
 
 Reports per-device peak memory (peak_bytes_in_use) and whether the run completed
-or OOM'd, for each D.
+or OOM'd, for each D. ``peak_bytes_in_use`` is a high-water mark that JAX does NOT
+reset between configs, so a multi-D sweep reports the CUMULATIVE peak (and the
+single-device peak also carries allocator fragmentation from earlier D's). For a
+trustworthy per-config number, run ONE D per process (as the usage above does).
+``max_iter`` only affects convergence, not the peak — the peak is reached in the
+first sweep — so ``--max-iter 2`` measures it cheaply.
 
 Note on the reported peak: the probe runs FULL CTM convergence (all four
 directional moves per sweep), so the per-device peak naturally reflects the
@@ -24,6 +35,7 @@ wires up.
 import argparse
 import os
 import sys
+import time
 
 import jax
 
@@ -47,20 +59,31 @@ def main():
     ap.add_argument("--D", type=int, nargs="+", default=[6, 8])
     ap.add_argument("--chi", type=int, default=24)
     ap.add_argument("--shard", action="store_true")
+    ap.add_argument("--max-iter", type=int, default=20)
     args = ap.parse_args()
     mesh = build_ctm_mesh() if args.shard else None
     n = jax.device_count() if args.shard else 1
+    x64 = jax.config.jax_enable_x64
     print(
-        f"# devices={jax.device_count()} shard={args.shard} mesh_n={n} chi={args.chi}"
+        f"# devices={jax.device_count()} shard={args.shard} mesh_n={n} "
+        f"chi={args.chi} max_iter={args.max_iter} x64={x64}"
     )
     for D in args.D:
+        t0 = time.perf_counter()
         try:
             e = heisenberg_dense_probe_energy(
-                D=D, chi=args.chi, device_mesh=mesh, seed=0
+                D=D, chi=args.chi, device_mesh=mesh, seed=0, max_iter=args.max_iter
             )
-            print(f"D={D}: OK  E={float(e):.6f}  per_device_peak={peak_gb():.2f} GB")
+            dt = time.perf_counter() - t0
+            print(
+                f"D={D}: OK  E={float(e):.6f}  per_device_peak={peak_gb():.2f} GB  "
+                f"wall={dt:.1f}s"
+            )
         except Exception as ex:  # noqa: BLE001 - benchmark reports OOM and continues
-            print(f"D={D}: FAILED ({type(ex).__name__}: {str(ex)[:80]})")
+            dt = time.perf_counter() - t0
+            print(
+                f"D={D}: FAILED ({type(ex).__name__}: {str(ex)[:90]})  wall={dt:.1f}s"
+            )
 
 
 if __name__ == "__main__":

--- a/tests/_ctm_sharding_parity_subproc.py
+++ b/tests/_ctm_sharding_parity_subproc.py
@@ -1,10 +1,16 @@
 """Run a small dense CTM single-device vs sharded and assert energy parity.
 
 Invoked by tests/test_ctm_sharding.py under
-XLA_FLAGS=--xla_force_host_platform_device_count=N. Exits 0 on parity (<1e-8).
+XLA_FLAGS=--xla_force_host_platform_device_count=N. Exits 0 on parity.
 
-Usage: _ctm_sharding_parity_subproc.py [D] [chi]
-The caller picks (D, chi) so that D² divides the device count cleanly.
+Usage: _ctm_sharding_parity_subproc.py [D] [chi] [well_conditioned] [thresh]
+  well_conditioned: 0 (random, default) or 1 (near-product, low-κ fixed point)
+  thresh:           parity threshold (default 1e-8)
+The caller picks (D, chi) so that D² divides the device count cleanly. Sharding
+reassociates the D²-axis contraction sum, so on a random (ill-conditioned) state
+at larger χ the sharded vs single energies differ by O(eps·κ) (~1e-4); a
+well-conditioned state keeps that at machine precision — pass well_conditioned=1
+with a tight thresh to exercise the physically-relevant regime.
 """
 
 import os
@@ -28,15 +34,19 @@ from tenax.algorithms.ctm_sharding import build_ctm_mesh
 def main() -> int:
     D = int(sys.argv[1]) if len(sys.argv) > 1 else 2
     chi = int(sys.argv[2]) if len(sys.argv) > 2 else 8
-    e_single = heisenberg_dense_probe_energy(D=D, chi=chi, device_mesh=None, seed=0)
+    well_conditioned = bool(int(sys.argv[3])) if len(sys.argv) > 3 else False
+    thresh = float(sys.argv[4]) if len(sys.argv) > 4 else 1e-8
+    kw = dict(D=D, chi=chi, seed=0, well_conditioned=well_conditioned)
+    e_single = heisenberg_dense_probe_energy(device_mesh=None, **kw)
     mesh = build_ctm_mesh()  # fake devices from XLA_FLAGS
-    e_sharded = heisenberg_dense_probe_energy(D=D, chi=chi, device_mesh=mesh, seed=0)
+    e_sharded = heisenberg_dense_probe_energy(device_mesh=mesh, **kw)
     err = abs(float(e_single) - float(e_sharded))
     print(
         f"devices={jax.device_count()} D={D} chi={chi} "
+        f"well_cond={int(well_conditioned)} thresh={thresh:.0e} "
         f"e_single={e_single:.10f} e_sharded={e_sharded:.10f} |delta|={err:.2e}"
     )
-    return 0 if err < 1e-8 else 1
+    return 0 if err < thresh else 1
 
 
 if __name__ == "__main__":

--- a/tests/_ctm_sharding_probe.py
+++ b/tests/_ctm_sharding_probe.py
@@ -20,22 +20,40 @@ from tenax.core.tensor import DenseTensor
 
 
 def heisenberg_dense_probe_energy(
-    *, D: int, chi: int, device_mesh=None, seed: int = 0
+    *,
+    D: int,
+    chi: int,
+    device_mesh=None,
+    seed: int = 0,
+    max_iter: int = 20,
+    well_conditioned: bool = False,
 ) -> float:
     """Tiny dense iPEPS Heisenberg energy via one CTM convergence (test probe).
 
-    Builds a deterministic random D-bond 1-site iPEPS ``A``, converges the dense
-    CTM (optionally on ``device_mesh``), returns the NN Heisenberg energy. Used
-    to assert the GSPMD-sharded forward CTM matches the single-device result
-    bit-for-bit.
+    Builds a deterministic D-bond 1-site iPEPS ``A``, converges the dense CTM
+    (optionally on ``device_mesh``), returns the NN Heisenberg energy. Used to
+    assert the GSPMD-sharded forward CTM matches the single-device result.
 
     Runs the 1-site cell through the default ``recipe="2x2"`` dispatch (the same
     path the production large-D CTM uses), with a fixed seed and small
     ``max_iter`` for a fast, deterministic probe.
+
+    ``well_conditioned``: when True, build a near-product-state tensor (one
+    dominant bond component) so the CTM fixed point has a well-separated leading
+    eigenvalue (low condition number). Sharding the contraction reassociates the
+    D²-axis sum, so sharded-vs-single agree only to O(eps·κ); on a random
+    (ill-conditioned) state at larger χ that gap reaches ~1e-4, but on a
+    well-conditioned state it stays at machine precision (~1e-17). The flag lets
+    a parity test assert tight agreement in the physically-relevant regime.
     """
     d = 2
     key = jax.random.PRNGKey(seed)
     data = jax.random.normal(key, (D, D, D, D, d))
+    if well_conditioned:
+        # Dominant single-bond component → near product state → well-separated
+        # leading CTM eigenvalue (low κ), so reassociation noise stays ~1e-17.
+        data = 0.02 * data
+        data = data.at[0, 0, 0, 0, :].add(1.0)
     data = data / (jnp.linalg.norm(data) + 1e-10)
     sym = U1Symmetry()
     bond_charges = np.zeros(D, dtype=np.int32)
@@ -61,7 +79,7 @@ def heisenberg_dense_probe_energy(
         {(0, 0): A},
         SINGLE_SITE_NEIGHBORS,
         chi=chi,
-        max_iter=20,
+        max_iter=max_iter,
         conv_tol=1e-12,
         plateau_patience=None,
         device_mesh=device_mesh,

--- a/tests/test_ctm_sharding_parity.py
+++ b/tests/test_ctm_sharding_parity.py
@@ -20,29 +20,62 @@ from _ctm_sharding_probe import heisenberg_dense_probe_energy
 _PARITY_PROBE = {2: (2, 8), 4: (4, 4)}
 
 
-@pytest.mark.parametrize("n_dev", [2, 4])
-def test_sharded_forward_matches_single_device(n_dev):
-    """Dense CTM energy under an N-device GSPMD mesh equals the single-device
-    result to <1e-8 (subprocess with fake CPU devices)."""
-    # ``--xla_force_host_platform_device_count=N`` fabricates N devices on the
-    # CPU platform only, so the subprocess MUST run on CPU.  On a GPU box JAX
-    # otherwise defaults to the single real GPU, the N-way mesh all-gather
-    # never finds its peers, and the child aborts on a rendezvous timeout.
-    # ``JAX_PLATFORMS=cpu`` pins the platform so the fake-device trick (and the
-    # GSPMD sharding it exercises) works regardless of host accelerators.
-    D, chi = _PARITY_PROBE[n_dev]
+def _run_parity_subproc(n_dev, D, chi, *, well_conditioned=False, thresh=1e-8):
+    """Drive the parity subprocess under ``n_dev`` fake CPU devices; return the
+    CompletedProcess.
+
+    ``--xla_force_host_platform_device_count=N`` fabricates N devices on the CPU
+    platform only, so the subprocess MUST run on CPU.  On a GPU box JAX otherwise
+    defaults to the single real GPU, the N-way mesh all-gather never finds its
+    peers, and the child aborts on a rendezvous timeout. ``JAX_PLATFORMS=cpu``
+    pins the platform so the fake-device trick (and the GSPMD sharding it
+    exercises) works regardless of host accelerators.
+    """
     env = dict(
         os.environ,
         XLA_FLAGS=f"--xla_force_host_platform_device_count={n_dev}",
         JAX_PLATFORMS="cpu",
     )
-    r = subprocess.run(
-        [sys.executable, "tests/_ctm_sharding_parity_subproc.py", str(D), str(chi)],
+    return subprocess.run(
+        [
+            sys.executable,
+            "tests/_ctm_sharding_parity_subproc.py",
+            str(D),
+            str(chi),
+            str(int(well_conditioned)),
+            repr(thresh),
+        ],
         env=env,
         capture_output=True,
         text=True,
         timeout=600,
     )
+
+
+@pytest.mark.parametrize("n_dev", [2, 4])
+def test_sharded_forward_matches_single_device(n_dev):
+    """Dense CTM energy under an N-device GSPMD mesh equals the single-device
+    result to <1e-8 (subprocess with fake CPU devices)."""
+    D, chi = _PARITY_PROBE[n_dev]
+    r = _run_parity_subproc(n_dev, D, chi)
+    assert r.returncode == 0, f"parity failed:\nSTDOUT:{r.stdout}\nSTDERR:{r.stderr}"
+
+
+def test_sharded_well_conditioned_tight_parity():
+    """On a WELL-CONDITIONED state the sharded forward CTM matches single-device
+    to ~1e-10 even at a larger χ where the contracted D²-axis is reassociated
+    across 4 devices (D=4 → 4 elements/device).
+
+    This guards the property that matters physically: sharding is exact up to
+    floating-point reassociation, and on a well-separated CTM fixed point that
+    reassociation stays at machine precision. The companion random-state probe
+    at the SAME (D=4, χ=8) diverges by ~1e-4 (the reassociation noise is
+    amplified by the random state's large condition number), so this case
+    exercises a regime the small-χ ``test_sharded_forward_matches_single_device``
+    cases (bit-exact only because their fixed points happen to be
+    well-conditioned) do not reach.
+    """
+    r = _run_parity_subproc(4, D=4, chi=8, well_conditioned=True, thresh=1e-10)
     assert r.returncode == 0, f"parity failed:\nSTDOUT:{r.stdout}\nSTDERR:{r.stderr}"
 
 


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, opened by @yingjerkao.

## Summary

First **real-GPU** run of the #632 rung-1 GSPMD-sharded dense forward CTM (the rung-1 plan's "Task 7" memory-feasibility benchmark, never run on hardware until now), on a 4× A100-80GB node — plus the CI-parity strengthening it surfaced.

**Verdict: GO on correctness, WEAK as a large-D lever.**

- **Correct.** Sharded == single-device to ~1e-17 on well-conditioned (physical-like) states. The ~1e-4 gaps seen on the benchmark's *random* probe states are floating-point **reassociation** of the sharded contraction axis (scales with device count, collapses on a well-conditioned state) — **not a bug**.
- **Memory.** Per-device peak drops only **~1.6×** on 4 GPUs (not ~4× — the projector SVD is replicated by design + per-move reshard buffers). Single-GPU forward ceiling at χ=24 is **D=10**; 4 GPUs reach **D=12** (the real OOM crossover). Net: **+2 in D**.
- **Why it doesn't reach large D.** Dense CTM memory ~**D⁶** ⇒ N GPUs buy only **N^(1/6)** in D. Reaching D≈16 would need ~64 GPUs.
- **Throughput unchanged** (7.83 vs 7.70 s/CTM-iter, compile-subtracted).
- **Scope:** forward-only; full `optimize_gs_ad` still needs rung-2 AD-backward sharding (unbuilt). Does not change the large-D-fermionic strategy (eager/YASTN for genuinely large D).

## Changes

- **Findings doc** `docs/superpowers/handoffs/2026-06-21-632-multigpu-dense-ctm-findings.md`.
- **CI parity gap fix:** `test_sharded_well_conditioned_tight_parity` (D=4/χ=8, N=4, near-product state, <1e-10). The pre-existing cases (D=2; D=4/χ=4) pass bit-exact, but only because their small-χ random fixed points happen to be well-conditioned — no case exercised a larger-χ regime where a random state diverges (~1e-4) but a physical one stays tight. Verified meaningful: the random state at the same (D,χ) fails 1e-10.
- Test-probe gains `max_iter` + `well_conditioned` kwargs; subproc accepts `well_conditioned` + threshold; throwaway bench gains `--max-iter`/wall-time and drops a misleading `reset_peak()` no-op.

## Test plan

- `uv run pytest tests/test_ctm_sharding.py tests/test_ctm_sharding_parity.py` → **8 passed** (CPU fake-device meshes).
- `ruff check` clean on all touched files.
- Memory/crossover numbers measured on 4× A100-80GB (forward CTM, f64, χ=24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)