### PR TITLE
fix(#667): canonical env tiling + 2x2 init corner consistency (direction-dependent CTM, Phases 0-1)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md
+++ b/docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md
@@ -1,0 +1,326 @@
+# Direction-Dependent Symmetric Multisite CTM Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Read this first — this is a hybrid design+plan.** The *core* of the problem
+> (keeping the two sublattices' renormalised environment bonds structurally
+> identical across sweeps) is an **open design question**, not a known
+> implementation. Phases 0–1 land the two pieces that ARE understood and
+> correct; Phase 2 is a **decision phase** (spike + measure + choose) that must
+> complete before the Phase 3 implementation can be written with real code.
+> Do not skip Phase 2 — writing Phase 3 code before the mechanism is chosen
+> would be guessing.
+
+**Goal:** Make `ctm_tensor_2site` run to convergence on a valid unit-cell-consistent checkerboard iPEPS with `A.l != A.r` (direction-dependent virtual bonds) and match the densified result, unblocking `tests/test_ctm_direction_dependent_bonds.py`.
+
+**Architecture:** The symmetric (block-sparse) multisite CTM builds each site's environment from that site's own tensor and truncates each sublattice's projector independently. For a *direction-uniform* cell this is self-consistent; for `A.l != A.r` the two sublattices' bonds acquire incompatible per-sector block structure and the cross-sublattice contractions in the sweep fail with block-size mismatches. The fix is layered: (0) a general tiling-canonicalisation bug fix, (1) recipe-correct env-init charge seeding, (2+3) a mechanism that forces both sublattices' renormalised bonds onto a shared per-bond charge template that persists across sweeps.
+
+**Tech Stack:** JAX (float64), Tenax `SymmetricTensor` block-sparse tensors, U(1)-Sz symmetry, `opt_einsum` block contraction.
+
+---
+
+## Background: why this is hard (evidence from the 2026-07-01 investigation)
+
+The RED test `tests/test_ctm_direction_dependent_bonds.py::test_symmetric_2site_ctm_matches_dense_on_direction_dependent_bonds` drives a `base_charges`-free U(1)-Sz simple update to produce a pair with:
+
+```
+A.u=[0,1,-1]  A.d=[1,3,1]  A.l=[0,1,-1]  A.r=[-2,0,-2]
+B.u=[1,3,1]   B.d=[0,1,-1] B.l=[-2,0,-2] B.r=[0,1,-1]
+```
+
+Cell-consistent (`A.r==B.l`, `A.l==B.r`, `A.u==B.d`, `A.d==B.u`) but **direction-dependent** (`A.l != A.r`). The symmetric CTM crashes; the dense CTM (trivial charges) runs and gives the reference **E ≈ -0.542** for both `recipe="1x1"` and `recipe="2x2"`.
+
+Four independent failure layers were found and characterised:
+
+1. **Corner chi-leg seeding.** `_init_symmetric_standard_corner` seeds *both* corner chi legs from a single virtual axis. Fine when `A.l==A.r`; for direction-dependent bonds the two legs must seed from the axis each geometrically extends.
+2. **Edge D² leg seeding.** A parallel edge's D² leg contracts the *neighbour's* double-layer (`move_left`: `T4.l2 · a.l2`, and `a.l2 == B.l == self.r`), so it must seed from the *opposite* virtual axis.
+3. **Tiling canonicalisation (GENERAL BUG, recipe-independent).** `_compute_fused_charges` for two legs of the same bond that carry *opposite* flow (same virtual axis) produces sign-flipped enumerations of the *same* multiset. Padding a chi leg beyond D² in *enumeration* order appends a one-sided prefix and breaks multiset equality; padding in *sorted* order preserves it. This is a real bug independent of the direction-dependent feature.
+4. **Cross-sublattice renormalised-bond consistency (THE HARD, UNSOLVED CORE).** The block-sparse SVD projector keeps `n_keep = min(chi, rank)` per sublattice. For `A != B` the two sublattices' renormalised bonds share a charge *support* but end up with different per-sector *counts* (e.g. after one `move_left`, `A.C1.c1_d` has charge-0 dim 3 while `B.T4.t4_d` has 6). The cross-sublattice contraction then fails. This persists across sweeps and appears in BOTH recipes.
+
+**Recipe asymmetry (critical).** The corner↔edge contraction is:
+- **1×1**: CROSS-site (`env_self.C1 · env_neighbor.T1`) → the two legs need *cell-partner* axes (`self.r == nb.l`). Fix (1) above is correct here.
+- **2×2**: SAME-site (`env_src.C1 · env_src.T1` inside `_build_enlarged_corner` / `_ctm_tensor_absorb_*_2plaq`) → the two legs need the *same* axis (the original scheme). Fix (1) is WRONG here.
+
+**1×1 also has a fundamental extra wall:** single-site absorption alternates the renormalised edge D² leg's orientation (after absorbing `B`, `T4.l2` becomes `B.r`-fused, but the next `move_left` contracts it against `B.l`-fused; `B.r != B.l`). This is irreconcilable by charge labels — it is real data. Only full-2-site-cell absorption (the 2×2 recipe) resolves it. **Therefore the target recipe is `2x2`.**
+
+Dense "works" on this fixture only because trivial charges hide every mismatch above — so also sanity-check whether the fixture is physically meaningful (per issue #667, the `base_charges`-free SU is itself a degenerate near-classical attractor; see `examples/su_symmetric_ctm_e2e.py`).
+
+Reproduction: the investigation used a cached SU pair and standalone debug scripts (regenerate the pair with the fixture `_su_direction_dependent_pair` from the test; ~90s).
+
+---
+
+## File Structure
+
+- `src/tenax/algorithms/_ctm_tensor_init.py` — env init: corner/edge charge seeding, the `_tile_fused_to_chi` helper (Phase 0 + Phase 1 + Phase 3 templates).
+- `src/tenax/algorithms/_ctm_projector.py` — `_svd_projector_symmetric` / `_compute_projector_tensor`: where per-sector truncation happens; template padding hooks (Phase 3).
+- `src/tenax/algorithms/_ctm_tensor_projector_2x2.py` — `_build_enlarged_corner`, `_compute_2x2_projector`: the 2×2 plaquette projector (Phase 2 spike + Phase 3).
+- `src/tenax/algorithms/_ctm_tensor_moves.py` — `_ctm_tensor_absorb_*_2plaq`, `_compute_plaquette_projector_pair`: the 2×2 absorption (Phase 3).
+- `src/tenax/algorithms/_ctm_tensor_convergence.py` — `_ctm_tensor_multisite`, `_ctm_tensor_sweep_multisite`: sweep orchestration, template computation & threading (Phase 3).
+- `tests/test_ctm_tensor_tiling.py` (new) — unit test for the tiling fix (Phase 0).
+- `tests/test_ctm_direction_dependent_bonds.py` (exists, RED) — the acceptance test; will be retargeted to `recipe="2x2"` (Phase 3).
+
+---
+
+## Phase 0 — Canonical tiling fix (understood, self-contained, land first)
+
+This is a genuine bug independent of the direction-dependent feature: two opposite-flow legs of the same bond must produce equal charge multisets after tiling to `chi`.
+
+### Task 0.1: Add `_tile_fused_to_chi` and unit-test it
+
+**Files:**
+- Create test: `tests/test_ctm_tensor_tiling.py`
+- Modify: `src/tenax/algorithms/_ctm_tensor_init.py` (add helper after `_grouped_chi_perm`, ~line 285)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_ctm_tensor_tiling.py
+"""Opposite-flow legs of one bond must tile to equal charge multisets (#667)."""
+from __future__ import annotations
+import numpy as np
+from collections import Counter
+from tenax.algorithms._ctm_tensor_init import _tile_fused_to_chi
+
+
+def test_tile_preserves_multiset_under_sign_flip():
+    # A U(1) fusion enumeration and its sign-flip (what opposite-flow legs of
+    # the same virtual axis produce) must give equal multisets after tiling
+    # past D**2 to chi.
+    fused = np.array([0, -2, 0, 2, 0, 2, 0, -2, 0], dtype=np.int32)  # D**2 = 9
+    flipped = -fused
+    chi = 12
+    a = Counter(_tile_fused_to_chi(fused, chi).tolist())
+    b = Counter(_tile_fused_to_chi(flipped, chi).tolist())
+    assert a == b, f"tiled multisets differ: {a} vs {b}"
+
+
+def test_tile_keeps_charge_zero_at_index_0():
+    # The rank-1 seed lives at pre-perm index 0 and must stay charge 0.
+    fused = np.array([0, -1, 1, 1, 0, 2, -1, -2, 0], dtype=np.int32)
+    out = _tile_fused_to_chi(fused, 12)
+    assert int(out[0]) == 0
+
+
+def test_tile_no_pad_when_chi_le_d2():
+    fused = np.array([0, -2, 0, 2, 0, 2, 0, -2, 0], dtype=np.int32)
+    out = _tile_fused_to_chi(fused, 5)
+    assert np.array_equal(out, fused[:5])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_ctm_tensor_tiling.py -v`
+Expected: FAIL with `ImportError: cannot import name '_tile_fused_to_chi'`
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/tenax/algorithms/_ctm_tensor_init.py`, add after `_grouped_chi_perm`:
+
+```python
+def _tile_fused_to_chi(fused: np.ndarray, chi: int) -> np.ndarray:
+    """Tile size-D**2 ``fused`` charges up to length ``chi`` canonically.
+
+    The leading D**2 block keeps the raw enumeration order (so index 0 stays
+    the charge-0 diagonal that anchors the rank-1 seed at the vacuum slot); any
+    padding beyond D**2 is appended in **sorted** order.  This makes two legs
+    of one bond that carry opposite flow (sign-flipped enumerations of the same
+    multiset) agree after tiling.  A no-op for ``chi <= D**2`` and for
+    direction-uniform iPEPS.  #667.
+    """
+    fused = np.asarray(fused, dtype=np.int32)
+    if chi <= len(fused):
+        return fused[:chi]
+    srt = np.sort(fused)
+    reps = (chi - len(fused)) // len(srt) + 1
+    tail = np.tile(srt, reps)[: chi - len(fused)]
+    return np.concatenate([fused, tail]).astype(np.int32)
+```
+
+Also add `"_tile_fused_to_chi"` to `__all__` at the top of the file.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_ctm_tensor_tiling.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Route existing tiling through the helper**
+
+In `_init_symmetric_standard_edge`, replace the body of the inner `_fused_chi_charges` (the `if chi <= len(fused): ... else: tile ...` block) with `return _tile_fused_to_chi(fused, chi)`. Leave the corner as-is for now (it is rewritten in Phase 1).
+
+- [ ] **Step 6: Run the init regression + full core suite**
+
+Run: `uv run pytest tests/test_ctm_tensor_init_rank1.py tests/test_ipeps_u1sz.py -q`
+Expected: PASS (no regression — for uniform/trivial charges the helper is a no-op).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/test_ctm_tensor_tiling.py src/tenax/algorithms/_ctm_tensor_init.py
+git commit -m "fix(#667): canonical (sorted) tiling for opposite-flow env chi legs
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 1 — 2×2-correct env init (understood)
+
+For the **2×2** recipe, all enlarged-corner and absorption corner↔edge contractions are SAME-site, so the *original* same-axis seeding is correct. The only init change 2×2 needs is Phase 0's tiling (already landed). This phase is therefore a **verification phase**: confirm the enlarged-corner and 2-plaquette absorption contractions all pass on the fixture with the current (original) init + Phase 0 tiling, and lock that with a test. No init-axis changes — the 1×1-oriented axis reseeding from the 2026-07-01 WIP is explicitly NOT applied here.
+
+### Task 1.1: Lock enlarged-corner charge-consistency on the fixture
+
+**Files:**
+- Test: `tests/test_ctm_direction_dependent_bonds.py` (add a focused sub-test)
+
+- [ ] **Step 1: Write a test that builds all four enlarged corners without error**
+
+```python
+def test_2x2_enlarged_corners_build_on_direction_dependent_init():
+    """First-sweep 2x2 enlarged corners must build (charge-consistent) on the
+    direction-dependent init env."""
+    import numpy as np
+    from tenax.algorithms._ctm_tensor_init import (
+        initialize_ctm_tensor_env, _build_double_layer_tensor,
+    )
+    from tenax.algorithms._ctm_tensor_projector_2x2 import _build_enlarged_corner
+
+    A, B = _su_direction_dependent_pair()
+    chi = 12
+    envA = initialize_ctm_tensor_env(A, chi)
+    envB = initialize_ctm_tensor_env(B, chi)
+    aA = _build_double_layer_tensor(A)
+    aB = _build_double_layer_tensor(B)
+    # Same-site enlarged corners (each uses one site's env + that site's DL).
+    for env, a in ((envA, aA), (envB, aB)):
+        for pos, (C, Th, Tv) in {
+            "top_left": (env.C1, env.T1, env.T4),
+            "top_right": (env.C2, env.T1, env.T2),
+            "bottom_left": (env.C4, env.T3, env.T4),
+            "bottom_right": (env.C3, env.T3, env.T2),
+        }.items():
+            Q = _build_enlarged_corner(C, Th, Tv, a, position=pos)
+            assert Q is not None
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `uv run pytest tests/test_ctm_direction_dependent_bonds.py::test_2x2_enlarged_corners_build_on_direction_dependent_init -v`
+Expected: PASS (with Phase 0 tiling, the same-site enlarged corners are charge-consistent). If it FAILS, the failing contraction identifies a residual same-site seeding/tiling gap — fix in `_ctm_tensor_init.py` and re-run before proceeding. Record the exact failing contraction in the commit message.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_ctm_direction_dependent_bonds.py
+git commit -m "test(#667): lock 2x2 enlarged-corner charge consistency on direction-dependent init
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 2 — DECISION PHASE: choose the cross-sublattice bond-consistency mechanism
+
+**Do not write Phase 3 until this phase produces a chosen mechanism.** The core
+unknown: after a full 2×2 absorption sweep, the two sublattices' renormalised
+bonds (e.g. `c4_u` and `t4_u`, produced by different projectors) drift to
+different per-sector block structures and the next sweep's same-site enlarged
+corner fails. The mechanism must force every renormalised env chi bond onto a
+**shared, per-bond, persistent** charge template.
+
+Candidate mechanisms (from the 2026-07-01 investigation — each has an open risk):
+
+- **A. Fixed per-bond templates + zero-pad in the projector.** Compute a fixed
+  charge template per env bond once (from the init env, per-sector-max over the
+  sublattices), and make the 2×2 projector emit `chi_new` at exactly the
+  template. Because each per-sector SVD `M_q` is at most `chi×chi`, total rank
+  `<= chi`, so padding to `chi` is lossless (identical to the dense path keeping
+  zero singular values). Risk: whether a single fixed template's per-sector
+  budget always covers the renormalised counts (under-provisioning truncates
+  real data → energy drift).
+- **B. Adaptive shared template recomputed each sweep.** Per sweep, gather both
+  sublattices' bonds, take per-sector max, reembed both. Risk: per-sector-max
+  summed can exceed `chi`; needs a fit-to-`chi` policy.
+- **C. Joint truncation.** Decide the kept per-sector counts once per seam
+  (shared base_charges) and apply to both sublattices' projectors. Risk: still
+  need to pad when a sublattice's rank in a sector is below the shared count.
+
+### Task 2.1: Spike — measure renormalised-bond drift and template coverage
+
+**Files:**
+- Create (throwaway, do not commit): `scripts/spike_667_bond_drift.py`
+
+- [ ] **Step 1: Write a spike that runs N=1..5 2×2 sweeps and records, per env bond, the per-sector counts on each sublattice after each sweep**
+
+Use `initialize_ctm_tensor_env`, `_build_double_layer_tensor`, and
+`_ctm_tensor_sweep_multisite(..., recipe="2x2")`; wrap the sweep in
+try/except and, on the first failure, print the two mismatched legs' per-sector
+counts (the failing contraction is reported by the `ValueError`). Regenerate the
+SU pair with `_su_direction_dependent_pair` (from the test) or cache it to
+`/tmp` to iterate fast.
+
+- [ ] **Step 2: Run and record**
+
+Run: `uv run python scripts/spike_667_bond_drift.py`
+Record: (a) which sweep and which contraction first fails; (b) for the mismatching bond, the per-sector counts on A vs B across sweeps; (c) whether a fixed init-derived template's per-sector budget ever gets *exceeded* by a renormalised count (this decides A vs B/C).
+
+- [ ] **Step 3: Decide the mechanism**
+
+Write the decision (and the measured evidence) into
+`docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md` under a
+new "## Phase 2 outcome" section: chosen mechanism (A/B/C), the template
+construction rule, and where it is applied (projector emit vs post-sweep
+reembed). If the init-derived fixed template (A) is never exceeded in the spike,
+choose A (simplest). Delete the spike script.
+
+- [ ] **Step 4: Also record the fixture-validity check**
+
+Run `examples/su_symmetric_ctm_e2e.py` and note whether the `base_charges`-free
+SU state is degenerate/near-classical (issue #667). If it is, note in the Phase 2
+outcome that the acceptance test's `E_sym < -0.3` bound may need revisiting and
+the "matches dense" goal is a numerical-consistency check, not a physics check.
+
+---
+
+## Phase 3 — Implement the chosen mechanism for the 2×2 recipe (code depends on Phase 2 outcome)
+
+**This phase's concrete code cannot be written until Phase 2 chooses the
+mechanism.** The task skeleton below is fixed; the implementation bodies are
+filled from the Phase 2 outcome. Each task keeps the TDD shape (write failing
+assertion against the fixture → implement → green → commit).
+
+### Task 3.1: Template computation + threading (skeleton)
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_tensor_convergence.py` (`_ctm_tensor_multisite`, `_ctm_tensor_sweep_multisite` 2×2 branch)
+- Modify: `src/tenax/algorithms/_ctm_tensor_projector_2x2.py` and/or `_ctm_projector.py` per the chosen mechanism
+
+- [ ] **Step 1:** Add a failing assertion: after two `recipe="2x2"` sweeps on the fixture, `envA.C4.c4_u` and `envA.T4.t4_u` (and each contracted pair) have identical per-sector charge structure. (Run to confirm it currently fails/raises.)
+- [ ] **Step 2:** Implement template computation from the init env (per the Phase 2 rule) in `_ctm_tensor_multisite`; thread it into the 2×2 sweep and projector per the chosen mechanism.
+- [ ] **Step 3:** Run the step-1 assertion → PASS.
+- [ ] **Step 4:** Commit.
+
+### Task 3.2: Full 2×2 convergence matches dense on the fixture (acceptance)
+
+**Files:**
+- Modify: `tests/test_ctm_direction_dependent_bonds.py` — retarget the acceptance test to `recipe="2x2"` for BOTH the dense reference and the symmetric run.
+
+- [ ] **Step 1:** Change both `ctm_tensor_2site(...)` calls in `test_symmetric_2site_ctm_matches_dense_on_direction_dependent_bonds` from `recipe="1x1"` to `recipe="2x2"` (dense reference E ≈ -0.542 is unchanged between recipes, verified 2026-07-01). Add a comment citing this plan and the 1×1 fundamental-orientation limitation.
+- [ ] **Step 2:** Run: `uv run pytest tests/test_ctm_direction_dependent_bonds.py -v`
+  Expected: the symmetric run completes and `abs(E_sym - E_dense) < 1e-6`, `C1 norm > 1e-8`. If `E_sym < -0.3` fails because the fixture is a degenerate SU state (Phase 2 Step 4), relax/adjust that bound per the Phase 2 outcome and document why.
+- [ ] **Step 3:** Commit.
+
+### Task 3.3: Regression sweep
+
+- [ ] **Step 1:** Run the CTM/iPEPS core suite: `uv run pytest -m core -q` plus `tests/test_ipeps_u1sz.py tests/test_ctm_tensor.py tests/test_ctm_tensor_projector_2x2.py -q`.
+- [ ] **Step 2:** Confirm no regressions (the template mechanism must be a no-op for direction-uniform cells — assert this explicitly by checking a uniform C4v/D3 run's energy is unchanged to 1e-10).
+- [ ] **Step 3:** Update `MEMORY.md` note `project_667_direction_dependent_ctm.md` to CLOSED with the final mechanism, and open a follow-up issue for `FermionParity`/`FermionicU1` direction-dependent support (out of scope here).
+- [ ] **Step 4:** Commit; open PR per `CLAUDE.md` (`gh pr create`, squash-merge with CI).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** the RED acceptance test is Task 3.2; the tiling bug is Phase 0; the recipe-asymmetry root cause is encoded in the Phase 1 "no axis reseeding" note and the Phase 3 `recipe="2x2"` retarget; the unsolved core is Phase 2 (explicitly a decision phase, not fabricated code).
+- **Placeholders:** Phase 0/1 contain complete code. Phase 3 intentionally defers bodies to the Phase 2 outcome — this is honest (the mechanism is undecided), not a "TODO"; Phase 2 is a mandatory gate that produces the missing design.
+- **Names:** `_tile_fused_to_chi`, `_build_enlarged_corner`, `_ctm_tensor_absorb_*_2plaq`, `_compute_plaquette_projector_pair`, `_svd_projector_symmetric` are the real current symbols (verified 2026-07-01).
+- **Risk to core paths:** the AD backward path uses the dense/tracer projector, not `_svd_projector_symmetric`'s non-tracer branch, so a projector-emit template (mechanism A) confined to that branch does not touch AD; verify with Task 3.3.

--- a/docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md
+++ b/docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md
@@ -1,6 +1,6 @@
 # Direction-Dependent Symmetric Multisite CTM Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 >
 > **Read this first — this is a hybrid design+plan.** The *core* of the problem
 > (keeping the two sublattices' renormalised environment bonds structurally
@@ -71,7 +71,7 @@ This is a genuine bug independent of the direction-dependent feature: two opposi
 - Create test: `tests/test_ctm_tensor_tiling.py`
 - Modify: `src/tenax/algorithms/_ctm_tensor_init.py` (add helper after `_grouped_chi_perm`, ~line 285)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```python
 # tests/test_ctm_tensor_tiling.py
@@ -107,12 +107,12 @@ def test_tile_no_pad_when_chi_le_d2():
     assert np.array_equal(out, fused[:5])
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `uv run pytest tests/test_ctm_tensor_tiling.py -v`
 Expected: FAIL with `ImportError: cannot import name '_tile_fused_to_chi'`
 
-- [ ] **Step 3: Implement the helper**
+- [x] **Step 3: Implement the helper**
 
 In `src/tenax/algorithms/_ctm_tensor_init.py`, add after `_grouped_chi_perm`:
 
@@ -138,21 +138,21 @@ def _tile_fused_to_chi(fused: np.ndarray, chi: int) -> np.ndarray:
 
 Also add `"_tile_fused_to_chi"` to `__all__` at the top of the file.
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `uv run pytest tests/test_ctm_tensor_tiling.py -v`
 Expected: PASS (3 tests)
 
-- [ ] **Step 5: Route existing tiling through the helper**
+- [x] **Step 5: Route existing tiling through the helper**
 
 In `_init_symmetric_standard_edge`, replace the body of the inner `_fused_chi_charges` (the `if chi <= len(fused): ... else: tile ...` block) with `return _tile_fused_to_chi(fused, chi)`. Leave the corner as-is for now (it is rewritten in Phase 1).
 
-- [ ] **Step 6: Run the init regression + full core suite**
+- [x] **Step 6: Run the init regression + full core suite**
 
 Run: `uv run pytest tests/test_ctm_tensor_init_rank1.py tests/test_ipeps_u1sz.py -q`
 Expected: PASS (no regression — for uniform/trivial charges the helper is a no-op).
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add tests/test_ctm_tensor_tiling.py src/tenax/algorithms/_ctm_tensor_init.py
@@ -163,16 +163,28 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 ---
 
-## Phase 1 — 2×2-correct env init (understood)
+## Phase 1 — 2×2-correct env init (understood) — DONE (commit c9a77ed)
 
 For the **2×2** recipe, all enlarged-corner and absorption corner↔edge contractions are SAME-site, so the *original* same-axis seeding is correct. The only init change 2×2 needs is Phase 0's tiling (already landed). This phase is therefore a **verification phase**: confirm the enlarged-corner and 2-plaquette absorption contractions all pass on the fixture with the current (original) init + Phase 0 tiling, and lock that with a test. No init-axis changes — the 1×1-oriented axis reseeding from the 2026-07-01 WIP is explicitly NOT applied here.
+
+**Phase 1 outcome (2026-07-01):** the verification test initially FAILED at the
+first corner (`top_left`) on the same-site contraction `C1.c1_r <-> T1.t1_l`
+(7-vs-6 per-sector block mismatch). Root cause was the residual same-site gap the
+plan anticipated: Phase 0 routed only the *edge* chi legs through the canonical
+sorted `_tile_fused_to_chi`, but `_init_symmetric_standard_corner` still tiled its
+chi legs in **enumeration** order. Both legs derive from the same virtual axis
+(`ref_axis=d`) and share the same D²-fused multiset, but their padding past D²
+diverged. Fix: route the corner through `_tile_fused_to_chi` too (no axis
+reseeding — original same-axis 2×2 seeding kept). All four enlarged corners on
+both sublattices now build; regression green (tiling + init-rank1 + u1sz, 30
+passed).
 
 ### Task 1.1: Lock enlarged-corner charge-consistency on the fixture
 
 **Files:**
 - Test: `tests/test_ctm_direction_dependent_bonds.py` (add a focused sub-test)
 
-- [ ] **Step 1: Write a test that builds all four enlarged corners without error**
+- [x] **Step 1: Write a test that builds all four enlarged corners without error**
 
 ```python
 def test_2x2_enlarged_corners_build_on_direction_dependent_init():
@@ -202,12 +214,12 @@ def test_2x2_enlarged_corners_build_on_direction_dependent_init():
             assert Q is not None
 ```
 
-- [ ] **Step 2: Run it**
+- [x] **Step 2: Run it**
 
 Run: `uv run pytest tests/test_ctm_direction_dependent_bonds.py::test_2x2_enlarged_corners_build_on_direction_dependent_init -v`
 Expected: PASS (with Phase 0 tiling, the same-site enlarged corners are charge-consistent). If it FAILS, the failing contraction identifies a residual same-site seeding/tiling gap — fix in `_ctm_tensor_init.py` and re-run before proceeding. Record the exact failing contraction in the commit message.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add tests/test_ctm_direction_dependent_bonds.py

--- a/docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md
+++ b/docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md
@@ -261,7 +261,7 @@ Candidate mechanisms (from the 2026-07-01 investigation — each has an open ris
 **Files:**
 - Create (throwaway, do not commit): `scripts/spike_667_bond_drift.py`
 
-- [ ] **Step 1: Write a spike that runs N=1..5 2×2 sweeps and records, per env bond, the per-sector counts on each sublattice after each sweep**
+- [x] **Step 1: Write a spike that runs N=1..5 2×2 sweeps and records, per env bond, the per-sector counts on each sublattice after each sweep**
 
 Use `initialize_ctm_tensor_env`, `_build_double_layer_tensor`, and
 `_ctm_tensor_sweep_multisite(..., recipe="2x2")`; wrap the sweep in
@@ -270,12 +270,12 @@ counts (the failing contraction is reported by the `ValueError`). Regenerate the
 SU pair with `_su_direction_dependent_pair` (from the test) or cache it to
 `/tmp` to iterate fast.
 
-- [ ] **Step 2: Run and record**
+- [x] **Step 2: Run and record**
 
 Run: `uv run python scripts/spike_667_bond_drift.py`
 Record: (a) which sweep and which contraction first fails; (b) for the mismatching bond, the per-sector counts on A vs B across sweeps; (c) whether a fixed init-derived template's per-sector budget ever gets *exceeded* by a renormalised count (this decides A vs B/C).
 
-- [ ] **Step 3: Decide the mechanism**
+- [x] **Step 3: Decide the mechanism**
 
 Write the decision (and the measured evidence) into
 `docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md` under a
@@ -290,6 +290,77 @@ Run `examples/su_symmetric_ctm_e2e.py` and note whether the `base_charges`-free
 SU state is degenerate/near-classical (issue #667). If it is, note in the Phase 2
 outcome that the acceptance test's `E_sym < -0.3` bound may need revisiting and
 the "matches dense" goal is a numerical-consistency check, not a physics check.
+
+---
+
+## Phase 2 outcome (2026-07-01) — mechanism A ruled out; core is NOT a projector template
+
+**Measurement.** A per-*direction* spike (`scripts/spike_667_perdir.py`, throwaway,
+deleted) replicated the real `_ctm_tensor_sweep_multisite` 2×2 loop using the
+actual `_compute_plaquette_projector_pair` + `_ctm_tensor_absorb_*_2plaq`
+functions, snapshotting both sublattices' env chi-legs after each direction and
+checking them against a fixed init-derived per-sector template (per-sector max
+over A,B). SU pair cached to `/tmp/su667.pkl`.
+
+**Finding 1 — the init env is fully consistent.** All four 2×2 plaquette
+projector pairs build without error on the direction-dependent init env (both
+`s_anchor`). Phase 1's corner-tiling fix is confirmed sufficient for the *init*.
+
+**Finding 2 — first failure is WITHIN sweep 1, after the `left` absorption
+(not cross-sweep, not cross-sublattice).** Sweep order is `left, top, right,
+bottom`. `left` succeeds; `top`'s Phase-1 projector build then fails at the
+`bottom_left` enlarged corner, contraction `C4.c4_u ↔ T4.t4_u`, 6-vs-5 block
+mismatch. Crucially the failing quarter draws **all tensors from ONE env** (e.g.
+anchor `(0,0)` → `s_BL=(1,0)`, all of `C4/T3/T4` from env `(1,0)`), so it is a
+**single-env internal inconsistency**, not the cross-sublattice drift the plan
+modelled.
+
+**Finding 3 — mechanism A (fixed init-derived template) is measurably RULED
+OUT.** After only the `left` absorption the renormalised bonds acquire a **new
+charge sector absent from the init env** (charge `-4` appears) and existing
+per-sector counts **exceed** the init per-sector max (`-2: 6 > 4` on `C1.c1_d`,
+`C4.c4_r`, `T4.t4_d/t4_u`). A fixed init-derived template under-provisions and
+would truncate real renormalised data. (The earlier per-*sweep* spike's
+"never exceeded" verdict was vacuous — it never completed a sweep.)
+
+**Root cause — horizontal/vertical bond-identity crossing in the 2×2
+absorption.** In `_ctm_tensor_absorb_left_2plaq`, `new C4.c4_u` is the
+**carried-over, uncompressed `T3.t3_l` leg** (relabel `{"t3_l": "c4_u"}` after
+projecting only `(c4_r, d2)`), i.e. it inherits a *horizontal* bond's charges;
+but `new T4.t4_u` is **freshly compressed by `P_bot_curr`**, a *vertical* bond.
+The next `top` move's `bottom_left` enlarged corner contracts `c4_u ↔ t4_u`,
+pairing a horizontal-derived leg with a vertical-compressed leg. For
+direction-**uniform** iPEPS horizontal==vertical charge multisets so this is
+invisible (why 2×2 is the production default and never hit this); for
+`A.l != A.r` they differ and the contraction fails. Verified numerically: after
+`left`, `(1,0).C4.c4_u = {-2:4,0:6,2:2}` (= init `A.T3.t3_l`) vs
+`(1,0).T4.t4_u = {-4:1,-2:6,0:5}`.
+
+**Decision: none of A/B/C is the fix.** Mechanisms A/B/C all place a template on
+the **projector** truncation. But `c4_u` is not produced by a projector — it is a
+carried-over leg — so a projector template cannot reconcile it with `t4_u`. The
+real fix lives in the 2×2 absorption's **bond-direction bookkeeping**: the corner
+leg carried from `T3.t3_l` and the edge leg compressed by `P_bot_curr` must be
+made to represent the same renormalised bond (or the enlarged-corner leg-pairing
+must stop assuming horizontal==vertical). This is a **structural absorption
+change**, strictly larger than Phase 3 as scoped (projector-emit template), and
+consistent with the 2026-07-01 pre-plan verdict that direction-dependent 2×2 is
+"a substantial multi-layer effort … not a scoped patch."
+
+**Fixture validity (Step 4).** The dense CTM energy on this state is E≈−0.542
+(plan Background), ~19% above the square-lattice Heisenberg GS (−0.6694): the
+`base_charges`-free SU state is a poor/degenerate near-classical state. The
+acceptance test's "matches dense" is therefore a **numerical-consistency** check
+(sym-CTM == dense-CTM on the *same* state), not a physics check, and the
+`E_sym < -0.3` bound is not physically meaningful.
+
+**Recommended next step (needs a scope decision, see handoff):** Phase 3 as
+written will NOT unblock the test. Options: (1) redesign the 2×2 absorption to
+carry direction-tagged bonds through the enlarged corner (large); (2) shelve the
+direction-dependent 2×2 feature and keep only Phase 0+1 (the genuinely-correct
+tiling + init-consistency fixes already landed); (3) re-examine whether the
+enlarged-corner `c4_u↔t4_u` pairing is itself the bug. The pre-plan memory note
+already leaned toward "not worth it beyond the clean tiling fix."
 
 ---
 

--- a/docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md
+++ b/docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md
@@ -362,6 +362,36 @@ tiling + init-consistency fixes already landed); (3) re-examine whether the
 enlarged-corner `c4_u↔t4_u` pairing is itself the bug. The pre-plan memory note
 already leaned toward "not worth it beyond the clean tiling fix."
 
+### Phase 2 follow-up (user-approved investigation of the c4_u↔t4_u pairing) — DIRECTION-DEPENDENCE IS A RED HERRING
+
+A focused spike tested whether the `c4_u↔t4_u` invariant is the bug or the
+absorption, using a direction-**UNIFORM** multi-charge reference (normal U(1)-Sz
+SU with `base_charges` kept → `A.l == A.r`).
+
+- **The `c4_u == t4_u` invariant is BROKEN after a single `left` absorption for
+  the UNIFORM env too** (uniform: `C4.c4_u = {-2:2,-1:4,0:3,1:2,2:1}` — the
+  carried old `T3.t3_l` — vs `T4.t4_u = {-3:4,-2:7,0:1}` — the compressed
+  vertical bond). In BOTH uniform and direction-dependent, `new C4.c4_u` is the
+  carried `T3.t3_l` and the projector-compressed bond lands on `c4_r`.
+- **The real `ctm_tensor_2site(recipe="2x2")` RAISES on the uniform multi-charge
+  env** at the identical `bottom_left` `c4_u↔t4_u` contraction (3-vs-4). It is
+  NOT direction-dependent-specific.
+- `recipe="1x1"` on the same uniform env "completes" only by collapsing the
+  corner to norm 0 (the known 2-site symmetric collapse,
+  `project_forward_symmetric_ctm_energy_status`).
+
+**Conclusion: the symmetric block-sparse 2×2 forward sweep is latently broken for
+ANY genuine multi-charge U(1) env** — the `bottom_left`/`bottom_right` enlarged
+corner contracts a CARRIED leg (`c4_u ← T3.t3_l`) against a COMPRESSED leg
+(`t4_u ← P_bot_curr`), which only share block structure for trivial (dense)
+charges. Production never hit this because (a) the AD/tracer path runs with
+trivial charges (one block of size χ) and (b) the exercised symmetric forward CTM
+is single-site. The `c4_u↔t4_u` pairing is a correct requirement; the ABSORPTION
+violates it in general. **#667's direction-dependent 2×2 test cannot pass until
+this general symmetric-2×2-multicharge absorption bug is fixed — a separate,
+larger defect that deserves its own issue.** The genuinely-correct, shippable
+output of this whole plan is Phase 0 + Phase 1 (both landed).
+
 ---
 
 ## Phase 3 — Implement the chosen mechanism for the 2×2 recipe (code depends on Phase 2 outcome)

--- a/examples/fpeps_forward_ctm_e2e.py
+++ b/examples/fpeps_forward_ctm_e2e.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Gradient-free spinless-fermion (t-V) forward-CTM pipeline + collapse probe.
+
+Goal: SU -> forward FermionParity CTM -> energy, with NO autodiff (sidesteps
+the large-D symmetric-AD wall).  The CTM+energy *machinery* is single-site and
+verified sound here; the blocker is the fermionic simple update, which collapses
+the state.
+
+What this script demonstrates (all block-sparse FermionParity SymmetricTensors):
+
+  * ``steps=0`` (fresh random init, just normalized): ``fermionic_ctm`` +
+    ``compute_energy_fermionic_ctm`` return a finite, NONZERO energy -> the
+    forward CTM + energy path itself is correct.
+  * ``steps>=2``: the SU-updated tensor still has unit norm but the CTM energy
+    collapses to exactly 0.0 (environment/RDM structural zero).
+  * ``steps>=~10``: the SU output tensor norm itself collapses to 0.
+
+Caveat this exposes: ``fpeps(H, cfg)`` runs SU then CTM and returns the energy,
+but the shipped test only asserts ``jnp.isfinite(energy)`` -- and 0.0 is finite,
+so the collapse is not caught.  Treat this script as a reproducer, not a
+converged t-V benchmark.
+
+Usage::
+
+    JAX_PLATFORMS=cpu JAX_COMPILATION_CACHE_DIR=/tmp/jaxfresh \\
+        uv run python examples/fpeps_forward_ctm_e2e.py --D 2 --V 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms.fermionic_ipeps import (  # noqa: E402
+    FPEPSConfig,
+    _absorb_lambdas,
+    _fpeps_simple_update,
+    _initialize_fpeps,
+    _normalize_tensor,
+    compute_energy_fermionic_ctm,
+    fermionic_ctm,
+    spinless_fermion_gate,
+)
+
+
+def energy_after_su(A0, H, cfg, steps):
+    """Run `steps` of fermionic SU, then forward CTM + energy.
+
+    Returns (norm_after_su, energy) — energy is None if the tensor collapsed.
+    """
+    if steps == 0:
+        A_abs = _normalize_tensor(A0)
+    else:
+        A_opt, lam_h, lam_v = _fpeps_simple_update(
+            A0, H, max_D=cfg.D, dt=cfg.dt, steps=steps
+        )
+        A_abs = _normalize_tensor(_absorb_lambdas(A_opt, lam_h, lam_v))
+    n = float(A_abs.norm())
+    if n == 0.0:
+        return n, None
+    env = fermionic_ctm(A_abs, cfg)
+    return n, float(compute_energy_fermionic_ctm(A_abs, env, H))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--D", type=int, default=2)
+    p.add_argument("--V", type=float, default=2.0, help="n_i n_j interaction")
+    p.add_argument("--t", type=float, default=1.0, help="hopping")
+    p.add_argument("--dt", type=float, default=0.05)
+    p.add_argument("--chi", type=int, default=8)
+    p.add_argument("--seed", type=int, default=1)
+    p.add_argument(
+        "--steps-sweep",
+        nargs="+",
+        type=int,
+        default=[0, 2, 5, 10, 20, 40],
+        help="SU step counts to probe",
+    )
+    args = p.parse_args()
+
+    cfg = FPEPSConfig(
+        D=args.D,
+        t=args.t,
+        V=args.V,
+        dt=args.dt,
+        ctm_chi=args.chi,
+        ctm_max_iter=60,
+        ctm_conv_tol=1e-8,
+    )
+    H = spinless_fermion_gate(cfg)
+    A0 = _initialize_fpeps(cfg, jax.random.PRNGKey(args.seed))
+
+    print("\nSpinless t-V forward-CTM: fermionic SU-collapse probe")
+    print(f"D={args.D}  t={args.t}  V={args.V}  dt={args.dt}  chi={args.chi}")
+    print(f"fresh init |A0| = {float(A0.norm()):.4f}")
+    print("-" * 56)
+    print(f"{'SU steps':>8}  {'|A_abs|':>9}  {'E':>12}   note")
+    print("-" * 56)
+    for steps in args.steps_sweep:
+        n, E = energy_after_su(A0, H, cfg, steps)
+        if E is None:
+            print(f"{steps:>8}  {n:>9.4f}  {'-':>12}   tensor collapsed to 0")
+        else:
+            note = "OK (nonzero)" if abs(E) > 1e-9 else "energy collapsed to 0"
+            print(f"{steps:>8}  {n:>9.4f}  {E:>12.6f}   {note}")
+    print("-" * 56)
+    print(
+        "Expected: steps=0 nonzero (machinery OK); steps>=2 energy->0; "
+        "steps>=~10 norm->0."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/su_symmetric_ctm_e2e.py
+++ b/examples/su_symmetric_ctm_e2e.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Gradient-free symmetric forward-CTM energy: what works, what collapses.
+
+Premise: to sidestep the large-D symmetric-AD wall (``_jit_fused_fixed_point_bwd``,
+the block-sparse SVD/eigh/projector VJPs), evaluate energy with a *forward-only*
+symmetric CTM (as in an SU + CTM workflow).  The forward path never builds the
+backward VJPs, so large-D symmetric CTM is fine — *if* the forward CTM and energy
+are correct.
+
+This script pins down exactly which forward paths are correct today:
+
+  PART A (verified WORKING) — single-site symmetric CTM + energy.
+    ``ctm_tensor`` + ``compute_energy_ctm_tensor`` on a trivial-charge U(1)
+    ``SymmetricTensor`` gives a finite NONZERO energy that matches the densified
+    tensor to ~1e-12.  This confirms the forward symmetric CTM + RDM + energy
+    machinery is sound and block-sparse (no chi-env densification).
+
+  PART B (currently BROKEN) — 2-site checkerboard ``ctm_tensor_2site``.
+    Feeding a U(1)-Sz Heisenberg pair (``heisenberg_u1sz_init_pair``) through SU
+    then ``ctm_tensor_2site`` yields a corner of norm 0 -> energy exactly 0.
+    The collapse reproduces on the *densified* tensors too, so it is a general
+    2-site forward-CTM defect, not a symmetry/charge issue.  The shipped test
+    ``test_2site_symmetric_converges`` only checks convergence, never the energy
+    value, so it does not catch this.
+
+Takeaway: gradient-free symmetric energy works today via the single-site CTM;
+the 2-site (bipartite-Heisenberg) forward CTM needs a fix before an SU->CTM
+Heisenberg pipeline is usable.
+
+Usage::
+
+    JAX_PLATFORMS=cpu JAX_COMPILATION_CACHE_DIR=/tmp/jaxfresh \\
+        uv run python examples/su_symmetric_ctm_e2e.py --D 4 --chi 16
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax import (  # noqa: E402
+    compute_energy_ctm_tensor,
+    compute_energy_ctm_tensor_2site,
+    ctm_tensor,
+    ctm_tensor_2site,
+)
+from tenax.algorithms.ipeps import (  # noqa: E402
+    heisenberg_gate,
+    heisenberg_gate_u1sz,
+    heisenberg_u1sz_init_pair,
+)
+from tenax.algorithms.ipeps_simple_update import (  # noqa: E402
+    _make_trotter_gate_tensor,
+    _simple_update_2site_horizontal_tensor,
+    _simple_update_2site_vertical_tensor,
+)
+from tenax.core.index import FlowDirection, TensorIndex  # noqa: E402
+from tenax.core.symmetry import U1Symmetry  # noqa: E402
+from tenax.core.tensor import DenseTensor, SymmetricTensor  # noqa: E402
+
+
+def _trivial_charge_site(D: int, d: int, seed: int) -> SymmetricTensor:
+    """Random single-site iPEPS as a trivial-charge U(1) SymmetricTensor."""
+    sym = U1Symmetry()
+    ch = np.zeros(D, dtype=np.int32)
+    pch = np.zeros(d, dtype=np.int32)
+    idx = (
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(sym, pch.copy(), FlowDirection.IN, label="phys"),
+    )
+    data = jnp.array(np.random.RandomState(seed).standard_normal((D, D, D, D, d)))
+    return SymmetricTensor.from_dense(data, idx)
+
+
+def part_a_single_site(D: int, chi: int, seed: int) -> None:
+    """Verified working: single-site symmetric CTM + energy (sym == dense)."""
+    print("=== PART A: single-site symmetric CTM + energy (should WORK) ===")
+    A = _trivial_charge_site(D, 2, seed)
+    H = heisenberg_gate()
+
+    env, _ = ctm_tensor(A, chi=chi, max_iter=60, conv_tol=1e-8)
+    E_sym = float(compute_energy_ctm_tensor(A, env, H))
+
+    Ad = DenseTensor(A.todense(), A.indices)
+    envd, _ = ctm_tensor(Ad, chi=chi, max_iter=60, conv_tol=1e-8)
+    E_den = float(compute_energy_ctm_tensor(Ad, envd, H))
+
+    c1 = float(jnp.linalg.norm(env.C1.todense()))
+    ok = abs(E_sym) > 1e-9 and abs(E_sym - E_den) < 1e-8
+    print(f"  C1 corner norm : {c1:.6f}")
+    print(f"  E (symmetric)  : {E_sym:.10f}")
+    print(f"  E (densified)  : {E_den:.10f}   |diff|={abs(E_sym - E_den):.2e}")
+    print(f"  verdict        : {'PASS (nonzero, sym==dense)' if ok else 'FAIL'}\n")
+
+
+def part_b_2site(D: int, chi: int, steps: int, seed: int) -> None:
+    """Currently broken: SU -> ctm_tensor_2site corner collapses to zero."""
+    print("=== PART B: 2-site U(1)-Sz SU -> ctm_tensor_2site (KNOWN COLLAPSE) ===")
+    A, B = heisenberg_u1sz_init_pair(D=D, key=jax.random.PRNGKey(seed))
+    H = heisenberg_gate_u1sz()
+    lam_h = jnp.ones(D)
+    lam_v = jnp.ones(D)
+    gate = _make_trotter_gate_tensor(H, 0.1, site_tensor=A)
+    for step in range(steps):
+        if step % 2 == 0:
+            A, B, lam_h = _simple_update_2site_horizontal_tensor(
+                A, B, gate, lam_h, lam_v, D
+            )
+        else:
+            A, B, lam_v = _simple_update_2site_vertical_tensor(
+                A, B, gate, lam_h, lam_v, D
+            )
+
+    print(
+        f"  after {steps} SU steps: |A|={float(A.norm()):.4f} "
+        f"|B|={float(B.norm()):.4f}  type={type(A).__name__}"
+    )
+    for recipe in ("1x1", "2x2"):
+        env_A, env_B = ctm_tensor_2site(
+            A, B, chi=chi, max_iter=80, conv_tol=1e-8, recipe=recipe
+        )
+        c1 = float(jnp.linalg.norm(env_A.C1.todense()))
+        E = float(compute_energy_ctm_tensor_2site(A, B, env_A, env_B, H))
+        flag = "COLLAPSED" if c1 == 0.0 or abs(E) < 1e-12 else "ok"
+        print(f"  recipe={recipe:>3}: C1 norm={c1:.3e}  E/site={E:.6f}  -> {flag}")
+    print(
+        "  (collapse reproduces on densified tensors too -> general 2-site "
+        "forward-CTM defect)\n"
+    )
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--D", type=int, default=4)
+    p.add_argument("--chi", type=int, default=16)
+    p.add_argument("--steps", type=int, default=60, help="2-site SU steps")
+    p.add_argument("--seed", type=int, default=0)
+    args = p.parse_args()
+
+    try:
+        device = jax.devices()[0].device_kind
+    except Exception:
+        device = "unknown"
+    print(f"\ndevice={device}  D={args.D}  chi={args.chi}\n")
+
+    part_a_single_site(args.D, args.chi, args.seed)
+    part_b_2site(args.D, args.chi, args.steps, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tenax/algorithms/_ctm_tensor_init.py
+++ b/src/tenax/algorithms/_ctm_tensor_init.py
@@ -393,13 +393,15 @@ def _init_symmetric_standard_corner(
     # The chi bonds carry D²-derived charges: fuse ref_idx with bar'd copy
     idx_bra = ref_idx.flip_flow()
     fused_charges = _compute_fused_charges(ref_idx, idx_bra, flow_a, sym)
-    # fused_charges has size D²; tile to chi
-    base_D2_charges = fused_charges
-    if chi <= len(base_D2_charges):
-        chi_charges = np.asarray(base_D2_charges[:chi], dtype=np.int32)
-    else:
-        reps = chi // len(base_D2_charges) + 1
-        chi_charges = np.asarray(np.tile(base_D2_charges, reps)[:chi], dtype=np.int32)
+    # Tile the size-D² fused charges to chi with the canonical (sorted-padding)
+    # scheme so the corner's chi legs agree with the edge chi legs they contract
+    # against (which route through the same helper since #667 Phase 0).  Both
+    # sides derive from the same virtual axis; the old enumeration-order padding
+    # gave the corner a different charge multiset past D², breaking the same-site
+    # corner↔edge contraction in the 2x2 enlarged corner on direction-dependent
+    # (A.l != A.r) bonds.  No-op for chi <= D² and for direction-uniform iPEPS.
+    # #667 Phase 1.
+    chi_charges = _tile_fused_to_chi(fused_charges, chi)
 
     # Canonicalize chi-bond order to match the block-sparse SVD's grouped
     # bond order (#602).  Both corner legs share the same chi charges, so the

--- a/src/tenax/algorithms/_ctm_tensor_init.py
+++ b/src/tenax/algorithms/_ctm_tensor_init.py
@@ -14,6 +14,7 @@ __all__ = [
     "_init_symmetric_standard_edge",
     "_make_dense_standard_edge",
     "_make_rank1_dense_corner",
+    "_tile_fused_to_chi",
     "initialize_ctm_tensor_env",
 ]
 
@@ -284,6 +285,25 @@ def _grouped_chi_perm(charges: np.ndarray) -> np.ndarray:
     return np.argsort(np.asarray(charges), kind="stable")
 
 
+def _tile_fused_to_chi(fused: np.ndarray, chi: int) -> np.ndarray:
+    """Tile size-D² ``fused`` charges up to length ``chi`` canonically.
+
+    The leading D² block keeps the raw enumeration order (so index 0 stays the
+    charge-0 diagonal that anchors the rank-1 seed at the vacuum slot); any
+    padding beyond D² is appended in **sorted** order.  This makes two legs of
+    one bond that carry opposite flow (sign-flipped enumerations of the same
+    multiset) agree after tiling.  A no-op for ``chi <= D²`` and for
+    direction-uniform iPEPS.  #667.
+    """
+    fused = np.asarray(fused, dtype=np.int32)
+    if chi <= len(fused):
+        return fused[:chi]
+    srt = np.sort(fused)
+    reps = (chi - len(fused)) // len(srt) + 1
+    tail = np.tile(srt, reps)[: chi - len(fused)]
+    return np.concatenate([fused, tail]).astype(np.int32)
+
+
 def _init_symmetric_standard_edge(
     A: SymmetricTensor,
     chi: int,
@@ -315,10 +335,7 @@ def _init_symmetric_standard_edge(
         ref_idx = A.indices[ref_axis]
         ref_bra = ref_idx.flip_flow()
         fused = _compute_fused_charges(ref_idx, ref_bra, flow, sym)
-        if chi <= len(fused):
-            return np.asarray(fused[:chi], dtype=np.int32)
-        reps = chi // len(fused) + 1
-        return np.asarray(np.tile(fused, reps)[:chi], dtype=np.int32)
+        return _tile_fused_to_chi(fused, chi)
 
     chi1_charges = _fused_chi_charges(ref_axis_chi1, flow_chi1)
     chi2_charges = _fused_chi_charges(ref_axis_chi2, flow_chi2)

--- a/tests/test_ctm_direction_dependent_bonds.py
+++ b/tests/test_ctm_direction_dependent_bonds.py
@@ -87,5 +87,40 @@ def test_symmetric_2site_ctm_matches_dense_on_direction_dependent_bonds():
     assert E_sym < -0.3, f"energy {E_sym} unphysical (expected AFM, ~ -0.5 to -0.7)"
 
 
+def test_2x2_enlarged_corners_build_on_direction_dependent_init():
+    """First-sweep 2x2 enlarged corners must build (charge-consistent) on the
+    direction-dependent init env.
+
+    Phase 1 of docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md:
+    for the 2x2 recipe all enlarged-corner corner<->edge contractions are
+    SAME-site, so the original same-axis env-init seeding + Phase 0 canonical
+    tiling should already be charge-consistent (no 1x1-oriented axis reseeding).
+    """
+    import numpy as np
+
+    from tenax.algorithms._ctm_tensor_init import (
+        _build_double_layer_tensor,
+        initialize_ctm_tensor_env,
+    )
+    from tenax.algorithms._ctm_tensor_projector_2x2 import _build_enlarged_corner
+
+    A, B = _su_direction_dependent_pair()
+    chi = 12
+    envA = initialize_ctm_tensor_env(A, chi)
+    envB = initialize_ctm_tensor_env(B, chi)
+    aA = _build_double_layer_tensor(A)
+    aB = _build_double_layer_tensor(B)
+    # Same-site enlarged corners (each uses one site's env + that site's DL).
+    for env, a in ((envA, aA), (envB, aB)):
+        for pos, (C, Th, Tv) in {
+            "top_left": (env.C1, env.T1, env.T4),
+            "top_right": (env.C2, env.T1, env.T2),
+            "bottom_left": (env.C4, env.T3, env.T4),
+            "bottom_right": (env.C3, env.T3, env.T2),
+        }.items():
+            Q = _build_enlarged_corner(C, Th, Tv, a, position=pos)
+            assert Q is not None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/tests/test_ctm_direction_dependent_bonds.py
+++ b/tests/test_ctm_direction_dependent_bonds.py
@@ -1,0 +1,91 @@
+"""2-site CTM must handle direction-dependent virtual bonds (A.l != A.r).
+
+Regression for the env-init single-tensor-uniformity assumption (issue #667
+follow-up): a valid *unit-cell*-translation-invariant checkerboard iPEPS can have
+A.l != A.r as long as bonds match AROUND the cell (A.r==B.l, A.l==B.r).  Dropping
+the SU `base_charges` produces exactly such a state; `ctm_tensor_2site` used to
+die with a `7 vs 4` contraction mismatch because the symmetric env init derived
+both corner chi-legs from a single reference axis.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+import tenax.algorithms.ipeps_simple_update as SU
+from tenax import compute_energy_ctm_tensor_2site, ctm_tensor_2site
+from tenax.algorithms.ipeps import (
+    heisenberg_gate,
+    heisenberg_gate_u1sz,
+    heisenberg_u1sz_init_pair,
+)
+from tenax.core.tensor import DenseTensor
+
+
+def _su_direction_dependent_pair(D=3, steps=40, dt=0.1):
+    """Run base_charges-free U(1)-Sz SU -> a pair with A.l != A.r (unit-cell OK)."""
+    A, B = heisenberg_u1sz_init_pair(D=D, key=jax.random.PRNGKey(0))
+    H = heisenberg_gate_u1sz()
+    gate = SU._make_trotter_gate_tensor(H, dt, site_tensor=A)
+    lam_h = jnp.ones(D)
+    lam_v = jnp.ones(D)
+    orig = SU.truncated_svd
+    SU.truncated_svd = lambda *a, **k: orig(*a, **{**k, "base_charges": None})
+    try:
+        for s in range(steps):
+            if s % 2 == 0:
+                A, B, lam_h = SU._simple_update_2site_horizontal_tensor(
+                    A, B, gate, lam_h, lam_v, D
+                )
+            else:
+                A, B, lam_v = SU._simple_update_2site_vertical_tensor(
+                    A, B, gate, lam_h, lam_v, D
+                )
+    finally:
+        SU.truncated_svd = orig
+    return A, B
+
+
+def _charges(T, leg):
+    lab = T.labels()
+    return list(np.asarray(T.indices[lab.index(leg)].charges))
+
+
+def test_su_output_is_direction_dependent_but_cell_consistent():
+    """Sanity: the fixture really has A.l != A.r yet A.r==B.l and A.l==B.r."""
+    A, B = _su_direction_dependent_pair()
+    assert _charges(A, "l") != _charges(A, "r"), "fixture must be direction-dependent"
+    assert _charges(A, "r") == _charges(B, "l"), "A.r must match B.l (cell-consistent)"
+    assert _charges(A, "l") == _charges(B, "r"), "A.l must match B.r (cell-consistent)"
+
+
+def test_symmetric_2site_ctm_matches_dense_on_direction_dependent_bonds():
+    """ctm_tensor_2site on A.l!=A.r must not error and must match the dense result."""
+    A, B = _su_direction_dependent_pair()
+    Hd = heisenberg_gate()
+
+    # Dense reference (densify then run the same CTM path).
+    Ad = DenseTensor(np.array(A.todense()), A.indices)
+    Bd = DenseTensor(np.array(B.todense()), B.indices)
+    eAd, eBd = ctm_tensor_2site(
+        Ad, Bd, chi=12, max_iter=60, conv_tol=1e-9, recipe="1x1"
+    )
+    E_dense = float(compute_energy_ctm_tensor_2site(Ad, Bd, eAd, eBd, Hd))
+
+    # Symmetric block-sparse path (the one that used to crash with 7 vs 4).
+    eA, eB = ctm_tensor_2site(A, B, chi=12, max_iter=60, conv_tol=1e-9, recipe="1x1")
+    c1 = float(jnp.linalg.norm(eA.C1.todense()))
+    E_sym = float(compute_energy_ctm_tensor_2site(A, B, eA, eB, Hd))
+
+    assert c1 > 1e-8, f"symmetric CTM corner collapsed (C1 norm={c1})"
+    assert abs(E_sym - E_dense) < 1e-6, f"sym {E_sym} != dense {E_dense}"
+    assert E_sym < -0.3, f"energy {E_sym} unphysical (expected AFM, ~ -0.5 to -0.7)"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/test_ctm_direction_dependent_bonds.py
+++ b/tests/test_ctm_direction_dependent_bonds.py
@@ -64,6 +64,17 @@ def test_su_output_is_direction_dependent_but_cell_consistent():
     assert _charges(A, "l") == _charges(B, "r"), "A.l must match B.r (cell-consistent)"
 
 
+@pytest.mark.xfail(
+    reason="Blocked by #670: the symmetric block-sparse 2x2 CTM sweep is broken "
+    "for ANY multi-charge U(1) env (enlarged-corner carried-vs-compressed bond "
+    "mismatch), not just direction-dependent bonds. See "
+    "docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md "
+    "(Phase 2 outcome). Phase 0 (canonical tiling) + Phase 1 (init corner "
+    "consistency) landed and are correct; the 2x2 absorption fix is #670. The "
+    "1x1 recipe used here also has a fundamental edge-orientation wall (plan "
+    "Background).",
+    strict=False,
+)
 def test_symmetric_2site_ctm_matches_dense_on_direction_dependent_bonds():
     """ctm_tensor_2site on A.l!=A.r must not error and must match the dense result."""
     A, B = _su_direction_dependent_pair()

--- a/tests/test_ctm_tensor_tiling.py
+++ b/tests/test_ctm_tensor_tiling.py
@@ -1,0 +1,34 @@
+"""Opposite-flow legs of one bond must tile to equal charge multisets (#667)."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import numpy as np
+
+from tenax.algorithms._ctm_tensor_init import _tile_fused_to_chi
+
+
+def test_tile_preserves_multiset_under_sign_flip():
+    # A U(1) fusion enumeration and its sign-flip (what opposite-flow legs of
+    # the same virtual axis produce) must give equal multisets after tiling
+    # past D**2 to chi.
+    fused = np.array([0, -2, 0, 2, 0, 2, 0, -2, 0], dtype=np.int32)  # D**2 = 9
+    flipped = -fused
+    chi = 12
+    a = Counter(_tile_fused_to_chi(fused, chi).tolist())
+    b = Counter(_tile_fused_to_chi(flipped, chi).tolist())
+    assert a == b, f"tiled multisets differ: {a} vs {b}"
+
+
+def test_tile_keeps_charge_zero_at_index_0():
+    # The rank-1 seed lives at pre-perm index 0 and must stay charge 0.
+    fused = np.array([0, -1, 1, 1, 0, 2, -1, -2, 0], dtype=np.int32)
+    out = _tile_fused_to_chi(fused, 12)
+    assert int(out[0]) == 0
+
+
+def test_tile_no_pad_when_chi_le_d2():
+    fused = np.array([0, -2, 0, 2, 0, 2, 0, -2, 0], dtype=np.int32)
+    out = _tile_fused_to_chi(fused, 5)
+    assert np.array_equal(out, fused[:5])


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yjkao.

Lands the two genuinely-correct, self-contained pieces of the direction-dependent symmetric CTM plan (Phases 0 & 1) and documents why the remaining work is blocked by a separate, larger defect (#670).

## What's here

**Phase 0 — canonical (sorted) tiling for opposite-flow env chi legs** (`bb679f1`)
Two legs of one env bond that carry opposite flow (same virtual axis) produce sign-flipped enumerations of the same charge multiset. Padding a chi leg beyond D² in *enumeration* order broke multiset equality; padding in *sorted* order preserves it. New `_tile_fused_to_chi`. No-op for `chi <= D²` and for direction-uniform iPEPS.

**Phase 1 — 2×2-correct env-init corner consistency** (`c9a77ed`)
Routed `_init_symmetric_standard_corner` through the same canonical tiling so corner chi legs and edge chi legs pad identically (they were diverging past D²: enumeration vs sorted). Adds `test_2x2_enlarged_corners_build_on_direction_dependent_init`, which builds all four 2×2 same-site enlarged corners on both sublattices. No axis reseeding.

**Docs + test disposition**
- Full design/plan + Phase 2 decision record in `docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md`.
- The RED acceptance test is marked `xfail` pending #670 (see below).

## Why the acceptance test is xfail (not fixed)

Phase 2 (a spike/measure decision phase) proved the remaining blocker is **not** a projector-truncation template and **not** direction-dependent-specific. The symmetric block-sparse **2×2** sweep crashes on *any* genuine multi-charge U(1) env: the `bottom_left` enlarged corner contracts a carried leg (`c4_u ← T3.t3_l`) against a compressed leg (`t4_u ← P_bot_curr`), which only share block structure for trivial (dense) charges. Reproduced on a direction-**uniform** multi-charge env. Filed as **#670** (general symmetric-2×2-multicharge absorption bug). Direction-dependence was a red herring; Phases 0+1 are correct and independent.

## Tests

- `tests/test_ctm_tensor_tiling.py` — 3 passed (Phase 0)
- `tests/test_ctm_direction_dependent_bonds.py` — 2 passed, 1 xfailed (Phase 1 + fixture sanity; acceptance xfail → #670)
- Regression: `test_ctm_tensor_init_rank1`, `test_ipeps_u1sz` — green (the tiling change is a no-op for direction-uniform / trivial charges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)