### PR TITLE
bench(#632): shard-only reach benchmark — dense CTM-AD value_and_grad D=10-12

### DIFF
--- a/docs/superpowers/handoffs/2026-07-01-632-shard-only-reach-grad-D10-12.md
+++ b/docs/superpowers/handoffs/2026-07-01-632-shard-only-reach-grad-D10-12.md
@@ -1,0 +1,90 @@
+# #632 shard-only reach benchmark — dense CTM-AD value_and_grad at D=10–12
+
+**Date:** 2026-07-01
+**Branch:** `feat/632-chunk-ctm-absorb-inc1`
+**Harness:** `examples/bench_ctm_shard_reach_grad.py` (uses the rung-2 probe
+`tests/_rung2_grad_probe.py::implicit_energy_and_grad`, recipe="2x2",
+`forward_gauge="phase"`, `adjoint_method="fixed_point"`, well-conditioned state).
+**Hardware:** 2× A100-SXM4-80GB (GPUs 1,2; ~64 GiB usable/device),
+`XLA_PYTHON_CLIENT_PREALLOCATE=false`, one D per process (clean per-device peak).
+**Context:** ordered after the Increment-2 chunked-backward NO-GO
+(`2026-07-01-chunk-ctm-absorb-increment2-backward-gate.md`) — the large-D backward
+memory lever is GSPMD sharding (rung-2), not chunking. This measures how far that
+lever reaches at D=10–12.
+
+**Verdict: on 2 GPUs, GSPMD sharding gives NO reach extension at D=10–12.** Every
+D≥10 config either already fits on 1 GPU or OOMs on both. Sharding relief is
+χ-gated *and* D-fading; it confirms the SVD-replication wall
+(`632-gspmd-svd-replication-rootcause`). A definitive 4-GPU test (rung-2's config,
+where +2-in-D was claimed) needs 4 clean A100s — unavailable at run time.
+
+## Harness validation (reproduces rung-2 exactly)
+
+Single-GPU D=8 χ=24 = **10.66 GB** — identical to the rung-2 gate 2B number. The
+probe is the rung-2 probe; the measurement path is trusted.
+
+## Results
+
+Per-device peak of the full `value_and_grad` (forward CTM + implicit-AD backward):
+
+### χ = 24
+| D | 1-GPU | 2-GPU sharded | relief |
+|---|---|---|---|
+| 6 | 2.16 GB | 1.15 GB | **1.88×** |
+| 8 | 10.66 GB | 6.85 GB | **1.56×** |
+| 10 | OOM (tried +29 GiB) | OOM (tried +31 GiB) | — |
+| 12 | autotuner-fail (`f64[144,24,144,144,24]` transpose) | OOM (tried +45 GiB) | — |
+
+### χ = 16
+| D | 1-GPU | 2-GPU sharded | relief |
+|---|---|---|---|
+| 6 | 0.81 GB | 0.91 GB | **0.89×** (overhead > relief) |
+| 8 | 5.10 GB | 4.84 GB | **1.05×** |
+| 10 | 23.21 GB | 23.20 GB | **1.00×** (none) |
+| 12 | OOM (tried +30.7 GiB) | OOM (tried **+77 GiB**) | — |
+
+## Reads
+
+1. **Relief is χ-gated.** At χ=24 sharding pays off (1.5–1.9× at D=6–8); at χ=16 it
+   is ~1.0× or worse (D=6 is 0.89× — the all-gather overhead exceeds the ÷N relief).
+   The sharded axis is the D² double-layer leg; at small χ the replicated part +
+   comm buffers dominate, so ÷N buys nothing.
+2. **Relief D-fades at fixed χ=24:** 1.88× (D6) → 1.56× (D8). The SVD-forced
+   replicated χ²·D⁶ intermediate grows as D⁶ while the shardable contraction relief
+   is fixed at ÷N, so the replicated fraction → 1 and relief → 1× as D grows.
+3. **No reach on 2 GPUs at D=10–12.** There is no config where 2-GPU fits and 1-GPU
+   OOMs: D=10 χ=16 fits on both; D=10 χ=24 and all D=12 OOM on both.
+4. **D=12 sharding is counterproductive.** 2-GPU allocates *more* than 1-GPU
+   (χ=16: +77 vs +30.7 GiB) — all-gather buffers for the replicated intermediate.
+
+## Mechanism (confirms `632-gspmd-svd-replication-rootcause`)
+
+The projector SVD is unshardable in XLA, forcing the dominant χ²·D⁶ backward
+intermediate **replicated** across devices. Sharding partitions the absorption
+*contraction* (÷N) but not the replicated SVD-bound part; as D grows (D⁶) or χ
+shrinks, the replicated part + all-gather overhead dominate → relief collapses to
+1× (and below). This is the *same* wall the chunked-backward NO-GO hit from the
+other side: neither chunk nor shard addresses the SVD-replicated backward
+intermediate — that is the structural D≥10 dense CTM-AD wall.
+
+## Limitation / open
+
+- **Only 2 clean A100s at run time** (GPU 0 held 61 GiB; GPU 4 at 96% util). rung-2
+  reported 4-GPU extends the single ceiling D=8 → D=10 at χ=24 (+2 in D, 21.45
+  GB/device). 2-GPU is insufficient to reach D=10 χ=24 (both OOM). A 4-GPU rerun
+  (`CUDA_VISIBLE_DEVICES=0,1,2,4` or any 4 free A100s) would test whether the +2-in-D
+  reproduces and whether it reaches into D=12. The relief-fade + D=12 counterproductive
+  overhead predict **D=12 is out of reach even at 4-GPU**, but that is untested here.
+- Practical takeaway (unchanged from `fermionic-large-d-tooling` / dense-pragmatic):
+  the large-D **forward** lever is split-CTM (χ²·D⁴, #650); the **backward** remains
+  SVD-replication-bound at D≥10. Multi-GPU dense CTM-AD is a modest "fit a bit
+  bigger" lever (χ≥24, D≤~10, needs ≥4 GPUs), not a D=12 enabler.
+
+## Reproduce
+
+```bash
+CUDA_VISIBLE_DEVICES=1  XLA_PYTHON_CLIENT_PREALLOCATE=false \
+  uv run python examples/bench_ctm_shard_reach_grad.py --D 8 --chi 24          # 1-GPU 10.66 GB
+CUDA_VISIBLE_DEVICES=1,2 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+  uv run python examples/bench_ctm_shard_reach_grad.py --D 8 --chi 24 --shard  # 2-GPU 6.85 GB (1.56x)
+```

--- a/docs/superpowers/handoffs/2026-07-01-632-shard-only-reach-grad-D10-12.md
+++ b/docs/superpowers/handoffs/2026-07-01-632-shard-only-reach-grad-D10-12.md
@@ -67,14 +67,42 @@ shrinks, the replicated part + all-gather overhead dominate → relief collapses
 other side: neither chunk nor shard addresses the SVD-replicated backward
 intermediate — that is the structural D≥10 dense CTM-AD wall.
 
+## Why D=10 χ=24 OOMs on one 80 GB A100 (buffer-level)
+
+BFC OOM dump (`jit__jit_fused_fixed_point_bwd`, 1-GPU): failed on a single **29.04 GiB**
+allocation; the big live buffers are **4.29 GiB = χ²·D⁶** (576·10⁶·8 B) absorb tensors;
+BFC pool cap = 59.44 GiB. The dominant tensor is the CTM edge-absorption χ²·D⁶ and its
+VJP transpose; it scales as **D⁶** (χ=24 peak: D6 2.16 / D8 10.66 / D10 → OOM; a single
+χ²·D⁶ is 0.22 / 1.21 / 4.29 GiB). Measured peaks are ~9× a single χ²·D⁶ array (the
+implicit-AD backward holds the paired-move sweep residuals + cotangents + Neumann carry
+simultaneously) → D10 peak projects to ~38 GiB, plus one fused op needs a single ~29–46 GiB
+buffer; concurrent, that exceeds 80 GB.
+
+**Genuine capacity wall, NOT fragmentation** (rules out the allocator-swap lever that
+rescued the χ=96 *forward* case, [[d8-cuda-async-vs-bfc-and-shard-nogo]]): default BFC OOMs
+at 29 GiB (59.44 GiB cap + 16 GiB regions holding 4.29 GiB buffers), `cuda_malloc_async`
+OOMs at 29 GiB, and `XLA_PYTHON_CLIENT_ALLOCATOR=platform` (no BFC cap/fragmentation) OOMs
+at an even larger **45.97 GiB** single buffer. All three exceed the card. 2-GPU does not
+rescue it: the SVD-replication (below) forces that χ²·D⁶ buffer replicated per device.
+
 ## Limitation / open
 
 - **Only 2 clean A100s at run time** (GPU 0 held 61 GiB; GPU 4 at 96% util). rung-2
   reported 4-GPU extends the single ceiling D=8 → D=10 at χ=24 (+2 in D, 21.45
   GB/device). 2-GPU is insufficient to reach D=10 χ=24 (both OOM). A 4-GPU rerun
-  (`CUDA_VISIBLE_DEVICES=0,1,2,4` or any 4 free A100s) would test whether the +2-in-D
-  reproduces and whether it reaches into D=12. The relief-fade + D=12 counterproductive
-  overhead predict **D=12 is out of reach even at 4-GPU**, but that is untested here.
+  would test whether the +2-in-D reproduces and whether it reaches into D=12. The
+  relief-fade + D=12 counterproductive overhead predict **D=12 is out of reach even
+  at 4-GPU**, but that is untested here.
+  - **4-GPU device mask (verified 2026-07-14):** the box's four A100s are PCI
+    indices 0,1,2,4 and the DGX **display** GPU is PCI index **3** — so pick the
+    A100s with `CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES=0,1,2,4`. A bare
+    `CUDA_VISIBLE_DEVICES=0,1,2,4` (default CUDA fastest-first ordering) may enumerate
+    the 4 GB display into the mask and fail/mismeasure — see
+    `2026-06-21-632-multigpu-dense-ctm-findings.md`. Add `NCCL_P2P_DISABLE=1` (a
+    plain 4-way all-reduce over these four devices was confirmed working today; without
+    it the box can stall in the NCCL clique rendezvous). Note: a 4-GPU run needs all
+    four A100s genuinely free — if one is shared/busy, its shard OOMs and stalls the
+    whole clique.
 - Practical takeaway (unchanged from `fermionic-large-d-tooling` / dense-pragmatic):
   the large-D **forward** lever is split-CTM (χ²·D⁴, #650); the **backward** remains
   SVD-replication-bound at D≥10. Multi-GPU dense CTM-AD is a modest "fit a bit

--- a/examples/bench_ctm_shard_reach_grad.py
+++ b/examples/bench_ctm_shard_reach_grad.py
@@ -1,0 +1,82 @@
+"""#632 shard-only reach benchmark — dense CTM-AD ``value_and_grad`` (forward CTM +
+implicit-AD backward), single-GPU vs N-GPU GSPMD mesh, at large D.
+
+This is the *shard-only* lever (rung-2 GSPMD ``device_mesh``), NOT chunking: the
+#632 Increment-2 gate showed chunking the backward is a NO-GO, so the large-D
+backward memory relief is GSPMD sharding. The backward shards via GSPMD
+propagating from the sharded env residuals (rung-2). Reports per-device peak of
+the full ``value_and_grad`` and whether it fit or OOM'd, extending the rung-2
+table (single ceiling D=8, 4-GPU D=10 at chi=24) toward D=10-12.
+
+NB: the mesh dim N must divide D^2 (the sharded double-layer leg). D=10 -> 100
+(N in {2,4,5}); D=12 -> 144 (N in {2,3,4,6}); D=11 -> 121 is NOT shardable.
+
+Usage (one D per process for a clean peak; PREALLOCATE=false for a faithful peak):
+    # single-GPU ceiling:
+    CUDA_VISIBLE_DEVICES=1 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        uv run python examples/bench_ctm_shard_reach_grad.py --D 10 --chi 24
+    # 2-GPU sharded:
+    CUDA_VISIBLE_DEVICES=1,2 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        uv run python examples/bench_ctm_shard_reach_grad.py --D 10 --chi 24 --shard
+"""
+
+import argparse
+import os
+import sys
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms.ctm_sharding import build_ctm_mesh  # noqa: E402
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tests"))
+from _rung2_grad_probe import implicit_energy_and_grad  # noqa: E402
+
+
+def peak_gb():
+    try:
+        return jax.devices()[0].memory_stats()["peak_bytes_in_use"] / 1e9
+    except Exception:
+        return float("nan")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--D", type=int, nargs="+", default=[10, 12])
+    ap.add_argument("--chi", type=int, default=24)
+    ap.add_argument("--shard", action="store_true")
+    ap.add_argument("--max-iter", type=int, default=30)
+    args = ap.parse_args()
+
+    n = jax.device_count()
+    mesh = build_ctm_mesh() if args.shard else None
+    mesh_n = n if args.shard else 1
+    print(
+        f"# devices={n} shard={args.shard} mesh_n={mesh_n} chi={args.chi} "
+        f"max_iter={args.max_iter} recipe=2x2 well_conditioned=True x64=True"
+    )
+    for D in args.D:
+        if args.shard and (D * D) % mesh_n != 0:
+            print(f"D={D}: SKIP (D^2={D*D} not divisible by mesh_n={mesh_n})")
+            continue
+        t0 = time.perf_counter()
+        try:
+            e, g = implicit_energy_and_grad(
+                D=D, chi=args.chi, device_mesh=mesh, seed=0,
+                well_conditioned=True, max_iter=args.max_iter,
+            )
+            gnorm = float((g ** 2).sum() ** 0.5)
+            dt = time.perf_counter() - t0
+            print(
+                f"D={D}: OK  E={e:.6f}  |g|={gnorm:.3e}  "
+                f"per_device_peak={peak_gb():.2f} GB  wall={dt:.1f}s"
+            )
+        except Exception as ex:  # noqa: BLE001
+            dt = time.perf_counter() - t0
+            print(f"D={D}: FAILED ({type(ex).__name__}: {str(ex)[:110]})  wall={dt:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/bench_ctm_shard_reach_grad.py
+++ b/examples/bench_ctm_shard_reach_grad.py
@@ -18,6 +18,15 @@ Usage (one D per process for a clean peak; PREALLOCATE=false for a faithful peak
     # 2-GPU sharded:
     CUDA_VISIBLE_DEVICES=1,2 XLA_PYTHON_CLIENT_PREALLOCATE=false \
         uv run python examples/bench_ctm_shard_reach_grad.py --D 10 --chi 24 --shard
+    # 4-GPU sharded (select the four A100s, exclude the DGX display GPU — with
+    # CUDA_DEVICE_ORDER=PCI_BUS_ID the display is PCI index 3, so 0,1,2,4 are the
+    # A100s; NCCL_P2P_DISABLE=1 avoids the box's 4-way NCCL stall):
+    CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES=0,1,2,4 NCCL_P2P_DISABLE=1 \
+        XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        uv run python examples/bench_ctm_shard_reach_grad.py --D 10 --chi 24 --shard
+
+Passing several --D (e.g. ``--D 10 12``) auto-re-execs one fresh subprocess per D
+so each per-device peak is uncontaminated by a prior config's high-water mark.
 """
 
 import argparse
@@ -50,6 +59,24 @@ def main():
     ap.add_argument("--max-iter", type=int, default=30)
     args = ap.parse_args()
 
+    # One D per process: peak_bytes_in_use is a process high-water mark that is
+    # NOT reset between configs, so running several D in one process would
+    # contaminate later rows with earlier allocations/fragmentation/OOM-autotune.
+    # When multiple D are requested, re-exec a fresh subprocess per D (inherits
+    # CUDA_VISIBLE_DEVICES etc.) so every reported peak is clean.
+    if len(args.D) > 1:
+        import subprocess
+
+        base = [sys.executable, __file__, "--chi", str(args.chi),
+                "--max-iter", str(args.max_iter)]
+        if args.shard:
+            base.append("--shard")
+        rc = 0
+        for D in args.D:
+            rc |= subprocess.call(base + ["--D", str(D)])
+        sys.exit(rc)
+
+    (D,) = args.D
     n = jax.device_count()
     mesh = build_ctm_mesh() if args.shard else None
     mesh_n = n if args.shard else 1
@@ -57,25 +84,24 @@ def main():
         f"# devices={n} shard={args.shard} mesh_n={mesh_n} chi={args.chi} "
         f"max_iter={args.max_iter} recipe=2x2 well_conditioned=True x64=True"
     )
-    for D in args.D:
-        if args.shard and (D * D) % mesh_n != 0:
-            print(f"D={D}: SKIP (D^2={D*D} not divisible by mesh_n={mesh_n})")
-            continue
-        t0 = time.perf_counter()
-        try:
-            e, g = implicit_energy_and_grad(
-                D=D, chi=args.chi, device_mesh=mesh, seed=0,
-                well_conditioned=True, max_iter=args.max_iter,
-            )
-            gnorm = float((g ** 2).sum() ** 0.5)
-            dt = time.perf_counter() - t0
-            print(
-                f"D={D}: OK  E={e:.6f}  |g|={gnorm:.3e}  "
-                f"per_device_peak={peak_gb():.2f} GB  wall={dt:.1f}s"
-            )
-        except Exception as ex:  # noqa: BLE001
-            dt = time.perf_counter() - t0
-            print(f"D={D}: FAILED ({type(ex).__name__}: {str(ex)[:110]})  wall={dt:.1f}s")
+    if args.shard and (D * D) % mesh_n != 0:
+        print(f"D={D}: SKIP (D^2={D*D} not divisible by mesh_n={mesh_n})")
+        return
+    t0 = time.perf_counter()
+    try:
+        e, g = implicit_energy_and_grad(
+            D=D, chi=args.chi, device_mesh=mesh, seed=0,
+            well_conditioned=True, max_iter=args.max_iter,
+        )
+        gnorm = float((g ** 2).sum() ** 0.5)
+        dt = time.perf_counter() - t0
+        print(
+            f"D={D}: OK  E={e:.6f}  |g|={gnorm:.3e}  "
+            f"per_device_peak={peak_gb():.2f} GB  wall={dt:.1f}s"
+        )
+    except Exception as ex:  # noqa: BLE001
+        dt = time.perf_counter() - t0
+        print(f"D={D}: FAILED ({type(ex).__name__}: {str(ex)[:110]})  wall={dt:.1f}s")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @Ying-Jer Kao.

Docs + example only (no src/test change). Follow-up to the #632 Increment-2 chunked-backward NO-GO (in #668): since the large-D backward memory lever is GSPMD sharding (rung-2), this measures how far *that* lever reaches at D=10-12 with the full implicit-AD `value_and_grad`.

**Harness validated:** 1-GPU D=8 χ=24 = 10.66 GB — matches the rung-2 gate 2B number exactly (uses the rung-2 probe, recipe=2×2).

**Result — on 2 A100s, sharding gives NO reach extension at D=10-12.** Relief is χ-gated and D-fading:

| D | χ=24 (1→2 GPU) | χ=16 (1→2 GPU) |
|---|---|---|
| 6 | 2.16→1.15 GB (1.88×) | 0.81→0.91 GB (0.89×) |
| 8 | 10.66→6.85 GB (1.56×) | 5.10→4.84 GB (1.05×) |
| 10 | OOM / OOM | 23.21→23.20 GB (1.00×) |
| 12 | autotune-fail / OOM | OOM / OOM (2-GPU +77 vs 1-GPU +30.7 GiB) |

Every D≥10 config either fits on 1-GPU (D10 χ16) or OOMs on both (D10 χ24, all D12); D=12 sharding is counterproductive (all-gather buffers for the replicated intermediate). This confirms the SVD-replication root cause at large D: the projector SVD forces the χ²·D⁶ backward intermediate replicated, so ÷N shards only the contraction. Neither chunk (#668 Inc-2 NO-GO) nor 2-GPU shard beats the SVD-bound backward.

**Caveat:** only 2 clean A100s at run time; rung-2's +2-in-D used 4 GPUs. The relief-fade + D=12 overhead predict D=12 out of reach even at 4-GPU, but that is untested. Full findings: `docs/superpowers/handoffs/2026-07-01-632-shard-only-reach-grad-D10-12.md`.