### PR TITLE
feat(#463): route single-site optimizer through split CTM (fuse_virtual_legs=False)

### DIFF
--- a/src/tenax/algorithms/_split_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_split_ctm_energy_ad.py
@@ -14,7 +14,11 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 
-__all__ = ["ctm_energy_split_explicit", "ctm_energy_split_implicit"]
+__all__ = [
+    "converge_split_env",
+    "ctm_energy_split_explicit",
+    "ctm_energy_split_implicit",
+]
 
 
 def _extract_single_site(site_tensors):
@@ -221,3 +225,30 @@ def ctm_energy_split_implicit(
     static = (chi, chi_I, max_iter, conv_tol, renormalize, min_iter)
     env = _split_ctm_converge(A, static)
     return compute_energy_split_ctm_tensor(A, env, gate)
+
+
+def converge_split_env(
+    A,
+    *,
+    chi: int,
+    max_iter: int = 100,
+    conv_tol: float = 1e-8,
+    chi_I: int | None = None,
+    renormalize: bool = True,
+    min_iter: int = 2,
+):
+    """Forward-only gauge-fixed split-CTM converge (no gradient).
+
+    Returns the *same* Γ-phase-fixed element-wise fixed-point
+    ``SplitCTMTensorEnv`` that :func:`ctm_energy_split_implicit`
+    differentiates.  Forward-only energy evaluations on the split path
+    (the optimizer's warm-start, line-search probe, and final-env eval)
+    must use this rather than the bare :func:`ctm_split_tensor` so they
+    land on the identical fixed point as the AD loss — keeping the
+    line-search φ(α) and the gradient dφ/dα mutually consistent.
+    """
+    if chi_I is None:
+        chi_I = chi
+    return _converge_split_gauge_fixed(
+        A, chi, chi_I, max_iter, conv_tol, renormalize, min_iter
+    )

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1239,6 +1239,10 @@ def _optimize_gs_ad_tensor(
     from tenax.algorithms._ctm_python_loop import python_loop_ctm_converge
     from tenax.algorithms._ctm_tensor import compute_energy_ctm_tensor
     from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
+    from tenax.algorithms._split_ctm_energy_ad import converge_split_env
+    from tenax.algorithms._split_ctm_tensor_energy import (
+        compute_energy_split_ctm_tensor,
+    )
     from tenax.algorithms.ad_utils import CTMRGGradientError
     from tenax.algorithms.ipeps_ad_policy import (
         ctm_converge_kwargs,
@@ -1297,6 +1301,45 @@ def _optimize_gs_ad_tensor(
     # Env warm-start cache — replaces flat env_leaves threading.
     _env_cache: dict[str, dict] = {}
 
+    # Split-CTM (fuse_virtual_legs=False) single-site path (#463 Phase 2).
+    # Routes the AD energy AND the forward-only CTMs (warm-start, line-search
+    # probe, final-env eval) through the split χ²·D⁴ forward so the memory win
+    # is real and the line-search φ(α)/dφ(α) stay consistent.  Only the
+    # simplest stable config is supported; reject the fused-env-coupled
+    # accelerators (bump, ramp, schedules, metric, cg) up front rather than
+    # silently feeding a SplitCTMTensorEnv to fused-only machinery.
+    use_split = not ctm_cfg.fuse_virtual_legs
+    if use_split:
+        if config.gs_recipe != "1x1":
+            raise NotImplementedError(
+                "fuse_virtual_legs=False (split CTM) requires gs_recipe='1x1'; "
+                f"got {config.gs_recipe!r}."
+            )
+        if _use_cg:
+            raise NotImplementedError(
+                "fuse_virtual_legs=False (split CTM) does not support cg_gates; "
+                "use fuse_virtual_legs=True."
+            )
+        if ctm_cfg.chi_auto_bump or ctm_cfg.ctmrg_heuristic_increase_chi:
+            raise NotImplementedError(
+                "in-CTM chi auto-bump is not supported on the split-CTM path; "
+                "use fuse_virtual_legs=True."
+            )
+        if ctm_cfg.chi_ramp is not None:
+            raise NotImplementedError(
+                "chi_ramp is not supported on the split-CTM path; "
+                "use fuse_virtual_legs=True."
+            )
+        if (
+            config.gs_ctm_conv_tol_schedule is not None
+            or config.gs_ctm_max_iter_schedule is not None
+            or config.gs_plateau_patience_schedule is not None
+        ):
+            raise NotImplementedError(
+                "CTM conv_tol/max_iter/plateau schedules are not supported on "
+                "the split-CTM path; use fuse_virtual_legs=True."
+            )
+
     use_explicit = not config.gs_implicit_ad
     explicit_steps = config.gs_explicit_ad_steps
     explicit_warmup = config.gs_explicit_ad_warmup
@@ -1346,9 +1389,32 @@ def _optimize_gs_ad_tensor(
         energy = _ctm_energy_fn(site_tensors)
         return energy
 
+    def _split_forward(A_norm):
+        """Forward-only gauge-fixed split-CTM converge (warm-start/probe/final).
+
+        Reads ``ctm_cfg`` live so any in-loop rebinding is honored (schedules
+        are rejected on the split path, so it is effectively static here).
+        Lands on the same fixed point the implicit-AD loss differentiates.
+        """
+        return converge_split_env(
+            A_norm,
+            chi=ctm_cfg.chi,
+            max_iter=ctm_cfg.max_iter,
+            conv_tol=ctm_cfg.conv_tol,
+            chi_I=ctm_cfg.chi_I,
+            renormalize=ctm_cfg.renormalize,
+            min_iter=ctm_cfg.min_iter,
+        )
+
     def _update_env_cache(params):
         """Re-run forward CTM (no grad) to warm-start next step."""
         A_norm = _params_to_A_norm(params)
+        if use_split:
+            # χ²·D⁴ split forward — no fused double layer is ever built.
+            # eps_T is unused (auto-bump is rejected on the split path).
+            _env_cache["envs"] = {(0, 0): _split_forward(A_norm)}
+            _env_cache["max_truncation_error"] = 0.0
+            return
         site_tensors = {(0, 0): A_norm}
         envs, info = python_loop_ctm_converge(
             site_tensors,
@@ -1399,6 +1465,11 @@ def _optimize_gs_ad_tensor(
         config.gs_metric_precond
         and config.gs_optimizer.lower() == "lbfgs"
         and not _cg_uses_tuple_params
+        # Metric preconditioning builds its inner product from the fused
+        # CTMTensorEnv (``env_for_metric`` below); the split path stores a
+        # SplitCTMTensorEnv, so disable it there rather than feed an
+        # incompatible env to the preconditioner.
+        and not use_split
     )
     if (
         _cg_uses_tuple_params
@@ -1412,6 +1483,19 @@ def _optimize_gs_ad_tensor(
             "supply a map_fn (params are a tuple of raw site tensors, but "
             "the metric path expects tensor-like params with .todense()). "
             "Falling back to non-preconditioned L-BFGS for this run.",
+            stacklevel=3,
+        )
+    if (
+        use_split
+        and config.gs_metric_precond
+        and config.gs_optimizer.lower() == "lbfgs"
+    ):
+        import warnings
+
+        warnings.warn(
+            "gs_metric_precond=True is not yet supported on the split-CTM path "
+            "(fuse_virtual_legs=False); the metric inner product needs the "
+            "fused CTMTensorEnv. Falling back to non-preconditioned L-BFGS.",
             stacklevel=3,
         )
     if _use_cg and _cg_map_fn is not None:
@@ -1469,6 +1553,12 @@ def _optimize_gs_ad_tensor(
     def loss_fn_fwd(p):
         """Forward-only loss for line search — warm-starts CTM from env cache."""
         A_norm = _params_to_A_norm(p)
+        if use_split:
+            # Same gauge-fixed split forward + split energy as the AD loss, so
+            # φ(α) (this probe) and dφ/dα (the implicit-AD gradient) agree.
+            env = _split_forward(A_norm)
+            _env_cache["envs"] = {(0, 0): env}
+            return float(compute_energy_split_ctm_tensor(A_norm, env, gate))
         site_tensors = {(0, 0): A_norm}
         envs, _ = python_loop_ctm_converge(
             site_tensors,
@@ -2477,9 +2567,7 @@ def _optimize_gs_ad_tensor(
             best_env_cache = dict(_env_cache)
 
         # End-of-step save: cadence-based + new-best detection.
-        _maybe_save_1s_checkpoint(
-            step, _chi_at_step_start, _best_energy_at_step_start
-        )
+        _maybe_save_1s_checkpoint(step, _chi_at_step_start, _best_energy_at_step_start)
 
     # Re-evaluate both final A and best_A with fully converged fresh CTM.
     # In-loop energies use warm-started CTM that can produce unphysical values
@@ -2489,6 +2577,12 @@ def _optimize_gs_ad_tensor(
     def _eval_fresh(p, env_init=None):
         """Evaluate energy with fully converged fresh CTM."""
         A_t = _params_to_A_norm(p)
+        if use_split:
+            # Final env is the split fixed point used by the gradient; return
+            # the SplitCTMTensorEnv (not the fused CTMTensorEnv).
+            env_ = _split_forward(A_t)
+            E_ = float(compute_energy_split_ctm_tensor(A_t, env_, gate))
+            return A_t, env_, E_
         envs, _ = python_loop_ctm_converge(
             {(0, 0): A_t},
             SINGLE_SITE_NEIGHBORS,

--- a/tests/test_split_ctm_fuse_flag.py
+++ b/tests/test_split_ctm_fuse_flag.py
@@ -308,3 +308,88 @@ def test_split_implicit_raises_for_multisite():
             gate,
             chi=4,
         )
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end optimizer integration (#463 Phase 2, Task 4)                      #
+# --------------------------------------------------------------------------- #
+
+
+def _split_opt_config(fuse, **overrides):
+    from tenax.algorithms.ipeps_config import CTMConfig as _CTMConfig
+    from tenax.algorithms.ipeps_config import iPEPSConfig
+
+    D = 2
+    chi = D * D
+    ctm_kw = dict(
+        chi=chi,
+        chi_I=chi,
+        fuse_virtual_legs=fuse,
+        max_iter=40,
+        conv_tol=1e-10,
+        min_iter=2,
+    )
+    ctm_kw.update(overrides.pop("ctm", {}))
+    cfg_kw = dict(
+        unit_cell="1x1",
+        gs_recipe="1x1",
+        gs_implicit_ad=True,
+        gs_num_steps=2,
+        gs_log_interval=1,
+        su_init=False,
+    )
+    cfg_kw.update(overrides)
+    return iPEPSConfig(ctm=_CTMConfig(**ctm_kw), **cfg_kw)
+
+
+def _split_opt_inputs():
+    A = jax.random.normal(jax.random.PRNGKey(3), (2, 2, 2, 2, 2))
+    A = A / jnp.linalg.norm(A)
+    return A, _heisenberg_gate()
+
+
+def test_optimize_gs_ad_split_returns_split_env():
+    """fuse_virtual_legs=False drives the whole 1-site optimizer through split.
+
+    The returned environment must be a ``SplitCTMTensorEnv`` (not the fused
+    ``CTMTensorEnv``), confirming the warm-start / line-search probe /
+    final-env eval all run the split χ²·D⁴ forward — not just the gradient.
+    """
+    from tenax.algorithms._split_ctm_tensor_init import SplitCTMTensorEnv
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    A, gate = _split_opt_inputs()
+    _, env, E = optimize_gs_ad(gate, A, _split_opt_config(fuse=False))
+    assert isinstance(env, SplitCTMTensorEnv)
+    assert jnp.isfinite(E)
+
+
+def test_optimize_gs_ad_fused_still_returns_fused_env():
+    """Regression: the default fused path is unchanged (returns CTMTensorEnv)."""
+    from tenax.algorithms._ctm_tensor import CTMTensorEnv
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    A, gate = _split_opt_inputs()
+    _, env, E = optimize_gs_ad(gate, A, _split_opt_config(fuse=True))
+    assert isinstance(env, CTMTensorEnv)
+    assert jnp.isfinite(E)
+
+
+def test_optimize_gs_ad_split_rejects_chi_auto_bump():
+    """The split optimizer path rejects fused-env-coupled accelerators."""
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    A, gate = _split_opt_inputs()
+    cfg = _split_opt_config(fuse=False, ctm={"chi_auto_bump": True, "chi_max": 6})
+    with pytest.raises(NotImplementedError, match="auto-bump"):
+        optimize_gs_ad(gate, A, cfg)
+
+
+def test_optimize_gs_ad_split_rejects_non_1x1_recipe():
+    """The split optimizer path requires gs_recipe='1x1'."""
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    A, gate = _split_opt_inputs()
+    cfg = _split_opt_config(fuse=False, gs_recipe="2x2")
+    with pytest.raises(NotImplementedError, match="1x1"):
+        optimize_gs_ad(gate, A, cfg)


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, opened by @yingjerkao.

Follow-up to #648 (single-site split-CTM AD). #648 wired the split AD **gradient**, but the rest of the 1-site optimizer still ran the fused (χ²·D⁶) CTM, so the split path was effectively gradient-only.

## Problem
In `_optimize_gs_ad_tensor`, three forward-only CTM evaluations were still fused regardless of `fuse_virtual_legs`:
1. **Warm-start** (`_update_env_cache`) → fused `python_loop_ctm_converge`, so the χ²·D⁴ memory win was unrealized (the fused CTM would OOM at exactly the large-D regime split exists for).
2. **Line-search probe** (`loss_fn_fwd`) → fused energy, while the AD loss returned a **split** energy. At production `chi_I=chi` these differ (they match only at lossless `chi_I=chi·D`), so the HZ line search evaluated φ(α) with fused energies but dφ/dα with split — a real consistency bug.
3. **Final env / observables** → returned a fused `CTMTensorEnv`, not the split env the gradient used.

## Change
- **`_split_ctm_energy_ad.converge_split_env`** — forward-only Γ-gauge-fixed split converge that lands on the *same* element-wise fixed point `ctm_energy_split_implicit` differentiates, so φ(α) and dφ/dα are mutually consistent.
- **`_optimize_gs_ad_tensor`** — `use_split = not ctm_cfg.fuse_virtual_legs`; branch warm-start / probe / final-env to the split forward + `compute_energy_split_ctm_tensor`. The returned env is now a `SplitCTMTensorEnv`.
- **Guards** — reject the fused-env-coupled accelerators up front on the split path (`gs_recipe≠1x1`, `chi_auto_bump`, `chi_ramp`, CTM conv_tol/max_iter/plateau schedules, `cg_gates`) and auto-disable `gs_metric_precond` with a warning (its metric inner product consumes the fused `env_for_metric`).

## Validation (`tests/test_split_ctm_fuse_flag.py`, 19 pass)
- `optimize_gs_ad(fuse_virtual_legs=False)` returns a `SplitCTMTensorEnv` with finite E over 2 steps.
- Fused path still returns `CTMTensorEnv` (regression).
- Split path rejects `chi_auto_bump` and non-`1x1` recipe.
- Fused 1-site optimizer regression (`test_ipeps_ad_history` + `test_ipeps_ad_conv_criterion`): 19 pass.

## Scope / deferred
- **Warm-start of the split forward** — currently the split forward (and the split AD loss) cold-start the CTM each eval; warm-starting from the cached split env is a perf-only follow-up.
- SymmetricTensor / fermionic split implicit (tests use U(1)-trivial DenseTensor).
- Multisite split forward (still `NotImplementedError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Update:** the deferred "warm-start of the split forward" item is now implemented in **#652** (stacked on this PR) — the AD loss / probe / warm-start / final-env reuse the cached `SplitCTMTensorEnv` as a forward seed, validated warm==cold to 1e-14.
