### PR TITLE
fix(#641): bound split-CTM dense forward convergence to chi²·D⁴

### DIFF
--- a/src/tenax/algorithms/_split_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_moves.py
@@ -8,7 +8,11 @@ __all__ = [
     "_ensure_edge_flows",
     "_ensure_tensor_flows",
     "_fused_charge_permutation",
+    "_grow_and_project_bounded",
+    "_grow_and_project_edge",
+    "_grow_edge_halves",
     "_grow_edge_no_double_layer",
+    "_precombine_projector_pair",
     "_project_grown_edge_tensor",
     "_reembed_target_for_projector",
     "_select_bond_entries",
@@ -35,6 +39,7 @@ from tenax.algorithms._tensor_utils import (
     absorb_sqrt_singular_values,
     fuse_indices,
     max_abs_normalize,
+    split_index,
 )
 from tenax.contraction.contractor import contract
 from tenax.core.index import FlowDirection, TensorIndex
@@ -46,6 +51,42 @@ from tenax.linalg import svd as tensor_svd
 # ------------------------------------------------------------------ #
 
 _VIRTUAL_LEGS = ("u", "d", "l", "r")
+
+
+def _grow_edge_halves(
+    T_ket: Tensor,
+    T_bra: Tensor,
+    A: Tensor,
+    A_bar: Tensor,
+    contracted_leg: str,
+    ket_I_label: str,
+    bra_I_label: str,
+) -> tuple[Tensor, Tensor]:
+    """Build the two open half-edges of a T-edge without joining them.
+
+    Each half is one boundary T contracted with its copy of ``A`` (ket) or
+    ``A.bar()`` (bra).  Both halves share the ``_I`` (interlayer) and ``phys``
+    labels, so a later ``contract(ket_half, bra_half)`` traces them.
+
+    Returns ``(ket_half, bra_half)``, each a 6-leg Tensor (``chi``, ``_I``,
+    and four ``D``/``phys`` legs).  Peak per half is ``chi * chi_I * D^3 * d``.
+    """
+    ket_D_label = f"{contracted_leg}_ket"
+    bra_D_label = f"{contracted_leg}_bra"
+
+    # --- Ket side ---
+    A_ket = A.relabel(contracted_leg, ket_D_label)
+    ket_half = contract(T_ket, A_ket).relabel(ket_I_label, "_I")
+
+    # --- Bra side: relabel virtual legs to uppercase ---
+    bra_mapping: dict[str, str] = {contracted_leg: bra_D_label}
+    for v in _VIRTUAL_LEGS:
+        if v != contracted_leg:
+            bra_mapping[v] = v.upper()
+    A_bra = A_bar.relabels(bra_mapping)
+    bra_half = contract(T_bra, A_bra).relabel(bra_I_label, "_I")
+
+    return ket_half, bra_half
 
 
 def _grow_edge_no_double_layer(
@@ -65,25 +106,16 @@ def _grow_edge_no_double_layer(
     physical and interlayer indices via label-based contraction.
 
     Returns an 8-leg Tensor with labels matching *output_labels*.
+
+    NOTE: this joins the two half-edges into a single ``chi^2 * D^6`` tensor.
+    The bounded path (:func:`_grow_and_project_edge`) avoids forming it; this
+    closed form is retained for the SymmetricTensor (fermionic) projection
+    path, whose order-dependent Koszul signs the bounded reorder does not yet
+    reproduce (issue #641 / #463 Phase 2-4).
     """
-    ket_D_label = f"{contracted_leg}_ket"
-    bra_D_label = f"{contracted_leg}_bra"
-
-    # --- Ket side ---
-    A_ket = A.relabel(contracted_leg, ket_D_label)
-    ket_half = contract(T_ket, A_ket)
-
-    # --- Bra side: relabel virtual legs to uppercase ---
-    bra_mapping: dict[str, str] = {contracted_leg: bra_D_label}
-    for v in _VIRTUAL_LEGS:
-        if v != contracted_leg:
-            bra_mapping[v] = v.upper()
-    A_bra = A_bar.relabels(bra_mapping)
-    bra_half = contract(T_bra, A_bra)
-
-    # --- Match interlayer labels, then contract (traces _I + phys) ---
-    ket_half = ket_half.relabel(ket_I_label, "_I")
-    bra_half = bra_half.relabel(bra_I_label, "_I")
+    ket_half, bra_half = _grow_edge_halves(
+        T_ket, T_bra, A, A_bar, contracted_leg, ket_I_label, bra_I_label
+    )
     return contract(ket_half, bra_half, output_labels=output_labels)
 
 
@@ -438,6 +470,148 @@ def _apply_projector(
     return result
 
 
+def _precombine_projector_pair(
+    P_first: Tensor,
+    P_second: Tensor,
+    chi_leg: str,
+    D1_leg: str,
+    D2_leg: str,
+    out_label: str,
+) -> Tensor:
+    """Fuse a sequential projector pair into one 4-leg operator (dense path).
+
+    Reproduces the two-step projection that :func:`_project_grown_edge_tensor`
+    applies to one side of a grown edge — ``fuse(chi_leg, D1) -> P_first.bar()
+    -> m`` then ``fuse(m, D2) -> P_second.bar() -> out`` — but as a standalone
+    operator ``op(chi_leg, D1_leg, D2_leg, out_label)``.  Contracting ``op``
+    into a half-edge over the two legs that live there absorbs the projectors
+    *before* the interlayer join, so the ``chi^2 * D^6`` edge never forms.
+
+    Both grown-corner projectors carry a ``fused`` leg whose parents are
+    always ``(chi-type, D-type)`` (the env bond first, the ``A`` virtual leg
+    second).  Splitting the ``fused`` leg therefore exposes the env-bond and
+    ``D`` components in a known order; relabelling them to the edge's legs
+    and contracting over the shared ``chi_new`` bond rebuilds the paired
+    operator.
+
+    DenseTensor only: ``split_index`` after ``.bar()`` does not preserve the
+    order-dependent Koszul signs that the closed-edge contraction encodes for
+    SymmetricTensor (issue #641 / #463 Phase 2-4), so the SymmetricTensor
+    projection stays on the closed ``_project_grown_edge_tensor`` path.
+    """
+    Pf = P_first.bar().relabel("chi_new", "_pcomb_m")
+    Pf = split_index(Pf, Pf.labels().index("fused"))
+    pf_labels = Pf.labels()  # (parent_chi, parent_D, _pcomb_m)
+    Pf = Pf.relabels({pf_labels[0]: chi_leg, pf_labels[1]: D1_leg})
+
+    Ps = P_second.bar().relabel("chi_new", out_label)
+    Ps = split_index(Ps, Ps.labels().index("fused"))
+    ps_labels = Ps.labels()  # (parent_chi == _pcomb_m, parent_D, out_label)
+    Ps = Ps.relabels({ps_labels[0]: "_pcomb_m", ps_labels[1]: D2_leg})
+
+    return contract(Pf, Ps)  # -> (chi_leg, D1_leg, D2_leg, out_label)
+
+
+def _grow_and_project_bounded(
+    T_ket: Tensor,
+    T_bra: Tensor,
+    A: Tensor,
+    A_bar: Tensor,
+    P_first: Tensor,
+    P_second: Tensor,
+    contracted_leg: str,
+    ket_I_label: str,
+    bra_I_label: str,
+    left_fuse: tuple[str, str, str],
+    right_fuse: tuple[str, str, str],
+) -> Tensor:
+    """Grow + project an edge without forming the ``chi^2 * D^6`` tensor.
+
+    Builds the two open half-edges, precombines each projector pair into a
+    4-leg operator, absorbs each operator into the half-edge holding the
+    majority of its legs, then joins.  Peak intermediate is ``chi^2 * D^3 * d``
+    (vs the closed path's ``chi^2 * D^6``), so the forward CTM convergence is
+    ``chi^2 * D^4``-bounded (issue #641).
+
+    Returns the 4-leg projected edge ``(left_chi, mid_ket, mid_bra,
+    right_chi)`` — identical (to machine precision) to
+    ``_project_grown_edge_tensor(_grow_edge_no_double_layer(...), ...)``.
+
+    DenseTensor only; see :func:`_precombine_projector_pair`.
+    """
+    ket_half, bra_half = _grow_edge_halves(
+        T_ket, T_bra, A, A_bar, contracted_leg, ket_I_label, bra_I_label
+    )
+
+    # left_fuse is (chi, D, D); right_fuse is (D, chi, D) — the env bond sits
+    # at position 0 of left_fuse and position 1 of right_fuse for every move.
+    la, lb, lc = left_fuse
+    ra, rb, rc = right_fuse
+    P_left = _precombine_projector_pair(P_first, P_second, la, lb, lc, "left_chi")
+    P_right = _precombine_projector_pair(P_first, P_second, rb, ra, rc, "right_chi")
+
+    def _absorb(op: Tensor) -> Tensor:
+        op_labels = set(op.labels())
+        in_ket = len(op_labels & set(ket_half.labels()))
+        in_bra = len(op_labels & set(bra_half.labels()))
+        return contract(op, ket_half) if in_ket >= in_bra else contract(op, bra_half)
+
+    # Join over (_I, phys, and the two cross-legs shared between the reduced
+    # halves) -> (left_chi, mid_ket, mid_bra, right_chi).
+    return contract(_absorb(P_left), _absorb(P_right))
+
+
+def _grow_and_project_edge(
+    T_ket: Tensor,
+    T_bra: Tensor,
+    A: Tensor,
+    A_bar: Tensor,
+    P_first: Tensor,
+    P_second: Tensor,
+    contracted_leg: str,
+    ket_I_label: str,
+    bra_I_label: str,
+    grow_output_labels: tuple[str, ...],
+    left_fuse: tuple[str, str, str],
+    right_fuse: tuple[str, str, str],
+) -> Tensor:
+    """Grow + project an edge, choosing the memory-bounded path when possible.
+
+    For DenseTensor inputs, routes through :func:`_grow_and_project_bounded`
+    (``chi^2 * D^4``-bounded, issue #641).  For SymmetricTensor inputs, falls
+    back to the closed ``chi^2 * D^6`` grow + project, which preserves the
+    fermionic Koszul-sign convention (bounded SymmetricTensor support is the
+    #463 Phase 2-4 follow-up).
+    """
+    if isinstance(T_ket, DenseTensor) and isinstance(T_bra, DenseTensor):
+        return _grow_and_project_bounded(
+            T_ket,
+            T_bra,
+            A,
+            A_bar,
+            P_first,
+            P_second,
+            contracted_leg,
+            ket_I_label,
+            bra_I_label,
+            left_fuse,
+            right_fuse,
+        )
+    Tg = _grow_edge_no_double_layer(
+        T_ket,
+        T_bra,
+        A,
+        A_bar,
+        contracted_leg,
+        ket_I_label,
+        bra_I_label,
+        grow_output_labels,
+    )
+    return _project_grown_edge_tensor(
+        Tg, P_first, P_second, left_fuse=left_fuse, right_fuse=right_fuse
+    )
+
+
 # ------------------------------------------------------------------ #
 # Directional CTM moves                                                #
 # ------------------------------------------------------------------ #
@@ -499,21 +673,17 @@ def _split_ctm_move_left(
 
     # --- Phase B: Sequential projector application to grown edge ---
 
-    T4g = _grow_edge_no_double_layer(
+    T4g = _grow_and_project_edge(
         env.T4_ket,
         env.T4_bra,
         A,
         A_bar,
+        P_ket,
+        P_bra,
         "l",
         "t4k_I",
         "t4b_I",
         ("t4k_d", "u", "U", "r", "R", "t4b_u", "d", "D"),
-    )
-
-    T4g = _project_grown_edge_tensor(
-        T4g,
-        P_ket,
-        P_bra,
         left_fuse=("t4k_d", "u", "U"),
         right_fuse=("d", "t4b_u", "D"),
     )
@@ -595,20 +765,17 @@ def _split_ctm_move_right(
 
     # --- Phase B: Sequential projector application to grown edge ---
 
-    T2g = _grow_edge_no_double_layer(
+    T2g = _grow_and_project_edge(
         env.T2_ket,
         env.T2_bra,
         A,
         A_bar,
+        P_bra,
+        P_ket,
         "r",
         "t2k_I",
         "t2b_I",
         ("t2k_u", "u", "U", "l", "L", "t2b_d", "d", "D"),
-    )
-    T2g = _project_grown_edge_tensor(
-        T2g,
-        P_bra,
-        P_ket,
         left_fuse=("t2k_u", "U", "u"),
         right_fuse=("D", "t2b_d", "d"),
     )
@@ -690,20 +857,17 @@ def _split_ctm_move_top(
 
     # --- Phase B: Sequential projector application to grown edge ---
 
-    T1g = _grow_edge_no_double_layer(
+    T1g = _grow_and_project_edge(
         env.T1_ket,
         env.T1_bra,
         A,
         A_bar,
+        P_ket,
+        P_bra,
         "u",
         "t1k_I",
         "t1b_I",
         ("t1k_l", "l", "L", "d", "D", "t1b_r", "r", "R"),
-    )
-    T1g = _project_grown_edge_tensor(
-        T1g,
-        P_ket,
-        P_bra,
         left_fuse=("t1k_l", "l", "L"),
         right_fuse=("r", "t1b_r", "R"),
     )
@@ -785,20 +949,17 @@ def _split_ctm_move_bottom(
 
     # --- Phase B: Sequential projector application to grown edge ---
 
-    T3g = _grow_edge_no_double_layer(
+    T3g = _grow_and_project_edge(
         env.T3_ket,
         env.T3_bra,
         A,
         A_bar,
+        P_bra,
+        P_ket,
         "d",
         "t3k_I",
         "t3b_I",
         ("t3k_r", "l", "L", "u", "U", "t3b_l", "r", "R"),
-    )
-    T3g = _project_grown_edge_tensor(
-        T3g,
-        P_bra,
-        P_ket,
         left_fuse=("t3k_r", "L", "l"),
         right_fuse=("R", "t3b_l", "r"),
     )

--- a/tests/test_split_ctm_tensor.py
+++ b/tests/test_split_ctm_tensor.py
@@ -284,6 +284,159 @@ class TestSplitCTMMoves:
             )
 
 
+class TestSplitCTMBoundedEdge:
+    """Issue #641: the dense forward move must avoid the chi^2*D^6 grown edge.
+
+    The bounded grow+project path (:func:`_grow_and_project_bounded`) absorbs
+    the projectors into the open half-edges before the interlayer join, so the
+    peak intermediate is chi^2*D^3*d instead of chi^2*D^6.  It must reproduce
+    the closed-path result (grow the full edge, then project) to machine
+    precision.
+    """
+
+    @pytest.mark.parametrize("D, seed", [(2, 1), (3, 7), (4, 11)])
+    def test_bounded_matches_closed_path_all_moves(self, D, seed):
+        """Bounded 4-leg projected edge == closed grow+project, every move."""
+        import tenax.algorithms._split_ctm_tensor_moves as moves
+
+        site = make_random_dense_site(D, 2, seed)
+        chi = 8
+        env = initialize_split_ctm_tensor_env(site, chi, chi)
+        for _ in range(6):
+            env = _split_ctm_tensor_sweep(env, site, chi, chi, True)
+        A_bar = site.bar()
+
+        # Capture the per-move (projectors, fuse tuples) the moves actually use
+        # by spying on the dispatcher, then compute both paths from them.
+        captured = []
+        orig = moves._grow_and_project_edge
+
+        def spy(*args, **kwargs):
+            captured.append((args, kwargs))
+            return orig(*args, **kwargs)
+
+        moves._grow_and_project_edge = spy
+        try:
+            moves._split_ctm_move_left(env, site, A_bar, chi, chi)
+            moves._split_ctm_move_right(env, site, A_bar, chi, chi)
+            moves._split_ctm_move_top(env, site, A_bar, chi, chi)
+            moves._split_ctm_move_bottom(env, site, A_bar, chi, chi)
+        finally:
+            moves._grow_and_project_edge = orig
+
+        assert len(captured) == 4
+        for args, kwargs in captured:
+            (T_ket, T_bra, A, A_bar_, P_first, P_second, leg, kI, bI, grow_out) = args
+            left_fuse = kwargs["left_fuse"]
+            right_fuse = kwargs["right_fuse"]
+
+            bounded = moves._grow_and_project_bounded(
+                T_ket,
+                T_bra,
+                A,
+                A_bar_,
+                P_first,
+                P_second,
+                leg,
+                kI,
+                bI,
+                left_fuse,
+                right_fuse,
+            )
+            closed_edge = moves._grow_edge_no_double_layer(
+                T_ket, T_bra, A, A_bar_, leg, kI, bI, grow_out
+            )
+            closed = moves._project_grown_edge_tensor(
+                closed_edge,
+                P_first,
+                P_second,
+                left_fuse=left_fuse,
+                right_fuse=right_fuse,
+            )
+
+            ref = closed.todense()
+            perm = tuple(bounded.labels().index(lbl) for lbl in closed.labels())
+            got = bounded.transpose(perm).todense()
+            scale = float(jnp.max(jnp.abs(ref))) + 1e-30
+            relerr = float(jnp.max(jnp.abs(ref - got))) / scale
+            assert relerr < 1e-10, f"move {leg}: relerr={relerr:.2e}"
+
+    def test_bounded_peak_is_chi2_d4_bounded(self):
+        """The dense grow+project must not allocate a chi^2*D^6 intermediate.
+
+        Tracks the largest dense array materialised during one bounded
+        grow+project and asserts it stays well under the chi^2*D^6 closed-path
+        peak (issue #641).  D=4, chi=16: chi^2*D^6 = 1.05e9 elems; the bounded
+        path's peak is ~chi^2*D^3*d = 5.2e5.
+        """
+        import tenax.algorithms._split_ctm_tensor_moves as moves
+
+        D, chi, d = 4, 16, 2
+        site = make_random_dense_site(D, d, seed=3)
+        env = initialize_split_ctm_tensor_env(site, chi, chi)
+        for _ in range(3):
+            env = _split_ctm_tensor_sweep(env, site, chi, chi, True)
+        A_bar = site.bar()
+
+        captured = {}
+        orig = moves._grow_and_project_edge
+
+        def spy(*args, **kwargs):
+            captured["args"] = (args, kwargs)
+            moves._grow_and_project_edge = orig  # capture once
+            return orig(*args, **kwargs)
+
+        moves._grow_and_project_edge = spy
+        try:
+            moves._split_ctm_move_left(env, site, A_bar, chi, chi)
+        finally:
+            moves._grow_and_project_edge = orig
+
+        args, kwargs = captured["args"]
+        (T_ket, T_bra, A, A_bar_, P_first, P_second, leg, kI, bI, _grow_out) = args
+
+        # Instrument DenseTensor construction to record the largest array size.
+        peak = {"n": 0}
+        real_init = DenseTensor.__init__
+
+        def tracking_init(self, data, indices, *a, **k):
+            try:
+                peak["n"] = max(peak["n"], int(np.prod(data.shape)))
+            except Exception:
+                pass
+            return real_init(self, data, indices, *a, **k)
+
+        DenseTensor.__init__ = tracking_init
+        try:
+            moves._grow_and_project_bounded(
+                T_ket,
+                T_bra,
+                A,
+                A_bar_,
+                P_first,
+                P_second,
+                leg,
+                kI,
+                bI,
+                kwargs["left_fuse"],
+                kwargs["right_fuse"],
+            )
+        finally:
+            DenseTensor.__init__ = real_init
+
+        closed_peak = chi**2 * D**6  # the chi^2*D^6 edge we must avoid
+        target = chi**2 * D**4  # the issue #641 chi^2*D^4 bound
+        assert peak["n"] > 0
+        # Bounded peak is chi^2*D^3*d (the half-edge); must meet the chi^2*D^4
+        # target and sit far below the closed chi^2*D^6 grown edge.
+        assert peak["n"] <= target, (
+            f"bounded peak {peak['n']:.2e} exceeds chi^2*D^4={target:.2e}"
+        )
+        assert peak["n"] < closed_peak / 10, (
+            f"bounded peak {peak['n']:.2e} not far below chi^2*D^6={closed_peak:.2e}"
+        )
+
+
 # ------------------------------------------------------------------ #
 # Phase 3: Convergence tests                                           #
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary

Resolves #641. The split-CTM forward move grew each `T`-edge into a closed 8-leg **`χ²·D⁶`** tensor (`_grow_edge_no_double_layer`) before applying the truncation projectors — **34 GB at D=8 χ=128**, the blow-up the issue measured on a bare `d=2` site. The split-aware *energy* eval was already `χ²·D⁴`-bounded, but the env *build* (`ctm_split_tensor`) was not.

## Root cause

The grown edge is `(χ, D, D, D, D, χ, D, D)` — 2 χ-legs + 6 D-legs = `χ²·D⁶`. Confirmed by instrumenting `_grow_edge_no_double_layer`: at D=8 χ=128 that's `4.3e9` elems × 8 B = **34 GB**, matching the report.

## Fix

A memory-bounded grow+project path that never forms the big edge:

1. Build the two **open half-edges** (`_grow_edge_halves`) — `χ·χ_I·D³·d` each.
2. **Precombine** each sequential projector pair into one 4-leg operator (`_precombine_projector_pair`), by `split_index`-ing the projector's fused leg and contracting the pair over the shared `chi_new` bond.
3. **Absorb** each operator into the half-edge holding the majority of its legs, *before* the interlayer join, then join.

Peak intermediate drops to **`χ²·D³·d`**.

| Stage | Peak (D=8, χ=128) |
|---|---|
| old grown edge (`χ²·D⁶`) | 34 GB |
| `χ²·D⁴` target | 0.54 GB |
| **new bounded (`χ²·D³·d`)** | **0.13 GB** |

End-to-end `ctm_split_tensor` peak measured at D=6 χ=48: `χ²·D³·d`, **108× below** the old `χ²·D⁶` edge and within the `χ²·D⁴` target.

## Scope

The bounded path runs for **DenseTensor** edges — the case #641 measured. **SymmetricTensor (fermionic)** edges keep the existing closed grow+project path: the reordered contraction does not yet reproduce its order-dependent Koszul signs (a clean per-element ±1 mismatch at D≥3), which is the **#463 Phase 2-4** follow-up. No fermionic behaviour change. `_grow_edge_no_double_layer` is refactored to share `_grow_edge_halves` and is retained for the fallback.

## Tests

- `test_bounded_matches_closed_path_all_moves` — new-vs-closed 4-leg edge parity to **machine precision** across all four moves (dense D=2/3/4).
- `test_bounded_peak_is_chi2_d4_bounded` — memory-regression test asserting the dense grow+project peak meets `χ²·D⁴` and sits far below `χ²·D⁶`.
- Existing suites green: split-CTM (44), coarse_grain + ctm_tensor + regularized_svd (60), fermionic split RDM + ED reference (14).

> 🤖 **AI-generated PR** — written by Claude Code, posted by @Ying-Jer Kao.