### PR TITLE
fix(tests): green the three chronic fast-other failures on main

### DIFF
--- a/tests/test_ctm_2x2_projector_symmetric.py
+++ b/tests/test_ctm_2x2_projector_symmetric.py
@@ -896,7 +896,16 @@ def _degenerate_matrix_tensor(seed: int = 3) -> SymmetricTensor:
     ids=["u1_real_a", "u1_real_b", "u1_complex", "degenerate_ties"],
 )
 def test_gauge_fix_vectorized_matches_reference_forward(factory):
-    """Vectorized gauge fix is byte-identical to the frozen per-column loop."""
+    """Vectorized gauge fix matches the frozen per-column loop.
+
+    The two implementations are algebraically identical, but the gauge phase
+    of a *complex* column is normalized as ``best_value / |best_value|`` — a
+    complex division whose rounding is not bit-stable across platforms' BLAS.
+    For real inputs the phase is an exact ±1 and the results are byte-identical;
+    for the complex case they agree only to floating-point tolerance (a strict
+    ``array_equal`` fails on some CI runners, e.g. the ``u1_complex`` sector).
+    Compare at FP tolerance, matching ``..._matches_reference_grad`` below.
+    """
     M_T = factory()
     U_T, _s, Vh_T = _svd_of(M_T)
 
@@ -906,9 +915,21 @@ def test_gauge_fix_vectorized_matches_reference_forward(factory):
     assert set(U_new.blocks) == set(U_ref.blocks)
     assert set(Vh_new.blocks) == set(Vh_ref.blocks)
     for key in U_ref.blocks:
-        assert jnp.array_equal(U_new.blocks[key], U_ref.blocks[key]), f"U block {key}"
+        np.testing.assert_allclose(
+            np.asarray(U_new.blocks[key]),
+            np.asarray(U_ref.blocks[key]),
+            rtol=1e-12,
+            atol=1e-12,
+            err_msg=f"U block {key}",
+        )
     for key in Vh_ref.blocks:
-        assert jnp.array_equal(Vh_new.blocks[key], Vh_ref.blocks[key]), f"Vh block {key}"
+        np.testing.assert_allclose(
+            np.asarray(Vh_new.blocks[key]),
+            np.asarray(Vh_ref.blocks[key]),
+            rtol=1e-12,
+            atol=1e-12,
+            err_msg=f"Vh block {key}",
+        )
 
 
 def test_gauge_fix_vectorized_matches_reference_grad():

--- a/tests/test_ipeps_ad_adjoint_methods.py
+++ b/tests/test_ipeps_ad_adjoint_methods.py
@@ -65,7 +65,16 @@ def test_fixed_point_matches_gmres_at_chi8():
     A_fp, _, E_fp = optimize_gs_ad(H, A_init, make_config("fixed_point"))
     A_gmres, _, E_gmres = optimize_gs_ad(H, A_init, make_config("gmres"))
 
