### PR TITLE
test(#463): validate 1-site split-CTM is production-correct (C4v) + lock CG-on-split guards

### DIFF
--- a/docs/superpowers/plans/2026-06-30-463-split-ctm-1site-validation-cg-guard.md
+++ b/docs/superpowers/plans/2026-06-30-463-split-ctm-1site-validation-cg-guard.md
@@ -1,0 +1,316 @@
+# Split-CTM 1-site Validation + CG Guard Lock-in — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add characterization/regression tests that (a) prove the 1-site split-CTM path is variationally correct with C4v, and (b) lock in the intended CG-on-split rejection at both guard layers — a pre-flip prerequisite for #463, with **no production-code changes**.
+
+**Architecture:** All three tests exercise *existing* behavior (the split path already ships; the guards already exist), so they pass on first run — they are regression locks, not TDD-driven new code. The Part-1 test runs one `optimize_gs_ad` with the split path + `gs_c4v=True` on the sublattice-rotated Heisenberg gate and asserts the converged energy lands in the physical variational window `[−0.6694, −0.60]` per site. The Part-2 tests assert the two CG guards raise `NotImplementedError`.
+
+**Tech Stack:** Python, JAX, pytest. Tenax `optimize_gs_ad` / `CTMConfig` / `iPEPSConfig`. Tests reuse helpers from `tests/test_split_ctm_fuse_flag.py`.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-463-split-ctm-1site-validation-cg-guard-design.md`
+
+**Why these tests / measured anchors (D=2, χ=10, gs_c4v=True, grad_norm |g|<1e-3):**
+- split+c4v converged to **−0.6505/site** (variational, +0.019 above QMC −0.6694).
+- fused+c4v converged to **−0.6601/site**. Gap 0.0096 persists at tight |g| ⇒ genuine bounded #425, both physical.
+- WITHOUT C4v split breaches to **−0.714** (below floor) — so the window test is meaningful only with `gs_c4v=True`.
+
+---
+
+## File Structure
+
+- **Create** `tests/test_split_ctm_production_correctness.py` — the one `slow` Part-1 variational-window test (+ optional companion). Isolated so the slow optimizer run stays out of the `core`-marked `test_split_ctm_fuse_flag.py`.
+- **Modify** `tests/test_split_ctm_fuse_flag.py` — append the two fast CG-guard regression tests (Part 2). This file is already `pytestmark = pytest.mark.core`; the guard tests are fast and belong there.
+- **Delete** `_split_floor_one.py`, `_split_floor_confirm.py` — scratch probe scripts in the repo root (untracked); remove so the tree is clean.
+- No `src/` changes.
+
+---
+
+## Task 1: CG guard layer-2 regression test (split AD `energy_fn` reject)
+
+**Files:**
+- Modify: `tests/test_split_ctm_fuse_flag.py` (append at end)
+
+- [ ] **Step 1: Add the test**
+
+Append to `tests/test_split_ctm_fuse_flag.py`:
+
+```python
+def test_split_energy_fn_guard_rejects_custom_energy_fn():
+    """Layer-2 CG guard: the split AD entry points reject a custom energy_fn.
+
+    CG runs by passing a coarse-grain energy_fn; the split path does not
+    support it yet (compute_energy_cg_split exists but is not wired through
+    the split AD). Lock the rejection so a refactor can't silently drop it.
+    """
+    from tenax.algorithms._split_ctm_energy_ad import (
+        ctm_energy_split_explicit,
+        ctm_energy_split_implicit,
+    )
+
+    A = _make_site(2, 2, seed=0)
+    gate = _heisenberg_gate()
+    for fn in (ctm_energy_split_implicit, ctm_energy_split_explicit):
+        with pytest.raises(NotImplementedError, match="custom energy_fn"):
+            fn(
+                {(0, 0): A},
+                SINGLE_SITE_NEIGHBORS,
+                gate,
+                chi=4,
+                energy_fn=lambda *a: 0.0,
+            )
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `uv run pytest tests/test_split_ctm_fuse_flag.py::test_split_energy_fn_guard_rejects_custom_energy_fn -v`
+Expected: PASS (the guard already exists; this locks it).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_split_ctm_fuse_flag.py
+git commit -m "test(#463): lock split-AD energy_fn (CG layer-2) rejection"
+```
+
+---
+
+## Task 2: CG guard layer-1 regression test (`cg_gates` optimizer reject)
+
+**Files:**
+- Modify: `tests/test_split_ctm_fuse_flag.py` (append at end)
+
+- [ ] **Step 1: Add the test**
+
+Append to `tests/test_split_ctm_fuse_flag.py`:
+
+```python
+def test_optimize_gs_ad_split_rejects_cg_gates():
+    """Layer-1 CG guard: the split optimizer path rejects cg_gates up front.
+
+    cg_gates couples to the fused CTMTensorEnv (compute_energy_cg uses the
+    fused diagonal-RDM env); the split path raises rather than silently
+    feeding a SplitCTMTensorEnv to fused-only machinery (ipeps_optimize.py).
+    """
+    import jax.numpy as jnp
+
+    from tenax.algorithms.coarse_grain import honeycomb_cg_gates
+    from tenax.algorithms.ipeps_config import CTMConfig as _CTMConfig
+    from tenax.algorithms.ipeps_config import iPEPSConfig
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    cfg = iPEPSConfig(
+        max_bond_dim=2,
+        ctm=_CTMConfig(chi=8, fuse_virtual_legs=False, max_iter=10, min_iter=2),
+        gs_num_steps=1,
+        gs_recipe="1x1",
+        unit_cell="1x1",
+        su_init=False,
+        gs_c4v=True,
+        gs_explicit_ad=True,
+        gs_explicit_ad_steps=5,
+        gs_explicit_ad_warmup=2,
+        gs_metric_precond=False,
+        cg_gates=honeycomb_cg_gates(),
+    )
+    dummy_gate = jnp.zeros((4, 4, 4, 4))  # d_eff placeholder for the CG supersite
+    with pytest.raises(NotImplementedError, match="cg_gates"):
+        optimize_gs_ad(dummy_gate, None, cfg)
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `uv run pytest tests/test_split_ctm_fuse_flag.py::test_optimize_gs_ad_split_rejects_cg_gates -v`
+Expected: PASS — raises `NotImplementedError` with message `"fuse_virtual_legs=False (split CTM) does not support cg_gates; ..."` (the guard fires before any CTM iteration, so the test is fast).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_split_ctm_fuse_flag.py
+git commit -m "test(#463): lock cg_gates (CG layer-1) rejection on split optimizer"
+```
+
+---
+
+## Task 3: 1-site split production-correctness window test (Part 1, `slow`)
+
+**Files:**
+- Create: `tests/test_split_ctm_production_correctness.py`
+
+- [ ] **Step 1: Create the test file**
+
+Create `tests/test_split_ctm_production_correctness.py`:
+
+```python
+"""Production-correctness of the 1-site split-CTM path (#463 pre-flip check).
+
+Validates that the split (``fuse_virtual_legs=False``) single-site path, run
+WITH C4v on the sublattice-rotated square Heisenberg gate (under which a 1-site
+iPEPS represents Neel order), converges to a *variational* energy: above the
+QMC ground-state energy and below the disordered energy.
+
+Empirical anchors (D=2, chi=10, gs_c4v=True, grad_norm |g|<1e-3):
+  split+c4v = -0.6505/site (variational, +0.019 above QMC -0.6694)
+  fused+c4v = -0.6601/site
+WITHOUT C4v the unconstrained 1-site CTM is non-variational for BOTH paths
+(split breaches to -0.714) -- so gs_c4v=True is mandatory here. The split/fused
+~0.01/site gap is the bounded #425 fixed-point difference (both physical).
+"""
+import jax.numpy as jnp
+import pytest
+
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+from tests.test_split_ctm_fuse_flag import _make_site
+
+# Sandvik QMC square-lattice spin-1/2 Heisenberg, energy per site.
+QMC_FLOOR = -0.6694
+ORDERED_CEIL = -0.60  # below the disordered/product energy => genuine order
+
+
+def _rotated_heisenberg():
+    """H_rot = -SzSz - 0.5(S+S+ + S-S-): sublattice-rotated so a 1-site iPEPS
+    represents Neel order (unitary image of the AFM Heisenberg gate)."""
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+    H = -jnp.kron(Sz, Sz) - 0.5 * (jnp.kron(Sp, Sp) + jnp.kron(Sm, Sm))
+    return H.reshape(2, 2, 2, 2)
+
+
+def _config(fuse):
+    return iPEPSConfig(
+        ctm=CTMConfig(
+            chi=10, chi_I=10, fuse_virtual_legs=fuse,
+            max_iter=80, conv_tol=1e-10, min_iter=4,
+        ),
+        unit_cell="1x1", gs_recipe="1x1", gs_implicit_ad=True,
+        gs_c4v=True, gs_metric_precond=False,
+        gs_conv_criterion="grad_norm", gs_grad_norm_tol=1e-3,
+        gs_num_steps=100, gs_log_interval=10, su_init=False,
+    )
+
+
+@pytest.mark.slow
+def test_split_1site_is_variational_with_c4v():
+    """Split + C4v on rotated Heisenberg must land in [-0.6694, -0.60]/site.
+
+    The lower bound is THE assertion: a correct variational 1-site path stays
+    above the QMC ground state; the #425-spurious sub-QMC fixed point (which
+    appears WITHOUT C4v, E=-0.714) would breach it.
+    """
+    A = _make_site(2, 2, seed=3)
+    _, _, E = optimize_gs_ad(_rotated_heisenberg(), A, _config(fuse=False))
+    E = float(E)  # per site = E_h + E_v
+    assert E >= QMC_FLOOR - 1e-3, (
+        f"split breaches QMC variational floor: E/site={E:.6f} < {QMC_FLOOR}"
+    )
+    assert E <= ORDERED_CEIL, (
+        f"split did not order: E/site={E:.6f} > {ORDERED_CEIL}"
+    )
+```
+
+- [ ] **Step 2: Run the test (slow — minutes on GPU, longer on CPU)**
+
+Run: `uv run pytest tests/test_split_ctm_production_correctness.py::test_split_1site_is_variational_with_c4v -v`
+Expected: PASS. The split optimization converges around step ~69 to E/site ≈ −0.6505, which satisfies −0.6694 ≤ −0.6505 ≤ −0.60.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_split_ctm_production_correctness.py
+git commit -m "test(#463): split 1-site variational-window production-correctness (slow, C4v)"
+```
+
+---
+
+## Task 4 (OPTIONAL): split-tracks-fused companion test
+
+Include only if the extra full optimization (~doubles the slow runtime) is acceptable. The window test (Task 3) is the primary deliverable; this documents the bounded #425 gap.
+
+**Files:**
+- Modify: `tests/test_split_ctm_production_correctness.py`
+
+- [ ] **Step 1: Append the companion test**
+
+```python
+@pytest.mark.slow
+def test_split_tracks_fused_with_c4v():
+    """Split and fused (both + C4v) converge within the bounded #425 gap.
+
+    Measured gap 0.0096/site at D=2 chi=10; assert <= 0.03 (3x margin). Both
+    paths are variational; this documents that split is a faithful (not
+    bit-identical) drop-in for fused on the 1-site path.
+    """
+    A = _make_site(2, 2, seed=3)
+    gate = _rotated_heisenberg()
+    _, _, E_split = optimize_gs_ad(gate, A, _config(fuse=False))
+    _, _, E_fused = optimize_gs_ad(gate, A, _config(fuse=True))
+    gap = abs(float(E_split) - float(E_fused))
+    assert gap <= 0.03, f"split-vs-fused gap too large: {gap:.4f} (expected ~0.0096)"
+```
+
+- [ ] **Step 2: Run**
+
+Run: `uv run pytest tests/test_split_ctm_production_correctness.py::test_split_tracks_fused_with_c4v -v`
+Expected: PASS (gap ≈ 0.0096 ≤ 0.03).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_split_ctm_production_correctness.py
+git commit -m "test(#463): document bounded split-vs-fused #425 gap (slow companion)"
+```
+
+---
+
+## Task 5: Clean up scratch probe scripts
+
+**Files:**
+- Delete: `_split_floor_one.py`, `_split_floor_confirm.py`
+
+- [ ] **Step 1: Remove the scratch scripts**
+
+```bash
+git rm -f --ignore-unmatch _split_floor_one.py _split_floor_confirm.py
+rm -f _split_floor_one.py _split_floor_confirm.py
+```
+
+- [ ] **Step 2: Confirm the tree is clean of scratch files**
+
+Run: `git status --porcelain | grep -E "_split_floor" || echo "clean"`
+Expected: `clean`
+
+- [ ] **Step 3: Commit (if anything was tracked)**
+
+```bash
+git commit -m "chore(#463): remove scratch split-CTM floor probe scripts" || true
+```
+
+---
+
+## Task 6: Full regression + suite green
+
+- [ ] **Step 1: Run the fast split-CTM suite (core)**
+
+Run: `uv run pytest tests/test_split_ctm_fuse_flag.py -v`
+Expected: ALL PASS — including the two new guard tests and the pre-existing 17.
+
+- [ ] **Step 2: Run the broader split-CTM suite (no slow)**
+
+Run: `uv run pytest tests/test_split_ctm_doublelayer_projector.py tests/test_split_ctm_tensor.py -m "not slow" -q`
+Expected: ALL PASS — no behavior change to any shipped path.
+
+- [ ] **Step 3: Run the new slow test once to confirm green**
+
+Run: `uv run pytest tests/test_split_ctm_production_correctness.py -v`
+Expected: PASS (Task 3, and Task 4 if included).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Part 1 (1-site production-correctness) → Task 3 (+ optional Task 4). Part 2 (CG guard lock-in, both layers) → Tasks 1 + 2. CG enablement doc → lives in the spec (`CG enablement (future)` section); no separate task. Suite-green acceptance → Task 6. Scratch cleanup → Task 5.
+- **No production code changes** — matches the "validation only, no new code" scope. All tests characterize/lock existing behavior, so each passes on first run (these are regression locks; to confirm a lock is real, temporarily delete the guard and re-run — the test should then fail).
+- **All test code is verified** against the current tree (both guards confirmed raising; split+c4v window confirmed at −0.6505 on GPU).
+- **Markers:** guard tests inherit `core` from `test_split_ctm_fuse_flag.py`'s `pytestmark`; window/companion tests use explicit `@pytest.mark.slow`.

--- a/docs/superpowers/specs/2026-06-29-463-split-ctm-1site-validation-cg-guard-design.md
+++ b/docs/superpowers/specs/2026-06-29-463-split-ctm-1site-validation-cg-guard-design.md
@@ -1,0 +1,172 @@
+# #463 — Split-CTM 1-site production-correctness validation + CG guard lock-in
+
+**Date:** 2026-06-29
+**Issue:** #463 (arch(ctm): unify split-CTM as the canonical path)
+**Status:** design — pre-implementation
+
+## Context
+
+Issue #463 migrates iPEPS CTM from the fused double-layer construction
+(`_build_double_layer_tensor`, peak χ²·D⁴·d²) to the split ket/bra path
+(peak χ²·D⁴·d, and Koszul-correct for fermions). The issue defines four
+phases:
+
+- **Phase 1** — split forward + split-aware RDM (shipped).
+- **Phase 2** — migrate callers behind `CTMConfig.fuse_virtual_legs` (shipped
+  for the **single-site dense bosonic** path: PRs #648/651/652/653/654/656/657).
+- **Phase 3** — flip the `fuse_virtual_legs` default to `False`.
+- **Phase 4** — archive the fused path (remove flag + delete
+  `_build_double_layer_tensor`), gated on the split path being default for
+  2+ release cycles.
+
+The user's "phase 4 flip" maps to the **flip-the-default** step (issue Phase 3).
+
+### Why we are *not* flipping in this work
+
+A literal global flip of `fuse_virtual_legs` from `True → False` would, by the
+current guards, raise `NotImplementedError` for **2-site bipartite** (the
+validated production Heisenberg config), c4v, honeycomb, multisite, and PESS,
+and is unsupported for SymmetricTensor/fermionic. Per issue #463's own
+structure, Phase 3 (flip) is gated on Phase 2 (migrate callers) being complete —
+and only the 1×1 dense bosonic path is migrated. Flipping now would regress
+production. **The flip is deliberately out of scope here.**
+
+This spec is the first, tightly-scoped prerequisite for an eventual flip:
+**prove the 1-site split path is production-correct, and lock in the
+(intended) CG rejection with a regression test.** The 2-site/2×2 split forward
+— the substantive prerequisite for a meaningful flip — is its own later spec.
+
+## Goals
+
+1. Upgrade the 1-site split correctness bar from "finite energy + single-eval
+   gradient-match" (today's tests) to "**faithful drop-in for the fused path
+   over a full optimization**."
+2. Lock in the intended CG-on-split rejection with a regression test, and
+   document precisely what a future effort needs to enable CG on split.
+
+## Non-goals (explicitly out of scope)
+
+- Flipping the `fuse_virtual_legs` default (Phase 3). Stays `True`.
+- 2-site / 2×2 / honeycomb / multisite split forward (separate spec).
+- SymmetricTensor / fermionic split AD.
+- **Enabling** CG on the split path (new wiring code — see below).
+- Any change to the auto-sentinel-vs-hard-flip default semantics (deferred to
+  the flip spec).
+
+## Findings that shaped the design
+
+1. **`chi_I=chi` is already lossless** with the rank-1 corner init. Existing
+   test `test_split_production_chi_I_converges_to_lossless` shows the
+   interlayer-truncation error (`chi_I=chi` vs lossless `chi_I=chi*D`) is ~0
+   even at D=3. ⟹ split == fused at the *production* interlayer bond, so a
+   clean split-vs-fused energy parity is achievable at default settings — we do
+   **not** need to pin `chi_I=chi*D` for the parity test.
+
+2. **A 1×1 unit cell cannot represent Néel order.** An absolute QMC comparison
+   is therefore meaningless at 1-site. The correct production-correctness bar
+   is *split reproduces the trusted fused result on the same 1×1 problem*, not
+   an absolute physical energy.
+
+3. **CG is blocked on the split path at two layers, despite the split-aware CG
+   energy already existing:**
+   - `coarse_grain.py` provides `compute_energy_cg_split` + `_split_rdm_dispatch`
+     (`_rdm{1x2,2x1,diagonal}_split_tensor`) — the split-aware CG RDM/energy
+     building blocks exist.
+   - `_split_ctm_energy_ad.ctm_energy_split_{explicit,implicit}` **reject any
+     custom `energy_fn`** ("custom energy_fn (e.g. coarse-grain) is not
+     supported on the split path").
+   - `ipeps_optimize._optimize_gs_ad_tensor` separately rejects `cg_gates` under
+     `fuse_virtual_legs=False` (`ipeps_optimize.py:1318`).
+
+   Enabling CG-on-split = threading `energy_fn` through the split AD path +
+   lifting both guards + validating the gradient. That is new code and is
+   **out of scope**; this spec only locks the rejection in place and documents
+   the enablement path.
+
+## Design
+
+### Part 1 — 1-site production-correctness test
+
+New test (target file: `tests/test_split_ctm_fuse_flag.py`, or a focused new
+`tests/test_split_ctm_production_parity.py` — implementation-plan decides).
+
+**Mechanism.** For D ∈ {2, 3}:
+
+1. Build a single 1×1 site tensor `A` from a fixed seed; use the existing
+   `_heisenberg_gate()` antiferromagnetic gate.
+2. Run `optimize_gs_ad(gate, A, config)` **twice** with identical config except
+   the flag:
+   - split: `CTMConfig(chi, chi_I=chi, fuse_virtual_legs=False)`,
+   - fused: `CTMConfig(chi, fuse_virtual_legs=True)`,
+   - both `unit_cell="1x1"`, `gs_recipe="1x1"`, `gs_implicit_ad=True`,
+     `forward_gauge="phase"`, same `gs_num_steps` (small, e.g. 5–10), same seed.
+3. Assert:
+   - `E_split_final ≈ E_fused_final` to `atol ≈ 1e-6` (faithful drop-in),
+   - `E_split_final < E_split_initial` (the optimizer actually descends),
+   - returned env is a `SplitCTMTensorEnv` (already covered elsewhere; keep or
+     cross-reference).
+
+**Tolerance rationale.** Single-eval split-vs-fused parity holds to ~1e-8 at
+lossless `chi_I` (existing `test_split_matches_fused_lossless_chi_I`). Over a
+full optimization, accumulated L-BFGS path divergence and the
+`chi_I=chi`-vs-lossless residual (~0 but nonzero) loosen this; `1e-6` is the
+proposed bar, to be tightened in the implementation plan if the empirical gap
+is smaller. The bar must be justified by a measured number, not guessed.
+
+**Marker.** `algorithm`-tier (runs an optimizer); not `core` — keeps CI-required
+checks fast.
+
+### Part 2 — CG guard lock-in + documentation
+
+1. **Regression test** (target: `tests/test_split_ctm_fuse_flag.py`): assert that
+   a CG configuration (`cg_gates` set) with `fuse_virtual_legs=False` raises
+   `NotImplementedError` with a message naming `cg_gates`. This pins the
+   `ipeps_optimize.py:1318` optimizer guard as *intended* behavior so a future
+   refactor can't silently drop it. (Optionally also assert the
+   `ctm_energy_split_{explicit,implicit}` `energy_fn` guard raises, to lock the
+   second layer.)
+2. **Documentation** — a short note (in this spec's "CG enablement (future)"
+   section below, and a one-line pointer where the guards live) recording that
+   the split-aware CG energy already exists and what wiring enables CG-on-split.
+
+#### CG enablement (future, NOT this spec)
+
+To run CG on the split path later:
+- thread a `compute_energy_cg_split`-backed `energy_fn` through
+  `ctm_energy_split_{explicit,implicit}` (remove the custom-`energy_fn` reject);
+- lift the `cg_gates` reject in `_optimize_gs_ad_tensor`
+  (`ipeps_optimize.py:1318`);
+- validate the CG gradient on split vs the fused CG path (cosine ≈ 1).
+- **Caveat:** split gives ~no CG-kagome memory win until D ≳ 16 (the
+  d_eff²=64 supersite factor dominates; see
+  `project_split_ctm_cg_memory_reality`). Enablement is correctness/uniformity,
+  not a memory lever at usable D.
+
+## Testing
+
+- Part 1: the new optimizer-parity test (D=2, D=3).
+- Part 2: the CG-rejection regression test(s).
+- Regression guard: the existing split-CTM suite
+  (`test_split_ctm_fuse_flag.py`, `test_split_ctm_doublelayer_projector.py`,
+  `test_split_ctm_tensor.py`) must stay green.
+
+## Acceptance criteria
+
+- [ ] 1-site split optimization matches fused to ≤1e-6 in final energy at
+      D∈{2,3}, and both descend from their initial energy.
+- [ ] CG + `fuse_virtual_legs=False` raises a clear `NotImplementedError`
+      (regression-locked).
+- [ ] Future CG-on-split enablement path is documented.
+- [ ] Full split-CTM test suite green; no behavior change to any shipped path.
+
+## Risks
+
+- **Optimizer-path divergence** between split and fused could exceed 1e-6 even
+  though single-eval parity is ~1e-8 (different L-BFGS trajectories from
+  floating-point-order differences). Mitigation: keep step count small, seed
+  fixed; if the empirical gap is larger, the parity bar should compare
+  *per-step* energies for the first step (where paths can't yet diverge) and
+  loosen the final-energy tolerance with a measured justification — decided in
+  the implementation plan, not guessed here.
+- **CG guard message drift** — the test should match on a stable substring
+  (`"cg_gates"`), not the full message.

--- a/docs/superpowers/specs/2026-06-29-463-split-ctm-1site-validation-cg-guard-design.md
+++ b/docs/superpowers/specs/2026-06-29-463-split-ctm-1site-validation-cg-guard-design.md
@@ -62,10 +62,37 @@ This spec is the first, tightly-scoped prerequisite for an eventual flip:
    clean split-vs-fused energy parity is achievable at default settings — we do
    **not** need to pin `chi_I=chi*D` for the parity test.
 
-2. **A 1×1 unit cell cannot represent Néel order.** An absolute QMC comparison
-   is therefore meaningless at 1-site. The correct production-correctness bar
-   is *split reproduces the trusted fused result on the same 1×1 problem*, not
-   an absolute physical energy.
+2. **(REVISED 2026-06-30 after empirical probing — supersedes the original
+   "fused-parity over optimization" bar.)** Three measured facts reshaped Part 1:
+
+   a. **Split ≠ fused over a full optimization, and it's structural (#425), not
+      truncation.** At D=2 χ=4 the bare-Heisenberg 1-site optimization gives
+      split → −0.0527 vs fused → +0.0311 (gap 0.084), **identical at
+      `chi_I=chi` and lossless `chi_I=chi*D` to 12 digits**, and unchanged by
+      `gs_metric_precond`. So the iterated split- and fused-CTM forwards select
+      *different fixed points* in the degenerate-corner SVD subspace — even
+      though a *single* evaluation is bit-identical at lossless χ_I (the existing
+      `test_split_matches_fused_lossless_chi_I`, 1e-8). ⟹ **"split == fused to
+      1e-6 over a full optimization" is known-false and cannot be a test bar.**
+
+   b. **An absolute reference IS achievable — via the sublattice-rotated
+      Heisenberg gate** `H_rot = −Sz⊗Sz − ½(S⁺⊗S⁺ + S⁻⊗S⁻)`, under which a 1-site
+      iPEPS represents Néel order, so E/site is comparable to QMC (−0.6694). The
+      original "absolute QMC meaningless at 1×1" claim was wrong — it only holds
+      for the *bare* (frustrated) gate.
+
+   c. **C4v is mandatory.** Without `gs_c4v=True` the unconstrained 1-site CTM is
+      non-variational for *both* paths (split converges cleanly to −0.714 *below*
+      the QMC floor; fused goes chaotic, |g|~1e7 stall-noise, E_best −0.763) —
+      the documented 1-site-CTM unreliability (`project_c3_floor_breach_smoking_gun`),
+      orthogonal to split. **With `gs_c4v=True`** both become stable and
+      variational and track within ~0.01/site. Measured converged values
+      (D=2, χ=10, grad_norm |g|<1e-3):
+      `split+c4v = −0.6505` (variational, +0.019 above QMC),
+      `fused+c4v = −0.6601` (variational, +0.009 above QMC). The 0.0096/site gap
+      **persists at tight |g|** ⟹ genuine bounded #425, not under-convergence.
+      Both sit in the physical window `[−0.6694, −0.60]` (above the QMC floor,
+      below the disordered energy ⟹ real order).
 
 3. **CG is blocked on the split path at two layers, despite the split-aware CG
    energy already existing:**
@@ -85,36 +112,53 @@ This spec is the first, tightly-scoped prerequisite for an eventual flip:
 
 ## Design
 
-### Part 1 — 1-site production-correctness test
+### Part 1 — 1-site production-correctness test (variational window, C4v)
 
-New test (target file: `tests/test_split_ctm_fuse_flag.py`, or a focused new
-`tests/test_split_ctm_production_parity.py` — implementation-plan decides).
+New test in a focused new file `tests/test_split_ctm_production_correctness.py`
+(keeps the slow optimizer test out of the `core`-marked `test_split_ctm_fuse_flag.py`).
 
-**Mechanism.** For D ∈ {2, 3}:
+**Mechanism (single split run — does NOT require running fused).**
 
-1. Build a single 1×1 site tensor `A` from a fixed seed; use the existing
-   `_heisenberg_gate()` antiferromagnetic gate.
-2. Run `optimize_gs_ad(gate, A, config)` **twice** with identical config except
-   the flag:
-   - split: `CTMConfig(chi, chi_I=chi, fuse_virtual_legs=False)`,
-   - fused: `CTMConfig(chi, fuse_virtual_legs=True)`,
-   - both `unit_cell="1x1"`, `gs_recipe="1x1"`, `gs_implicit_ad=True`,
-     `forward_gauge="phase"`, same `gs_num_steps` (small, e.g. 5–10), same seed.
-3. Assert:
-   - `E_split_final ≈ E_fused_final` to `atol ≈ 1e-6` (faithful drop-in),
-   - `E_split_final < E_split_initial` (the optimizer actually descends),
-   - returned env is a `SplitCTMTensorEnv` (already covered elsewhere; keep or
-     cross-reference).
+1. Build the sublattice-rotated Heisenberg gate
+   `H_rot = −Sz⊗Sz − ½(S⁺⊗S⁺ + S⁻⊗S⁻)` so a 1-site iPEPS represents Néel order.
+2. Run `optimize_gs_ad(gate, A, config)` once with the **split** path AND C4v:
+   - `CTMConfig(chi=10, chi_I=10, fuse_virtual_legs=False, max_iter=80,
+     conv_tol=1e-10, min_iter=4)`,
+   - `iPEPSConfig(unit_cell="1x1", gs_recipe="1x1", gs_implicit_ad=True,
+     gs_c4v=True, gs_metric_precond=False, gs_conv_criterion="grad_norm",
+     gs_grad_norm_tol=1e-3, gs_num_steps=100, su_init=False)`,
+   - `A = _make_site(2, 2, seed=3)` (D=2).
+3. Assert on the returned final energy `E` (per site = E_h + E_v):
+   - **Variational:** `E >= QMC_FLOOR - 1e-3` with `QMC_FLOOR = -0.6694` — split
+     stays above the QMC ground-state energy. *This is the assertion that
+     catches the failure mode:* without C4v split breaches to −0.714; with the
+     #425-spurious fixed point it would dip below the floor.
+   - **Ordered:** `E <= -0.60` — below the disordered/product energy, proving the
+     1-site Néel ansatz actually found order (not stuck high).
+   - i.e. `−0.6694 ≤ E ≤ −0.60`. Measured split+c4v value: **−0.6505** (margin
+     +0.019 above floor, −0.050 below the ordered bound — comfortable both ways).
 
-**Tolerance rationale.** Single-eval split-vs-fused parity holds to ~1e-8 at
-lossless `chi_I` (existing `test_split_matches_fused_lossless_chi_I`). Over a
-full optimization, accumulated L-BFGS path divergence and the
-`chi_I=chi`-vs-lossless residual (~0 but nonzero) loosen this; `1e-6` is the
-proposed bar, to be tightened in the implementation plan if the empirical gap
-is smaller. The bar must be justified by a measured number, not guessed.
+**Why a window, not fused-parity.** Split and fused converge to *different*
+fixed points (#425, gap ~0.01/site, both physical) — see finding 2a/2c. A
+1e-6 fused-parity bar is known-false. The physical window `[−0.6694, −0.60]`
+is the well-defined bar: it is exactly what a *correct* variational 1-site path
+must satisfy, and it is violated by the spurious sub-QMC fixed point the
+no-C4v probe exposed. Single-run ⟹ ~half the wall-clock of a split+fused pair.
 
-**Marker.** `algorithm`-tier (runs an optimizer); not `core` — keeps CI-required
-checks fast.
+**Optional companion (separate test, same file).** A `split-tracks-fused` check:
+run fused+c4v with the same config and assert `abs(E_split - E_fused) <= 0.03`
+(measured 0.0096, 3× margin). Marked `slow`; documents the bounded #425 gap.
+Include only if the extra optimizer run is acceptable; the window test is the
+primary deliverable.
+
+**Marker.** `slow` (one full implicit-AD optimization, ~minutes on GPU, much
+longer on CPU). Runs on push-to-main / `run-full-tests`, NOT the `core` CI gate.
+Use `@pytest.mark.slow` explicitly (do not rely on filename auto-marking).
+
+**Convergence caveat.** L-BFGS wobbles mid-run (line-search overshoot, stall
+recovery) — the assertion must be on the **final/E_best** energy after
+`grad_norm` convergence (|g|<1e-3, ~step 69 measured), never on an arbitrary
+intermediate step.
 
 ### Part 2 — CG guard lock-in + documentation
 
@@ -144,29 +188,38 @@ To run CG on the split path later:
 
 ## Testing
 
-- Part 1: the new optimizer-parity test (D=2, D=3).
-- Part 2: the CG-rejection regression test(s).
+- Part 1: the new `slow` variational-window test (split+c4v, rotated Heisenberg).
+- Part 2: the CG-rejection regression test(s) (both guard layers).
 - Regression guard: the existing split-CTM suite
   (`test_split_ctm_fuse_flag.py`, `test_split_ctm_doublelayer_projector.py`,
   `test_split_ctm_tensor.py`) must stay green.
 
 ## Acceptance criteria
 
-- [ ] 1-site split optimization matches fused to ≤1e-6 in final energy at
-      D∈{2,3}, and both descend from their initial energy.
-- [ ] CG + `fuse_virtual_legs=False` raises a clear `NotImplementedError`
-      (regression-locked).
+- [ ] `slow` split+c4v rotated-Heisenberg optimization lands in the physical
+      window `−0.6694 ≤ E/site ≤ −0.60` (variational + ordered), at D=2 χ=10
+      with `gs_c4v=True`, `gs_conv_criterion="grad_norm"`, `gs_grad_norm_tol=1e-3`.
+- [ ] CG + `fuse_virtual_legs=False` raises a clear `NotImplementedError` at BOTH
+      guard layers (optimizer `cg_gates` reject + split-AD `energy_fn` reject),
+      regression-locked.
 - [ ] Future CG-on-split enablement path is documented.
 - [ ] Full split-CTM test suite green; no behavior change to any shipped path.
 
 ## Risks
 
-- **Optimizer-path divergence** between split and fused could exceed 1e-6 even
-  though single-eval parity is ~1e-8 (different L-BFGS trajectories from
-  floating-point-order differences). Mitigation: keep step count small, seed
-  fixed; if the empirical gap is larger, the parity bar should compare
-  *per-step* energies for the first step (where paths can't yet diverge) and
-  loosen the final-energy tolerance with a measured justification — decided in
-  the implementation plan, not guessed here.
-- **CG guard message drift** — the test should match on a stable substring
-  (`"cg_gates"`), not the full message.
+- **The variational-window bar is config-sensitive.** It only holds *with*
+  `gs_c4v=True`; without C4v split breaches to −0.714 (measured). The test MUST
+  set `gs_c4v=True` and assert on the converged `E_best`, never an intermediate
+  step (L-BFGS wobbles). The −0.60 ordered bound has −0.050 margin and the QMC
+  floor +0.019 margin against the measured −0.6505; both comfortable.
+- **Runtime.** One implicit-AD optimization to |g|<1e-3 took ~69 steps (~minutes
+  on GPU, ~20+ min on CPU). Hence `slow`-marked and kept off the `core` gate. If
+  CI runtime is a concern, χ=8 / `gs_grad_norm_tol=2e-3` still clears the window
+  (split was already above the floor by step ~6) — the plan may lower these, but
+  must re-measure that the window still holds before tightening.
+- **CG guard message drift** — match on a stable substring (`"cg_gates"` /
+  `"energy_fn"`), not the full message.
+- **#425 is the real flip blocker, not this spec.** This validation *confirms*
+  the 1-site split path is variational with C4v; it does NOT close the bounded
+  ~0.01/site split-vs-fused fixed-point gap. Whether that gap is acceptable for
+  making split canonical (the actual flip) is a separate decision, out of scope.

--- a/tests/test_split_ctm_fuse_flag.py
+++ b/tests/test_split_ctm_fuse_flag.py
@@ -489,3 +489,61 @@ def test_validate_split_ctm_config_rejects_chi_changing_knobs():
 
     # Valid fixed-χ split config: no raise.
     validate_split_ctm_config(CTMConfig(**base), "1x1")
+
+
+def test_split_energy_fn_guard_rejects_custom_energy_fn():
+    """Layer-2 CG guard: the split AD entry points reject a custom energy_fn.
+
+    CG runs by passing a coarse-grain energy_fn; the split path does not
+    support it yet (compute_energy_cg_split exists but is not wired through
+    the split AD). Lock the rejection so a refactor can't silently drop it.
+    """
+    from tenax.algorithms._split_ctm_energy_ad import (
+        ctm_energy_split_explicit,
+        ctm_energy_split_implicit,
+    )
+
+    A = _make_site(2, 2, seed=0)
+    gate = _heisenberg_gate()
+    for fn in (ctm_energy_split_implicit, ctm_energy_split_explicit):
+        with pytest.raises(NotImplementedError, match="custom energy_fn"):
+            fn(
+                {(0, 0): A},
+                SINGLE_SITE_NEIGHBORS,
+                gate,
+                chi=4,
+                energy_fn=lambda *a: 0.0,
+            )
+
+
+def test_optimize_gs_ad_split_rejects_cg_gates():
+    """Layer-1 CG guard: the split optimizer path rejects cg_gates up front.
+
+    cg_gates couples to the fused CTMTensorEnv (compute_energy_cg uses the
+    fused diagonal-RDM env); the split path raises rather than silently
+    feeding a SplitCTMTensorEnv to fused-only machinery (ipeps_optimize.py).
+    """
+    import jax.numpy as jnp
+
+    from tenax.algorithms.coarse_grain import honeycomb_cg_gates
+    from tenax.algorithms.ipeps_config import CTMConfig as _CTMConfig
+    from tenax.algorithms.ipeps_config import iPEPSConfig
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    cfg = iPEPSConfig(
+        max_bond_dim=2,
+        ctm=_CTMConfig(chi=8, fuse_virtual_legs=False, max_iter=10, min_iter=2),
+        gs_num_steps=1,
+        gs_recipe="1x1",
+        unit_cell="1x1",
+        su_init=False,
+        gs_c4v=True,
+        gs_explicit_ad=True,
+        gs_explicit_ad_steps=5,
+        gs_explicit_ad_warmup=2,
+        gs_metric_precond=False,
+        cg_gates=honeycomb_cg_gates(),
+    )
+    dummy_gate = jnp.zeros((4, 4, 4, 4))  # d_eff placeholder for the CG supersite
+    with pytest.raises(NotImplementedError, match="cg_gates"):
+        optimize_gs_ad(dummy_gate, None, cfg)

--- a/tests/test_split_ctm_production_correctness.py
+++ b/tests/test_split_ctm_production_correctness.py
@@ -1,0 +1,75 @@
+"""Production-correctness of the 1-site split-CTM path (#463 pre-flip check).
+
+Validates that the split (``fuse_virtual_legs=False``) single-site path, run
+WITH C4v on the sublattice-rotated square Heisenberg gate (under which a 1-site
+iPEPS represents Neel order), converges to a *variational* energy: above the
+QMC ground-state energy and below the disordered energy.
+
+Empirical anchors (D=2, chi=10, gs_c4v=True, grad_norm |g|<1e-3):
+  split+c4v = -0.6505/site (variational, +0.019 above QMC -0.6694)
+  fused+c4v = -0.6601/site
+WITHOUT C4v the unconstrained 1-site CTM is non-variational for BOTH paths
+(split breaches to -0.714) -- so gs_c4v=True is mandatory here. The split/fused
+~0.01/site gap is the bounded #425 fixed-point difference (both physical).
+"""
+
+import jax.numpy as jnp
+import pytest
+
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+from tests.test_split_ctm_fuse_flag import _make_site
+
+# Sandvik QMC square-lattice spin-1/2 Heisenberg, energy per site.
+QMC_FLOOR = -0.6694
+ORDERED_CEIL = -0.60  # below the disordered/product energy => genuine order
+
+
+def _rotated_heisenberg():
+    """H_rot = -SzSz - 0.5(S+S+ + S-S-): sublattice-rotated so a 1-site iPEPS
+    represents Neel order (unitary image of the AFM Heisenberg gate)."""
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+    H = -jnp.kron(Sz, Sz) - 0.5 * (jnp.kron(Sp, Sp) + jnp.kron(Sm, Sm))
+    return H.reshape(2, 2, 2, 2)
+
+
+def _config(fuse):
+    return iPEPSConfig(
+        ctm=CTMConfig(
+            chi=10,
+            chi_I=10,
+            fuse_virtual_legs=fuse,
+            max_iter=80,
+            conv_tol=1e-10,
+            min_iter=4,
+        ),
+        unit_cell="1x1",
+        gs_recipe="1x1",
+        gs_implicit_ad=True,
+        gs_c4v=True,
+        gs_metric_precond=False,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-3,
+        gs_num_steps=100,
+        gs_log_interval=10,
+        su_init=False,
+    )
+
+
+@pytest.mark.slow
+def test_split_1site_is_variational_with_c4v():
+    """Split + C4v on rotated Heisenberg must land in [-0.6694, -0.60]/site.
+
+    The lower bound is THE assertion: a correct variational 1-site path stays
+    above the QMC ground state; the #425-spurious sub-QMC fixed point (which
+    appears WITHOUT C4v, E=-0.714) would breach it.
+    """
+    A = _make_site(2, 2, seed=3)
+    _, _, E = optimize_gs_ad(_rotated_heisenberg(), A, _config(fuse=False))
+    E = float(E)  # per site = E_h + E_v
+    assert E >= QMC_FLOOR - 1e-3, (
+        f"split breaches QMC variational floor: E/site={E:.6f} < {QMC_FLOOR}"
+    )
+    assert E <= ORDERED_CEIL, f"split did not order: E/site={E:.6f} > {ORDERED_CEIL}"


### PR DESCRIPTION
## Summary

Pre-flip validation for #463 (make split-CTM canonical). **Test-only — no `src/` changes.** Establishes that the single-site dense split-CTM path is production-correct *with C4v*, and regression-locks the intended CG-on-split rejection. Does **not** flip the `fuse_virtual_legs` default (that stays gated on 2-site / SymmetricTensor coverage).

### What this adds
- **CG guard regression tests** (`tests/test_split_ctm_fuse_flag.py`): lock both layers that reject coarse-grained optimization on the split path — the optimizer `cg_gates` reject and the split-AD `energy_fn` reject. These guards already exist; the tests prevent a refactor from silently dropping them.
- **1-site variational-window test** (`tests/test_split_ctm_production_correctness.py`, `slow`): runs the split path **with `gs_c4v=True`** on the sublattice-rotated square Heisenberg gate (so a 1-site iPEPS represents Néel order) and asserts the converged energy lands in the physical window `[-0.6694, -0.60]/site` — i.e. above the QMC ground state (variational) and below the disordered energy (ordered).
- **Design spec + implementation plan** under `docs/superpowers/`.

### Key finding (why C4v is load-bearing)
Empirical probing (D=2, χ=10, grad-norm |g|<1e-3):
- **With** `gs_c4v=True`: split converges stably to **−0.6505/site** (variational, +0.019 above QMC). Fused lands at −0.6601. Both physical.
- **Without** C4v: the unconstrained 1-site CTM is non-variational for *both* paths (split breaches to −0.714; fused goes chaotic) — a documented 1-site-CTM limitation, orthogonal to split.

The residual ~0.01/site split-vs-fused difference is the bounded **#425 fixed-point** gap (persists at tight |g|, both above the QMC floor). Whether that gap is acceptable for making split canonical is the decision the *flip* phase must weigh — out of scope here.

## Test plan
- [x] `tests/test_split_ctm_fuse_flag.py` — full file green (25 passed), incl. the 2 new guard tests
- [x] Fast split-CTM suite (`fuse_flag` + `doublelayer_projector` + `tensor`, `-m "not slow"`) — **84 passed, no regressions**
- [x] `test_split_1site_is_variational_with_c4v` — **PASSED** under pytest (E/site=−0.6505, in window); `slow`-marked, off the core CI gate
- [x] Rebased onto `origin/main`; guard tests re-verified green on the new base

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)