### PR TITLE
fix(#463): close two split-path guard gaps flagged by Codex review

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1334,10 +1334,15 @@ def _optimize_gs_ad_tensor(
             config.gs_ctm_conv_tol_schedule is not None
             or config.gs_ctm_max_iter_schedule is not None
             or config.gs_plateau_patience_schedule is not None
+            # gs_chi_schedule_steps (set by optimize_gs_ad_chi_schedule) drives
+            # _advance_chi_stage_if_due -> _apply_chi_bump -> pad_dense_env_chi,
+            # which assumes a fused CTMTensorEnv and crashes on a split env.
+            or config.gs_chi_schedule_steps is not None
         ):
             raise NotImplementedError(
-                "CTM conv_tol/max_iter/plateau schedules are not supported on "
-                "the split-CTM path; use fuse_virtual_legs=True."
+                "CTM conv_tol/max_iter/plateau and chi (gs_chi_schedule_steps / "
+                "optimize_gs_ad_chi_schedule) schedules are not supported on the "
+                "split-CTM path; use fuse_virtual_legs=True."
             )
 
     use_explicit = not config.gs_implicit_ad
@@ -1496,14 +1501,14 @@ def _optimize_gs_ad_tensor(
     if (
         use_split
         and config.gs_metric_precond
-        and config.gs_optimizer.lower() == "lbfgs"
+        and config.gs_optimizer.lower() in ("lbfgs", "cg")
     ):
         import warnings
 
         warnings.warn(
             "gs_metric_precond=True is not yet supported on the split-CTM path "
             "(fuse_virtual_legs=False); the metric inner product needs the "
-            "fused CTMTensorEnv. Falling back to non-preconditioned L-BFGS.",
+            "fused CTMTensorEnv. Falling back to non-preconditioned optimization.",
             stacklevel=3,
         )
     if _use_cg and _cg_map_fn is not None:
@@ -2165,7 +2170,11 @@ def _optimize_gs_ad_tensor(
 
         # Compute search direction
         if is_cg:
-            if config.gs_metric_precond and not use_c4v:
+            # ``not use_split``: the metric inner product (precondition_gradient)
+            # consumes the fused CTMTensorEnv edge fields; on the split path the
+            # cache holds a SplitCTMTensorEnv, so fall back to plain CG (a
+            # warning was emitted up front).  Mirrors is_metric_lbfgs.
+            if config.gs_metric_precond and not use_c4v and not use_split:
                 from tenax.algorithms._metric_precond import precondition_gradient
 
                 env_for_metric = _env_cache["envs"][(0, 0)]

--- a/tests/test_split_ctm_fuse_flag.py
+++ b/tests/test_split_ctm_fuse_flag.py
@@ -433,3 +433,35 @@ def test_optimize_gs_ad_split_rejects_non_1x1_recipe():
     cfg = _split_opt_config(fuse=False, gs_recipe="2x2")
     with pytest.raises(NotImplementedError, match="1x1"):
         optimize_gs_ad(gate, A, cfg)
+
+
+def test_optimize_gs_ad_split_rejects_chi_schedule():
+    """Split path rejects gs_chi_schedule_steps up front.
+
+    Without the guard the schedule advances into _apply_chi_bump ->
+    pad_dense_env_chi, which assumes a fused CTMTensorEnv and would
+    AttributeError on the cached SplitCTMTensorEnv (Codex review on #651).
+    """
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    A, gate = _split_opt_inputs()
+    cfg = _split_opt_config(fuse=False, gs_chi_schedule_steps=[(4, 1)])
+    with pytest.raises(NotImplementedError, match="schedule"):
+        optimize_gs_ad(gate, A, cfg)
+
+
+def test_optimize_gs_ad_split_cg_metric_does_not_crash():
+    """Split + CG + gs_metric_precond falls back to plain CG (no crash).
+
+    The metric inner product needs the fused CTMTensorEnv; on the split path
+    the cache holds a SplitCTMTensorEnv, so metric preconditioning must be
+    disabled for the CG optimizer too — not just L-BFGS (Codex review on #651).
+    """
+    from tenax.algorithms._split_ctm_tensor_init import SplitCTMTensorEnv
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    A, gate = _split_opt_inputs()
+    cfg = _split_opt_config(fuse=False, gs_optimizer="cg", gs_metric_precond=True)
+    _, env, E = optimize_gs_ad(gate, A, cfg)
+    assert isinstance(env, SplitCTMTensorEnv)
+    assert jnp.isfinite(E)


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, opened by @yingjerkao.

Addresses the **Codex automated review** findings on #651 (single-site split-CTM optimizer integration). Both are crash bugs where fused-`CTMTensorEnv` assumptions fire on a cached `SplitCTMTensorEnv`.

## P1 — chi schedules not rejected (`AttributeError` instead of clean error)
The split guard rejected the `conv_tol`/`max_iter`/`plateau` schedules but **not** `gs_chi_schedule_steps` (set by `optimize_gs_ad_chi_schedule`). A scheduled split run advanced into `_advance_chi_stage_if_due` → `_apply_chi_bump` → `pad_dense_env_chi`, which indexes fused `T1..T4` fields. **Fix:** add `gs_chi_schedule_steps` to the schedule-rejection guard. This also makes the README "fixed χ … rejected" claim (#654) accurate.

## P2 — metric preconditioning disabled only for L-BFGS, not CG
`gs_metric_precond` auto-disable on split covered `gs_optimizer="lbfgs"` only; with `gs_optimizer="cg"` the CG branch still called `precondition_gradient(A, env_for_metric, …)` with the split env. **Fix:** gate the CG metric branch on `not use_split` (mirrors `is_metric_lbfgs`) and broaden the up-front fallback warning to cover CG too.

(My existing `_use_cg` guard rejects *coarse-grain gates* — a different thing from the `gs_optimizer="cg"` conjugate-gradient optimizer.)

## Safety
Fused path is untouched: the CG gate's `not use_split` is always `True` for fused, and the warning only fires on split.

## Tests (`tests/test_split_ctm_fuse_flag.py`, 22 pass)
- `test_optimize_gs_ad_split_rejects_chi_schedule` — `gs_chi_schedule_steps` raises `NotImplementedError`.
- `test_optimize_gs_ad_split_cg_metric_does_not_crash` — split + CG + `gs_metric_precond=True` runs, warns, returns a `SplitCTMTensorEnv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
