### PR TITLE
feat(#632): Increment 1 — chunked dense-CTM edge absorption (forward, 1×1)

### DIFF
--- a/docs/superpowers/handoffs/2026-07-01-chunk-ctm-absorb-increment1-build.md
+++ b/docs/superpowers/handoffs/2026-07-01-chunk-ctm-absorb-increment1-build.md
@@ -1,0 +1,68 @@
+# Chunked dense-CTM absorb — Increment 1 build findings
+
+**Date:** 2026-07-01
+**Branch:** `feat/632-chunk-ctm-absorb-inc1`
+**Gate:** `docs/superpowers/handoffs/2026-06-30-chunk-shard-ctm-move-findings.md` (STRONG GO)
+**Plan:** `docs/superpowers/plans/2026-07-01-chunk-ctm-absorb-increment1.md`
+
+## What shipped
+
+- **`src/tenax/algorithms/_ctm_chunked_absorb.py`** — raw-array chunked edge-absorption core for all four
+  1×1 CTM directions (left/right/top/bottom) + `_raw_in_label_order` helper. Each core
+  function reproduces `T_new = conj(P1)ᵀ · (edge·a) · P2` via `jax.lax.map(batch_size=K)` over the
+  boundary-χ axis without materializing the full χ²·D⁶ intermediate.
+- **`src/tenax/algorithms/_ctm_tensor_moves.py`** — `chunk_size: int | None = None` added to all four
+  1×1 `_ctm_tensor_move_*` functions; chunked branch is dense-gated
+  (`isinstance(env_self.T*, DenseTensor)`); default `None` leaves the production path
+  byte-for-byte unchanged.
+- **`src/tenax/algorithms/_ctm_tensor_convergence.py`** — `chunk_size` threaded into
+  `_ctm_tensor_sweep_multisite`; `_shard_a` hoisted and wired into the 1×1 branch (previously
+  2×2-only) so chunking composes with the GSPMD device mesh.
+- **`src/tenax/algorithms/_ctm_python_loop.py`** — `ctm_chunk_size` added to `_make_jit_ctm_step`
+  (cache key + `static_argnames`) and `python_loop_ctm_converge` / `_python_loop_chi_ramp`.
+- **`src/tenax/algorithms/ipeps_config.py`** — `CTMConfig.ctm_chunk_size: int | None = None` field.
+- **`src/tenax/algorithms/ipeps_ad_policy.py`** — `ctm_chunk_size` forwarded through
+  `ctm_converge_kwargs` and the `ctm_energy_implicit` call chain.
+- **`tests/test_ctm_chunked_absorb.py`** — 19 `core`-marked parity tests.
+
+## Design note: gate target vs production path
+
+The gate (`2026-06-30-chunk-shard-ctm-move-findings.md`) validated the lever on `_compiled_move_*`
+(test-only dead code). Production runs the label-based `Tensor.contract()` absorb path inside
+`_apply_projector_tensor`. Increment 1 chunks that path via `_ctm_chunked_absorb.py`, called from
+the four `_ctm_tensor_move_*` functions when the dense gate fires. The production relabel /
+`_flip_leg_flow` / `_phase_fix_normalize_tensor` tail is reused verbatim — only the `T*_new` array
+and its three `TensorIndex` objects are computed differently in the chunked branch.
+
+## Parity guarantees
+
+| Level | Oracle | Bound |
+|---|---|---|
+| core (chunked vs monolith einsum, 4 dirs, K=1/K>1/ragged, real) | `_monolith_{left,right,top,bottom}` | rel ≤ 1e-12 |
+| core (complex projectors, LEFT) | same | rel ≤ 1e-12 |
+| full-move (chunked vs default, 4 dirs) | `_ctm_tensor_move_*` default | rel ≤ 1e-12 on C/T fields |
+| full-move (ragged chunk_size=5, chi=12) | same | rel ≤ 1e-12 |
+| end-to-end converge (chunk on == off, 8 fixed 1×1 sweeps) | `python_loop_ctm_converge` default | rel ≤ 1e-10 |
+
+Default-off (`chunk_size=None`) is byte-for-byte the original path; the existing test suite
+confirms no regressions.
+
+## Scope / deferrals
+
+- **Forward only.** The implicit-AD backward (`_ctm_energy_ad.py`, `jit_step_bwd`) deliberately
+  does NOT receive the `ctm_chunk_size` knob — that is Increment 2, gate-first.
+- **1×1 recipe.** The 2×2 absorb path is untouched (each 2×2 move already has its own per-move
+  sharding path; chunking there is separate work).
+- **Dense only.** Symmetric and fermionic envs: the dense gate in the move functions means the
+  chunked branch is simply not entered; no warning is emitted (the knob is a no-op).
+- **No optimize_gs_ad benchmark.** The D=10–12 / large-χ multi-GPU benchmark depends on Increment
+  2 (correct + bounded-memory grads through the chunked backward). Do not wire `optimize_gs_ad`
+  until Increment 2 gate passes.
+
+## Next: Increment 2
+
+Gate the chunked backward through the implicit-AD adjoint before any optimize wiring:
+1. Verify AD through the chunked forward gives finite, correct gradients (compare to default at small D/χ).
+2. Confirm peak memory through the backward also drops (the gain may be partial — lax.map
+   rematerializes per chunk in backward, which is the intended behavior).
+3. Only then wire `ctm_chunk_size` into `_ctm_energy_ad.py:jit_step_bwd` and `optimize_gs_ad`.

--- a/docs/superpowers/handoffs/2026-07-01-chunk-ctm-absorb-increment1-build.md
+++ b/docs/superpowers/handoffs/2026-07-01-chunk-ctm-absorb-increment1-build.md
@@ -53,8 +53,10 @@ confirms no regressions.
   does NOT receive the `ctm_chunk_size` knob — that is Increment 2, gate-first.
 - **1×1 recipe.** The 2×2 absorb path is untouched (each 2×2 move already has its own per-move
   sharding path; chunking there is separate work).
-- **Dense only.** Symmetric and fermionic envs: the dense gate in the move functions means the
-  chunked branch is simply not entered; no warning is emitted (the knob is a no-op).
+- **Dense only.** Symmetric and fermionic envs: when `chunk_size` is set but the env is not
+  dense, the move functions emit `warnings.warn("chunk_size is set but env is not dense
+  (SymmetricTensor); falling back to the standard fused-index CTM path.")` and fall back to the
+  standard fused-index CTM path.
 - **No optimize_gs_ad benchmark.** The D=10–12 / large-χ multi-GPU benchmark depends on Increment
   2 (correct + bounded-memory grads through the chunked backward). Do not wire `optimize_gs_ad`
   until Increment 2 gate passes.

--- a/docs/superpowers/handoffs/2026-07-01-chunk-ctm-absorb-increment2-backward-gate.md
+++ b/docs/superpowers/handoffs/2026-07-01-chunk-ctm-absorb-increment2-backward-gate.md
@@ -1,0 +1,127 @@
+# Chunked dense-CTM backward — Increment 2 gate findings
+
+**Date:** 2026-07-01
+**Branch:** `feat/632-chunk-ctm-absorb-inc1`
+**Parent:** Increment 1 (forward 1×1 chunked absorb, #668) — `2026-07-01-chunk-ctm-absorb-increment1-build.md`
+**Harness:** `examples/spike_chunk_backward_gate.py`
+**Hardware:** single A100-SXM4-80GB (GPU 1; ~64 GiB usable limit), `XLA_PYTHON_CLIENT_PREALLOCATE=false`.
+**Verdict: GATE = NO-GO.** Chunking the implicit-AD *backward* is numerically exact but *increases*
+peak memory — it defeats XLA's existing rematerialization of the χ²·D⁶ absorb intermediate and
+adds `lax.map` stacked-residual + VJP-transpose overhead. The backward must stay monolith; large-D
+backward memory relief comes from GSPMD sharding (rung-2), not chunking.
+
+## Question
+
+Increment 1 chunks the forward χ²·D⁶ edge absorption via `lax.map` over the boundary-χ axis. Does
+that compose with the implicit-AD **backward** (`_ctm_energy_ad.py`, `custom_vjp` + fixed-point
+Neumann/GMRES adjoint) — i.e. when `ctm_chunk_size` is threaded into `jit_step_bwd`, does
+`jax.vjp` through the chunked `lax.map` keep the adjoint's `Jᵀ` matvec memory-bounded (÷K), or does
+it re-materialize / regress? The user's stated risk: "if the backward re-materializes χ²·D⁶ it
+becomes the new wall."
+
+## Architecture finding (why chunk ≠ shard for the backward)
+
+- **device_mesh sharding reaches the backward automatically** via GSPMD propagating from the
+  sharded env residuals the forward saves (rung-2, `2026-06-21-632-rung2-backward-sharding-gate`).
+  Line 1020 (`jit_step_bwd = _make_jit_ctm_step(neighbors, recipe)`) was never touched for sharding.
+- **Chunking cannot propagate that way.** It is a `lax.map` control structure that must be
+  *explicitly present* in the differentiated `jit_step_bwd`. So the gate wiring under test was the
+  minimal (and only) src change:
+  ```python
+  jit_step_bwd = _make_jit_ctm_step(neighbors, recipe, ctm_chunk_size=ctm_chunk_size)
+  jit_step_bwd = partial(jit_step_bwd, chunk_size=ctm_chunk_size)
+  ```
+  (`recipe="1x1"`, dense; `None` chunk size = byte-for-byte no-op.)
+
+## Correctness — PASS (but not the open question)
+
+Grads are exact whether the backward is chunked or monolith, because the forward fixed point is
+bit-identical (Increment 1 forward parity ≤1e-12) and the adjoint of the chunked sweep = adjoint of
+the monolith sweep at that fixed point — the *same* linear operator `Jᵀ`, differing only by FP
+reassociation of the `lax.map` sum.
+
+| config | `value_and_grad` D=2 χ=6 recipe=1×1 | grad max\|Δ\| vs chunk-off |
+|---|---|---|
+| chunk-on forward + **chunked** backward (gate wiring) | `chunk_engaged=True` | **2.1e-25** |
+| chunk-on forward + **monolith** backward (merged Inc-1) | `chunk_engaged=True` | **0.0** |
+
+Correctness was never the risk — **peak memory** is.
+
+## Memory — NO-GO (the decisive result)
+
+Per-device peak of the full `value_and_grad` (forward CTM + implicit-AD backward),
+`recipe="1x1"`, well-conditioned state (identical χ²·D⁶ intermediate sizes; fast clean adjoint):
+
+| D | χ | monolith (OFF) | chunked | outcome |
+|---|---|---|---|---|
+| 8 | 32 | **18.37 GB** | 26.11 (K=16) / 24.77 (K=8) / 23.56 (K=1) GB | chunk **+28–42 %** |
+| 10 | 16 | **28.01 GB (fits)** | **OOM (>64)** | chunk turns a fit into **OOM** |
+| 10 | 24 | OOM (tried +29 GiB) | OOM (57.5 GiB pre-remat) | both fail |
+| 10 | 32 | OOM (65.9→57 remat) | OOM (**79.5**→79 remat blocked) | chunk **+13.6 GiB** pre-remat |
+| 12 | 32 | OOM (tried +52 GiB) | OOM (autotuner transpose `f64[144,32,144,144,32]`) | both fail |
+
+- **Chunk-size trend (D=8 χ=32):** peak *decreases* with more chunks (26.11→24.77→23.56 as K→1) —
+  the mechanism works *directionally* — but every chunked variant sits **above** the monolith.
+  A large fixed overhead dominates the small chunkable gain.
+- **Headline (D=10 χ=16):** monolith fits comfortably at **28 GB**; the chunked backward **OOMs**.
+- **Forward-only isolation (D=8 χ=32):** OFF and chunk=8 are **identical (7.61 GB)** — the overhead
+  is *purely in the backward*; the forward `lax.map` neither helps nor hurts here (the ~2 GB absorb
+  intermediate is below the pipeline's ~7.6 GB waterline).
+
+## Mechanism
+
+The XLA rematerialization log is the smoking gun. At D=10 χ=32:
+```
+OFF     : ...only reduced to 56.57GiB, down from 65.90GiB originally   (remat recoups ~9 GiB ≈ one χ²D⁶ array)
+chunk=8 : ...only reduced to 78.87GiB, down from 79.49GiB originally   (remat recoups ~0.6 GiB — blocked)
+```
+XLA **already rematerializes** the χ²·D⁶ absorb intermediate in the monolith backward (recompute
+instead of store). The `lax.map` chunking:
+1. **Blocks that rematerialization** — the scan structure forces stacked per-chunk residuals XLA
+   cannot recompute away.
+2. **Adds VJP-transpose intermediates** — the chunked reverse pass builds transposes
+   (`f64[144,32,144,144,32]` = D²·χ·D²·D²·χ) that are themselves χ²·D⁶-scale and even fail XLA
+   autotuning at D=12.
+
+Net: the chunked backward is *strictly worse* than the monolith. The feared "re-materializes χ²·D⁶"
+is real, but the remedy is **not** chunking — XLA's automatic activation-checkpointing already does
+it better than an explicit `lax.map` can.
+
+Also note the **irreducible ~56 GiB floor** (D=10 χ=32, same in both configs after remat): the
+D≥10 single-GPU backward wall is *not* the (remat-able) absorb intermediate but the env/linearized-
+sweep/adjoint structure, which chunking the absorb cannot touch.
+
+## Decision & production state
+
+- **Reverted the gate wiring.** Line 1020 stays `jit_step_bwd = _make_jit_ctm_step(neighbors, recipe)`
+  (backward monolith). The only production change is a **comment** documenting why the backward is
+  not chunked. `ctm_chunk_size` keeps its documented **forward-only** scope (commit 4ad4d91).
+- Merged behavior (forward-chunk + monolith-backward) gives **exact** grads (guarded by new CI test
+  `tests/test_ctm_chunk_backward_grad.py`).
+
+## Consequences for #632
+
+- **Increment 2 (chunked backward): NO-GO — do not build.** The `optimize_gs_ad` chunk-backward
+  benchmark that depended on it is **moot**.
+- **chunk∘shard multiply thesis holds for the isolated forward move only** (Increment 1 gate), *not*
+  the `value_and_grad` pipeline: (a) the forward absorb is below the CTM-convergence waterline until
+  very large D, and (b) the backward is XLA-remat'd / floor-bound. The **backward's large-D memory
+  lever is GSPMD sharding (rung-2, merged)** — chunking is not additive there.
+- Open (separate, lower priority): does the *forward*-chunk help the `optimize_gs_ad` forward at
+  D≥12 where the forward absorb may exceed the convergence waterline? Not tested here; Increment 1's
+  isolated-move gate overstated the pipeline benefit.
+
+## Reproduce
+
+```bash
+# correctness (CPU): grad chunk-on vs off, recipe=1x1
+JAX_PLATFORMS=cpu uv run python examples/spike_chunk_backward_gate.py --mode correctness --D 2 --chi 6 --chunk 2
+# memory (single A100, one config per process for a clean peak):
+CUDA_VISIBLE_DEVICES=1 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+  uv run python examples/spike_chunk_backward_gate.py --mode memory --D 10 --chi 16 --chunk 0   # OFF: 28 GB
+CUDA_VISIBLE_DEVICES=1 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+  uv run python examples/spike_chunk_backward_gate.py --mode memory --D 10 --chi 16 --chunk 8   # chunk: OOM
+# forward-only isolation:
+... --mode memory --no-grad --D 8 --chi 32 --chunk 0   # 7.61 GB
+... --mode memory --no-grad --D 8 --chi 32 --chunk 8   # 7.61 GB (identical)
+```

--- a/docs/superpowers/plans/2026-07-01-chunk-ctm-absorb-increment1.md
+++ b/docs/superpowers/plans/2026-07-01-chunk-ctm-absorb-increment1.md
@@ -611,7 +611,8 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 - **Increment 2** — chunked **backward** through the implicit-AD adjoint (`_ctm_energy_ad.py`, custom_vjp + fixed-point). This is gate-first: prove correct + bounded-memory grads through the chunked move BEFORE wiring `optimize_gs_ad`. The forward `device_mesh`/`ctm_chunk_size` are deliberately NOT threaded into the backward step (`:1007`).
 - **2×2 recipe** chunking (more absorb call sites; the 2×2 absorb already has per-move sharding).
-- **Symmetric / fermionic** envs (knob is a no-op there; large-D symmetric → YASTN).
+- **Symmetric / fermionic** envs (setting `ctm_chunk_size` on a non-dense env falls back to the
+  standard fused-index CTM path with a `warnings.warn`; large-D symmetric → YASTN).
 - The **D=10–12 / large-χ multi-GPU `optimize_gs_ad` benchmark** (depends on Increment 2).
 
 ---

--- a/docs/superpowers/plans/2026-07-01-chunk-ctm-absorb-increment1.md
+++ b/docs/superpowers/plans/2026-07-01-chunk-ctm-absorb-increment1.md
@@ -1,0 +1,621 @@
+# Chunked dense-CTM absorb (Increment 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a default-OFF `chunk_size` knob that runs the expensive χ²·D⁶ edge absorption of the production dense 1×1 CTM moves via a chunked `lax.map` over the boundary-χ axis, composing with the existing GSPMD mesh so per-device peak memory drops ≈÷(N·K) at large D.
+
+**Architecture:** The gate (`docs/superpowers/handoffs/2026-06-30-chunk-shard-ctm-move-findings.md`, STRONG GO) validated the lever on raw einsum (`_compiled_move_*`, which is *test-only dead code*). Production runs the label-based `Tensor.contract()` absorb path. So we add a small raw-array chunked core (`_ctm_chunked_absorb.py`) that faithfully reproduces `contract(edge, a)` + `_apply_projector_tensor`'s `T_new`, and call it from the four 1×1 `_ctm_tensor_move_*` functions **only when** `chunk_size` is set AND the env is a `DenseTensor` (the large-D multi-GPU use case; symmetric large-D is YASTN territory). Default-off path is byte-for-byte unchanged. The knob threads through `CTMConfig.ctm_chunk_size` → `ctm_converge_kwargs` → `ctm_energy_implicit`/`python_loop_ctm_converge` → `_make_jit_ctm_step` → `_ctm_tensor_sweep_multisite` → the 1×1 move, exactly mirroring how `device_mesh` is threaded today. We also wire the per-move re-shard (`_shard_a`) into the 1×1 sweep branch (currently 2×2-only) so chunk composes with the mesh on the 1×1 recipe the multi-GPU dense studies use.
+
+**Tech Stack:** Python, JAX (`jax.lax.map(..., batch_size=...)`, `jnp.einsum`/`tensordot`), Tenax `DenseTensor`/`TensorIndex`, pytest (`-m core`).
+
+**Scope:** Increment 1 = **forward** only, **dense** only, recipe **1×1** first. Out of scope: Increment 2 (chunked backward through the implicit-AD adjoint — gate-first, separate plan), 2×2 recipe, symmetric/fermionic envs, and the `optimize_gs_ad` multi-GPU benchmark.
+
+---
+
+## Background facts the executor needs (verified against source)
+
+Production 1×1 moves live in `src/tenax/algorithms/_ctm_tensor_moves.py`:
+`_ctm_tensor_move_left` (line 997), `_ctm_tensor_move_right` (1052), `_ctm_tensor_move_top` (1106), `_ctm_tensor_move_bottom` (1160).
+
+Each has the same shape. For LEFT (the reference):
+```python
+# THE χ²·D⁶ PEAK:
+T4_with_a = contract(env_self.T4, a)                       # (t4_d, t4_u, u2, d2, r2)
+T4g = _fuse_pair_by_label(T4_with_a, "t4_d", "u2", "fl", IN)
+T4g = _fuse_pair_by_label(T4g, "t4_u", "d2", "fr", OUT)    # (fl, fr, r2)
+P_1, P_2, _eps_t = _compute_projector_tensor(C1g, C4g, chi, projector_method, base_charges, projector_backward)
+C1_new, C4_new, T4_new = _apply_projector_with_reembed(P_1, P_2, C1g, C4g, T4g, "fl", "fr")
+```
+`_apply_projector_with_reembed` for `DenseTensor` delegates to `_apply_projector_tensor` (line 253), which computes:
+```python
+P1_bar = P_1.bar(); P2_bar = P_2.bar()
+C1_new = contract(P1_bar, C1g)                  # cheap, no peak
+C4_new = contract(P2_bar, C4g)                  # cheap, no peak
+P_left = P1_bar.relabel("fused", fused_l); step = contract(P_left, Tg)      # uses Tg (peak)
+P_right = P_2.relabels({"fused": fused_r, "chi_new": "chi_new_r"}); T_new = contract(step, P_right)
+# T_new labels: (chi_new, <surviving D2>, chi_new_r)
+```
+So the chunked core must reproduce `T_new = conj(P_1)ᵀ · (edge·a) · P_2` (P_1 is barred = conj data + flipped flow; P_2 is **not** barred), chunked over the boundary-χ axis, **without** materializing `edge·a`. The corners `C1_new/C4_new` are cheap and identical whether chunked or not.
+
+**Per-direction map** (canonical edge leg order; `a` canonical `(u2, d2, l2, r2)`; per-chunk einsum contracts the shared `a` leg; output of the full einsum is `(chunk_χ, other_χ, <3 free D² legs>)`):
+
+| dir | edge (canonical) | shared `a` leg | full einsum | `fl`=(χ_chunk, D²) | `fr`=(χ_other, D²) | surviving D² | T_new relabels | flow flip |
+|-----|------------------|----------------|-------------|--------------------|--------------------|--------------|----------------|-----------|
+| left   | T4 `(t4_d, l2, t4_u)` | l2 | `"ijk,lmjn->iklmn"` | `(t4_d, u2)` | `(t4_u, d2)` | `r2` | `chi_new→t4_d, chi_new_r→t4_u, r2→l2` | flip `l2` |
+| right  | T2 `(t2_u, r2, t2_d)` | r2 | `"ijk,lmnj->iklmn"` | `(t2_u, u2)` | `(t2_d, d2)` | `l2` | `chi_new→t2_u, chi_new_r→t2_d, l2→r2` | flip `r2` |
+| top    | T1 `(t1_l, u2, t1_r)` | u2 | `"ijk,jlmn->iklmn"` | `(t1_l, l2)` | `(t1_r, r2)` | `d2` | `chi_new→t1_l, chi_new_r→t1_r, d2→u2` | flip `u2` |
+| bottom | T3 `(t3_r, d2, t3_l)` | d2 | `"ijk,ljmn->iklmn"` | `(t3_r, l2)` | `(t3_l, r2)` | `u2` | `chi_new→t3_r, chi_new_r→t3_l, u2→d2` | flip `d2` |
+
+The relabel + flow-flip + `_phase_fix_normalize_tensor` tail in each production move is **reused verbatim** in the chunked branch — only the `T*_new` *value* and its three `TensorIndex` objects are produced differently.
+
+`DenseTensor(data, indices)` (`src/tenax/core/tensor.py:468`): `data` is a JAX array, `indices` a tuple of `TensorIndex`. `.todense()` returns the raw array; `.transpose(axes)` permutes; `.labels()`/`.indices` expose metadata; `TensorIndex.relabel(new)` and `.flip_flow()` exist.
+
+---
+
+## File Structure
+
+- **Create** `src/tenax/algorithms/_ctm_chunked_absorb.py` — raw-array chunked edge-absorption core (one function per direction) + a small raw-extraction helper. One clear responsibility: compute the new edge `T_new` array via `lax.map` over boundary-χ.
+- **Modify** `src/tenax/algorithms/_ctm_tensor_moves.py` — add `chunk_size` param + dense-gated chunked branch to the four 1×1 `_ctm_tensor_move_*`.
+- **Modify** `src/tenax/algorithms/_ctm_tensor_convergence.py` — thread `chunk_size` into `_ctm_tensor_sweep_multisite` and the 1×1 dispatch loop; wire `_shard_a` into the 1×1 branch.
+- **Modify** `src/tenax/algorithms/_ctm_python_loop.py` — add `ctm_chunk_size` to `_make_jit_ctm_step` (cache key + static arg) and `python_loop_ctm_converge`.
+- **Modify** `src/tenax/algorithms/ipeps_config.py` — add `CTMConfig.ctm_chunk_size` field + docstring.
+- **Modify** `src/tenax/algorithms/ipeps_ad_policy.py` — forward `ctm_chunk_size` in `ctm_converge_kwargs` and the `ctm_energy_implicit` call.
+- **Create** `tests/test_ctm_chunked_absorb.py` — parity unit tests (core + full move) and an end-to-end converge parity test, marked `core`.
+
+---
+
+## Task 1: Chunked absorb core (the validated lever, raw arrays)
+
+**Files:**
+- Create: `src/tenax/algorithms/_ctm_chunked_absorb.py`
+- Test: `tests/test_ctm_chunked_absorb.py`
+
+- [ ] **Step 1: Write the failing test (core parity for the LEFT contraction)**
+
+This test pins the chunked core against the monolithic einsum+sandwich (the gate's G4 oracle), at K=1 (chunk_size=χ) and K>1.
+
+```python
+# tests/test_ctm_chunked_absorb.py
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+import pytest
+
+from tenax.algorithms._ctm_chunked_absorb import _chunked_T_new_left
+
+
+def _monolith_left(T4, a, P1, P2, chi, D2):
+    # Faithful reference: contract(T4, a) then conj(P1)^T · Tg · P2 (matches
+    # _apply_projector_tensor for the LEFT move).
+    T4a = jnp.einsum("ijk,lmjn->iklmn", T4, a)          # (t4_d, t4_u, u2, d2, r2)
+    Tg = T4a.transpose(0, 2, 1, 3, 4).reshape(chi * D2, chi * D2, D2)  # (fl, fr, r2)
+    step = jnp.tensordot(P1.conj(), Tg, axes=([0], [0]))  # (chi_new, fr, r2)
+    return jnp.tensordot(step, P2, axes=([1], [0]))       # (chi_new, r2, chi_new_r)
+
+
+@pytest.mark.parametrize("batch", [16, 8, 5])  # K=1, K=2, ragged
+def test_chunked_left_matches_monolith(batch):
+    D, chi = 3, 16
+    D2 = D * D
+    k = jax.random.split(jax.random.PRNGKey(0), 4)
+    T4 = jax.random.normal(k[0], (chi, D2, chi))
+    a = jax.random.normal(k[1], (D2, D2, D2, D2))
+    P1 = jax.random.normal(k[2], (chi * D2, chi))
+    P2 = jax.random.normal(k[3], (chi * D2, chi))
+    ref = _monolith_left(T4, a, P1, P2, chi, D2)
+    got = _chunked_T_new_left(T4, a, P1, P2, chi, D2, batch)
+    rel = float(jnp.max(jnp.abs(got - ref)) / (jnp.max(jnp.abs(ref)) + 1e-30))
+    assert rel <= 1e-12, rel
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_ctm_chunked_absorb.py::test_chunked_left_matches_monolith -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tenax.algorithms._ctm_chunked_absorb'`.
+
+- [ ] **Step 3: Write the core module**
+
+```python
+# src/tenax/algorithms/_ctm_chunked_absorb.py
+"""Chunked dense-CTM edge absorption (raw arrays).
+
+Reproduces the expensive ``contract(edge, a)`` + projector sandwich of the
+1x1 ``_ctm_tensor_move_*`` functions, but chunks the boundary-chi axis with
+``lax.map`` so the chi^2 * D^6 intermediate is never materialized in full.
+Numerically faithful to ``_apply_projector_tensor`` (T_new = conj(P1)^T . (edge.a) . P2;
+P1 is barred -> conj data, P2 is not). Dense path only. See the gate findings
+docs/superpowers/handoffs/2026-06-30-chunk-shard-ctm-move-findings.md (STRONG GO).
+"""
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax import lax
+
+
+def _chunked_T_new_left(T4, a, P1, P2, chi, D2, batch):
+    """LEFT: edge T4 (t4_d, l2, t4_u), a (u2, d2, l2, r2).
+
+    P1 raw (fl=(t4_d, u2), chi_new); P2 raw (fr=(t4_u, d2), chi_new).
+    Returns T_new (chi_new, r2, chi_new_r).
+    """
+    P1r = P1.reshape(chi, D2, -1)                       # (t4_d, u2, chi_new)
+
+    def per_i(args):
+        T4_i, P1_i = args                               # (l2, t4_u), (u2, chi_new)
+        T4a_i = jnp.einsum("jk,lmjn->klmn", T4_i, a)    # (t4_u, u2, d2, r2)
+        Tg_i = T4a_i.transpose(1, 0, 2, 3).reshape(D2, chi * D2, D2)  # (u2, (t4_u,d2), r2)
+        step = jnp.tensordot(P1_i.conj(), Tg_i, axes=([0], [0]))      # (chi_new, fr, r2)
+        return jnp.tensordot(step, P2, axes=([1], [0]))              # (chi_new, r2, chi_new_r)
+
+    return lax.map(per_i, (T4, P1r), batch_size=batch).sum(0)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_ctm_chunked_absorb.py::test_chunked_left_matches_monolith -v`
+Expected: PASS for all three `batch` values.
+
+- [ ] **Step 5: Add the other three directions + their parity tests**
+
+Append to the test file (one monolith reference + parametrized test per direction). Each monolith mirrors `_monolith_left` with that direction's einsum, transpose-to-`(fl_D2, fr, surv)`, identical sandwich. Use the per-direction table in Background. Example for RIGHT:
+
+```python
+def _monolith_right(T2, a, P1, P2, chi, D2):
+    T2a = jnp.einsum("ijk,lmnj->iklmn", T2, a)          # (t2_u, t2_d, u2, d2, l2)
+    Tg = T2a.transpose(0, 2, 1, 3, 4).reshape(chi * D2, chi * D2, D2)  # (fl=(t2_u,u2), fr=(t2_d,d2), l2)
+    step = jnp.tensordot(P1.conj(), Tg, axes=([0], [0]))
+    return jnp.tensordot(step, P2, axes=([1], [0]))     # (chi_new, l2, chi_new_r)
+```
+
+Add the matching core functions to `_ctm_chunked_absorb.py`:
+
+```python
+def _chunked_T_new_right(T2, a, P1, P2, chi, D2, batch):
+    """RIGHT: edge T2 (t2_u, r2, t2_d). P1 fl=(t2_u,u2), P2 fr=(t2_d,d2). T_new (chi_new, l2, chi_new_r)."""
+    P1r = P1.reshape(chi, D2, -1)                       # (t2_u, u2, chi_new)
+
+    def per_i(args):
+        T2_i, P1_i = args                               # (r2, t2_d), (u2, chi_new)
+        T2a_i = jnp.einsum("jk,lmnj->klmn", T2_i, a)    # (t2_d, u2, d2, l2)
+        Tg_i = T2a_i.transpose(1, 0, 2, 3).reshape(D2, chi * D2, D2)  # (u2, (t2_d,d2), l2)
+        step = jnp.tensordot(P1_i.conj(), Tg_i, axes=([0], [0]))
+        return jnp.tensordot(step, P2, axes=([1], [0]))
+
+    return lax.map(per_i, (T2, P1r), batch_size=batch).sum(0)
+
+
+def _chunked_T_new_top(T1, a, P1, P2, chi, D2, batch):
+    """TOP: edge T1 (t1_l, u2, t1_r). P1 fl=(t1_l,l2), P2 fr=(t1_r,r2). T_new (chi_new, d2, chi_new_r)."""
+    P1r = P1.reshape(chi, D2, -1)                       # (t1_l, l2, chi_new)
+
+    def per_i(args):
+        T1_i, P1_i = args                               # (u2, t1_r), (l2, chi_new)
+        T1a_i = jnp.einsum("jk,jlmn->klmn", T1_i, a)    # (t1_r, d2, l2, r2)
+        # need (fl_D2=l2, fr=(t1_r,r2), surv=d2): order axes (l2, t1_r, r2, d2)
+        Tg_i = T1a_i.transpose(2, 0, 3, 1).reshape(D2, chi * D2, D2)  # (l2, (t1_r,r2), d2)
+        step = jnp.tensordot(P1_i.conj(), Tg_i, axes=([0], [0]))      # (chi_new, fr, d2)
+        return jnp.tensordot(step, P2, axes=([1], [0]))              # (chi_new, d2, chi_new_r)
+
+    return lax.map(per_i, (T1, P1r), batch_size=batch).sum(0)
+
+
+def _chunked_T_new_bottom(T3, a, P1, P2, chi, D2, batch):
+    """BOTTOM: edge T3 (t3_r, d2, t3_l). P1 fl=(t3_r,l2), P2 fr=(t3_l,r2). T_new (chi_new, u2, chi_new_r)."""
+    P1r = P1.reshape(chi, D2, -1)                       # (t3_r, l2, chi_new)
+
+    def per_i(args):
+        T3_i, P1_i = args                               # (d2, t3_l), (l2, chi_new)
+        T3a_i = jnp.einsum("jk,ljmn->klmn", T3_i, a)    # (t3_l, u2, l2, r2)
+        # need (fl_D2=l2, fr=(t3_l,r2), surv=u2): order axes (l2, t3_l, r2, u2)
+        Tg_i = T3a_i.transpose(2, 0, 3, 1).reshape(D2, chi * D2, D2)  # (l2, (t3_l,r2), u2)
+        step = jnp.tensordot(P1_i.conj(), Tg_i, axes=([0], [0]))      # (chi_new, fr, u2)
+        return jnp.tensordot(step, P2, axes=([1], [0]))              # (chi_new, u2, chi_new_r)
+
+    return lax.map(per_i, (T3, P1r), batch_size=batch).sum(0)
+```
+
+> NOTE for top/bottom: the per-chunk einsum output is `(other_χ, A, B, C)` where the free `a` legs land in `a`'s declaration order minus the shared leg. The `transpose(2, 0, 3, 1)` puts `(fl_D2, other_χ, fr_D2, surv)` so the reshape yields `(fl_D2, fr, surv)`. The parametrized parity test is the oracle — if a transpose is wrong it fails loudly. Verify each direction's einsum output ordering against the per-direction table before trusting the transpose.
+
+- [ ] **Step 6: Run all core parity tests**
+
+Run: `uv run pytest tests/test_ctm_chunked_absorb.py -v -k "matches_monolith"`
+Expected: PASS for all 4 directions × 3 batch sizes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tenax/algorithms/_ctm_chunked_absorb.py tests/test_ctm_chunked_absorb.py
+git commit -m "feat(#632): chunked dense-CTM edge-absorption core (raw arrays)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Wire chunked core into the 1×1 LEFT move (dense-gated, default-off)
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_tensor_moves.py:997-1049` (`_ctm_tensor_move_left`)
+- Test: `tests/test_ctm_chunked_absorb.py`
+
+- [ ] **Step 1: Write the failing test (full LEFT move, chunked == non-chunked)**
+
+```python
+# tests/test_ctm_chunked_absorb.py  (append)
+import numpy as np
+from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env, _build_double_layer_tensor
+from tenax.algorithms._ctm_tensor_moves import _ctm_tensor_move_left
+from tenax.core.tensor import DenseTensor
+
+
+def _random_dense_site(D=3, phys=2, seed=0):
+    # Build a DenseTensor site A[u,d,l,r,phys] with the labels the CTM expects.
+    from tenax.core.index import TensorIndex
+    from tenax.algorithms._ctm_tensor_init import IN, OUT
+    rng = np.random.default_rng(seed)
+    arr = jnp.asarray(rng.standard_normal((D, D, D, D, phys)))
+    labels = ["u", "d", "l", "r", "phys"]
+    flows = [IN, OUT, IN, OUT, OUT]
+    idx = tuple(TensorIndex.from_dim(s, f, label=l) for s, f, l in zip(arr.shape, flows, labels))
+    return DenseTensor(arr, idx)
+
+
+def test_full_left_move_chunked_matches_default():
+    chi = 12
+    A = _random_dense_site()
+    a = _build_double_layer_tensor(A)
+    env = initialize_ctm_tensor_env(A, chi)
+    base = _ctm_tensor_move_left(env, env, a, chi)[0]
+    chunked = _ctm_tensor_move_left(env, env, a, chi, chunk_size=4)[0]
+    for field in ("C1", "C4", "T4"):
+        b = getattr(base, field).transpose(tuple(range(getattr(base, field).ndim))).todense()
+        c = getattr(chunked, field).todense()
+        # align leg order via labels before comparing
+        bl = list(getattr(base, field).labels()); cl = list(getattr(chunked, field).labels())
+        perm = [cl.index(x) for x in bl]
+        c = jnp.transpose(getattr(chunked, field).todense(), perm)
+        rel = float(jnp.max(jnp.abs(c - getattr(base, field).todense())) / (jnp.max(jnp.abs(b)) + 1e-30))
+        assert rel <= 1e-12, (field, rel)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_ctm_chunked_absorb.py::test_full_left_move_chunked_matches_default -v`
+Expected: FAIL — `TypeError: _ctm_tensor_move_left() got an unexpected keyword argument 'chunk_size'`.
+
+- [ ] **Step 3: Add a raw-extraction helper to the core module**
+
+```python
+# src/tenax/algorithms/_ctm_chunked_absorb.py  (append)
+def _raw_in_label_order(T, order):
+    """Return T's raw array transposed to the given label order (DenseTensor only)."""
+    cur = list(T.labels())
+    perm = [cur.index(lbl) for lbl in order]
+    return T.transpose(tuple(perm)).todense()
+```
+
+- [ ] **Step 4: Add the chunked branch to `_ctm_tensor_move_left`**
+
+Add `chunk_size: int | None = None` to the signature (after `projector_backward`). Replace the block from `# T4(self) · a(neighbor)` through the `_apply_projector_with_reembed(...)` call with:
+
+```python
+    # Native projector (needs only the grown corners, not the grown edge)
+    P_1, P_2, _eps_t = _compute_projector_tensor(
+        C1g, C4g, chi, projector_method, base_charges, projector_backward
+    )
+
+    if chunk_size is not None and isinstance(env_self.T4, DenseTensor):
+        from tenax.algorithms._ctm_chunked_absorb import (
+            _chunked_T_new_left,
+            _raw_in_label_order,
+        )
+
+        chi_dim = env_self.T4.indices[env_self.T4.labels().index("t4_d")].dim
+        D2 = a.indices[a.labels().index("r2")].dim
+        T4_raw = _raw_in_label_order(env_self.T4, ["t4_d", "l2", "t4_u"])
+        a_raw = _raw_in_label_order(a, ["u2", "d2", "l2", "r2"])
+        P1_bar = P_1.bar()
+        P1_raw = _raw_in_label_order(P1_bar, ["fused", "chi_new"]).conj()  # un-bar data: bar conjugated it
+        P2_raw = _raw_in_label_order(P_2, ["fused", "chi_new"])
+        T4_arr = _chunked_T_new_left(T4_raw, a_raw, P1_raw, P2_raw, chi_dim, D2, chunk_size)
+
+        # Cheap corners (identical to _apply_projector_tensor)
+        C1_new = contract(P1_bar, C1g)
+        C4_new = contract(P_2.bar(), C4g)
+        # Rewrap T_new with the production index objects: first leg = P1_bar.chi_new,
+        # middle = a's surviving (r2) leg, third = P_2.chi_new relabeled chi_new_r.
+        chi_new_idx = P1_bar.indices[P1_bar.labels().index("chi_new")]
+        surv_idx = a.indices[a.labels().index("r2")]
+        chi_new_r_idx = P_2.indices[P_2.labels().index("chi_new")].relabel("chi_new_r")
+        T4_new = DenseTensor(T4_arr, (chi_new_idx, surv_idx, chi_new_r_idx))
+    else:
+        # T4(self) · a(neighbor)  — the χ²·D⁶ peak (default path, unchanged)
+        T4_with_a = contract(env_self.T4, a)
+        T4g = _fuse_pair_by_label(T4_with_a, "t4_d", "u2", "fl", IN)
+        T4g = _fuse_pair_by_label(T4g, "t4_u", "d2", "fr", OUT)
+        C1_new, C4_new, T4_new = _apply_projector_with_reembed(
+            P_1, P_2, C1g, C4g, T4g, "fl", "fr"
+        )
+```
+
+The existing relabel / `_flip_leg_flow` / `_phase_fix_normalize_tensor` tail (lines 1040-1048) stays unchanged and runs for both branches.
+
+> CRITICAL re P1 conjugation: `_chunked_T_new_left` applies `P1_i.conj()` internally (matching `_apply_projector_tensor`'s `P1_bar = P_1.bar()`, which conjugates). We extract `P1_bar` (already conj'd by `.bar()`) and `.conj()` it back to recover the un-conjugated `P_1` data, because the core conjugates again. Net data passed to the core = `P_1` (un-barred), so the core's `.conj()` reproduces `P_1.bar()`'s data. The parity test verifies this; if it fails by a complex conjugate, drop the `.conj()` on `P1_raw` and extract from `P_1` directly. (For real f64 inputs the conj is a no-op and the test passes either way — keep it correct for the complex path.)
+
+- [ ] **Step 5: Run the full-move parity test**
+
+Run: `uv run pytest tests/test_ctm_chunked_absorb.py::test_full_left_move_chunked_matches_default -v`
+Expected: PASS (rel ≤ 1e-12 on C1/C4/T4).
+
+- [ ] **Step 6: Run the existing CTM move tests to confirm default-off is untouched**
+
+Run: `uv run pytest tests/test_ctm_compiled.py -m core -q && uv run pytest -k "ctm" -m core -q`
+Expected: PASS (no regressions; default path byte-identical).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tenax/algorithms/_ctm_chunked_absorb.py src/tenax/algorithms/_ctm_tensor_moves.py tests/test_ctm_chunked_absorb.py
+git commit -m "feat(#632): chunked branch in 1x1 left CTM move (dense, default-off)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Generalize to RIGHT / TOP / BOTTOM 1×1 moves
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_tensor_moves.py` (`_ctm_tensor_move_right` 1052, `_ctm_tensor_move_top` 1106, `_ctm_tensor_move_bottom` 1160)
+- Test: `tests/test_ctm_chunked_absorb.py`
+
+- [ ] **Step 1: Write the failing tests (full move parity for each direction)**
+
+Add `test_full_right_move_chunked_matches_default`, `..._top...`, `..._bottom...`, each identical in shape to `test_full_left_move_chunked_matches_default` but calling the matching move and comparing the fields that move updates (right: C2/C3/T2; top: C1/C2/T1; bottom: C4/C3/T3).
+
+```python
+# tests/test_ctm_chunked_absorb.py  (append; one per direction)
+from tenax.algorithms._ctm_tensor_moves import (
+    _ctm_tensor_move_right, _ctm_tensor_move_top, _ctm_tensor_move_bottom,
+)
+
+@pytest.mark.parametrize("move_fn,fields", [
+    (_ctm_tensor_move_right, ("C2", "C3", "T2")),
+    (_ctm_tensor_move_top, ("C1", "C2", "T1")),
+    (_ctm_tensor_move_bottom, ("C4", "C3", "T3")),
+])
+def test_full_move_chunked_matches_default(move_fn, fields):
+    chi = 12
+    A = _random_dense_site()
+    a = _build_double_layer_tensor(A)
+    env = initialize_ctm_tensor_env(A, chi)
+    base = move_fn(env, env, a, chi)[0]
+    chunked = move_fn(env, env, a, chi, chunk_size=4)[0]
+    for field in fields:
+        bl = list(getattr(base, field).labels()); cl = list(getattr(chunked, field).labels())
+        perm = [cl.index(x) for x in bl]
+        c = jnp.transpose(getattr(chunked, field).todense(), perm)
+        b = getattr(base, field).todense()
+        rel = float(jnp.max(jnp.abs(c - b)) / (jnp.max(jnp.abs(b)) + 1e-30))
+        assert rel <= 1e-12, (field, rel)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_ctm_chunked_absorb.py::test_full_move_chunked_matches_default -v`
+Expected: FAIL — `TypeError: ... unexpected keyword argument 'chunk_size'`.
+
+- [ ] **Step 3: Add the chunked branch to each of the three moves**
+
+For each move, mirror Task 2 Step 4 using that direction's row in the per-direction table:
+- Add `chunk_size: int | None = None` to the signature.
+- Move the `_compute_projector_tensor(...)` call above the branch (it needs only the grown corners).
+- In the chunked branch: extract the edge raw via `_raw_in_label_order(edge, <canonical order>)`, `a` raw via `["u2","d2","l2","r2"]`, `P1_raw` from `P_1.bar()` then `.conj()`, `P2_raw` from `P_2`; call the matching `_chunked_T_new_<dir>`; build `*_new` corners via `contract(P1_bar, Cg)` / `contract(P_2.bar(), Cg)`; rewrap `T*_new = DenseTensor(arr, (P1_bar.chi_new, a.<surviving>, P_2.chi_new→chi_new_r))`.
+  - RIGHT surviving = `l2`; edge canonical `["t2_u","r2","t2_d"]`; corners C2g (P_1 side), C3g (P_2 side).
+  - TOP surviving = `d2`; edge canonical `["t1_l","u2","t1_r"]`; corners C1g, C2g.
+  - BOTTOM surviving = `u2`; edge canonical `["t3_r","d2","t3_l"]`; corners C4g, C3g.
+- Leave the per-direction relabel / `_flip_leg_flow` / `_phase_fix_normalize_tensor` tail unchanged for both branches.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_ctm_chunked_absorb.py::test_full_move_chunked_matches_default -v`
+Expected: PASS for all three directions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tenax/algorithms/_ctm_tensor_moves.py tests/test_ctm_chunked_absorb.py
+git commit -m "feat(#632): chunked branch in 1x1 right/top/bottom CTM moves
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Thread `chunk_size` through sweep → jit step → converge → config; wire `_shard_a` into 1×1
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_tensor_convergence.py:274-340` (`_ctm_tensor_sweep_multisite`, 1×1 branch)
+- Modify: `src/tenax/algorithms/_ctm_python_loop.py` (`_make_jit_ctm_step` cache key + static arg; `python_loop_ctm_converge` + `_python_loop_chi_ramp`)
+- Modify: `src/tenax/algorithms/ipeps_config.py` (`CTMConfig.ctm_chunk_size`)
+- Modify: `src/tenax/algorithms/ipeps_ad_policy.py` (`ctm_converge_kwargs` + `ctm_energy_implicit` call)
+- Test: `tests/test_ctm_chunked_absorb.py`
+
+- [ ] **Step 1: Write the failing end-to-end test (CTM converge, chunk on == off)**
+
+```python
+# tests/test_ctm_chunked_absorb.py  (append)
+from tenax.algorithms._ctm_python_loop import python_loop_ctm_converge
+
+
+def test_converge_1x1_chunk_matches_default():
+    chi = 12
+    A = _random_dense_site(D=2)
+    site_tensors = {(0, 0): A}
+    neighbors = {(0, 0): {d: (0, 0) for d in ("left", "right", "top", "bottom")}}
+    kw = dict(chi=chi, max_iter=8, min_iter=8, recipe="1x1", conv_tol=0.0)
+    envs_off, _ = python_loop_ctm_converge(site_tensors, neighbors, **kw)
+    envs_on, _ = python_loop_ctm_converge(site_tensors, neighbors, ctm_chunk_size=3, **kw)
+    e_off, e_on = envs_off[(0, 0)], envs_on[(0, 0)]
+    for field in e_off._fields:
+        b = getattr(e_off, field); c = getattr(e_on, field)
+        perm = [list(c.labels()).index(x) for x in list(b.labels())]
+        cc = jnp.transpose(c.todense(), perm)
+        rel = float(jnp.max(jnp.abs(cc - b.todense())) / (jnp.max(jnp.abs(b.todense())) + 1e-30))
+        assert rel <= 1e-10, (field, rel)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_ctm_chunked_absorb.py::test_converge_1x1_chunk_matches_default -v`
+Expected: FAIL — `TypeError: python_loop_ctm_converge() got an unexpected keyword argument 'ctm_chunk_size'`.
+
+- [ ] **Step 3: Thread `chunk_size` into the sweep's 1×1 branch + wire `_shard_a` there**
+
+In `_ctm_tensor_sweep_multisite` (`_ctm_tensor_convergence.py`):
+- Add `chunk_size: int | None = None` to the signature (after `device_mesh`).
+- Hoist the `_shard_a` definition (currently inside the `recipe == "2x2"` branch, lines 348-358) so it is defined before the `if recipe == "1x1":` block, available to both.
+- In the 1×1 loop (lines 328-340), pass the re-sharded `a` and the chunk size:
+
+```python
+    if recipe == "1x1":
+        for direction, move_fn in _DIRECTION_MOVES:
+            for coord in _sort_coords_for_direction(all_coords, direction):
+                nb = neighbors[coord][direction]
+                envs[coord], eps_t = move_fn(
+                    envs[coord],
+                    envs[nb],
+                    _shard_a(double_layers[nb], direction),
+                    chi,
+                    projector_method,
+                    base_charges=base_charges,
+                    projector_backward=projector_backward,
+                    chunk_size=chunk_size,
+                )
+                max_eps = jnp.maximum(max_eps, jnp.asarray(eps_t))
+```
+
+> The four 1×1 `move_fn` already accept `chunk_size` (Tasks 2-3). `_shard_a` is a no-op when `device_mesh is None`, so the chunk-only path (no mesh) is unaffected.
+
+- [ ] **Step 4: Thread `chunk_size` through `_make_jit_ctm_step`**
+
+In `_ctm_python_loop.py`:
+- Add `ctm_chunk_size=None` param to `_make_jit_ctm_step`; include it in `cache_key` (4-tuple: `(id(neighbors), recipe, device_mesh, ctm_chunk_size)`) and add the type to `_JIT_STEP_CACHE`'s annotation.
+- Add `"chunk_size"` to `_step`'s `static_argnames` and pass `chunk_size=ctm_chunk_size` into the `_ctm_tensor_sweep_multisite(...)` call. (`chunk_size` is a Python int/None, so it must be static — it changes shapes inside `lax.map`.)
+
+```python
+def _make_jit_ctm_step(neighbors, recipe="2x2", device_mesh=None, ctm_chunk_size=None):
+    cache_key = (id(neighbors), recipe, device_mesh, ctm_chunk_size)
+    ...
+    @partial(jax.jit, static_argnames=("chi", "projector_method", "renormalize",
+                                       "projector_backward", "chunk_size"))
+    def _step(site_tensors, envs, *, chi, projector_method="svd", renormalize=False,
+              projector_backward="auto", chunk_size=None):
+        double_layers = {c: _build_double_layer_tensor(A) for c, A in site_tensors.items()}
+        return _ctm_tensor_sweep_multisite(
+            envs, double_layers, neighbors, chi, renormalize, projector_method,
+            projector_backward=projector_backward, recipe=recipe,
+            device_mesh=device_mesh, chunk_size=chunk_size,
+        )
+```
+
+Then in `python_loop_ctm_converge`: add `ctm_chunk_size: int | None = None` param; pass `ctm_chunk_size=ctm_chunk_size` to `_make_jit_ctm_step`; and pass `chunk_size=ctm_chunk_size` in every `jit_step(...)` call (the QR warm-up loop and via `_run_ctm_loop_with_bump` — check whether the bump helper forwards extra kwargs; if not, the warm-up + main loop both need `chunk_size=ctm_chunk_size` threaded). Also add `ctm_chunk_size` to `_python_loop_chi_ramp` and forward it in its recursive `python_loop_ctm_converge` call.
+
+> Inspect `src/tenax/algorithms/_ctm_loop_core.py::_run_ctm_loop_with_bump` first: it calls `jit_step` internally, so `chunk_size` must reach it. Either (a) bind it via `functools.partial(jit_step, chunk_size=ctm_chunk_size)` before passing `jit_step` into the helper, or (b) add a `chunk_size` passthrough param. Option (a) is the smaller change and avoids touching the bump helper's signature — prefer it. Apply the same `partial` to the warm-up loop's `jit_step`.
+
+- [ ] **Step 5: Run the end-to-end parity test**
+
+Run: `uv run pytest tests/test_ctm_chunked_absorb.py::test_converge_1x1_chunk_matches_default -v`
+Expected: PASS (rel ≤ 1e-10 across all env fields after 8 fixed sweeps).
+
+- [ ] **Step 6: Add the `CTMConfig` field + policy threading**
+
+In `ipeps_config.py`, add to `CTMConfig` (after `device_mesh`, line 250) — appended last to preserve positional ABI:
+
+```python
+    ctm_chunk_size: int | None = None
+    """Chunk the χ²·D⁶ edge absorption over the boundary-χ axis via
+    ``lax.map(batch_size=ctm_chunk_size)`` (1×1 recipe, dense envs only).
+    Lowers per-device peak memory ≈÷K at large D and composes with
+    ``device_mesh`` (≈÷(N·K)). ``None`` (default) → single monolithic
+    contraction (byte-for-byte unchanged). See the #632 chunk×shard gate."""
+```
+
+In `ipeps_ad_policy.py`: add `"ctm_chunk_size": ctm_cfg.ctm_chunk_size` to the `ctm_converge_kwargs` dict (next to `"device_mesh"`, ~line 189), and `ctm_chunk_size=ctm_cfg.ctm_chunk_size` to the `ctm_energy_implicit(...)` call (next to `device_mesh=`, ~line 373). Then thread `ctm_chunk_size` through `ctm_energy_implicit` → `_run_forward` → `_sigma_gauged_ctm_converge`/`python_loop_ctm_converge` exactly as `device_mesh` is threaded today (grep `device_mesh` in `_ctm_energy_ad.py` and add a sibling `ctm_chunk_size` param at each forward call site; leave the backward step builder at `_ctm_energy_ad.py:1007` as-is — backward chunking is Increment 2).
+
+- [ ] **Step 7: Run config + policy + CTM test buckets**
+
+Run: `uv run pytest tests/test_ctm_chunked_absorb.py -m core -q && uv run pytest -k "config or ipeps_ad or ctm" -m core -q`
+Expected: PASS, no regressions.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/tenax/algorithms/_ctm_tensor_convergence.py src/tenax/algorithms/_ctm_python_loop.py src/tenax/algorithms/ipeps_config.py src/tenax/algorithms/ipeps_ad_policy.py tests/test_ctm_chunked_absorb.py
+git commit -m "feat(#632): thread ctm_chunk_size config through forward 1x1 CTM + wire _shard_a into 1x1
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: CI marker, docs, and full-suite check
+
+**Files:**
+- Modify: `tests/test_ctm_chunked_absorb.py` (ensure `core` marker)
+- Modify: `docs/superpowers/handoffs/` (new short Increment-1 build note)
+
+- [ ] **Step 1: Confirm the test file is `core`-marked and runs in the required CI bucket**
+
+`conftest.py` auto-marks by filename. Confirm `test_ctm_chunked_absorb.py` lands in `core` (not `slow`):
+Run: `uv run pytest tests/test_ctm_chunked_absorb.py -m core --collect-only -q`
+Expected: all tests collected under `-m core`. If any are mis-bucketed, add an explicit `@pytest.mark.core` or rename per `conftest.py` rules.
+
+- [ ] **Step 2: Run the full core bucket (the CI required check)**
+
+Run: `uv run pytest -m core -q`
+Expected: PASS (this is what `Tests (Python 3.11/3.12)` gate on).
+
+- [ ] **Step 3: Write a short build-findings note**
+
+Create `docs/superpowers/handoffs/2026-07-01-chunk-ctm-absorb-increment1-build.md` summarizing: what shipped (forward 1×1 dense chunked absorb + `ctm_chunk_size`), the parity guarantees (core/full-move/converge rel bounds), the default-off contract, and the explicit deferral of Increment 2 (backward gate) and 2×2/symmetric. Note that `device_mesh` is still dropped at the backward (`_ctm_energy_ad.py:1007`) — that's Increment 2's problem.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_ctm_chunked_absorb.py docs/superpowers/handoffs/2026-07-01-chunk-ctm-absorb-increment1-build.md
+git commit -m "docs/test(#632): Increment-1 chunked-absorb build note + core CI marker
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (against the gate findings "Build (recommended)" + the two confirmed decisions):
+- "opt-in `n_chunks`/`batch` knob on the edge contraction" → `ctm_chunk_size` (Tasks 1-4). ✓
+- "composed with the `ctm_sharding` mesh" → `_shard_a` wired into the 1×1 branch (Task 4 Step 3); chunk keeps `a` sharded inside `lax.map` (gate G3a). ✓
+- "all 4 moves + corner accumulation" → 4 moves chunked (Tasks 2-3); corners use the cheap `contract(P_bar, Cg)` path. ✓
+- "default-OFF (bit-identical when off) + parity CI" → default `None`; core/full-move/converge parity tests, `core`-marked (Tasks 1-5). ✓
+- Decision: chunk the production Tensor absorb path, not the dead `_compiled_move_*` → done via `_ctm_chunked_absorb.py` called from `_ctm_tensor_move_*`. ✓
+- Decision: 1×1 recipe first → only the 1×1 path is touched; 2×2 untouched (deferred). ✓
+
+**2. Placeholder scan:** No "TBD"/"handle edge cases"/"similar to Task N". Per-direction differences are given as an explicit table + per-direction core functions. The two "inspect first" notes (Task 4 Step 4 on `_run_ctm_loop_with_bump`; Task 1 Step 5 transpose verification) are guarded by the parity oracle, not hand-waves.
+
+**3. Type/name consistency:** `chunk_size` (move-level param) vs `ctm_chunk_size` (config/converge-level) is intentional and consistent: `ctm_chunk_size` is the public config name; it maps to the `chunk_size` kwarg at `_make_jit_ctm_step`/move boundary. Core functions `_chunked_T_new_{left,right,top,bottom}` and `_raw_in_label_order` are referenced with matching signatures across tasks. `DenseTensor(data, indices)`, `.bar()`, `.todense()`, `TensorIndex.relabel`/`.flip_flow`/`.dim` all match `src/tenax/core/tensor.py`.
+
+---
+
+## Out of scope (do NOT build here)
+
+- **Increment 2** — chunked **backward** through the implicit-AD adjoint (`_ctm_energy_ad.py`, custom_vjp + fixed-point). This is gate-first: prove correct + bounded-memory grads through the chunked move BEFORE wiring `optimize_gs_ad`. The forward `device_mesh`/`ctm_chunk_size` are deliberately NOT threaded into the backward step (`:1007`).
+- **2×2 recipe** chunking (more absorb call sites; the 2×2 absorb already has per-move sharding).
+- **Symmetric / fermionic** envs (knob is a no-op there; large-D symmetric → YASTN).
+- The **D=10–12 / large-χ multi-GPU `optimize_gs_ad` benchmark** (depends on Increment 2).
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-01-chunk-ctm-absorb-increment1.md`.

--- a/examples/spike_chunk_backward_gate.py
+++ b/examples/spike_chunk_backward_gate.py
@@ -1,0 +1,183 @@
+"""#632 Increment 2 gate — chunked dense-CTM *backward* through the implicit-AD adjoint.
+
+The forward chunking (Increment 1) avoids materializing the chi^2 * D^6 edge-absorption
+intermediate via ``lax.map`` over the boundary-chi axis. The open question this gate
+answers: does the implicit-AD *backward* (``_ctm_energy_ad.py``, custom_vjp + fixed-point
+Neumann/GMRES adjoint) also stay bounded once ``ctm_chunk_size`` is threaded into
+``jit_step_bwd`` — i.e. does ``jax.vjp`` through the chunked ``lax.map`` chunk the reverse
+pass, or does XLA re-materialize the full chi^2 * D^6 intermediate (making the backward the
+new wall)?
+
+Gate sub-parts (mirrors the rung-2 backward-sharding gate structure):
+  C1 correctness : value_and_grad grad parity, chunk-off vs chunk-on (recipe=1x1, dense).
+  C2 memory      : 3-way per-device peak of full value_and_grad (fwd+bwd) —
+                   (off, fwd-chunk-only[legacy], fwd+bwd-chunk) — isolates the BACKWARD.
+  C3 reach       : does fwd+bwd-chunk run where off / fwd-only OOM?
+
+Usage:
+    # correctness (CPU, fast):
+    JAX_PLATFORMS=cpu uv run python examples/spike_chunk_backward_gate.py --mode correctness --D 2 --chi 6
+    # memory (single A100, one D per process for a clean peak):
+    CUDA_VISIBLE_DEVICES=1 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        uv run python examples/spike_chunk_backward_gate.py --mode memory --D 8 --chi 32 --chunk 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import warnings
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+
+from tenax.algorithms._ctm_energy_ad import ctm_energy_implicit  # noqa: E402
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS  # noqa: E402
+from tenax.core.index import FlowDirection, TensorIndex  # noqa: E402
+from tenax.core.symmetry import U1Symmetry  # noqa: E402
+from tenax.core.tensor import DenseTensor  # noqa: E402
+
+_D_PHYS = 2
+
+
+def _indices(D: int):
+    sym = U1Symmetry()
+    bc = np.zeros(D, dtype=np.int32)
+    pc = np.zeros(_D_PHYS, dtype=np.int32)
+    return (
+        TensorIndex.from_charges(sym, bc.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, bc.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, bc.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, bc.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(sym, pc.copy(), FlowDirection.IN, label="phys"),
+    )
+
+
+def _init_data(D: int, seed: int, well_conditioned: bool):
+    key = jax.random.PRNGKey(seed)
+    data = jax.random.normal(key, (D, D, D, D, _D_PHYS))
+    if well_conditioned:
+        data = 0.02 * data
+        data = data.at[0, 0, 0, 0, :].add(1.0)
+    return data / (jnp.linalg.norm(data) + 1e-10)
+
+
+def energy_and_grad(
+    *, D, chi, chunk, seed=0, well_conditioned=True, max_iter=50, gmres_maxiter=200,
+    grad=True,
+):
+    """(value_and_)grad of the recipe=1x1 implicit-AD CTM energy, ctm_chunk_size=chunk.
+
+    ``grad=False`` runs only the forward (energy, no backward) so the forward and
+    backward peak contributions can be isolated.
+    """
+    idx = _indices(D)
+    gate = jnp.diag(jnp.array([0.25, -0.25, -0.25, 0.25])).reshape(2, 2, 2, 2)
+    data0 = _init_data(D, seed, well_conditioned)
+
+    def loss(data):
+        A = DenseTensor(data, idx)
+        return ctm_energy_implicit(
+            {(0, 0): A},
+            SINGLE_SITE_NEIGHBORS,
+            gate,
+            chi=chi,
+            max_iter=max_iter,
+            conv_tol=1e-10,
+            forward_gauge="phase",
+            adjoint_method="fixed_point",
+            recipe="1x1",
+            ctm_chunk_size=chunk,
+            gmres_maxiter=gmres_maxiter,
+        )
+
+    if grad:
+        e, g = jax.value_and_grad(loss)(data0)
+        return float(e), np.asarray(g)
+    # forward-only: call eagerly (the implicit-AD energy has host-side control
+    # flow, so it cannot be wrapped in a single jax.jit). The forward CTM sweeps
+    # are internally jitted; the peak is reached inside them regardless.
+    e = loss(data0)
+    jax.block_until_ready(e)
+    return float(e), np.zeros_like(data0)
+
+
+def peak_gb():
+    try:
+        return jax.devices()[0].memory_stats()["peak_bytes_in_use"] / 1e9
+    except Exception:
+        return float("nan")
+
+
+def _correctness(args):
+    # Capture warnings so we can DETECT a silent fallback (chunk requested but env
+    # not dense -> monolith path, which would make the whole gate meaningless).
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        e_off, g_off = energy_and_grad(D=args.D, chi=args.chi, chunk=None)
+        e_on, g_on = energy_and_grad(D=args.D, chi=args.chi, chunk=args.chunk)
+    fell_back = any("not dense" in str(w.message) for w in caught)
+    de = abs(e_off - e_on)
+    dg = float(np.max(np.abs(g_off - g_on)))
+    gmax = float(np.max(np.abs(g_off)))
+    print(f"# devices={jax.devices()} x64={jax.config.jax_enable_x64}")
+    print(
+        f"[C1] D={args.D} chi={args.chi} chunk={args.chunk} recipe=1x1  "
+        f"|dE|={de:.2e}  grad_max|delta|={dg:.2e}  gmax={gmax:.3e}  "
+        f"chunk_fell_back_to_monolith={fell_back}"
+    )
+    ok = (de < 1e-9) and (dg < 1e-9) and (not fell_back)
+    print(f"[C1] {'PASS' if ok else 'FAIL'} "
+          f"(need |dE|<1e-9, grad delta<1e-9, chunk engaged)")
+    return ok
+
+
+def _memory(args):
+    lbl = "chunk=OFF" if args.chunk is None else f"chunk={args.chunk}"
+    # well_conditioned=True: the chi^2*D^6 intermediate is STRUCTURAL (same size
+    # regardless of values), but a well-separated leading CTM eigenvalue makes the
+    # adjoint fixed-point converge fast and stay on the fused path (no eager-GMRES
+    # fallback), giving a clean structural peak in bounded wall time.
+    which = "grad(fwd+bwd)" if args.grad else "fwd-only"
+    try:
+        e, g = energy_and_grad(
+            D=args.D, chi=args.chi, chunk=args.chunk,
+            well_conditioned=True, max_iter=args.max_iter,
+            gmres_maxiter=args.gmres_maxiter, grad=args.grad,
+        )
+        print(
+            f"[C2] D={args.D} chi={args.chi} {lbl} {which} "
+            f"recipe=1x1  OK  E={e:.6f}  |g|={float(np.linalg.norm(g)):.3e}  "
+            f"peak={peak_gb():.2f} GB"
+        )
+    except Exception as ex:  # noqa: BLE001
+        print(
+            f"[C2] D={args.D} chi={args.chi} {lbl} {which} "
+            f"recipe=1x1  FAILED ({type(ex).__name__}: {str(ex)[:100]})"
+        )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["correctness", "memory"], default="correctness")
+    ap.add_argument("--D", type=int, default=2)
+    ap.add_argument("--chi", type=int, default=6)
+    ap.add_argument("--chunk", type=int, default=2)
+    ap.add_argument("--max-iter", type=int, default=6)
+    ap.add_argument("--gmres-maxiter", type=int, default=30)
+    ap.add_argument("--no-grad", dest="grad", action="store_false",
+                    help="forward-only peak (isolate fwd from bwd)")
+    args = ap.parse_args()
+    if args.chunk is not None and args.chunk <= 0:
+        args.chunk = None  # allow --chunk 0 to mean OFF from a shell sweep
+    if args.mode == "correctness":
+        _correctness(args)
+    else:
+        _memory(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tenax/algorithms/_ctm_chunked_absorb.py
+++ b/src/tenax/algorithms/_ctm_chunked_absorb.py
@@ -5,7 +5,8 @@ Reproduces the expensive ``contract(edge, a)`` + projector sandwich of the
 ``lax.map`` so the chi^2 * D^6 intermediate is never materialized in full.
 Numerically faithful to ``_apply_projector_tensor`` (T_new = conj(P1)^T . (edge.a) . P2;
 P1 is barred -> conj data, P2 is not). Dense path only. See the gate findings
-docs/superpowers/handoffs/2026-06-30-chunk-shard-ctm-move-findings.md (STRONG GO).
+docs/superpowers/handoffs/2026-06-30-chunk-shard-ctm-move-findings.md (#632 gate,
+STRONG GO).
 """
 from __future__ import annotations
 
@@ -19,6 +20,7 @@ def _chunked_T_new_left(T4, a, P1, P2, chi, D2, batch):
     P1 raw (fl=(t4_d, u2), chi_new); P2 raw (fr=(t4_u, d2), chi_new).
     Returns T_new (chi_new, r2, chi_new_r).
     """
+    assert batch >= 1, f"batch must be >= 1, got {batch}"
     P1r = P1.reshape(chi, D2, -1)                       # (t4_d, u2, chi_new)
 
     def per_i(args):
@@ -32,7 +34,11 @@ def _chunked_T_new_left(T4, a, P1, P2, chi, D2, batch):
 
 
 def _chunked_T_new_right(T2, a, P1, P2, chi, D2, batch):
-    """RIGHT: edge T2 (t2_u, r2, t2_d). P1 fl=(t2_u,u2), P2 fr=(t2_d,d2). T_new (chi_new, l2, chi_new_r)."""
+    """RIGHT: edge T2 (t2_u, r2, t2_d). P1 fl=(t2_u,u2), P2 fr=(t2_d,d2).
+
+    Returns T_new (chi_new, l2, chi_new_r).
+    """
+    assert batch >= 1, f"batch must be >= 1, got {batch}"
     P1r = P1.reshape(chi, D2, -1)                       # (t2_u, u2, chi_new)
 
     def per_i(args):
@@ -46,7 +52,11 @@ def _chunked_T_new_right(T2, a, P1, P2, chi, D2, batch):
 
 
 def _chunked_T_new_top(T1, a, P1, P2, chi, D2, batch):
-    """TOP: edge T1 (t1_l, u2, t1_r). P1 fl=(t1_l,l2), P2 fr=(t1_r,r2). T_new (chi_new, d2, chi_new_r)."""
+    """TOP: edge T1 (t1_l, u2, t1_r). P1 fl=(t1_l,l2), P2 fr=(t1_r,r2).
+
+    Returns T_new (chi_new, d2, chi_new_r).
+    """
+    assert batch >= 1, f"batch must be >= 1, got {batch}"
     P1r = P1.reshape(chi, D2, -1)                       # (t1_l, l2, chi_new)
 
     def per_i(args):
@@ -61,7 +71,11 @@ def _chunked_T_new_top(T1, a, P1, P2, chi, D2, batch):
 
 
 def _chunked_T_new_bottom(T3, a, P1, P2, chi, D2, batch):
-    """BOTTOM: edge T3 (t3_r, d2, t3_l). P1 fl=(t3_r,l2), P2 fr=(t3_l,r2). T_new (chi_new, u2, chi_new_r)."""
+    """BOTTOM: edge T3 (t3_r, d2, t3_l). P1 fl=(t3_r,l2), P2 fr=(t3_l,r2).
+
+    Returns T_new (chi_new, u2, chi_new_r).
+    """
+    assert batch >= 1, f"batch must be >= 1, got {batch}"
     P1r = P1.reshape(chi, D2, -1)                       # (t3_r, l2, chi_new)
 
     def per_i(args):

--- a/src/tenax/algorithms/_ctm_chunked_absorb.py
+++ b/src/tenax/algorithms/_ctm_chunked_absorb.py
@@ -87,3 +87,10 @@ def _chunked_T_new_bottom(T3, a, P1, P2, chi, D2, batch):
         return jnp.tensordot(step, P2, axes=([1], [0]))              # (chi_new, u2, chi_new_r)
 
     return lax.map(per_i, (T3, P1r), batch_size=batch).sum(0)
+
+
+def _raw_in_label_order(T, order):
+    """Return T's raw array transposed to the given label order (DenseTensor only)."""
+    cur = list(T.labels())
+    perm = [cur.index(lbl) for lbl in order]
+    return T.transpose(tuple(perm)).todense()

--- a/src/tenax/algorithms/_ctm_chunked_absorb.py
+++ b/src/tenax/algorithms/_ctm_chunked_absorb.py
@@ -1,0 +1,75 @@
+"""Chunked dense-CTM edge absorption (raw arrays).
+
+Reproduces the expensive ``contract(edge, a)`` + projector sandwich of the
+1x1 ``_ctm_tensor_move_*`` functions, but chunks the boundary-chi axis with
+``lax.map`` so the chi^2 * D^6 intermediate is never materialized in full.
+Numerically faithful to ``_apply_projector_tensor`` (T_new = conj(P1)^T . (edge.a) . P2;
+P1 is barred -> conj data, P2 is not). Dense path only. See the gate findings
+docs/superpowers/handoffs/2026-06-30-chunk-shard-ctm-move-findings.md (STRONG GO).
+"""
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax import lax
+
+
+def _chunked_T_new_left(T4, a, P1, P2, chi, D2, batch):
+    """LEFT: edge T4 (t4_d, l2, t4_u), a (u2, d2, l2, r2).
+
+    P1 raw (fl=(t4_d, u2), chi_new); P2 raw (fr=(t4_u, d2), chi_new).
+    Returns T_new (chi_new, r2, chi_new_r).
+    """
+    P1r = P1.reshape(chi, D2, -1)                       # (t4_d, u2, chi_new)
+
+    def per_i(args):
+        T4_i, P1_i = args                               # (l2, t4_u), (u2, chi_new)
+        T4a_i = jnp.einsum("jk,lmjn->klmn", T4_i, a)    # (t4_u, u2, d2, r2)
+        Tg_i = T4a_i.transpose(1, 0, 2, 3).reshape(D2, chi * D2, D2)  # (u2, (t4_u,d2), r2)
+        step = jnp.tensordot(P1_i.conj(), Tg_i, axes=([0], [0]))      # (chi_new, fr, r2)
+        return jnp.tensordot(step, P2, axes=([1], [0]))              # (chi_new, r2, chi_new_r)
+
+    return lax.map(per_i, (T4, P1r), batch_size=batch).sum(0)
+
+
+def _chunked_T_new_right(T2, a, P1, P2, chi, D2, batch):
+    """RIGHT: edge T2 (t2_u, r2, t2_d). P1 fl=(t2_u,u2), P2 fr=(t2_d,d2). T_new (chi_new, l2, chi_new_r)."""
+    P1r = P1.reshape(chi, D2, -1)                       # (t2_u, u2, chi_new)
+
+    def per_i(args):
+        T2_i, P1_i = args                               # (r2, t2_d), (u2, chi_new)
+        T2a_i = jnp.einsum("jk,lmnj->klmn", T2_i, a)    # (t2_d, u2, d2, l2)
+        Tg_i = T2a_i.transpose(1, 0, 2, 3).reshape(D2, chi * D2, D2)  # (u2, (t2_d,d2), l2)
+        step = jnp.tensordot(P1_i.conj(), Tg_i, axes=([0], [0]))
+        return jnp.tensordot(step, P2, axes=([1], [0]))
+
+    return lax.map(per_i, (T2, P1r), batch_size=batch).sum(0)
+
+
+def _chunked_T_new_top(T1, a, P1, P2, chi, D2, batch):
+    """TOP: edge T1 (t1_l, u2, t1_r). P1 fl=(t1_l,l2), P2 fr=(t1_r,r2). T_new (chi_new, d2, chi_new_r)."""
+    P1r = P1.reshape(chi, D2, -1)                       # (t1_l, l2, chi_new)
+
+    def per_i(args):
+        T1_i, P1_i = args                               # (u2, t1_r), (l2, chi_new)
+        T1a_i = jnp.einsum("jk,jlmn->klmn", T1_i, a)    # (t1_r, d2, l2, r2)
+        # need (fl_D2=l2, fr=(t1_r,r2), surv=d2): order axes (l2, t1_r, r2, d2)
+        Tg_i = T1a_i.transpose(2, 0, 3, 1).reshape(D2, chi * D2, D2)  # (l2, (t1_r,r2), d2)
+        step = jnp.tensordot(P1_i.conj(), Tg_i, axes=([0], [0]))      # (chi_new, fr, d2)
+        return jnp.tensordot(step, P2, axes=([1], [0]))              # (chi_new, d2, chi_new_r)
+
+    return lax.map(per_i, (T1, P1r), batch_size=batch).sum(0)
+
+
+def _chunked_T_new_bottom(T3, a, P1, P2, chi, D2, batch):
+    """BOTTOM: edge T3 (t3_r, d2, t3_l). P1 fl=(t3_r,l2), P2 fr=(t3_l,r2). T_new (chi_new, u2, chi_new_r)."""
+    P1r = P1.reshape(chi, D2, -1)                       # (t3_r, l2, chi_new)
+
+    def per_i(args):
+        T3_i, P1_i = args                               # (d2, t3_l), (l2, chi_new)
+        T3a_i = jnp.einsum("jk,ljmn->klmn", T3_i, a)    # (t3_l, u2, l2, r2)
+        # need (fl_D2=l2, fr=(t3_l,r2), surv=u2): order axes (l2, t3_l, r2, u2)
+        Tg_i = T3a_i.transpose(2, 0, 3, 1).reshape(D2, chi * D2, D2)  # (l2, (t3_l,r2), u2)
+        step = jnp.tensordot(P1_i.conj(), Tg_i, axes=([0], [0]))      # (chi_new, fr, u2)
+        return jnp.tensordot(step, P2, axes=([1], [0]))              # (chi_new, u2, chi_new_r)
+
+    return lax.map(per_i, (T3, P1r), batch_size=batch).sum(0)

--- a/src/tenax/algorithms/_ctm_chunked_absorb.py
+++ b/src/tenax/algorithms/_ctm_chunked_absorb.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import jax.numpy as jnp
 from jax import lax
 
+from tenax.core.tensor import DenseTensor
+
 
 def _chunked_T_new_left(T4, a, P1, P2, chi, D2, batch):
     """LEFT: edge T4 (t4_d, l2, t4_u), a (u2, d2, l2, r2).
@@ -91,6 +93,10 @@ def _chunked_T_new_bottom(T3, a, P1, P2, chi, D2, batch):
 
 def _raw_in_label_order(T, order):
     """Return T's raw array transposed to the given label order (DenseTensor only)."""
+    assert isinstance(T, DenseTensor), (
+        f"_raw_in_label_order requires a DenseTensor, got {type(T).__name__}; "
+        "chunked absorption is dense-only."
+    )
     cur = list(T.labels())
     perm = [cur.index(lbl) for lbl in order]
     return T.transpose(tuple(perm)).todense()

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -364,6 +364,7 @@ def ctm_energy_implicit(
     chi_max: int | None = None,
     recipe: str = "2x2",
     device_mesh=None,
+    ctm_chunk_size: int | None = None,
 ) -> jnp.ndarray:
     """Compute iPEPS energy with implicit-differentiation backward (GMRES).
 
@@ -516,6 +517,7 @@ def ctm_energy_implicit(
         chi_max,
         recipe,
         device_mesh,
+        ctm_chunk_size,
     )
 
 
@@ -542,6 +544,7 @@ def _sigma_gauged_ctm_converge(
     chi_max: int | None = None,
     recipe: str = "2x2",
     device_mesh=None,
+    ctm_chunk_size: int | None = None,
 ):
     """CTM convergence with sigma gauge fixing for element-wise fixed point.
 
@@ -567,7 +570,13 @@ def _sigma_gauged_ctm_converge(
         bump_step_size=ctmrg_heuristic_increase_chi_step_size,
     )
 
-    jit_step = _make_jit_ctm_step(neighbors, recipe, device_mesh=device_mesh)
+    jit_step_raw = _make_jit_ctm_step(
+        neighbors, recipe, device_mesh=device_mesh, ctm_chunk_size=ctm_chunk_size
+    )
+    # Bind chunk_size so the bump helper and warmup loop pass it transparently.
+    from functools import partial as _partial
+
+    jit_step = _partial(jit_step_raw, chunk_size=ctm_chunk_size)
     envs = (
         env_init
         if env_init is not None
@@ -761,6 +770,7 @@ def _ctm_energy_implicit_dispatch(
     chi_max,
     recipe="2x2",
     device_mesh=None,
+    ctm_chunk_size=None,
 ):
     """Dispatch to custom_vjp-decorated function with caching.
 
@@ -798,6 +808,7 @@ def _ctm_energy_implicit_dispatch(
         chi_max,
         recipe,  # distinct sweep recipe → distinct cached forward+backward
         device_mesh,  # sharded vs single → distinct cached forward+backward
+        ctm_chunk_size,  # distinct chunk size → distinct forward lax.map shape
     )
 
     entry = _VJP_CACHE.get(cache_key)
@@ -843,6 +854,7 @@ def _ctm_energy_implicit_dispatch(
         chi_max=chi_max,
         recipe=recipe,
         device_mesh=device_mesh,
+        ctm_chunk_size=ctm_chunk_size,
     )
     _VJP_CACHE[cache_key] = (f, mutables)
     return f(params_data_tuple)
@@ -874,6 +886,7 @@ def _make_implicit_vjp_fn(
     chi_max: int | None = None,
     recipe: str = "2x2",
     device_mesh=None,
+    ctm_chunk_size: int | None = None,
 ):
     """Build a custom_vjp-decorated function closed over static config.
 
@@ -948,6 +961,7 @@ def _make_implicit_vjp_fn(
                 plateau_patience=plateau_patience,
                 recipe=recipe,
                 device_mesh=device_mesh,
+                ctm_chunk_size=ctm_chunk_size,
             )
             # chi_ramp doesn't trigger in-CTM bump (mutex enforced in dispatch);
             # chi_post is the final ramp stage's chi, which equals ``chi`` for
@@ -975,6 +989,7 @@ def _make_implicit_vjp_fn(
                 chi_max=chi_max,
                 recipe=recipe,
                 device_mesh=device_mesh,
+                ctm_chunk_size=ctm_chunk_size,
             )
         return envs, chi_post
 

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -1017,6 +1017,14 @@ def _make_implicit_vjp_fn(
 
     # Build JIT'd sweep step for backward (same recipe as forward, so the
     # fixed-point adjoint differentiates the sweep the forward converged).
+    # ``ctm_chunk_size`` is deliberately NOT threaded here: the #632 Increment-2
+    # gate measured that chunking the adjoint's J^T matvec (VJP through the
+    # chunked lax.map absorb) *increases* peak memory — it defeats XLA's existing
+    # rematerialization of the chi^2*D^6 intermediate and adds stacked-residual /
+    # VJP-transpose overhead (D=10 chi=16: monolith 28 GB fits, chunked OOMs).
+    # The backward stays monolith (XLA remat handles it better); large-D backward
+    # memory relief comes from GSPMD sharding (rung-2), not chunking. See
+    # docs/superpowers/handoffs/2026-07-01-chunk-ctm-absorb-increment2-backward-gate.md.
     jit_step_bwd = _make_jit_ctm_step(neighbors, recipe)
 
     # --- JIT'd building blocks for the backward ---

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -574,9 +574,7 @@ def _sigma_gauged_ctm_converge(
         neighbors, recipe, device_mesh=device_mesh, ctm_chunk_size=ctm_chunk_size
     )
     # Bind chunk_size so the bump helper and warmup loop pass it transparently.
-    from functools import partial as _partial
-
-    jit_step = _partial(jit_step_raw, chunk_size=ctm_chunk_size)
+    jit_step = partial(jit_step_raw, chunk_size=ctm_chunk_size)
     envs = (
         env_init
         if env_init is not None

--- a/src/tenax/algorithms/_ctm_python_loop.py
+++ b/src/tenax/algorithms/_ctm_python_loop.py
@@ -57,16 +57,18 @@ class CTMConvergeInfo(NamedTuple):
 # cost.  Diagnosed in docs/plans/2026-05-09-ipeps-ad-jit-cost-diagnosis.md.
 # Keyed by id(neighbors) — safe because neighbors dicts are constructed once
 # per optimizer invocation and stay alive throughout.
-# Key is (id(neighbors), recipe, device_mesh): a 3-tuple of an int, a str and a
-# ``jax.sharding.Mesh | None`` (Mesh imported only under TYPE_CHECKING; the
-# annotation is a string here thanks to ``from __future__ import annotations``).
-_JIT_STEP_CACHE: dict[tuple[int, str, Mesh | None], Callable] = {}
+# Key is (id(neighbors), recipe, device_mesh, ctm_chunk_size): a 4-tuple of an
+# int, a str, a ``jax.sharding.Mesh | None`` and an ``int | None`` (Mesh
+# imported only under TYPE_CHECKING; the annotation is a string here thanks to
+# ``from __future__ import annotations``).
+_JIT_STEP_CACHE: dict[tuple[int, str, Mesh | None, int | None], Callable] = {}
 
 
 def _make_jit_ctm_step(
     neighbors: dict[Coord, dict[str, Coord]],
     recipe: str = "2x2",
     device_mesh=None,
+    ctm_chunk_size: int | None = None,
 ):
     """Create a JIT-compiled CTM step function for a given neighbor topology.
 
@@ -80,7 +82,7 @@ def _make_jit_ctm_step(
         A JIT-compiled function with signature::
 
             step(site_tensors, envs, *, chi, projector_method,
-                 renormalize, projector_backward)
+                 renormalize, projector_backward, chunk_size)
                  -> tuple[dict[Coord, CTMTensorEnv], jax.Array]
 
         The returned tuple is ``(new_envs, max_truncation_error)`` where
@@ -93,11 +95,13 @@ def _make_jit_ctm_step(
     # ``device_mesh`` is captured (static, non-traced) in the closure, so it
     # must participate in the cache key: the sharded and single-device steps
     # are different compiled functions.
+    # ``ctm_chunk_size`` is static: different chunk sizes yield differently
+    # shaped lax.map computations that must not share a JIT cache entry.
     # Asymmetric keying: ``neighbors`` is an unhashable dict so we fall back to
     # ``id()``; ``device_mesh`` is a hashable ``jax.sharding.Mesh`` (or None)
     # with a value ``__eq__``, so it is used directly — equal meshes share a
     # cache entry and we avoid id-reuse hazards after GC.
-    cache_key = (id(neighbors), recipe, device_mesh)
+    cache_key = (id(neighbors), recipe, device_mesh, ctm_chunk_size)
     cached = _JIT_STEP_CACHE.get(cache_key)
     if cached is not None:
         return cached
@@ -109,6 +113,7 @@ def _make_jit_ctm_step(
             "projector_method",
             "renormalize",
             "projector_backward",
+            "chunk_size",
         ),
     )
     def _step(
@@ -119,6 +124,7 @@ def _make_jit_ctm_step(
         projector_method: str = "svd",
         renormalize: bool = False,
         projector_backward: str = "auto",
+        chunk_size: int | None = None,
     ) -> tuple[dict[Coord, CTMTensorEnv], jax.Array, jax.Array]:
         double_layers = {
             c: _build_double_layer_tensor(A) for c, A in site_tensors.items()
@@ -133,6 +139,7 @@ def _make_jit_ctm_step(
             projector_backward=projector_backward,
             recipe=recipe,
             device_mesh=device_mesh,
+            chunk_size=chunk_size,
         )
 
     _JIT_STEP_CACHE[cache_key] = _step
@@ -162,6 +169,7 @@ def python_loop_ctm_converge(
     chi_max: int | None = None,
     recipe: str = "2x2",
     device_mesh=None,
+    ctm_chunk_size: int | None = None,
 ) -> tuple[dict[Coord, CTMTensorEnv], CTMConvergeInfo]:
     """Run CTM to convergence using a Python for-loop over JIT'd sweeps.
 
@@ -240,10 +248,16 @@ def python_loop_ctm_converge(
             plateau_patience=plateau_patience,
             recipe=recipe,
             device_mesh=device_mesh,
+            ctm_chunk_size=ctm_chunk_size,
         )
 
     # Build the JIT'd step function (captures neighbors + device_mesh in closure)
-    jit_step = _make_jit_ctm_step(neighbors, recipe, device_mesh=device_mesh)
+    jit_step = _make_jit_ctm_step(
+        neighbors, recipe, device_mesh=device_mesh, ctm_chunk_size=ctm_chunk_size
+    )
+    # Bind chunk_size so callers that don't know about it (e.g.
+    # _run_ctm_loop_with_bump) pass it transparently.
+    jit_step = partial(jit_step, chunk_size=ctm_chunk_size)
 
     # chi may grow during the loop when ``ctmrg_heuristic_increase_chi``
     # is enabled (variPEPS-style in-CTM bump; Issue #492).  ``chi_current``
@@ -355,6 +369,7 @@ def _python_loop_chi_ramp(
     plateau_patience: int | None = None,
     recipe: str = "2x2",
     device_mesh=None,
+    ctm_chunk_size: int | None = None,
 ) -> tuple[dict[Coord, CTMTensorEnv], CTMConvergeInfo]:
     """Run CTM with chi-ramp schedule."""
     envs = env_init
@@ -408,6 +423,7 @@ def _python_loop_chi_ramp(
             plateau_patience=stage_patience,
             recipe=recipe,
             device_mesh=device_mesh,
+            ctm_chunk_size=ctm_chunk_size,
         )
         prev_chi = stage_chi
 

--- a/src/tenax/algorithms/_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_ctm_tensor_convergence.py
@@ -281,6 +281,7 @@ def _ctm_tensor_sweep_multisite(
     projector_backward: str = "auto",
     recipe: str = "2x2",
     device_mesh=None,
+    chunk_size: int | None = None,
 ) -> tuple[dict[Coord, CTMTensorEnv], jax.Array, jax.Array]:
     """One full multisite CTM sweep over all sites and directions.
 
@@ -324,6 +325,26 @@ def _ctm_tensor_sweep_multisite(
     all_coords = list(envs.keys())
     max_eps = jnp.asarray(0.0)
     max_smallest_S = jnp.asarray(0.0)
+
+    # GSPMD: when a device mesh is supplied, re-shard the absorbed double-layer
+    # ``a`` onto its surviving-leg layout for the move's direction so the
+    # dominant χ²·D⁶ absorption intermediate stays at ≈1/N per device.
+    # ``with_sharding_constraint`` is a pure layout hint (never changes
+    # numerics), so the flag-off path below is a literal no-op identical to
+    # the single-device code.  Hoisted here so it is available to both the
+    # 1x1 and 2x2 branches.
+    if device_mesh is not None:
+        from tenax.algorithms.ctm_sharding import (
+            constrain_double_layer_for_move,
+        )
+
+        def _shard_a(a, direction):
+            return constrain_double_layer_for_move(a, direction, device_mesh)
+    else:
+
+        def _shard_a(a, direction):
+            return a
+
     if recipe == "1x1":
         for direction, move_fn in _DIRECTION_MOVES:
             for coord in _sort_coords_for_direction(all_coords, direction):
@@ -331,31 +352,16 @@ def _ctm_tensor_sweep_multisite(
                 envs[coord], eps_t = move_fn(
                     envs[coord],
                     envs[nb],
-                    double_layers[nb],
+                    _shard_a(double_layers[nb], direction),
                     chi,
                     projector_method,
                     base_charges=base_charges,
                     projector_backward=projector_backward,
+                    chunk_size=chunk_size,
                 )
                 max_eps = jnp.maximum(max_eps, jnp.asarray(eps_t))
     elif recipe == "2x2":
-        # GSPMD: when a device mesh is supplied, re-shard the absorbed
-        # double-layer ``a`` onto its surviving-leg layout for the move's
-        # direction so the dominant χ²·D⁶ absorption intermediate stays at
-        # ≈1/N per device.  ``with_sharding_constraint`` is a pure layout hint
-        # (never changes numerics), so the flag-off path below is a literal
-        # no-op identical to the single-device code.
-        if device_mesh is not None:
-            from tenax.algorithms.ctm_sharding import (
-                constrain_double_layer_for_move,
-            )
-
-            def _shard_a(a, direction):
-                return constrain_double_layer_for_move(a, direction, device_mesh)
-        else:
-
-            def _shard_a(a, direction):
-                return a
+        # (The _shard_a closure is now defined above, shared with 1x1.)
 
         # variPEPS-style 2-plaquette absorption: for each direction, two
         # phases.

--- a/src/tenax/algorithms/_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_ctm_tensor_moves.py
@@ -1131,6 +1131,7 @@ def _ctm_tensor_move_right(
     projector_method: str = "svd",
     base_charges: np.ndarray | None = None,
     projector_backward: str = "auto",
+    chunk_size: int | None = None,
 ) -> tuple[CTMTensorEnv, jax.Array]:
     """Right move: updates C2, T2, C3.
 
@@ -1141,6 +1142,12 @@ def _ctm_tensor_move_right(
     Dense reference: C2g = einsum('ce,buc->eub', C2, T1)
                      C3g = einsum('im,hdi->mdh', C3, T3)
                      T2g = einsum('erm,udlr->eumdl', T2, a)
+
+    Args:
+        chunk_size: When not None and env_self.T2 is a DenseTensor, use the
+            chunked raw core (_chunked_T_new_right) to compute T2_new without
+            materializing the full chi^2*D^6 intermediate.  Default (None)
+            uses the standard fused-index path unchanged.
     """
     # C2(self) · T1(neighbor)
     C2_l = env_self.C2.relabel("c2_l", "t1_r")
@@ -1152,18 +1159,33 @@ def _ctm_tensor_move_right(
     C3g = contract(C3_u, env_neighbor.T3)  # (c3_l, t3_r, d2)
     C3g = _fuse_pair_by_label(C3g, "c3_l", "d2", "fused", IN)  # (fused, t3_r)
 
-    # T2(self) · a(neighbor)
-    T2_with_a = contract(env_self.T2, a)
-    T2g = _fuse_pair_by_label(T2_with_a, "t2_u", "u2", "fl", IN)
-    T2g = _fuse_pair_by_label(T2g, "t2_d", "d2", "fr", OUT)
-
-    # Native projector
+    # Native projector (needs only the grown corners, not the grown edge)
     P_1, P_2, _eps_t = _compute_projector_tensor(
         C2g, C3g, chi, projector_method, base_charges, projector_backward
     )
-    C2_new, C3_new, T2_new = _apply_projector_with_reembed(
-        P_1, P_2, C2g, C3g, T2g, "fl", "fr"
-    )
+
+    if chunk_size is not None and isinstance(env_self.T2, DenseTensor):
+        C2_new, C3_new, T2_new = _chunked_T_new_apply(
+            env_self.T2, a, P_1, P_2, C2g, C3g,
+            ["t2_u", "r2", "t2_d"], "t2_u", "l2",
+            _chunked_T_new_right, chunk_size,
+        )
+    else:
+        if chunk_size is not None:
+            import warnings
+            warnings.warn(
+                "chunk_size is set but env is not dense (SymmetricTensor); "
+                "falling back to the standard fused-index CTM path.",
+                stacklevel=2,
+            )
+        # T2(self) · a(neighbor)
+        T2_with_a = contract(env_self.T2, a)
+        T2g = _fuse_pair_by_label(T2_with_a, "t2_u", "u2", "fl", IN)
+        T2g = _fuse_pair_by_label(T2g, "t2_d", "d2", "fr", OUT)
+
+        C2_new, C3_new, T2_new = _apply_projector_with_reembed(
+            P_1, P_2, C2g, C3g, T2g, "fl", "fr"
+        )
 
     # Relabel to expected output labels
     C2_new = C2_new.relabels({"chi_new": "c2_l", "t1_l": "c2_d"})
@@ -1185,6 +1207,7 @@ def _ctm_tensor_move_top(
     projector_method: str = "svd",
     base_charges: np.ndarray | None = None,
     projector_backward: str = "auto",
+    chunk_size: int | None = None,
 ) -> tuple[CTMTensorEnv, jax.Array]:
     """Top move: updates C1, T1, C2.
 
@@ -1195,6 +1218,12 @@ def _ctm_tensor_move_top(
     Dense reference: C1g = einsum('ab,alg->blg', C1, T4)
                      C2g = einsum('ce,erm->crm', C2, T2)
                      T1g = einsum('buc,udlr->bcdlr', T1, a)
+
+    Args:
+        chunk_size: When not None and env_self.T1 is a DenseTensor, use the
+            chunked raw core (_chunked_T_new_top) to compute T1_new without
+            materializing the full chi^2*D^6 intermediate.  Default (None)
+            uses the standard fused-index path unchanged.
     """
     # C1(self) · T4(neighbor)
     C1_d = env_self.C1.relabel("c1_d", "t4_d")
@@ -1206,18 +1235,33 @@ def _ctm_tensor_move_top(
     C2g = contract(C2_d, env_neighbor.T2)  # (c2_l, r2, t2_d)
     C2g = _fuse_pair_by_label(C2g, "c2_l", "r2", "fused", IN)  # (fused, t2_d)
 
-    # T1(self) · a(neighbor)
-    T1_with_a = contract(env_self.T1, a)
-    T1g = _fuse_pair_by_label(T1_with_a, "t1_l", "l2", "fl", IN)
-    T1g = _fuse_pair_by_label(T1g, "t1_r", "r2", "fr", OUT)
-
-    # Native projector
+    # Native projector (needs only the grown corners, not the grown edge)
     P_1, P_2, _eps_t = _compute_projector_tensor(
         C1g, C2g, chi, projector_method, base_charges, projector_backward
     )
-    C1_new, C2_new, T1_new = _apply_projector_with_reembed(
-        P_1, P_2, C1g, C2g, T1g, "fl", "fr"
-    )
+
+    if chunk_size is not None and isinstance(env_self.T1, DenseTensor):
+        C1_new, C2_new, T1_new = _chunked_T_new_apply(
+            env_self.T1, a, P_1, P_2, C1g, C2g,
+            ["t1_l", "u2", "t1_r"], "t1_l", "d2",
+            _chunked_T_new_top, chunk_size,
+        )
+    else:
+        if chunk_size is not None:
+            import warnings
+            warnings.warn(
+                "chunk_size is set but env is not dense (SymmetricTensor); "
+                "falling back to the standard fused-index CTM path.",
+                stacklevel=2,
+            )
+        # T1(self) · a(neighbor)
+        T1_with_a = contract(env_self.T1, a)
+        T1g = _fuse_pair_by_label(T1_with_a, "t1_l", "l2", "fl", IN)
+        T1g = _fuse_pair_by_label(T1g, "t1_r", "r2", "fr", OUT)
+
+        C1_new, C2_new, T1_new = _apply_projector_with_reembed(
+            P_1, P_2, C1g, C2g, T1g, "fl", "fr"
+        )
 
     # Relabel to expected output labels
     C1_new = C1_new.relabels({"chi_new": "c1_d", "t4_u": "c1_r"})
@@ -1239,6 +1283,7 @@ def _ctm_tensor_move_bottom(
     projector_method: str = "svd",
     base_charges: np.ndarray | None = None,
     projector_backward: str = "auto",
+    chunk_size: int | None = None,
 ) -> tuple[CTMTensorEnv, jax.Array]:
     """Bottom move: updates C4, T3, C3.
 
@@ -1249,6 +1294,12 @@ def _ctm_tensor_move_bottom(
     Dense reference: C4g = einsum('gh,alg->hal', C4, T4).transpose(0,2,1)
                      C3g = einsum('im,erm->ire', C3, T2)
                      T3g = einsum('hdi,udlr->hiulr', T3, a)
+
+    Args:
+        chunk_size: When not None and env_self.T3 is a DenseTensor, use the
+            chunked raw core (_chunked_T_new_bottom) to compute T3_new without
+            materializing the full chi^2*D^6 intermediate.  Default (None)
+            uses the standard fused-index path unchanged.
     """
     # C4(self) · T4(neighbor)
     C4_r = env_self.C4.relabel("c4_r", "t4_u")
@@ -1260,18 +1311,33 @@ def _ctm_tensor_move_bottom(
     C3g = contract(C3_l, env_neighbor.T2)  # (c3_u, t2_u, r2)
     C3g = _fuse_pair_by_label(C3g, "c3_u", "r2", "fused", IN)  # (fused, t2_u)
 
-    # T3(self) · a(neighbor)
-    T3_with_a = contract(env_self.T3, a)
-    T3g = _fuse_pair_by_label(T3_with_a, "t3_r", "l2", "fl", IN)
-    T3g = _fuse_pair_by_label(T3g, "t3_l", "r2", "fr", OUT)
-
-    # Native projector
+    # Native projector (needs only the grown corners, not the grown edge)
     P_1, P_2, _eps_t = _compute_projector_tensor(
         C4g, C3g, chi, projector_method, base_charges, projector_backward
     )
-    C4_new, C3_new, T3_new = _apply_projector_with_reembed(
-        P_1, P_2, C4g, C3g, T3g, "fl", "fr"
-    )
+
+    if chunk_size is not None and isinstance(env_self.T3, DenseTensor):
+        C4_new, C3_new, T3_new = _chunked_T_new_apply(
+            env_self.T3, a, P_1, P_2, C4g, C3g,
+            ["t3_r", "d2", "t3_l"], "t3_r", "u2",
+            _chunked_T_new_bottom, chunk_size,
+        )
+    else:
+        if chunk_size is not None:
+            import warnings
+            warnings.warn(
+                "chunk_size is set but env is not dense (SymmetricTensor); "
+                "falling back to the standard fused-index CTM path.",
+                stacklevel=2,
+            )
+        # T3(self) · a(neighbor)
+        T3_with_a = contract(env_self.T3, a)
+        T3g = _fuse_pair_by_label(T3_with_a, "t3_r", "l2", "fl", IN)
+        T3g = _fuse_pair_by_label(T3g, "t3_l", "r2", "fr", OUT)
+
+        C4_new, C3_new, T3_new = _apply_projector_with_reembed(
+            P_1, P_2, C4g, C3g, T3g, "fl", "fr"
+        )
 
     # Relabel to expected output labels
     C4_new = C4_new.relabels({"chi_new": "c4_r", "t4_d": "c4_u"})

--- a/src/tenax/algorithms/_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_ctm_tensor_moves.py
@@ -22,6 +22,13 @@ __all__ = [
 import jax
 import numpy as np
 
+from tenax.algorithms._ctm_chunked_absorb import (
+    _chunked_T_new_bottom,
+    _chunked_T_new_left,
+    _chunked_T_new_right,
+    _chunked_T_new_top,
+    _raw_in_label_order,
+)
 from tenax.algorithms._ctm_projector import (
     _compute_projector_tensor,
     _reembed_fused,
@@ -994,6 +1001,51 @@ def _ctm_tensor_absorb_bottom_2plaq_fused(
     return C4_new, T3_new, C3_new
 
 
+def _chunked_T_new_apply(
+    edge, a, P_1, P_2, C1g, C4g,
+    edge_label_order, chi_leg, surv_leg, chunked_fn, chunk_size,
+):
+    """Chunked edge absorption for a 1x1 dense move.
+
+    Computes (C1_new, C4_new, T_new) with the expensive chi^2 * D^6 edge
+    contraction chunked over the boundary-chi axis via ``chunked_fn`` (from
+    _ctm_chunked_absorb), avoiding materializing the full intermediate.
+    Bit-identical to the fused-index path (_apply_projector_tensor). Dense only.
+
+    Args:
+        edge:  the parallel edge DenseTensor being grown (T4/T2/T1/T3).
+        a:     double-layer DenseTensor (labels u2,d2,l2,r2).
+        P_1, P_2: projector pair (labels fused, chi_new).
+        C1g, C4g: grown corners (P_1 side, P_2 side).
+        edge_label_order: canonical edge leg order, e.g. ["t4_d","l2","t4_u"].
+        chi_leg: edge's boundary-chi (chunk) leg label, e.g. "t4_d".
+        surv_leg: surviving a-leg label (the new edge's D2 leg), e.g. "r2".
+        chunked_fn: the matching _chunked_T_new_* raw function.
+        chunk_size: lax.map batch size over the boundary-chi axis.
+
+    Returns:
+        (C1_new, C4_new, T_new) Tensors. T_new labels (chi_new, <surv_leg>, chi_new_r).
+    """
+    chi_dim = edge.indices[list(edge.labels()).index(chi_leg)].dim
+    D2 = a.indices[list(a.labels()).index(surv_leg)].dim
+    edge_raw = _raw_in_label_order(edge, edge_label_order)
+    a_raw = _raw_in_label_order(a, ["u2", "d2", "l2", "r2"])
+    # The raw core conjugates P1 internally (matches P_1.bar()); pass P_1 as-is.
+    P1_raw = _raw_in_label_order(P_1, ["fused", "chi_new"])
+    P2_raw = _raw_in_label_order(P_2, ["fused", "chi_new"])
+    T_arr = chunked_fn(edge_raw, a_raw, P1_raw, P2_raw, chi_dim, D2, chunk_size)
+
+    # Cheap corners (identical to _apply_projector_tensor)
+    P1_bar = P_1.bar()
+    C1_new = contract(P1_bar, C1g)
+    C4_new = contract(P_2.bar(), C4g)
+    chi_new_idx = P1_bar.indices[list(P1_bar.labels()).index("chi_new")]
+    surv_idx = a.indices[list(a.labels()).index(surv_leg)]
+    chi_new_r_idx = P_2.indices[list(P_2.labels()).index("chi_new")].relabel("chi_new_r")
+    T_new = DenseTensor(T_arr, (chi_new_idx, surv_idx, chi_new_r_idx))
+    return C1_new, C4_new, T_new
+
+
 def _ctm_tensor_move_left(
     env_self: CTMTensorEnv,
     env_neighbor: CTMTensorEnv,
@@ -1036,32 +1088,19 @@ def _ctm_tensor_move_left(
     )
 
     if chunk_size is not None and isinstance(env_self.T4, DenseTensor):
-        from tenax.algorithms._ctm_chunked_absorb import (
-            _chunked_T_new_left,
-            _raw_in_label_order,
+        C1_new, C4_new, T4_new = _chunked_T_new_apply(
+            env_self.T4, a, P_1, P_2, C1g, C4g,
+            ["t4_d", "l2", "t4_u"], "t4_d", "r2",
+            _chunked_T_new_left, chunk_size,
         )
-
-        chi_dim = env_self.T4.indices[list(env_self.T4.labels()).index("t4_d")].dim
-        D2 = a.indices[list(a.labels()).index("r2")].dim
-        T4_raw = _raw_in_label_order(env_self.T4, ["t4_d", "l2", "t4_u"])
-        a_raw = _raw_in_label_order(a, ["u2", "d2", "l2", "r2"])
-        P1_bar = P_1.bar()
-        # Pass un-conjugated P1 data; the core conjugates P1 internally.
-        P1_raw = _raw_in_label_order(P1_bar, ["fused", "chi_new"]).conj()
-        P2_raw = _raw_in_label_order(P_2, ["fused", "chi_new"])
-        T4_arr = _chunked_T_new_left(T4_raw, a_raw, P1_raw, P2_raw, chi_dim, D2, chunk_size)
-
-        # Corners: identical to _apply_projector_tensor
-        C1_new = contract(P1_bar, C1g)   # (chi_new, t1_r)
-        C4_new = contract(P_2.bar(), C4g)  # (chi_new, t3_l)
-
-        # Rewrap T4_new with production TensorIndex objects.
-        # Shape (chi_new, r2, chi_new_r) matching default _apply_projector_tensor output.
-        chi_new_idx = P1_bar.indices[list(P1_bar.labels()).index("chi_new")]
-        surv_idx = a.indices[list(a.labels()).index("r2")]
-        chi_new_r_idx = P_2.indices[list(P_2.labels()).index("chi_new")].relabel("chi_new_r")
-        T4_new = DenseTensor(T4_arr, (chi_new_idx, surv_idx, chi_new_r_idx))
     else:
+        if chunk_size is not None:
+            import warnings
+            warnings.warn(
+                "chunk_size is set but env is not dense (SymmetricTensor); "
+                "falling back to the standard fused-index CTM path.",
+                stacklevel=2,
+            )
         # T4(self) · a(neighbor)
         T4_with_a = contract(env_self.T4, a)
         T4g = _fuse_pair_by_label(T4_with_a, "t4_d", "u2", "fl", IN)

--- a/src/tenax/algorithms/_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_ctm_tensor_moves.py
@@ -1002,6 +1002,7 @@ def _ctm_tensor_move_left(
     projector_method: str = "svd",
     base_charges: np.ndarray | None = None,
     projector_backward: str = "auto",
+    chunk_size: int | None = None,
 ) -> tuple[CTMTensorEnv, jax.Array]:
     """Left move: updates C1, T4, C4.
 
@@ -1012,6 +1013,12 @@ def _ctm_tensor_move_left(
     Dense reference: C1g = einsum('ab,buc->auc', C1, T1)
                      C4g = einsum('gh,hdi->gdi', C4, T3)
                      T4g = einsum('alg,udlr->augdr', T4, a)
+
+    Args:
+        chunk_size: When not None and env_self.T4 is a DenseTensor, use the
+            chunked raw core (_chunked_T_new_left) to compute T4_new without
+            materializing the full chi^2*D^6 intermediate.  Default (None)
+            uses the standard fused-index path unchanged.
     """
     # C1(self) · T1(neighbor)
     C1_r = env_self.C1.relabel("c1_r", "t1_l")
@@ -1023,18 +1030,46 @@ def _ctm_tensor_move_left(
     C4g = contract(C4_u, env_neighbor.T3)  # (c4_r, d2, t3_l)
     C4g = _fuse_pair_by_label(C4g, "c4_r", "d2", "fused", IN)  # (fused, t3_l)
 
-    # T4(self) · a(neighbor)
-    T4_with_a = contract(env_self.T4, a)
-    T4g = _fuse_pair_by_label(T4_with_a, "t4_d", "u2", "fl", IN)
-    T4g = _fuse_pair_by_label(T4g, "t4_u", "d2", "fr", OUT)
-
-    # Native projector
+    # Native projector (needs only the grown corners, not the grown edge)
     P_1, P_2, _eps_t = _compute_projector_tensor(
         C1g, C4g, chi, projector_method, base_charges, projector_backward
     )
-    C1_new, C4_new, T4_new = _apply_projector_with_reembed(
-        P_1, P_2, C1g, C4g, T4g, "fl", "fr"
-    )
+
+    if chunk_size is not None and isinstance(env_self.T4, DenseTensor):
+        from tenax.algorithms._ctm_chunked_absorb import (
+            _chunked_T_new_left,
+            _raw_in_label_order,
+        )
+
+        chi_dim = env_self.T4.indices[list(env_self.T4.labels()).index("t4_d")].dim
+        D2 = a.indices[list(a.labels()).index("r2")].dim
+        T4_raw = _raw_in_label_order(env_self.T4, ["t4_d", "l2", "t4_u"])
+        a_raw = _raw_in_label_order(a, ["u2", "d2", "l2", "r2"])
+        P1_bar = P_1.bar()
+        # Pass un-conjugated P1 data; the core conjugates P1 internally.
+        P1_raw = _raw_in_label_order(P1_bar, ["fused", "chi_new"]).conj()
+        P2_raw = _raw_in_label_order(P_2, ["fused", "chi_new"])
+        T4_arr = _chunked_T_new_left(T4_raw, a_raw, P1_raw, P2_raw, chi_dim, D2, chunk_size)
+
+        # Corners: identical to _apply_projector_tensor
+        C1_new = contract(P1_bar, C1g)   # (chi_new, t1_r)
+        C4_new = contract(P_2.bar(), C4g)  # (chi_new, t3_l)
+
+        # Rewrap T4_new with production TensorIndex objects.
+        # Shape (chi_new, r2, chi_new_r) matching default _apply_projector_tensor output.
+        chi_new_idx = P1_bar.indices[list(P1_bar.labels()).index("chi_new")]
+        surv_idx = a.indices[list(a.labels()).index("r2")]
+        chi_new_r_idx = P_2.indices[list(P_2.labels()).index("chi_new")].relabel("chi_new_r")
+        T4_new = DenseTensor(T4_arr, (chi_new_idx, surv_idx, chi_new_r_idx))
+    else:
+        # T4(self) · a(neighbor)
+        T4_with_a = contract(env_self.T4, a)
+        T4g = _fuse_pair_by_label(T4_with_a, "t4_d", "u2", "fl", IN)
+        T4g = _fuse_pair_by_label(T4g, "t4_u", "d2", "fr", OUT)
+
+        C1_new, C4_new, T4_new = _apply_projector_with_reembed(
+            P_1, P_2, C1g, C4g, T4g, "fl", "fr"
+        )
 
     # Relabel to expected output labels
     C1_new = C1_new.relabels({"chi_new": "c1_d", "t1_r": "c1_r"})

--- a/src/tenax/algorithms/ipeps_ad_policy.py
+++ b/src/tenax/algorithms/ipeps_ad_policy.py
@@ -187,6 +187,10 @@ def ctm_converge_kwargs(
         # final-env forward CTM evals too, so the whole optimize loop runs
         # sharded (not just the value_and_grad). None (default) → single-device.
         "device_mesh": ctm_cfg.device_mesh,
+        # Chunked edge absorption (#632 chunk×shard): lowers peak memory ÷K
+        # (1×1 recipe, dense envs). Composes with device_mesh (÷N·K total).
+        # None (default) → single monolithic contraction, unchanged.
+        "ctm_chunk_size": ctm_cfg.ctm_chunk_size,
     }
 
 
@@ -371,6 +375,9 @@ def make_ctm_energy_fn(
             # GSPMD device mesh (#632): when set, shards the implicit-AD forward
             # CTM + backward across the mesh. None (default) → single-device.
             device_mesh=ctm_cfg.device_mesh,
+            # Chunked edge absorption (#632 chunk×shard): lowers peak memory ÷K
+            # (1×1 recipe, dense envs). None (default) → monolithic, unchanged.
+            ctm_chunk_size=ctm_cfg.ctm_chunk_size,
         )
 
     return _ctm_energy_fn

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -248,6 +248,13 @@ class CTMConfig:
     # unchanged. Build a mesh via ``tenax.algorithms.ctm_sharding.build_ctm_mesh``.
     # Appended at the end of the dataclass to preserve positional CTMConfig ABI.
     device_mesh: jax.sharding.Mesh | None = None
+    # Chunk the χ²·D⁶ edge absorption over the boundary-χ axis via
+    # ``lax.map(batch_size=ctm_chunk_size)`` (1×1 recipe, dense envs only).
+    # Lowers per-device peak memory ≈÷K at large D and composes with
+    # ``device_mesh`` (≈÷(N·K)). ``None`` (default) → single monolithic
+    # contraction (byte-for-byte unchanged). See the #632 chunk×shard gate.
+    # Appended at the end of the dataclass to preserve positional CTMConfig ABI.
+    ctm_chunk_size: int | None = None
 
     def __post_init__(self):
         valid_modes = {None, "c4v_reference"}

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -253,6 +253,10 @@ class CTMConfig:
     # Lowers per-device peak memory ≈÷K at large D and composes with
     # ``device_mesh`` (≈÷(N·K)). ``None`` (default) → single monolithic
     # contraction (byte-for-byte unchanged). See the #632 chunk×shard gate.
+    # Applies to the **forward** CTM sweep only; the implicit-AD backward is
+    # not yet chunked, so this alone does not lower peak memory of
+    # ``optimize_gs_ad`` gradients (that is a follow-up). Use it for
+    # large-D forward energy/observables.
     # Appended at the end of the dataclass to preserve positional CTMConfig ABI.
     ctm_chunk_size: int | None = None
 

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -253,10 +253,10 @@ class CTMConfig:
     # Lowers per-device peak memory ≈÷K at large D and composes with
     # ``device_mesh`` (≈÷(N·K)). ``None`` (default) → single monolithic
     # contraction (byte-for-byte unchanged). See the #632 chunk×shard gate.
-    # Applies to the **forward** CTM sweep only; the implicit-AD backward is
-    # not yet chunked, so this alone does not lower peak memory of
-    # ``optimize_gs_ad`` gradients (that is a follow-up). Use it for
-    # large-D forward energy/observables.
+    # Applies to the implicit-AD **forward** CTM sweep (recipe="1x1", dense)
+    # only. The explicit-AD path (``ctm_energy_explicit``) and the split-CTM
+    # path (``fuse_virtual_legs=False``) do not consult this knob yet
+    # (Increment 2). Use it for large-D forward energy/observables.
     # Appended at the end of the dataclass to preserve positional CTMConfig ABI.
     ctm_chunk_size: int | None = None
 
@@ -377,6 +377,10 @@ class CTMConfig:
                 "without an explicit ceiling the in-CTM bump would silently "
                 "no-op (chi can never grow above its initial value). "
                 "Set chi_max to the largest chi you want CTM to grow into."
+            )
+        if self.ctm_chunk_size is not None and self.ctm_chunk_size < 1:
+            raise ValueError(
+                f"ctm_chunk_size must be None or a positive int, got {self.ctm_chunk_size}"
             )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,9 @@ _FILE_MARKERS = {
     "test_heisenberg_d4_chi_scaling.py": "core",
     "test_heisenberg_d8_chi_scaling.py": "core",
     "test_ctm_sharding_parity.py": "slow",
+    # Chunked dense-CTM edge absorption (chunk x shard #632 Increment 1): fast
+    # mechanism unit tests; collected as core so CI required checks run them.
+    "test_ctm_chunked_absorb.py": "core",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,9 @@ _FILE_MARKERS = {
     # Chunked dense-CTM edge absorption (chunk x shard #632 Increment 1): fast
     # mechanism unit tests; collected as core so CI required checks run them.
     "test_ctm_chunked_absorb.py": "core",
+    # #632 Increment 2 gate byproduct: forward-chunk grads through the (monolith)
+    # implicit-AD backward stay exact. Tiny D=2 CPU value_and_grad parity.
+    "test_ctm_chunk_backward_grad.py": "core",
 }
 
 

--- a/tests/test_ctm_chunk_backward_grad.py
+++ b/tests/test_ctm_chunk_backward_grad.py
@@ -1,0 +1,80 @@
+"""#632 Increment 2 gate byproduct — forward-chunk grads are exact through the
+(monolith) implicit-AD backward.
+
+Increment 1 (#668) threads ``ctm_chunk_size`` through the *forward* 1x1 CTM absorb
+(chunked ``lax.map``). The Increment-2 gate established that chunking the *backward*
+is a NO-GO (it defeats XLA rematerialization and increases peak memory —
+``docs/superpowers/handoffs/2026-07-01-chunk-ctm-absorb-increment2-backward-gate.md``),
+so the backward stays monolith. This guards the correctness half that IS shipped:
+``value_and_grad`` with a chunked forward reaches a bit-identical fixed point, so
+its gradient (via the monolith adjoint) matches the non-chunked gradient exactly.
+
+Increment 1's tests were forward-only (converge parity); this closes the
+``value_and_grad``-through-the-chunked-forward coverage gap. Tiny D=2 on CPU.
+"""
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+
+from tenax.algorithms._ctm_energy_ad import ctm_energy_implicit  # noqa: E402
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS  # noqa: E402
+from tenax.core.index import FlowDirection, TensorIndex  # noqa: E402
+from tenax.core.symmetry import U1Symmetry  # noqa: E402
+from tenax.core.tensor import DenseTensor  # noqa: E402
+
+
+def _indices(D: int):
+    sym = U1Symmetry()
+    bc = np.zeros(D, dtype=np.int32)
+    pc = np.zeros(2, dtype=np.int32)
+    return (
+        TensorIndex.from_charges(sym, bc.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, bc.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, bc.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, bc.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(sym, pc.copy(), FlowDirection.IN, label="phys"),
+    )
+
+
+def _energy_and_grad(D: int, chi: int, chunk):
+    idx = _indices(D)
+    gate = jnp.diag(jnp.array([0.25, -0.25, -0.25, 0.25])).reshape(2, 2, 2, 2)
+    key = jax.random.PRNGKey(0)
+    data0 = jax.random.normal(key, (D, D, D, D, 2))
+    # near-product init -> well-separated leading CTM eigenvalue (clean adjoint)
+    data0 = 0.02 * data0
+    data0 = data0.at[0, 0, 0, 0, :].add(1.0)
+    data0 = data0 / (jnp.linalg.norm(data0) + 1e-10)
+
+    def loss(data):
+        A = DenseTensor(data, idx)
+        return ctm_energy_implicit(
+            {(0, 0): A},
+            SINGLE_SITE_NEIGHBORS,
+            gate,
+            chi=chi,
+            max_iter=50,
+            conv_tol=1e-10,
+            forward_gauge="phase",
+            adjoint_method="fixed_point",
+            recipe="1x1",
+            ctm_chunk_size=chunk,
+        )
+
+    e, g = jax.value_and_grad(loss)(data0)
+    return float(e), np.asarray(g)
+
+
+def test_forward_chunk_grad_matches_monolith():
+    """value_and_grad with ctm_chunk_size (chunked forward, monolith backward)
+    matches the non-chunked gradient to machine precision (bit-identical fixed
+    point => same adjoint operator)."""
+    e_off, g_off = _energy_and_grad(D=2, chi=6, chunk=None)
+    e_on, g_on = _energy_and_grad(D=2, chi=6, chunk=2)
+    assert abs(e_off - e_on) < 1e-12, abs(e_off - e_on)
+    dg = float(np.max(np.abs(g_off - g_on)))
+    assert dg < 1e-10, dg

--- a/tests/test_ctm_chunked_absorb.py
+++ b/tests/test_ctm_chunked_absorb.py
@@ -1,0 +1,129 @@
+"""Parity tests for chunked dense-CTM edge-absorption core.
+
+Each test verifies that _chunked_T_new_{left,right,top,bottom} matches the
+monolithic einsum reference at rel-error <= 1e-12 (x64), across three batch
+sizes including a ragged one.
+"""
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+import pytest
+
+from tenax.algorithms._ctm_chunked_absorb import (
+    _chunked_T_new_left,
+    _chunked_T_new_right,
+    _chunked_T_new_top,
+    _chunked_T_new_bottom,
+)
+
+
+# ---------------------------------------------------------------------------
+# Monolith references (ground truth)
+# ---------------------------------------------------------------------------
+
+def _monolith_left(T4, a, P1, P2, chi, D2):
+    # Faithful reference: contract(T4, a) then conj(P1)^T . Tg . P2 (matches
+    # _apply_projector_tensor for the LEFT move).
+    T4a = jnp.einsum("ijk,lmjn->iklmn", T4, a)          # (t4_d, t4_u, u2, d2, r2)
+    Tg = T4a.transpose(0, 2, 1, 3, 4).reshape(chi * D2, chi * D2, D2)  # (fl, fr, r2)
+    step = jnp.tensordot(P1.conj(), Tg, axes=([0], [0]))  # (chi_new, fr, r2)
+    return jnp.tensordot(step, P2, axes=([1], [0]))       # (chi_new, r2, chi_new_r)
+
+
+def _monolith_right(T2, a, P1, P2, chi, D2):
+    T2a = jnp.einsum("ijk,lmnj->iklmn", T2, a)          # (t2_u, t2_d, u2, d2, l2)
+    Tg = T2a.transpose(0, 2, 1, 3, 4).reshape(chi * D2, chi * D2, D2)  # (fl=(t2_u,u2), fr=(t2_d,d2), l2)
+    step = jnp.tensordot(P1.conj(), Tg, axes=([0], [0]))
+    return jnp.tensordot(step, P2, axes=([1], [0]))     # (chi_new, l2, chi_new_r)
+
+
+def _monolith_top(T1, a, P1, P2, chi, D2):
+    T1a = jnp.einsum("ijk,jlmn->iklmn", T1, a)          # (t1_l, t1_r, d2, l2, r2)
+    # fl=(t1_l,l2), fr=(t1_r,r2), surv=d2 -> order (t1_l, l2, t1_r, r2, d2)
+    Tg = T1a.transpose(0, 3, 1, 4, 2).reshape(chi * D2, chi * D2, D2)
+    step = jnp.tensordot(P1.conj(), Tg, axes=([0], [0]))
+    return jnp.tensordot(step, P2, axes=([1], [0]))     # (chi_new, d2, chi_new_r)
+
+
+def _monolith_bottom(T3, a, P1, P2, chi, D2):
+    T3a = jnp.einsum("ijk,ljmn->iklmn", T3, a)          # (t3_r, t3_l, u2, l2, r2)
+    # fl=(t3_r,l2), fr=(t3_l,r2), surv=u2 -> order (t3_r, l2, t3_l, r2, u2)
+    Tg = T3a.transpose(0, 3, 1, 4, 2).reshape(chi * D2, chi * D2, D2)
+    step = jnp.tensordot(P1.conj(), Tg, axes=([0], [0]))
+    return jnp.tensordot(step, P2, axes=([1], [0]))     # (chi_new, u2, chi_new_r)
+
+
+# ---------------------------------------------------------------------------
+# LEFT
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("batch", [16, 8, 5])  # K=1, K=2, ragged
+def test_chunked_left_matches_monolith(batch):
+    D, chi = 3, 16
+    D2 = D * D
+    k = jax.random.split(jax.random.PRNGKey(0), 4)
+    T4 = jax.random.normal(k[0], (chi, D2, chi))
+    a = jax.random.normal(k[1], (D2, D2, D2, D2))
+    P1 = jax.random.normal(k[2], (chi * D2, chi))
+    P2 = jax.random.normal(k[3], (chi * D2, chi))
+    ref = _monolith_left(T4, a, P1, P2, chi, D2)
+    got = _chunked_T_new_left(T4, a, P1, P2, chi, D2, batch)
+    rel = float(jnp.max(jnp.abs(got - ref)) / (jnp.max(jnp.abs(ref)) + 1e-30))
+    assert rel <= 1e-12, rel
+
+
+# ---------------------------------------------------------------------------
+# RIGHT
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("batch", [16, 8, 5])
+def test_chunked_right_matches_monolith(batch):
+    D, chi = 3, 16
+    D2 = D * D
+    k = jax.random.split(jax.random.PRNGKey(1), 4)
+    T2 = jax.random.normal(k[0], (chi, D2, chi))
+    a = jax.random.normal(k[1], (D2, D2, D2, D2))
+    P1 = jax.random.normal(k[2], (chi * D2, chi))
+    P2 = jax.random.normal(k[3], (chi * D2, chi))
+    ref = _monolith_right(T2, a, P1, P2, chi, D2)
+    got = _chunked_T_new_right(T2, a, P1, P2, chi, D2, batch)
+    rel = float(jnp.max(jnp.abs(got - ref)) / (jnp.max(jnp.abs(ref)) + 1e-30))
+    assert rel <= 1e-12, rel
+
+
+# ---------------------------------------------------------------------------
+# TOP
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("batch", [16, 8, 5])
+def test_chunked_top_matches_monolith(batch):
+    D, chi = 3, 16
+    D2 = D * D
+    k = jax.random.split(jax.random.PRNGKey(2), 4)
+    T1 = jax.random.normal(k[0], (chi, D2, chi))
+    a = jax.random.normal(k[1], (D2, D2, D2, D2))
+    P1 = jax.random.normal(k[2], (chi * D2, chi))
+    P2 = jax.random.normal(k[3], (chi * D2, chi))
+    ref = _monolith_top(T1, a, P1, P2, chi, D2)
+    got = _chunked_T_new_top(T1, a, P1, P2, chi, D2, batch)
+    rel = float(jnp.max(jnp.abs(got - ref)) / (jnp.max(jnp.abs(ref)) + 1e-30))
+    assert rel <= 1e-12, rel
+
+
+# ---------------------------------------------------------------------------
+# BOTTOM
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("batch", [16, 8, 5])
+def test_chunked_bottom_matches_monolith(batch):
+    D, chi = 3, 16
+    D2 = D * D
+    k = jax.random.split(jax.random.PRNGKey(3), 4)
+    T3 = jax.random.normal(k[0], (chi, D2, chi))
+    a = jax.random.normal(k[1], (D2, D2, D2, D2))
+    P1 = jax.random.normal(k[2], (chi * D2, chi))
+    P2 = jax.random.normal(k[3], (chi * D2, chi))
+    ref = _monolith_bottom(T3, a, P1, P2, chi, D2)
+    got = _chunked_T_new_bottom(T3, a, P1, P2, chi, D2, batch)
+    rel = float(jnp.max(jnp.abs(got - ref)) / (jnp.max(jnp.abs(ref)) + 1e-30))
+    assert rel <= 1e-12, rel

--- a/tests/test_ctm_chunked_absorb.py
+++ b/tests/test_ctm_chunked_absorb.py
@@ -269,3 +269,33 @@ def test_full_left_move_chunked_ragged_matches_default():
             / (jnp.max(jnp.abs(b_arr)) + 1e-30)
         )
         assert rel <= 1e-12, f"ragged chunk: field={field!r} rel={rel}"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end parity: python_loop_ctm_converge with ctm_chunk_size (Task 4)
+# ---------------------------------------------------------------------------
+
+def test_converge_1x1_chunk_matches_default():
+    """python_loop_ctm_converge with ctm_chunk_size=3 must produce identical
+    envs to the default path (rel <= 1e-10) after 8 fixed sweeps (1x1 recipe).
+    """
+    from tenax.algorithms._ctm_python_loop import python_loop_ctm_converge
+
+    chi = 12
+    D, d = 2, 2
+    A = _random_dense_site_tensor(D, d, seed=99)
+    site_tensors = {(0, 0): A}
+    neighbors = {(0, 0): {direction: (0, 0) for direction in ("left", "right", "top", "bottom")}}
+    kw = dict(chi=chi, max_iter=8, min_iter=8, recipe="1x1", conv_tol=0.0)
+    envs_off, _ = python_loop_ctm_converge(site_tensors, neighbors, **kw)
+    envs_on, _ = python_loop_ctm_converge(site_tensors, neighbors, ctm_chunk_size=3, **kw)
+    e_off, e_on = envs_off[(0, 0)], envs_on[(0, 0)]
+    for field in e_off._fields:
+        b = getattr(e_off, field)
+        c = getattr(e_on, field)
+        b_labels = list(b.labels())
+        c_labels = list(c.labels())
+        perm = [c_labels.index(x) for x in b_labels]
+        cc = jnp.transpose(c.todense(), perm)
+        rel = float(jnp.max(jnp.abs(cc - b.todense())) / (jnp.max(jnp.abs(b.todense())) + 1e-30))
+        assert rel <= 1e-10, (field, rel)

--- a/tests/test_ctm_chunked_absorb.py
+++ b/tests/test_ctm_chunked_absorb.py
@@ -19,7 +19,12 @@ from tenax.algorithms._ctm_tensor_init import (
     _build_double_layer_tensor,
     initialize_ctm_tensor_env,
 )
-from tenax.algorithms._ctm_tensor_moves import _ctm_tensor_move_left
+from tenax.algorithms._ctm_tensor_moves import (
+    _ctm_tensor_move_bottom,
+    _ctm_tensor_move_left,
+    _ctm_tensor_move_right,
+    _ctm_tensor_move_top,
+)
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.symmetry import U1Symmetry
 from tenax.core.tensor import DenseTensor
@@ -210,6 +215,35 @@ def test_full_left_move_chunked_matches_default():
             / (jnp.max(jnp.abs(b_arr)) + 1e-30)
         )
         assert rel <= 1e-12, f"field={field!r} rel={rel}"
+
+
+@pytest.mark.parametrize("move_fn,fields", [
+    (_ctm_tensor_move_right, ("C2", "C3", "T2")),
+    (_ctm_tensor_move_top, ("C1", "C2", "T1")),
+    (_ctm_tensor_move_bottom, ("C4", "C3", "T3")),
+])
+def test_full_move_chunked_matches_default(move_fn, fields):
+    """Chunked branch of right/top/bottom CTM moves must match default (rel <= 1e-12)."""
+    D, d, chi = 2, 2, 12
+    A = _random_dense_site_tensor(D, d, seed=7)
+    a = _build_double_layer_tensor(A)
+    env = initialize_ctm_tensor_env(A, chi)
+    base_env, _ = move_fn(env, env, a, chi)
+    chunked_env, _ = move_fn(env, env, a, chi, chunk_size=4)
+    for field in fields:
+        b = getattr(base_env, field)
+        c = getattr(chunked_env, field)
+        b_arr = b.todense()
+        c_arr = c.todense()
+        b_labels = list(b.labels())
+        c_labels = list(c.labels())
+        perm = [c_labels.index(x) for x in b_labels]
+        c_arr_aligned = jnp.transpose(c_arr, perm)
+        rel = float(
+            jnp.max(jnp.abs(c_arr_aligned - b_arr))
+            / (jnp.max(jnp.abs(b_arr)) + 1e-30)
+        )
+        assert rel <= 1e-12, f"move={move_fn.__name__!r} field={field!r} rel={rel}"
 
 
 def test_full_left_move_chunked_ragged_matches_default():

--- a/tests/test_ctm_chunked_absorb.py
+++ b/tests/test_ctm_chunked_absorb.py
@@ -6,6 +6,7 @@ sizes including a ragged one.
 """
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 
@@ -157,3 +158,57 @@ def test_chunked_left_complex_projector():
     got = _chunked_T_new_left(T4, a, P1, P2, chi, D2, batch=8)
     rel = float(jnp.max(jnp.abs(got - ref)) / (jnp.max(jnp.abs(ref)) + 1e-30))
     assert rel <= 1e-12, f"complex-projector rel error {rel} > 1e-12"
+
+
+# ---------------------------------------------------------------------------
+# Full 1x1 LEFT move: chunked branch == default branch (Task 2)
+# ---------------------------------------------------------------------------
+
+from tenax.algorithms._ctm_tensor_init import (
+    _build_double_layer_tensor,
+    initialize_ctm_tensor_env,
+)
+from tenax.algorithms._ctm_tensor_moves import _ctm_tensor_move_left
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import U1Symmetry
+from tenax.core.tensor import DenseTensor
+
+
+def _random_dense_site_tensor(D: int, d: int, seed: int = 0) -> DenseTensor:
+    """Random dense iPEPS site tensor with labels (u,d,l,r,phys), all-zero U(1) charges."""
+    rng = np.random.RandomState(seed)
+    data = jnp.array(rng.randn(D, D, D, D, d), dtype=jnp.float64)
+    sym = U1Symmetry()
+    indices = (
+        TensorIndex.from_charges(sym, np.zeros(D, dtype=np.int32), FlowDirection.IN, label="u"),
+        TensorIndex.from_charges(sym, np.zeros(D, dtype=np.int32), FlowDirection.OUT, label="d"),
+        TensorIndex.from_charges(sym, np.zeros(D, dtype=np.int32), FlowDirection.IN, label="l"),
+        TensorIndex.from_charges(sym, np.zeros(D, dtype=np.int32), FlowDirection.OUT, label="r"),
+        TensorIndex.from_charges(sym, np.zeros(d, dtype=np.int32), FlowDirection.IN, label="phys"),
+    )
+    return DenseTensor(data, indices)
+
+
+def test_full_left_move_chunked_matches_default():
+    """Chunked branch of _ctm_tensor_move_left must be bit-identical to default (rel <= 1e-12)."""
+    D, d, chi = 2, 2, 12
+    A = _random_dense_site_tensor(D, d, seed=7)
+    a = _build_double_layer_tensor(A)
+    env = initialize_ctm_tensor_env(A, chi)
+    base_env, _ = _ctm_tensor_move_left(env, env, a, chi)
+    chunked_env, _ = _ctm_tensor_move_left(env, env, a, chi, chunk_size=4)
+    for field in ("C1", "C4", "T4"):
+        b = getattr(base_env, field)
+        c = getattr(chunked_env, field)
+        b_arr = b.todense()
+        c_arr = c.todense()
+        # align leg order via labels before comparing
+        b_labels = list(b.labels())
+        c_labels = list(c.labels())
+        perm = [c_labels.index(x) for x in b_labels]
+        c_arr_aligned = jnp.transpose(c_arr, perm)
+        rel = float(
+            jnp.max(jnp.abs(c_arr_aligned - b_arr))
+            / (jnp.max(jnp.abs(b_arr)) + 1e-30)
+        )
+        assert rel <= 1e-12, f"field={field!r} rel={rel}"

--- a/tests/test_ctm_chunked_absorb.py
+++ b/tests/test_ctm_chunked_absorb.py
@@ -5,9 +5,16 @@ monolithic einsum reference at rel-error <= 1e-12 (x64), across three batch
 sizes including a ragged one.
 """
 import jax
-jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _enable_x64():
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    yield
+    jax.config.update("jax_enable_x64", prev)
 
 from tenax.algorithms._ctm_chunked_absorb import (
     _chunked_T_new_left,
@@ -127,3 +134,26 @@ def test_chunked_bottom_matches_monolith(batch):
     got = _chunked_T_new_bottom(T3, a, P1, P2, chi, D2, batch)
     rel = float(jnp.max(jnp.abs(got - ref)) / (jnp.max(jnp.abs(ref)) + 1e-30))
     assert rel <= 1e-12, rel
+
+
+# ---------------------------------------------------------------------------
+# Complex-projector path (M-3): verifies P1.conj() is correct for complex P1
+# ---------------------------------------------------------------------------
+
+def test_chunked_left_complex_projector():
+    """LEFT with complex P1/P2 and T4 — exercises P1.conj() on non-real inputs."""
+    D, chi = 3, 16
+    D2 = D * D
+    keys = jax.random.split(jax.random.PRNGKey(42), 8)
+    T4 = (jax.random.normal(keys[0], (chi, D2, chi))
+          + 1j * jax.random.normal(keys[1], (chi, D2, chi)))
+    a  = (jax.random.normal(keys[2], (D2, D2, D2, D2))
+          + 1j * jax.random.normal(keys[3], (D2, D2, D2, D2)))
+    P1 = (jax.random.normal(keys[4], (chi * D2, chi))
+          + 1j * jax.random.normal(keys[5], (chi * D2, chi)))
+    P2 = (jax.random.normal(keys[6], (chi * D2, chi))
+          + 1j * jax.random.normal(keys[7], (chi * D2, chi)))
+    ref = _monolith_left(T4, a, P1, P2, chi, D2)
+    got = _chunked_T_new_left(T4, a, P1, P2, chi, D2, batch=8)
+    rel = float(jnp.max(jnp.abs(got - ref)) / (jnp.max(jnp.abs(ref)) + 1e-30))
+    assert rel <= 1e-12, f"complex-projector rel error {rel} > 1e-12"

--- a/tests/test_ctm_chunked_absorb.py
+++ b/tests/test_ctm_chunked_absorb.py
@@ -9,6 +9,21 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+from tenax.algorithms._ctm_chunked_absorb import (
+    _chunked_T_new_bottom,
+    _chunked_T_new_left,
+    _chunked_T_new_right,
+    _chunked_T_new_top,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    _build_double_layer_tensor,
+    initialize_ctm_tensor_env,
+)
+from tenax.algorithms._ctm_tensor_moves import _ctm_tensor_move_left
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import U1Symmetry
+from tenax.core.tensor import DenseTensor
+
 
 @pytest.fixture(autouse=True, scope="session")
 def _enable_x64():
@@ -16,13 +31,6 @@ def _enable_x64():
     jax.config.update("jax_enable_x64", True)
     yield
     jax.config.update("jax_enable_x64", prev)
-
-from tenax.algorithms._ctm_chunked_absorb import (
-    _chunked_T_new_left,
-    _chunked_T_new_right,
-    _chunked_T_new_top,
-    _chunked_T_new_bottom,
-)
 
 
 # ---------------------------------------------------------------------------
@@ -164,16 +172,6 @@ def test_chunked_left_complex_projector():
 # Full 1x1 LEFT move: chunked branch == default branch (Task 2)
 # ---------------------------------------------------------------------------
 
-from tenax.algorithms._ctm_tensor_init import (
-    _build_double_layer_tensor,
-    initialize_ctm_tensor_env,
-)
-from tenax.algorithms._ctm_tensor_moves import _ctm_tensor_move_left
-from tenax.core.index import FlowDirection, TensorIndex
-from tenax.core.symmetry import U1Symmetry
-from tenax.core.tensor import DenseTensor
-
-
 def _random_dense_site_tensor(D: int, d: int, seed: int = 0) -> DenseTensor:
     """Random dense iPEPS site tensor with labels (u,d,l,r,phys), all-zero U(1) charges."""
     rng = np.random.RandomState(seed)
@@ -212,3 +210,28 @@ def test_full_left_move_chunked_matches_default():
             / (jnp.max(jnp.abs(b_arr)) + 1e-30)
         )
         assert rel <= 1e-12, f"field={field!r} rel={rel}"
+
+
+def test_full_left_move_chunked_ragged_matches_default():
+    """Ragged chunk_size=5 on chi=12 (5 does not divide 12) must match default (rel <= 1e-12)."""
+    D, d, chi = 2, 2, 12
+    A = _random_dense_site_tensor(D, d, seed=13)
+    a = _build_double_layer_tensor(A)
+    env = initialize_ctm_tensor_env(A, chi)
+    base_env, _ = _ctm_tensor_move_left(env, env, a, chi)
+    chunked_env, _ = _ctm_tensor_move_left(env, env, a, chi, chunk_size=5)
+    for field in ("C1", "C4", "T4"):
+        b = getattr(base_env, field)
+        c = getattr(chunked_env, field)
+        b_arr = b.todense()
+        c_arr = c.todense()
+        # align leg order via labels before comparing
+        b_labels = list(b.labels())
+        c_labels = list(c.labels())
+        perm = [c_labels.index(x) for x in b_labels]
+        c_arr_aligned = jnp.transpose(c_arr, perm)
+        rel = float(
+            jnp.max(jnp.abs(c_arr_aligned - b_arr))
+            / (jnp.max(jnp.abs(b_arr)) + 1e-30)
+        )
+        assert rel <= 1e-12, f"ragged chunk: field={field!r} rel={rel}"


### PR DESCRIPTION
## Summary

**Increment 1 of #632** — a default-OFF `ctm_chunk_size` knob that runs the χ²·D⁶ edge absorption of the production **dense 1×1** CTM moves via a chunked `lax.map` over the boundary-χ axis, so per-device peak memory drops ≈÷K and composes with the existing GSPMD `device_mesh` (≈÷(N·K)). Builds on the STRONG-GO gate (#665).

**Key design point:** the gate validated the lever on `_compiled_move_*` (raw einsum) — but that module is *test-only dead code*. Production forward CTM runs the label-based `Tensor.contract()` absorb path. So this chunks the *real* path: a raw-array core (`_ctm_chunked_absorb.py`) called from the four `_ctm_tensor_move_*`, **dense-gated, default-off**, reusing the production relabel/flow-fix tail so the chunked result is **bit-identical** to the default.

### What ships
- `_ctm_chunked_absorb.py` — raw chunked cores `_chunked_T_new_{left,right,top,bottom}` + `_raw_in_label_order`.
- `_chunked_T_new_apply` helper + `chunk_size` branch in all four 1×1 dense moves.
- `CTMConfig.ctm_chunk_size` threaded through the **forward** CTM (config → policy → `ctm_energy_implicit` → sweep → move), mirroring `device_mesh`; `chunk_size` is a JIT static arg + part of the step/VJP cache keys.
- `_shard_a` (per-move re-shard) wired into the 1×1 sweep branch (was 2×2-only) so chunk composes with the mesh on the 1×1 recipe the multi-GPU dense studies use.

### Scope / deferrals (deliberate)
- **Forward only.** The implicit-AD **backward** is NOT chunked — that's Increment 2, **gate-first** (we must verify chunked-backward through the adjoint is correct + bounded-memory before wiring `optimize_gs_ad`). The backward step (`_ctm_energy_ad.py` `jit_step_bwd`) intentionally does not receive the knob.
- 2×2 recipe / symmetric / fermionic envs: knob is inert (symmetric falls back with a `warnings.warn`; 2×2 silently ignores).

## Test Plan
- [x] Core parity: chunked vs monolithic einsum, all 4 directions, K=1 / K>1 / ragged, real **and** complex projectors, rel ≤ 1e-12.
- [x] Full-move parity: chunked vs default per move (left/right/top/bottom), rel ≤ 1e-12.
- [x] End-to-end converge parity: `chunk on == off` over 8 fixed 1×1 sweeps, rel ≤ 1e-10.
- [x] Default-off is byte-for-byte the original path; `-m core` green (GPU-sharding failures are environmental).
- [x] `ctm_chunk_size` validated (`ValueError` on non-positive); config/policy tests pass.

Docs: plan `docs/superpowers/plans/2026-07-01-chunk-ctm-absorb-increment1.md`, build note `docs/superpowers/handoffs/2026-07-01-chunk-ctm-absorb-increment1-build.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
