### PR TITLE
refactor(#463): consolidate split-CTM guards into one validator (TODO #512)

### DIFF
--- a/src/tenax/algorithms/ipeps_ad_policy.py
+++ b/src/tenax/algorithms/ipeps_ad_policy.py
@@ -41,6 +41,45 @@ def validate_ctm_for_implicit_ad(ctm_cfg: CTMConfig) -> None:
         )
 
 
+def validate_split_ctm_config(ctm_cfg: CTMConfig, recipe: str) -> None:
+    """Reject ``CTMConfig`` combinations the split-CTM path cannot honor.
+
+    The split (``fuse_virtual_legs=False``) forward is fixed-χ single-site, so
+    every χ-changing knob is unsupported.  Raising up front beats the failure
+    modes of letting one through: ``chi_ramp`` would be *silently ignored*
+    (the split forward never reads it), and the end-of-step ``chi_auto_bump``
+    would *crash* when ``_maybe_bump_chi`` pads a ``SplitCTMTensorEnv`` with
+    the fused-only ``pad_dense_env_chi``.
+
+    Shared single source of truth for ``make_ctm_energy_fn``'s split branch and
+    the ``_optimize_gs_ad_tensor`` dispatcher so both entry points reject
+    identically.  Covers only the ``CTMConfig``-level knobs; ``cg_gates`` and
+    the ``iPEPSConfig`` schedules are guarded by the optimizer dispatcher.
+    """
+    if recipe != "1x1":
+        raise NotImplementedError(
+            "fuse_virtual_legs=False (split CTM) requires gs_recipe='1x1'; "
+            f"got recipe={recipe!r}."
+        )
+    if ctm_cfg.ctmrg_heuristic_increase_chi:
+        raise NotImplementedError(
+            "in-CTM chi auto-bump (ctmrg_heuristic_increase_chi) is not "
+            "supported on the split-CTM path; use fuse_virtual_legs=True."
+        )
+    # TODO(#512): chi_auto_bump and chi_ramp are deprecated and slated for
+    # removal next release; drop these two checks once the fields are gone.
+    if ctm_cfg.chi_auto_bump:
+        raise NotImplementedError(
+            "chi_auto_bump is not supported on the split-CTM path; "
+            "use fuse_virtual_legs=True."
+        )
+    if ctm_cfg.chi_ramp is not None:
+        raise NotImplementedError(
+            "chi_ramp is not supported on the split-CTM path; "
+            "use fuse_virtual_legs=True."
+        )
+
+
 def resolve_projector_backward(
     config: iPEPSConfig,
     *,
@@ -221,21 +260,7 @@ def make_ctm_energy_fn(
         Phase 2); guard the unsupported combinations up front so the failure
         is a clear policy error rather than a downstream shape mismatch.
         """
-        if recipe != "1x1":
-            raise NotImplementedError(
-                "fuse_virtual_legs=False (split CTM) requires gs_recipe='1x1'; "
-                f"got recipe={recipe!r}."
-            )
-        if ctm_cfg.chi_ramp is not None:
-            raise NotImplementedError(
-                "chi_ramp is not supported on the split-CTM path; "
-                "use fuse_virtual_legs=True."
-            )
-        if ctm_cfg.ctmrg_heuristic_increase_chi:
-            raise NotImplementedError(
-                "in-CTM chi auto-bump is not supported on the split-CTM path; "
-                "use fuse_virtual_legs=True."
-            )
+        validate_split_ctm_config(ctm_cfg, recipe)
         if use_explicit:
             return ctm_energy_split_explicit(
                 site_tensors,

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1247,6 +1247,7 @@ def _optimize_gs_ad_tensor(
     from tenax.algorithms.ipeps_ad_policy import (
         ctm_converge_kwargs,
         make_ctm_energy_fn,
+        validate_split_ctm_config,
     )
 
     cg_gates = config.cg_gates
@@ -1310,24 +1311,13 @@ def _optimize_gs_ad_tensor(
     # silently feeding a SplitCTMTensorEnv to fused-only machinery.
     use_split = not ctm_cfg.fuse_virtual_legs
     if use_split:
-        if config.gs_recipe != "1x1":
-            raise NotImplementedError(
-                "fuse_virtual_legs=False (split CTM) requires gs_recipe='1x1'; "
-                f"got {config.gs_recipe!r}."
-            )
+        # Shared single source of truth for the CTMConfig-level rejects
+        # (recipe + the three χ-changing knobs); see validate_split_ctm_config.
+        validate_split_ctm_config(ctm_cfg, config.gs_recipe)
+        # iPEPSConfig-level rejects the shared helper can't see.
         if _use_cg:
             raise NotImplementedError(
                 "fuse_virtual_legs=False (split CTM) does not support cg_gates; "
-                "use fuse_virtual_legs=True."
-            )
-        if ctm_cfg.chi_auto_bump or ctm_cfg.ctmrg_heuristic_increase_chi:
-            raise NotImplementedError(
-                "in-CTM chi auto-bump is not supported on the split-CTM path; "
-                "use fuse_virtual_legs=True."
-            )
-        if ctm_cfg.chi_ramp is not None:
-            raise NotImplementedError(
-                "chi_ramp is not supported on the split-CTM path; "
                 "use fuse_virtual_legs=True."
             )
         if (

--- a/tests/test_split_ctm_fuse_flag.py
+++ b/tests/test_split_ctm_fuse_flag.py
@@ -381,7 +381,7 @@ def test_optimize_gs_ad_split_rejects_chi_auto_bump():
 
     A, gate = _split_opt_inputs()
     cfg = _split_opt_config(fuse=False, ctm={"chi_auto_bump": True, "chi_max": 6})
-    with pytest.raises(NotImplementedError, match="auto-bump"):
+    with pytest.raises(NotImplementedError, match="chi_auto_bump"):
         optimize_gs_ad(gate, A, cfg)
 
 
@@ -393,3 +393,27 @@ def test_optimize_gs_ad_split_rejects_non_1x1_recipe():
     cfg = _split_opt_config(fuse=False, gs_recipe="2x2")
     with pytest.raises(NotImplementedError, match="1x1"):
         optimize_gs_ad(gate, A, cfg)
+
+
+def test_validate_split_ctm_config_rejects_chi_changing_knobs():
+    """The shared split-CTM validator rejects every χ-changing knob (one source
+    of truth for both make_ctm_energy_fn and the optimizer dispatcher)."""
+    from tenax.algorithms.ipeps_ad_policy import validate_split_ctm_config
+
+    base = dict(chi=4, chi_I=4, fuse_virtual_legs=False)
+
+    with pytest.raises(NotImplementedError, match="1x1"):
+        validate_split_ctm_config(CTMConfig(**base), "2x2")
+    with pytest.raises(NotImplementedError, match="ctmrg_heuristic_increase_chi"):
+        validate_split_ctm_config(
+            CTMConfig(**base, ctmrg_heuristic_increase_chi=True, chi_max=6), "1x1"
+        )
+    with pytest.raises(NotImplementedError, match="chi_auto_bump"):
+        validate_split_ctm_config(
+            CTMConfig(**base, chi_auto_bump=True, chi_max=6), "1x1"
+        )
+    with pytest.raises(NotImplementedError, match="chi_ramp"):
+        validate_split_ctm_config(CTMConfig(**base, chi_ramp=[(4, 10)]), "1x1")
+
+    # Valid fixed-χ split config: no raise.
+    validate_split_ctm_config(CTMConfig(**base), "1x1")


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, opened by @yingjerkao.

Cleanup follow-up to #648/#651/#652. Consolidates the split-CTM (`fuse_virtual_legs=False`) config rejects that were duplicated across two entry points.

## Why
The split-path guards lived in two places with drifting messages:
- `make_ctm_energy_fn`'s split branch (`ipeps_ad_policy`) — checked recipe, `chi_ramp`, `ctmrg_heuristic_increase_chi`.
- `_optimize_gs_ad_tensor` (`ipeps_optimize`) — checked recipe, `cg_gates`, `chi_auto_bump`/`ctmrg_heuristic_increase_chi`, `chi_ramp`, schedules.

## Change
- Extract the `CTMConfig`-level rejects (recipe + the three χ-changing knobs) into a single `validate_split_ctm_config(ctm_cfg, recipe)` helper; both sites call it. The `iPEPSConfig`-level rejects (`cg_gates`, schedules) stay in the optimizer dispatcher.
- Fix the misleading **"in-CTM chi auto-bump"** message the optimizer applied to the *end-of-step* `chi_auto_bump`, and tighten the test match to the field name.
- Add a fast direct unit test for the validator (all four reject branches + the valid fixed-χ config).

## The guards stay on purpose
They are **protective, not dead**: the split forward is fixed-χ single-site, so
- `chi_ramp` would be **silently ignored** (the forward never reads it), and
- `chi_auto_bump` would **crash** (`_maybe_bump_chi` pads a `SplitCTMTensorEnv` with the fused-only `pad_dense_env_chi`).

A clear `NotImplementedError` up front beats both.

## Tie to #512
`chi_auto_bump` and `chi_ramp` are deprecated (#512) and slated for removal **next release**. The helper carries a `TODO(#512)` so those two checks are dropped when the fields are gone; `ctmrg_heuristic_increase_chi` (the surviving in-CTM bump) stays guarded.

## Tests
`tests/test_split_ctm_fuse_flag.py`: **20 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