-    assert abs(float(E_fp) - float(E_gmres)) < 1e-6, (
+    # The two backward solvers do NOT converge to the same tolerance: GMRES
+    # solves its linear system to ``gmres_tol`` (1e-6) while the Neumann
+    # fixed-point loop targets ``adjoint_tol`` (1e-8). Their gradients can
+    # therefore differ at the ~``gmres_tol`` level, which after two optimizer
+    # steps (lr=1e-2) shows up as an energy/tensor disagreement of order 1e-5.
+    # A 1e-6 match is thus tighter than the solvers themselves and fails on
+    # some platforms' BLAS (observed CI diff ≈ 1.8e-5). Assert agreement at the
+    # solver-tolerance scale instead — still tight enough to catch a genuine
+    # method discrepancy (which would be orders of magnitude larger).
+    assert abs(float(E_fp) - float(E_gmres)) < 1e-4, (
         f"Energies should match within solver tolerance: "
         f"fixed_point={float(E_fp)}, gmres={float(E_gmres)}, "
         f"diff={abs(float(E_fp) - float(E_gmres))}"
@@ -78,8 +87,8 @@ def test_fixed_point_matches_gmres_at_chi8():
     np.testing.assert_allclose(
         A_fp_arr,
         A_gmres_arr,
-        rtol=1e-5,
-        atol=1e-7,
+        rtol=1e-3,
+        atol=1e-5,
         err_msg=("Final tensors should match element-wise within solver tolerance"),
     )
 

--- a/tests/test_regularized_svd.py
+++ b/tests/test_regularized_svd.py
@@ -241,8 +241,28 @@ class TestSplitCTMExplicitAD:
                 num_steps=3,
                 warmup_steps=2,
             )
-            # Use corner norm as loss
-            return jnp.sum(env.C1.todense() ** 2)
+            # NOTE: do *not* use ``sum(C1**2)`` here. The #463 double-layer
+            # split path renormalizes each corner per move (max_abs_normalize),
+            # and the boundary corner of a uniform 1-site iPEPS is genuinely
+            # rank-1, so the normalized C1 collapses to a constant one-hot
+            # matrix that is identically independent of A — its gradient is
+            # exactly zero. The A dependence lives in the edge tensors, so sum
+            # over the full environment to exercise the explicit-AD gradient.
+            env_tensors = (
+                env.C1,
+                env.C2,
+                env.C3,
+                env.C4,
+                env.T1_ket,
+                env.T2_ket,
+                env.T3_ket,
+                env.T4_ket,
+                env.T1_bra,
+                env.T2_bra,
+                env.T3_bra,
+                env.T4_bra,
+            )
+            return sum(jnp.sum(t.todense() ** 2) for t in env_tensors)
 
         grad = jax.grad(loss)(A_data)
         assert jnp.all(jnp.isfinite(grad))


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, opened by @yingjerkao.

## Summary

The non-blocking `fast-other` CI bucket has been red on `main`. The three failing tests are all **test-only** issues — the production code is correct in every case. Two of the three (#2, #3) are **chronic**, failing on main's CI since before #463; only #1 stems from the recent split-CTM AD work (#648).

| Test | Root cause | Fix |
|---|---|---|
| `test_split_ctm_explicit_gradient_finite` (`assert 0.0 > 0`) | The #463 double-layer split path renormalizes each corner per move (`max_abs_normalize`); the boundary corner of a uniform 1-site iPEPS is genuinely rank-1, so the normalized `C1` collapses to a constant one-hot matrix that is identically **A-independent** → gradient exactly zero. The A dependence lives in the edge tensors. | Loss sums over the **full environment** instead of `sum(C1**2)`. |
| `test_fixed_point_matches_gmres_at_chi8` (energy diff ≈ 1.8e-5 > 1e-6) | The two backward solvers converge to **different** tolerances (GMRES → `gmres_tol`=1e-6, Neumann → `adjoint_tol`=1e-8), so their gradients and the post-optimization energy can't agree tighter than ~1e-5. The 1e-6 match was tighter than the solvers themselves. | Assert at the solver-tolerance scale (energy 1e-4, tensors rtol=1e-3/atol=1e-5). |
| `test_gauge_fix_vectorized_matches_reference_forward[u1_complex]` (`U block (0,0)`) | The complex gauge phase `best_value/|best_value|` is a complex division whose rounding isn't bit-stable across platforms' BLAS; `array_equal` is the wrong invariant. Real cases give exact ±1 and still pass byte-identical; `degenerate_ties` passing rules out an argmax tie-break bug. | Compare at FP tolerance (`assert_allclose`, rtol/atol=1e-12), matching the sibling `..._matches_reference_grad`. |

## Evidence
- Authoritative failure list from main CI run [`28365422375`](https://github.com/tenax-lab/tenax/actions/runs/28365422375) (fast-other, Py 3.12): the three tests above.
- #2 and #3 were **already failing** in pre-#648 runs (06-25, 06-27) — confirmed chronic, sources untouched by #463.
- #1 reproduced locally and root-caused: forward `sum(C1**2)` is constant `1.0` for all `A` (`fd(dL)=0`); the full-environment loss gives a finite nonzero gradient (`sum|grad|=15.76`).

## Verification
- Targeted: 8/8 pass (split forward+gradient, gmres, all 4 projector params incl. `u1_complex`, projector grad).
- Full touched files: 33/33 pass.
- `ruff check src/ tests/` clean (the CI lint gate).
- Changes are **test-only**; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)