### PR TITLE
feat(#463): warm-start the split forward from the cached env

### DIFF
--- a/src/tenax/algorithms/_split_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_split_ctm_energy_ad.py
@@ -109,19 +109,27 @@ def _split_env_max_diff(env_new, env_old) -> float:
 
 
 def _converge_split_gauge_fixed(
-    A, chi, chi_I, max_iter, conv_tol, renormalize, min_iter
+    A, chi, chi_I, max_iter, conv_tol, renormalize, min_iter, env_init=None
 ):
     """Run gauge-fixed split-CTM to an element-wise fixed point.
 
     Returns the converged ``SplitCTMTensorEnv``.  Convergence is measured
     element-wise on the Γ-phase-fixed env (not the corner spectrum, which
     plateaus on the degenerate 1-site corner — see ``ctm_split_tensor``).
-    """
-    from tenax.algorithms._split_ctm_tensor_init import (
-        initialize_split_ctm_tensor_env,
-    )
 
-    env = initialize_split_ctm_tensor_env(A, chi, chi_I)
+    When *env_init* (a ``SplitCTMTensorEnv``) is given it seeds the sweep
+    (warm-start) instead of the fresh rank-1 corner init.  The Γ phase-fix
+    canonicalizes the gauge each sweep, so a warm seed converges to the
+    identical fixed point as a cold start — only faster.
+    """
+    if env_init is not None:
+        env = env_init
+    else:
+        from tenax.algorithms._split_ctm_tensor_init import (
+            initialize_split_ctm_tensor_env,
+        )
+
+        env = initialize_split_ctm_tensor_env(A, chi, chi_I)
     prev = None
     for it in range(max_iter):
         env = _split_step(A, env, chi, chi_I, renormalize)
@@ -132,23 +140,26 @@ def _converge_split_gauge_fixed(
     return env
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(1,))
-def _split_ctm_converge(A, static):
+@partial(jax.custom_vjp, nondiff_argnums=(2,))
+def _split_ctm_converge(A, env_init, static):
     """Converge gauge-fixed split-CTM; custom-VJP via implicit differentiation.
 
     ``static = (chi, chi_I, max_iter, conv_tol, renormalize, min_iter)``
-    is a hashable tuple of non-differentiable CTM settings.  Returns the
-    converged ``SplitCTMTensorEnv`` pytree.
+    is a hashable tuple of non-differentiable CTM settings.  *env_init* is an
+    optional ``SplitCTMTensorEnv`` warm-start seed (``None`` → fresh init);
+    it carries **zero** gradient because the fixed point is seed-independent
+    (mirrors ``env_init_leaves`` in ``ad_utils.ctm_tensor_converge``).
+    Returns the converged ``SplitCTMTensorEnv`` pytree.
     """
     chi, chi_I, max_iter, conv_tol, renormalize, min_iter = static
     return _converge_split_gauge_fixed(
-        A, chi, chi_I, max_iter, conv_tol, renormalize, min_iter
+        A, chi, chi_I, max_iter, conv_tol, renormalize, min_iter, env_init=env_init
     )
 
 
-def _split_ctm_converge_fwd(A, static):
-    env = _split_ctm_converge(A, static)
-    return env, (A, env)
+def _split_ctm_converge_fwd(A, env_init, static):
+    env = _split_ctm_converge(A, env_init, static)
+    return env, (A, env, env_init)
 
 
 def _split_ctm_converge_bwd(static, residuals, g):
@@ -158,9 +169,10 @@ def _split_ctm_converge_bwd(static, residuals, g):
     pytree).  We accumulate ``λ`` in env space using ``J^T = (∂f/∂env)^T``,
     then project once to A space with ``(∂f/∂A)^T λ``.  Mirrors the
     YASTN-style iterative VJP in ``ad_utils._ctm_tensor_converge_bwd``.
+    The warm-start seed ``env_init`` gets a zero cotangent.
     """
     chi, chi_I, max_iter, conv_tol, renormalize, min_iter = static
-    A, env = residuals
+    A, env, env_init = residuals
 
     # J^T in env space (A fixed) and (∂f/∂A)^T projector (env fixed).
     _, vjp_env_fn = jax.vjp(lambda e: _split_step(A, e, chi, chi_I, renormalize), env)
@@ -182,7 +194,9 @@ def _split_ctm_converge_bwd(static, residuals, g):
             break
 
     dA = vjp_A_fn(lam)[0]
-    return (dA,)
+    # Warm-start seed is gradient-free (fixed point is seed-independent).
+    d_env_init = None if env_init is None else jax.tree.map(jnp.zeros_like, env_init)
+    return (dA, d_env_init)
 
 
 _split_ctm_converge.defvjp(_split_ctm_converge_fwd, _split_ctm_converge_bwd)
@@ -200,6 +214,7 @@ def ctm_energy_split_implicit(
     renormalize: bool = True,
     min_iter: int = 2,
     energy_fn=None,
+    env_init=None,
     **_ignored,
 ):
     """Single-site iPEPS energy with implicit (fixed-point) split-CTM AD.
@@ -208,6 +223,9 @@ def ctm_energy_split_implicit(
     the gradient is obtained by implicit differentiation (Neumann series),
     avoiding storage of the unrolled CTM iterations.  Single-site only
     (``recipe="1x1"``); multisite has no split forward yet.
+
+    *env_init* is an optional ``SplitCTMTensorEnv`` warm-start seed for the
+    forward CTM (gradient-free); ``None`` cold-starts from a fresh init.
     """
     A = _extract_single_site(site_tensors)
     if energy_fn is not None:
@@ -223,7 +241,7 @@ def ctm_energy_split_implicit(
     )
 
     static = (chi, chi_I, max_iter, conv_tol, renormalize, min_iter)
-    env = _split_ctm_converge(A, static)
+    env = _split_ctm_converge(A, env_init, static)
     return compute_energy_split_ctm_tensor(A, env, gate)
 
 
@@ -236,6 +254,7 @@ def converge_split_env(
     chi_I: int | None = None,
     renormalize: bool = True,
     min_iter: int = 2,
+    env_init=None,
 ):
     """Forward-only gauge-fixed split-CTM converge (no gradient).
 
@@ -246,9 +265,12 @@ def converge_split_env(
     must use this rather than the bare :func:`ctm_split_tensor` so they
     land on the identical fixed point as the AD loss — keeping the
     line-search φ(α) and the gradient dφ/dα mutually consistent.
+
+    *env_init* is an optional ``SplitCTMTensorEnv`` warm-start seed; ``None``
+    cold-starts from a fresh init.
     """
     if chi_I is None:
         chi_I = chi
     return _converge_split_gauge_fixed(
-        A, chi, chi_I, max_iter, conv_tol, renormalize, min_iter
+        A, chi, chi_I, max_iter, conv_tol, renormalize, min_iter, env_init=env_init
     )

--- a/src/tenax/algorithms/ipeps_ad_policy.py
+++ b/src/tenax/algorithms/ipeps_ad_policy.py
@@ -237,6 +237,8 @@ def make_ctm_energy_fn(
                 "use fuse_virtual_legs=True."
             )
         if use_explicit:
+            # The explicit split forward re-initializes internally; no
+            # env_init warm-start yet (perf follow-up).
             return ctm_energy_split_explicit(
                 site_tensors,
                 neighbors,
@@ -249,6 +251,11 @@ def make_ctm_energy_fn(
                 renormalize=ctm_cfg.renormalize,
                 energy_fn=energy_fn,
             )
+        # Warm-start the gauge-fixed forward from the cached split env (the
+        # optimizer stores a {coord: SplitCTMTensorEnv} dict).  The seed is
+        # gradient-free, so this only speeds convergence.
+        _cached = env_cache.get("envs", None)
+        split_env_init = _cached.get((0, 0)) if _cached else None
         return ctm_energy_split_implicit(
             site_tensors,
             neighbors,
@@ -260,6 +267,7 @@ def make_ctm_energy_fn(
             renormalize=ctm_cfg.renormalize,
             min_iter=ctm_cfg.min_iter,
             energy_fn=energy_fn,
+            env_init=split_env_init,
         )
 
     def _ctm_energy_fn(site_tensors):

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1389,12 +1389,18 @@ def _optimize_gs_ad_tensor(
         energy = _ctm_energy_fn(site_tensors)
         return energy
 
-    def _split_forward(A_norm):
+    def _split_env_seed(envs_dict):
+        """Extract the single-site SplitCTMTensorEnv seed from a cache dict."""
+        return envs_dict.get((0, 0)) if envs_dict else None
+
+    def _split_forward(A_norm, env_init=None):
         """Forward-only gauge-fixed split-CTM converge (warm-start/probe/final).
 
         Reads ``ctm_cfg`` live so any in-loop rebinding is honored (schedules
         are rejected on the split path, so it is effectively static here).
         Lands on the same fixed point the implicit-AD loss differentiates.
+        *env_init* (a ``SplitCTMTensorEnv``) warm-starts the forward; the seed
+        is gradient-free so it only speeds convergence.
         """
         return converge_split_env(
             A_norm,
@@ -1404,6 +1410,7 @@ def _optimize_gs_ad_tensor(
             chi_I=ctm_cfg.chi_I,
             renormalize=ctm_cfg.renormalize,
             min_iter=ctm_cfg.min_iter,
+            env_init=env_init,
         )
 
     def _update_env_cache(params):
@@ -1412,7 +1419,8 @@ def _optimize_gs_ad_tensor(
         if use_split:
             # χ²·D⁴ split forward — no fused double layer is ever built.
             # eps_T is unused (auto-bump is rejected on the split path).
-            _env_cache["envs"] = {(0, 0): _split_forward(A_norm)}
+            seed = _split_env_seed(_env_cache.get("envs"))
+            _env_cache["envs"] = {(0, 0): _split_forward(A_norm, env_init=seed)}
             _env_cache["max_truncation_error"] = 0.0
             return
         site_tensors = {(0, 0): A_norm}
@@ -1556,7 +1564,8 @@ def _optimize_gs_ad_tensor(
         if use_split:
             # Same gauge-fixed split forward + split energy as the AD loss, so
             # φ(α) (this probe) and dφ/dα (the implicit-AD gradient) agree.
-            env = _split_forward(A_norm)
+            seed = _split_env_seed(_env_cache.get("envs"))
+            env = _split_forward(A_norm, env_init=seed)
             _env_cache["envs"] = {(0, 0): env}
             return float(compute_energy_split_ctm_tensor(A_norm, env, gate))
         site_tensors = {(0, 0): A_norm}
@@ -2579,8 +2588,9 @@ def _optimize_gs_ad_tensor(
         A_t = _params_to_A_norm(p)
         if use_split:
             # Final env is the split fixed point used by the gradient; return
-            # the SplitCTMTensorEnv (not the fused CTMTensorEnv).
-            env_ = _split_forward(A_t)
+            # the SplitCTMTensorEnv (not the fused CTMTensorEnv).  Warm-start
+            # from the passed env_init dict when available.
+            env_ = _split_forward(A_t, env_init=_split_env_seed(env_init))
             E_ = float(compute_energy_split_ctm_tensor(A_t, env_, gate))
             return A_t, env_, E_
         envs, _ = python_loop_ctm_converge(

--- a/tests/test_split_ctm_fuse_flag.py
+++ b/tests/test_split_ctm_fuse_flag.py
@@ -222,6 +222,46 @@ def test_split_implicit_grad_matches_explicit():
     assert rel < 1e-6, f"gradient magnitude mismatch: rel={rel}"
 
 
+def test_split_implicit_warm_start_matches_cold():
+    """env_init warm-start yields the identical energy + gradient as cold start.
+
+    The Γ-gauge-fixed split fixed point is seed-independent, so warm-starting
+    the forward — even from a *different* tensor's converged env — must not
+    change the energy or the implicit gradient; it only speeds convergence.
+    The custom_vjp returns a zero cotangent for env_init.
+    """
+    from tenax.algorithms._split_ctm_energy_ad import (
+        converge_split_env,
+        ctm_energy_split_implicit,
+    )
+
+    D, seed = 2, 11
+    chi = D * D
+    A = _make_site(D, 2, seed=seed)
+    A_seed = _make_site(D, 2, seed=5)
+    gate = _heisenberg_gate()
+    kw = dict(chi=chi, chi_I=chi, max_iter=80, conv_tol=1e-12, min_iter=2)
+    warm_env = converge_split_env(A_seed, **kw)
+
+    def cold(a):
+        return ctm_energy_split_implicit(
+            {(0, 0): a}, SINGLE_SITE_NEIGHBORS, gate, **kw
+        ).real
+
+    def warm(a):
+        return ctm_energy_split_implicit(
+            {(0, 0): a}, SINGLE_SITE_NEIGHBORS, gate, env_init=warm_env, **kw
+        ).real
+
+    e_c, g_c = jax.value_and_grad(cold)(A)
+    e_w, g_w = jax.value_and_grad(warm)(A)
+    gc = jnp.concatenate([x.ravel() for x in jax.tree.leaves(g_c)])
+    gw = jnp.concatenate([x.ravel() for x in jax.tree.leaves(g_w)])
+
+    assert jnp.allclose(e_c, e_w, atol=1e-10), f"energy: cold={e_c} warm={e_w}"
+    assert float(jnp.linalg.norm(gc - gw) / jnp.linalg.norm(gc)) < 1e-8
+
+
 def test_make_ctm_energy_fn_dispatches_to_split_implicit():
     """make_ctm_energy_fn routes to the split path when fuse_virtual_legs=False.
 


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, opened by @yingjerkao.

**Stacked on #651** (base is `feat/463-split-ctm-optimizer-integration`); review/merge #651 first. GitHub will retarget this PR to `main` once #651 lands.

Completes the single-site split-CTM optimizer integration by closing the one perf gap #651 left open: the gauge-fixed forward cold-started from a fresh rank-1 init on **every** evaluation (AD loss, line-search probe, warm-start refresh, final-env eval). This reuses the cached `SplitCTMTensorEnv` as a forward seed.

## Change
- **`_split_ctm_energy_ad`** — thread an optional `env_init` (`SplitCTMTensorEnv`) seed through `_converge_split_gauge_fixed`, the `_split_ctm_converge` `custom_vjp` (new differentiable arg with a **zero** cotangent — the gauge-fixed fixed point is seed-independent, mirroring `env_init_leaves` in `ad_utils.ctm_tensor_converge`), `ctm_energy_split_implicit`, and `converge_split_env`.
- **`ipeps_ad_policy`** — the split implicit branch reads the cached `{coord: env}` and passes the `(0,0)` seed to `ctm_energy_split_implicit`.
- **`ipeps_optimize`** — `_split_forward` accepts `env_init`; warm-start / probe / final-env pass the cached split env via `_split_env_seed`.

## Validation (`tests/test_split_ctm_fuse_flag.py`, 20 pass)
- **Warm-start == cold-start**: energy and gradient match to 1e-10 / 1e-8 even when seeded from a *different* tensor's converged env (verified directly at 3.8e-15 / 3.1e-14). This confirms the fixed point is seed-independent and `env_init`'s cotangent is genuinely zero.
- End-to-end optimizer (2 steps) still returns a `SplitCTMTensorEnv`.

## Scope / deferred
- Explicit-AD split warm-start (the unrolled forward re-initializes internally).
- SymmetricTensor / fermionic split implicit; multisite split forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
