### PR TITLE
bench(#632): large-D × large-χ multi-GPU frontier — split-1GPU beats dense-2GPU (phase 1)

### DIFF
--- a/docs/superpowers/handoffs/2026-07-01-632-largeD-largechi-multigpu-frontier-findings.md
+++ b/docs/superpowers/handoffs/2026-07-01-632-largeD-largechi-multigpu-frontier-findings.md
@@ -82,3 +82,10 @@ Full sweep driver: `scratchpad/run_frontier_sweep.sh` (anchor-gated, per-D early
 - Split reach for D≤10 is a **grid cap (χ=128), not a measured wall** — split's true single-GPU χ ceiling at D=8/10 is higher and unmeasured (phase-2 item a).
 - **2 GPUs only** (GPUs 1,2 clean; 0 held 61 GiB, 4 busy). A 4-GPU dense run would raise shard relief modestly (N=4 shards all of D²∈{36,64,100,144}) but the ~1.1–1.4× / no-D-reach pattern predicts it stays a "fit a bit bigger" lever, not a D-enabler.
 - Well-conditioned near-product state (clean adjoint); a random/critical state would have a harder backward but similar peak scaling (D⁶ dense / D⁴ split).
+
+## Harness follow-ups (non-blocking; for phase-2 reuse of this harness)
+
+Surfaced by the whole-branch review; none affected this run's numbers, but worth tightening before the phase-2 split-reach sweep reuses `bench_ctm_frontier_grad.py`:
+- **Narrow the run-time `except`** (`examples/bench_ctm_frontier_grad.py`): it catches all `Exception` and prints `FAILED(...)`. Every failure here was a legitimate XLA `RESOURCE_EXHAUSTED`/autotuner error (verified by the printed exc-type + GiB counts), but a genuine probe bug (TypeError/shape/NaN) would also be reported as a `FAILED` cell rather than surfacing — re-raise non-XLA exceptions so a real bug can't masquerade as a "wall". A NaN energy would still print `OK E=nan`; add a finite check if phase 2 hits ill-conditioned states.
+- **Lock the JAX-free-at-import invariant** with a subprocess assertion (in-process `"jax" not in sys.modules` is unreliable once another test imports jax) so a future top-level jax import in the harness fails loudly.
+- Align the probe's `chi_I=chi_I or chi` to `chi_I if chi_I is not None else chi` (matches `ctm_energy_split_implicit`'s own convention; only matters if a caller passes `chi_I=0`).

--- a/docs/superpowers/handoffs/2026-07-01-632-largeD-largechi-multigpu-frontier-findings.md
+++ b/docs/superpowers/handoffs/2026-07-01-632-largeD-largechi-multigpu-frontier-findings.md
@@ -1,0 +1,84 @@
+# Large-D × large-χ multi-GPU frontier — phase 1 findings
+
+**Date:** 2026-07-01
+**Branch:** `bench/632-frontier-multigpu` (off #668)
+**Harness:** `examples/bench_ctm_frontier_grad.py` + `tests/_frontier_grad_probe.py`
+**Hardware:** 2× A100-80GB (GPUs 1,2), f64, `XLA_PYTHON_CLIENT_PREALLOCATE=false`, one config/process, recipe=1×1, `value_and_grad` (energy + gradient), well-conditioned 1-site state, max_iter=30.
+**Spec:** `docs/superpowers/specs/2026-07-01-632-largeD-largechi-multigpu-frontier-design.md`
+
+**Verdict: split-CTM on 1 GPU reaches far larger (D, χ) than dense-CTM on 2 GPUs — the memory-efficient *algorithm* (χ²·D⁴, single-GPU) dominates the multi-GPU *dense* apparatus (χ²·D⁶ + shard + chunk). Multi-GPU dense is NOT the large-(D,χ) lever; split-CTM is.**
+
+## Harness anchor
+
+dense-1×1 D=8 χ=24 = **11.01 GB** (shard-reach recipe=2×2 was 10.66 GB — recipe differs; same order, path trusted). Split and dense energies/‖g‖ agree to ~4 digits at every D (D6 both E=+0.000044; D8 both −0.000405; D10 both −0.000226) — cross-path validation of the probe. (Energies are tiny because the well-conditioned init is a near-product state; this is a memory/reach study, not a ground-state energy.)
+
+## Frontier — per-device peak (GB), recipe=1×1, value_and_grad
+
+### Config 1 — split-CTM, 1-GPU (χ²·D⁴)
+| D | χ=24 | χ=48 | χ=96 | χ=128 | reach (max χ OK) |
+|---|------|------|------|-------|------------------|
+| 6 | 0.28 | 0.98 | 3.78 | 6.42 | **≥128** (grid cap, not a wall) |
+| 8 | 0.71 | 2.58 | 9.68 | 16.93 | **≥128** (grid cap) |
+| 10 | 1.60 | 5.71 | 22.43 | 39.89 | **≥128** (grid cap) |
+| 12 | 3.20 | 11.59 | 46.35 | **autotuner-fail** | **96** (χ128 = compile wall, not OOM) |
+
+### Configs 2–4 — dense (χ²·D⁶): 1-GPU / 2-GPU shard / 2-GPU shard+chunk8
+| D | χ | dense 1-GPU | 2-GPU shard | 2-GPU shard+chunk8 |
+|---|---|-------------|-------------|--------------------|
+| 6 | 16 | 1.20 | 1.07 | 1.07 |
+| 6 | 24 | 2.69 | 1.27 | 1.27 |
+| 6 | 32 | 4.13 | 2.91 | 2.91 |
+| 8 | 16 | 5.10 | 3.95 | 3.95 |
+| 8 | 24 | 11.01 | 9.78 | 9.78 |
+| 8 | 32 | 18.37 | 16.50 | 16.50 |
+| 10 | 16 | 28.01 | 19.64 | 19.64 |
+| 10 | 24 | **OOM** (29.0 GiB) | **OOM** (34.5 GiB) | **OOM** (34.5 GiB) |
+| 12 | 16 | **autotuner-fail** | **autotuner-fail** | **autotuner-fail** |
+
+Dense reach (max χ OK): D6 ≥32, D8 ≥32, D10 =16, D12 = none (χ16 fails XLA autotuning on the `f64[144,12,…]` transpose — the giant-gemm compile wall, not memory), for **all three** dense configs.
+
+## Reads
+
+1. **Split-1GPU vs dense-2GPU — split wins by a wide margin.**
+   - **D=10:** split reaches **χ≥128 (39.89 GB) on 1 GPU**; dense-2GPU caps at **χ16 (19.64 GB)**, OOMs at χ24. Split does ~8× the χ at 1 GPU vs dense at 2 GPUs.
+   - **D=8:** split χ128 = 16.93 GB (1 GPU) ≈ dense-2GPU χ32 = 16.50 GB — same peak, 4× the χ.
+   - **D=12:** split runs to **χ96 (46 GB, 1 GPU)**; dense (1- or 2-GPU) **cannot compile even χ16**. Split is the *only* path that runs D=12.
+
+2. **Shard relief is weak and χ-gated: ~1.1–1.4×, no D-reach extension.**
+   - D8 χ24: 11.01→9.78 = 1.13×; D8 χ32: 18.37→16.50 = 1.11×; D10 χ16: 28.01→19.64 = **1.43×** (best); D6 χ24: 2.69→1.27 = 2.1× (small D, small absolute).
+   - Critically, 2-GPU does **not** extend the reach: both 1- and 2-GPU cap at **D10 χ16** (χ24 OOMs on both). Confirms `632-shard-only-reach-grad-D10-12` (SVD-replication-bound; the χ²·D⁶ backward intermediate stays replicated per device).
+
+3. **Chunk adds nothing to the `value_and_grad` peak.** Config 4 (shard+chunk8) peaks are **identical** to config 3 (shard-only) at every cell — chunk gives 0 GB relief in the pipeline. Confirms the Increment-2 NO-GO from the pipeline side: the forward absorb chunk is below the CTM-convergence memory waterline and the backward is (correctly) not chunked. (Config 4's shorter wall times are just JAX persistent-compile-cache warmth from config 3's identical shapes, not a memory effect.)
+
+4. **The composition gap, made concrete.** split-1GPU (χ²·D⁴) reaches D=12 χ96 and D≤10 χ≥128 on **one** GPU; the entire dense multi-GPU apparatus (shard + chunk on **two** GPUs) caps at D10 χ16 / D8 χ32. The memory-efficient algorithm on 1 GPU dominates the multi-GPU dense path everywhere on the frontier.
+
+5. **Two walls both observed and distinct.** *Memory OOM* (dense D10 χ24 on 1- and 2-GPU). *Autotuner compile-fail* on the giant transpose (`f64[144,12,…]` for dense D12; `f64[12,128,128,12,12,12,2]` for split D12 χ128) — a compile wall independent of per-device memory. Split D12 χ128 fails on the autotuner, not OOM, so multi-GPU sharding would not rescue that specific cell.
+
+## Recommendation (feeds phase 2)
+
+**Building split × multi-GPU (thread `device_mesh` into the split path) is the only lever that could push past split's *memory* wall — but multi-GPU dense is a dead end.** The data is unambiguous: multi-GPU on the *dense* path buys ~1.1–1.4× and never extends the D reach, so it is not worth further investment as a large-(D,χ) enabler. The open large-(D,χ) question is whether sharding the *split* χ²·D⁴ path across GPUs extends its already-large reach:
+
+- Split-1GPU already reaches **D=12 χ96 = 46 GB** and **D≤10 χ≥128** (grid cap, not measured to OOM) on one 80 GB card. Its memory headroom is large, so its reach is even higher than measured for D≤10.
+- Sharding split across 2 GPUs would help where split hits a **memory** wall — i.e., very large χ at D≤10 (χ ≫ 128) or reaching **D=14**. It would *not* help split's D=12 χ128 cell, which is an **autotuner compile** wall, not memory.
+- **Suggested phase 2:** (a) first push split-1GPU χ to its true memory wall at D=8/10 (grid capped at 128 here) to quantify the single-GPU split ceiling; (b) then gate whether `device_mesh` on the split path shards the χ²·D⁴ intermediate for a real per-device ÷N — the same GSPMD question, but on a path where the dominant intermediate may shard better than dense's SVD-replicated one. If split's dominant backward intermediate is *also* SVD-replication-bound, multi-GPU split will fade like dense and phase 2 should instead target `chi_I < χ` (the split-only interlayer-bond memory lever, held = χ here) and the D=12/14 autotuner compile wall.
+
+## Reproduce
+
+```bash
+cd /home/yjkao/tenax-632-frontier   # worktree, cuda13 env
+# anchor:
+CUDA_VISIBLE_DEVICES=1 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+  uv run python examples/bench_ctm_frontier_grad.py --path dense --D 8 --chi 24
+# split reach (1-GPU), dense 1-GPU, dense 2-GPU shard, dense 2-GPU shard+chunk:
+CUDA_VISIBLE_DEVICES=1   ... --path split --D 10 --chi 128
+CUDA_VISIBLE_DEVICES=1   ... --path dense --D 10 --chi 16
+CUDA_VISIBLE_DEVICES=1,2 ... --path dense --D 10 --chi 16 --shard
+CUDA_VISIBLE_DEVICES=1,2 ... --path dense --D 10 --chi 16 --shard --chunk 8
+```
+Full sweep driver: `scratchpad/run_frontier_sweep.sh` (anchor-gated, per-D early-exit on OOM, 900s/run timeout).
+
+## Limitations / open
+
+- Split reach for D≤10 is a **grid cap (χ=128), not a measured wall** — split's true single-GPU χ ceiling at D=8/10 is higher and unmeasured (phase-2 item a).
+- **2 GPUs only** (GPUs 1,2 clean; 0 held 61 GiB, 4 busy). A 4-GPU dense run would raise shard relief modestly (N=4 shards all of D²∈{36,64,100,144}) but the ~1.1–1.4× / no-D-reach pattern predicts it stays a "fit a bit bigger" lever, not a D-enabler.
+- Well-conditioned near-product state (clean adjoint); a random/critical state would have a harder backward but similar peak scaling (D⁶ dense / D⁴ split).

--- a/docs/superpowers/plans/2026-07-01-632-largeD-largechi-multigpu-frontier.md
+++ b/docs/superpowers/plans/2026-07-01-632-largeD-largechi-multigpu-frontier.md
@@ -1,0 +1,560 @@
+# Large-D × large-χ multi-GPU frontier benchmark (phase 1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Measure the reachable (D, χ) frontier of one iPEPS `value_and_grad` step across split-CTM (1-GPU, χ²·D⁴), dense (1-GPU, χ²·D⁶), and dense multi-GPU (shard, shard+chunk), all at recipe=1×1, to answer whether split-1GPU reaches larger (D, χ) than dense-2GPU and where each wall is.
+
+**Architecture:** A path-dispatching probe (`tests/_frontier_grad_probe.py`) wraps the two production AD entry points — `ctm_energy_implicit` (dense, recipe=1×1, optionally `device_mesh`-sharded and `ctm_chunk_size`-chunked) and `ctm_energy_split_implicit` (split, single-GPU) — behind one `jax.value_and_grad`, reusing the trusted rung-2 probe's 1-site iPEPS + gate + well-conditioned init so peaks are comparable to the shard-reach benchmark. A CLI harness (`examples/bench_ctm_frontier_grad.py`) runs one (path, D, χ) per process and reports per-device peak, distinguishing the two orthogonal walls (divisibility SKIP vs memory OOM). A GPU sweep on GPUs 1,2 fills a findings doc.
+
+**Tech Stack:** Python, JAX (x64, `jax.value_and_grad`, `memory_stats()["peak_bytes_in_use"]`), Tenax `DenseTensor` / `ctm_energy_implicit` / `ctm_energy_split_implicit` / `build_ctm_mesh`, pytest (`-m core`), 2× A100 (GPUs 1,2).
+
+**Spec:** `docs/superpowers/specs/2026-07-01-632-largeD-largechi-multigpu-frontier-design.md`
+
+## Global Constraints
+
+- **No `src/tenax/**` change.** Only `tests/`, `examples/`, `docs/` are touched. (`tests/conftest.py` marker-dict edits are test-infra, allowed.)
+- **Branch/worktree:** `bench/632-frontier-multigpu`, worktree `/home/yjkao/tenax-632-frontier`, based on `origin/main` f9b8f6e (#668 — has `ctm_chunk_size` + `_shard_a`-in-1×1). Do all work here; leave `/home/yjkao/tenax` untouched.
+- **Recipe fixed at `"1x1"`** for every dense config (split is intrinsically 1×1).
+- **x64 always** (`jax.config.update("jax_enable_x64", True)`).
+- **One (path, D, χ) per process** for a clean cumulative per-device peak; `XLA_PYTHON_CLIENT_PREALLOCATE=false` on GPU runs.
+- **State:** 1-site dense iPEPS, well-conditioned, gate `diag(0.25,-0.25,-0.25,0.25).reshape(2,2,2,2)` — reuse `_rung2_grad_probe._indices` / `_init_data` verbatim.
+- **Two orthogonal walls:** divisibility `D² % N == 0` (SKIP, decided before running) vs memory OOM (FAILED at run time). Never conflate them.
+- **Commit messages end with:** `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Path-dispatching frontier probe (dense + split → value_and_grad)
+
+**Files:**
+- Create: `tests/_frontier_grad_probe.py`
+- Create: `tests/test_frontier_probe.py`
+- Modify: `tests/conftest.py` (add `"test_frontier_probe.py": "core"` to `_FILE_MARKERS`)
+
+**Interfaces:**
+- Consumes: `_rung2_grad_probe._indices(D) -> tuple[TensorIndex, ...]`, `_rung2_grad_probe._init_data(D, seed, well_conditioned) -> jax.Array (D,D,D,D,2)`; `tenax.algorithms._ctm_energy_ad.ctm_energy_implicit`; `tenax.algorithms._split_ctm_energy_ad.ctm_energy_split_implicit`; `tenax.algorithms._ctm_tensor_convergence.SINGLE_SITE_NEIGHBORS`; `tenax.core.tensor.DenseTensor`.
+- Produces: `frontier_energy_and_grad(*, path, D, chi, chi_I=None, device_mesh=None, ctm_chunk_size=None, seed=0, well_conditioned=True, max_iter=30) -> tuple[float, np.ndarray]`. `path ∈ {"dense","split"}`. Raises `ValueError` on an unknown path, or on `device_mesh`/`ctm_chunk_size` passed to `path="split"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_frontier_probe.py
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import numpy as np
+import pytest
+
+from _frontier_grad_probe import frontier_energy_and_grad
+
+
+@pytest.mark.parametrize("path", ["dense", "split"])
+def test_frontier_probe_finite(path):
+    e, g = frontier_energy_and_grad(path=path, D=2, chi=6, max_iter=15)
+    assert np.isfinite(e), e
+    assert np.all(np.isfinite(g)), path
+    assert g.shape == (2, 2, 2, 2, 2), g.shape
+
+
+def test_frontier_split_rejects_mesh():
+    with pytest.raises(ValueError):
+        frontier_energy_and_grad(path="split", D=2, chi=6, device_mesh=object())
+
+
+def test_frontier_split_rejects_chunk():
+    with pytest.raises(ValueError):
+        frontier_energy_and_grad(path="split", D=2, chi=6, ctm_chunk_size=4)
+
+
+def test_frontier_unknown_path():
+    with pytest.raises(ValueError):
+        frontier_energy_and_grad(path="nope", D=2, chi=6)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/yjkao/tenax-632-frontier && JAX_PLATFORMS=cpu uv run pytest tests/test_frontier_probe.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named '_frontier_grad_probe'`.
+
+- [ ] **Step 3: Write the probe module**
+
+```python
+# tests/_frontier_grad_probe.py
+"""Frontier benchmark probe: value_and_grad of the CTM-AD energy across paths.
+
+Dispatches the dense (``ctm_energy_implicit``, recipe="1x1", optionally sharded
++ chunked) and split (``ctm_energy_split_implicit``, single-GPU, chi^2 * D^4)
+paths to a common ``jax.value_and_grad`` for the large-D x large-chi multi-GPU
+frontier study (phase 1, #632). Reuses the rung-2 probe's 1-site dense iPEPS +
+gate + well-conditioned init so per-device peaks are directly comparable to the
+shard-reach benchmark.
+"""
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from tenax.algorithms._ctm_energy_ad import ctm_energy_implicit
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
+from tenax.algorithms._split_ctm_energy_ad import ctm_energy_split_implicit
+from tenax.core.tensor import DenseTensor
+
+from _rung2_grad_probe import _indices, _init_data  # pristine helpers (do not edit)
+
+_HEISENBERG = jnp.diag(jnp.array([0.25, -0.25, -0.25, 0.25])).reshape(2, 2, 2, 2)
+
+
+def frontier_energy_and_grad(
+    *,
+    path,
+    D,
+    chi,
+    chi_I=None,
+    device_mesh=None,
+    ctm_chunk_size=None,
+    seed=0,
+    well_conditioned=True,
+    max_iter=30,
+):
+    """Return (energy: float, grad: (D,D,D,D,2) array) of one value_and_grad step.
+
+    path="dense": ctm_energy_implicit(recipe="1x1", device_mesh=..., ctm_chunk_size=...)
+    path="split": ctm_energy_split_implicit(chi_I=chi_I or chi)  # single-GPU only
+    """
+    idx = _indices(D)
+    data0 = _init_data(D, seed, well_conditioned)
+
+    if path == "dense":
+
+        def loss(data):
+            A = DenseTensor(data, idx)
+            return ctm_energy_implicit(
+                {(0, 0): A},
+                SINGLE_SITE_NEIGHBORS,
+                _HEISENBERG,
+                chi=chi,
+                max_iter=max_iter,
+                conv_tol=1e-10,
+                forward_gauge="phase",
+                adjoint_method="fixed_point",
+                recipe="1x1",
+                device_mesh=device_mesh,
+                ctm_chunk_size=ctm_chunk_size,
+            )
+
+    elif path == "split":
+        if device_mesh is not None:
+            raise ValueError("split path is single-GPU only (no device_mesh)")
+        if ctm_chunk_size is not None:
+            raise ValueError("split path does not support ctm_chunk_size")
+
+        def loss(data):
+            A = DenseTensor(data, idx)
+            return ctm_energy_split_implicit(
+                {(0, 0): A},
+                SINGLE_SITE_NEIGHBORS,
+                _HEISENBERG,
+                chi=chi,
+                chi_I=chi_I or chi,
+                max_iter=max_iter,
+                conv_tol=1e-10,
+            )
+
+    else:
+        raise ValueError(f"unknown path {path!r} (expected 'dense' or 'split')")
+
+    e, g = jax.value_and_grad(loss)(data0)
+    return float(e), np.asarray(g)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/yjkao/tenax-632-frontier && JAX_PLATFORMS=cpu uv run pytest tests/test_frontier_probe.py -q`
+Expected: PASS (4 tests: 2 parametrized finite + 3 guard raises — note `test_frontier_probe_finite` yields 2).
+
+- [ ] **Step 5: Mark the test file `core` in conftest**
+
+In `tests/conftest.py`, inside the `_FILE_MARKERS` dict, next to the `test_ctm_chunk_backward_grad.py` entry (near the `#632 Increment` comments), add:
+
+```python
+    # #632 frontier benchmark (phase 1): tiny D=2 CPU value_and_grad finite +
+    # path-guard checks. Fast; core so CI required checks run them.
+    "test_frontier_probe.py": "core",
+```
+
+- [ ] **Step 6: Confirm the marker + core collection**
+
+Run: `cd /home/yjkao/tenax-632-frontier && uv run pytest tests/test_frontier_probe.py -m core --collect-only -q`
+Expected: all 5 test items collected under `-m core` (none deselected).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/yjkao/tenax-632-frontier
+git add tests/_frontier_grad_probe.py tests/test_frontier_probe.py tests/conftest.py
+git commit -m "$(printf 'feat(#632): frontier value_and_grad probe (dense/split path dispatch)\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 2: CLI harness + divisibility guard (the two-walls reporting)
+
+**Files:**
+- Create: `examples/bench_ctm_frontier_grad.py`
+- Create: `tests/test_frontier_bench_guard.py`
+- Modify: `tests/conftest.py` (add `"test_frontier_bench_guard.py": "core"`)
+
+**Interfaces:**
+- Consumes: `frontier_energy_and_grad` (Task 1); `tenax.algorithms.ctm_sharding.build_ctm_mesh`.
+- Produces: `skip_reason(D, mesh_n, shard) -> str | None` (pure; SKIP reason iff a sharded config is un-shardable), `peak_gb() -> float`, and a `main()` CLI. `skip_reason` and `peak_gb` are importable **without** importing JAX (JAX/tenax imports live inside `main`/`peak_gb`).
+
+- [ ] **Step 1: Write the failing guard test**
+
+```python
+# tests/test_frontier_bench_guard.py
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "examples"))
+from bench_ctm_frontier_grad import skip_reason
+
+
+def test_skip_divisibility_n2():
+    # N=2: all even D^2 shard; odd D^2 does not.
+    assert skip_reason(10, 2, True) is None   # 100 % 2 == 0
+    assert skip_reason(12, 2, True) is None   # 144 % 2 == 0
+    assert skip_reason(11, 2, True) is not None  # 121 % 2 != 0
+
+
+def test_skip_divisibility_n3():
+    # N=3: 144 shards; 64 and 100 do not.
+    assert skip_reason(12, 3, True) is None      # 144 % 3 == 0
+    assert skip_reason(8, 3, True) is not None   # 64 % 3 != 0
+    assert skip_reason(10, 3, True) is not None  # 100 % 3 != 0
+
+
+def test_no_shard_never_skips():
+    assert skip_reason(11, 2, False) is None
+    assert skip_reason(8, 1, False) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/yjkao/tenax-632-frontier && uv run pytest tests/test_frontier_bench_guard.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'bench_ctm_frontier_grad'`.
+
+- [ ] **Step 3: Write the harness**
+
+```python
+# examples/bench_ctm_frontier_grad.py
+"""#632 large-D x large-chi multi-GPU frontier benchmark — value_and_grad reach.
+
+Per-device peak of ONE value_and_grad step across (all at recipe=1x1):
+  --path split               1-GPU  ctm_energy_split_implicit (chi^2 * D^4)
+  --path dense               1-GPU  ctm_energy_implicit recipe=1x1 (chi^2 * D^6)
+  --path dense --shard       N-GPU  + GSPMD device_mesh
+  --path dense --shard --chunk K   N-GPU  + device_mesh + ctm_chunk_size
+
+One (path, D, chi) per process for a clean cumulative peak (shard-reach method).
+
+Two orthogonal walls (see the design spec):
+  divisibility : --shard needs D^2 % mesh_n == 0  -> SKIP (decided before running)
+  memory (OOM) : a shardable config can still exceed RAM -> FAILED(RESOURCE_EXHAUSTED)
+
+Usage (PREALLOCATE=false for a faithful peak; one config per process):
+    CUDA_VISIBLE_DEVICES=1   XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        uv run python examples/bench_ctm_frontier_grad.py --path split --D 10 --chi 48
+    CUDA_VISIBLE_DEVICES=1,2 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        uv run python examples/bench_ctm_frontier_grad.py --path dense --D 10 --chi 24 --shard --chunk 8
+"""
+import argparse
+import os
+import sys
+import time
+
+
+def skip_reason(D, mesh_n, shard):
+    """SKIP reason iff a sharded config is un-shardable (D^2 not divisible by N)."""
+    if shard and (D * D) % mesh_n != 0:
+        return f"D^2={D * D} % mesh_n={mesh_n} != 0"
+    return None
+
+
+def peak_gb():
+    import jax
+
+    try:
+        return jax.devices()[0].memory_stats()["peak_bytes_in_use"] / 1e9
+    except Exception:  # noqa: BLE001
+        return float("nan")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--path", choices=["dense", "split"], required=True)
+    ap.add_argument("--D", type=int, nargs="+", default=[6, 8, 10, 12])
+    ap.add_argument("--chi", type=int, default=24)
+    ap.add_argument("--chi-I", type=int, default=None, dest="chi_I")
+    ap.add_argument("--shard", action="store_true")
+    ap.add_argument("--chunk", type=int, default=0, help="ctm_chunk_size (0=off; dense only)")
+    ap.add_argument("--max-iter", type=int, default=30)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    from tenax.algorithms.ctm_sharding import build_ctm_mesh
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tests"))
+    from _frontier_grad_probe import frontier_energy_and_grad
+
+    n = jax.device_count()
+    shard = args.shard and args.path == "dense"
+    if args.shard and args.path == "split":
+        print("# WARN: --shard ignored on split path (single-GPU only)")
+    chunk = args.chunk if (args.chunk > 0 and args.path == "dense") else None
+    if args.chunk > 0 and args.path == "split":
+        print("# WARN: --chunk ignored on split path")
+    mesh = build_ctm_mesh() if shard else None
+    mesh_n = n if shard else 1
+    print(
+        f"# path={args.path} devices={n} shard={shard} mesh_n={mesh_n} "
+        f"chi={args.chi} chi_I={args.chi_I} chunk={chunk} max_iter={args.max_iter} "
+        f"recipe=1x1 x64=True"
+    )
+    for D in args.D:
+        reason = skip_reason(D, mesh_n, shard)
+        if reason is not None:
+            print(f"path={args.path} D={D} chi={args.chi}: SKIP ({reason})")
+            continue
+        t0 = time.perf_counter()
+        try:
+            e, g = frontier_energy_and_grad(
+                path=args.path,
+                D=D,
+                chi=args.chi,
+                chi_I=args.chi_I,
+                device_mesh=mesh,
+                ctm_chunk_size=chunk,
+                seed=args.seed,
+                well_conditioned=True,
+                max_iter=args.max_iter,
+            )
+            gnorm = float((g ** 2).sum() ** 0.5)
+            dt = time.perf_counter() - t0
+            print(
+                f"path={args.path} D={D} chi={args.chi} OK  E={e:.6f}  |g|={gnorm:.3e}  "
+                f"per_device_peak={peak_gb():.2f} GB  wall={dt:.1f}s"
+            )
+        except Exception as ex:  # noqa: BLE001
+            dt = time.perf_counter() - t0
+            print(
+                f"path={args.path} D={D} chi={args.chi} "
+                f"FAILED({type(ex).__name__}: {str(ex)[:110]})  wall={dt:.1f}s"
+            )
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run the guard test to verify it passes**
+
+Run: `cd /home/yjkao/tenax-632-frontier && uv run pytest tests/test_frontier_bench_guard.py -q`
+Expected: PASS (3 tests). Fast — no JAX imported (guard + module import are JAX-free).
+
+- [ ] **Step 5: CPU smoke of the full CLI (both paths run end-to-end)**
+
+Run:
+```bash
+cd /home/yjkao/tenax-632-frontier
+JAX_PLATFORMS=cpu uv run python examples/bench_ctm_frontier_grad.py --path split --D 2 --chi 6 --max-iter 10
+JAX_PLATFORMS=cpu uv run python examples/bench_ctm_frontier_grad.py --path dense --D 2 --chi 6 --max-iter 10
+```
+Expected: each prints one `path=... D=2 chi=6 OK  E=...  |g|=...  per_device_peak=... GB  wall=...s` line (peak may be `nan` on CPU — acceptable; the smoke checks wiring, not memory).
+
+- [ ] **Step 6: Mark the guard test `core` in conftest**
+
+In `tests/conftest.py` `_FILE_MARKERS`, directly after the `test_frontier_probe.py` entry from Task 1, add:
+
+```python
+    "test_frontier_bench_guard.py": "core",
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/yjkao/tenax-632-frontier
+git add examples/bench_ctm_frontier_grad.py tests/test_frontier_bench_guard.py tests/conftest.py
+git commit -m "$(printf 'feat(#632): frontier CLI harness + divisibility guard (two-walls reporting)\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 3: GPU frontier sweep on GPUs 1,2 (the measurement)
+
+**Files:** Run-only. Capture raw stdout to `/tmp/claude-1007/-home-yjkao-tenax/25ff8739-c4e3-4407-adf4-d89bb2c91531/scratchpad/frontier_scan.txt`.
+
+This task is measurement, not TDD. Each command is one config/process (clean peak). The χ values below are a **starting grid**; for each config, step χ up until it OOMs to find that config's reach (the frontier), and step down one if the first χ already OOMs.
+
+- [ ] **Step 1: Harness validation anchor (reproduce a trusted number)**
+
+Run:
+```bash
+cd /home/yjkao/tenax-632-frontier
+SCRATCH=/tmp/claude-1007/-home-yjkao-tenax/25ff8739-c4e3-4407-adf4-d89bb2c91531/scratchpad/frontier_scan.txt
+CUDA_VISIBLE_DEVICES=1 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+  uv run python examples/bench_ctm_frontier_grad.py --path dense --D 8 --chi 24 | tee -a "$SCRATCH"
+```
+Expected: `path=dense D=8 chi=24 OK ... per_device_peak≈? GB`. Record the number. (This is the dense-1×1 anchor; note it may differ from shard-reach's recipe=2×2 10.66 GB — recipe differs. If it OOMs unexpectedly at D=8 χ=24 on an 80 GB card, stop and investigate before the full sweep.)
+
+- [ ] **Step 2: Config 1 — split-CTM, 1-GPU (push χ high)**
+
+Run (GPU 1; step χ up per D until OOM):
+```bash
+cd /home/yjkao/tenax-632-frontier
+SCRATCH=/tmp/claude-1007/-home-yjkao-tenax/25ff8739-c4e3-4407-adf4-d89bb2c91531/scratchpad/frontier_scan.txt
+for D in 6 8 10 12; do for CHI in 24 32 48 64 96; do
+  CUDA_VISIBLE_DEVICES=1 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+    uv run python examples/bench_ctm_frontier_grad.py --path split --D $D --chi $CHI | tee -a "$SCRATCH"
+done; done
+```
+Expected: `OK` lines with per-device peak until a χ OOMs (`FAILED(...RESOURCE_EXHAUSTED...)`); the last `OK` χ per D is split's reach at that D.
+
+- [ ] **Step 3: Config 2 — dense, 1-GPU baseline**
+
+Run (GPU 1):
+```bash
+cd /home/yjkao/tenax-632-frontier
+SCRATCH=/tmp/claude-1007/-home-yjkao-tenax/25ff8739-c4e3-4407-adf4-d89bb2c91531/scratchpad/frontier_scan.txt
+for D in 6 8 10 12; do for CHI in 16 24 32; do
+  CUDA_VISIBLE_DEVICES=1 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+    uv run python examples/bench_ctm_frontier_grad.py --path dense --D $D --chi $CHI | tee -a "$SCRATCH"
+done; done
+```
+Expected: dense OOMs at far smaller χ than split (χ²·D⁶ vs χ²·D⁴).
+
+- [ ] **Step 4: Config 3 — dense, 2-GPU shard**
+
+Run (GPUs 1,2):
+```bash
+cd /home/yjkao/tenax-632-frontier
+SCRATCH=/tmp/claude-1007/-home-yjkao-tenax/25ff8739-c4e3-4407-adf4-d89bb2c91531/scratchpad/frontier_scan.txt
+for D in 6 8 10 12; do for CHI in 16 24 32; do
+  CUDA_VISIBLE_DEVICES=1,2 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+    uv run python examples/bench_ctm_frontier_grad.py --path dense --D $D --chi $CHI --shard | tee -a "$SCRATCH"
+done; done
+```
+Expected: `OK`/`FAILED` per cell; SKIP never fires (all D² even → divisible by 2). Compare peak vs config 2 for the shard relief.
+
+- [ ] **Step 5: Config 4 — dense, 2-GPU shard + chunk**
+
+Run (GPUs 1,2; chunk K such that χ%K==0, e.g. K=8 for χ∈{16,24,32}):
+```bash
+cd /home/yjkao/tenax-632-frontier
+SCRATCH=/tmp/claude-1007/-home-yjkao-tenax/25ff8739-c4e3-4407-adf4-d89bb2c91531/scratchpad/frontier_scan.txt
+for D in 6 8 10 12; do for CHI in 16 24 32; do
+  CUDA_VISIBLE_DEVICES=1,2 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+    uv run python examples/bench_ctm_frontier_grad.py --path dense --D $D --chi $CHI --shard --chunk 8 | tee -a "$SCRATCH"
+done; done
+```
+Expected: per-device peak vs config 3 (chunk may not help the `value_and_grad` peak — Inc2 found backward chunk is NO-GO; forward chunk is below the convergence waterline until large D. This measures whether that holds in the pipeline). Note in the findings whichever way it goes.
+
+- [ ] **Step 6: Sanity-scan the raw file**
+
+Run: `cat /tmp/claude-1007/-home-yjkao-tenax/25ff8739-c4e3-4407-adf4-d89bb2c91531/scratchpad/frontier_scan.txt`
+Confirm every line is a `# header`, `OK`, `SKIP`, or `FAILED` line (no tracebacks leaked). If a config produced a Python traceback rather than a `FAILED(...)` line, the probe raised something the harness did not catch — investigate before writing findings.
+
+---
+
+### Task 4: Findings handoff + verdict
+
+**Files:**
+- Create: `docs/superpowers/handoffs/2026-07-01-632-largeD-largechi-multigpu-frontier-findings.md`
+
+- [ ] **Step 1: Write the findings doc from the scratch file**
+
+Fill this template with the measured numbers from Task 3 (`frontier_scan.txt`):
+
+```markdown
+# Large-D × large-χ multi-GPU frontier — phase 1 findings
+
+**Date:** 2026-07-01
+**Branch:** `bench/632-frontier-multigpu` (off #668)
+**Harness:** `examples/bench_ctm_frontier_grad.py` + `tests/_frontier_grad_probe.py`
+**Hardware:** 2× A100-80GB (GPUs 1,2), f64, `XLA_PYTHON_CLIENT_PREALLOCATE=false`, one config/process.
+**Spec:** `docs/superpowers/specs/2026-07-01-632-largeD-largechi-multigpu-frontier-design.md`
+**Verdict: <split-1GPU vs dense-2GPU — which reaches larger (D, χ); one line>**
+
+## Harness anchor
+dense-1×1 D=8 χ=24 = <…> GB (vs shard-reach recipe=2×2 10.66 GB — recipe differs).
+
+## Frontier (per-device peak GB; OK / OOM / SKIP), recipe=1×1, value_and_grad
+
+### split-CTM, 1-GPU (χ²·D⁴)
+| D | χ=24 | 32 | 48 | 64 | 96 | reach (max χ OK) |
+|---|---|---|---|---|---|---|
+| 6 | … | | | | | |
+| 8 | … | | | | | |
+| 10 | … | | | | | |
+| 12 | … | | | | | |
+
+### dense, 1-GPU / 2-GPU shard / 2-GPU shard+chunk (χ²·D⁶)
+| D | χ | dense 1-GPU | dense 2-GPU shard | dense 2-GPU shard+chunk |
+|---|---|---|---|---|
+| 6 | 16 | … | … | … |
+| … | | | | |
+
+## Reads
+1. **Split-1GPU vs dense-2GPU frontier:** <which reaches larger (D, χ); by how much>.
+2. **Shard relief in the pipeline:** dense 2-GPU vs 1-GPU factor at each (D, χ) — <χ-gated? D-fading? matches shard-reach ~1.2–2×?>.
+3. **Chunk in value_and_grad:** <did shard+chunk beat shard-only, or confirm Inc2's forward-below-waterline / backward-NO-GO?>.
+4. **The composition gap made concrete:** split has no multi-GPU column; its 1-GPU reach is <above/below> dense's best 2-GPU reach.
+
+## Recommendation (feeds phase 2)
+<Is building split × multi-GPU (thread device_mesh into the split path) worth it —
+i.e., is dense-2GPU ever ahead of split-1GPU on the frontier? If split-1GPU
+dominates everywhere, multi-GPU is not the large-(D,χ) lever and phase 2 should
+target the split single-GPU ceiling (e.g., chi_I<χ, split forward χ²·D⁴ at larger
+χ) instead. State the call.>
+
+## Reproduce
+<paste the exact command block from the plan Task 3>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /home/yjkao/tenax-632-frontier
+git add docs/superpowers/handoffs/2026-07-01-632-largeD-largechi-multigpu-frontier-findings.md
+git commit -m "$(printf 'docs(#632): large-D x large-chi multi-GPU frontier findings (phase 1)\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+- [ ] **Step 3: Full core-bucket regression (no CI break)**
+
+Run: `cd /home/yjkao/tenax-632-frontier && uv run pytest -m core -q`
+Expected: PASS — the two new test files are collected and green; nothing else regresses (no `src/` change).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 4-config matrix (split-1GPU, dense-1GPU, dense-2GPU shard, dense-2GPU shard+chunk), recipe=1×1 → Task 1 probe (dense/split dispatch, `device_mesh`, `ctm_chunk_size`) + Task 3 sweep (all four). ✓
+- value_and_grad operation → `jax.value_and_grad` in the probe. ✓
+- Two orthogonal walls (divisibility SKIP vs memory OOM) → `skip_reason` (Task 2) + try/except OOM reporting (Task 2 harness); tested in `test_frontier_bench_guard.py`. ✓
+- Component 1 (`tests/_frontier_grad_probe.py`) / Component 2 (`examples/bench_ctm_frontier_grad.py`) → Tasks 1 / 2. ✓
+- Validation: finite E + finite ‖g‖ both paths → `test_frontier_probe_finite`; split rejects mesh/chunk → guard tests. ✓ (The qualitative split-vs-dense energy approach is an *observation* recorded in the findings Reads, not a CI assertion — avoids a flaky tolerance; consistent with the spec's "not equality" framing.)
+- Deliverable findings doc → Task 4. ✓
+- No `src/` change; #668 branch base → Global Constraints + worktree. ✓
+- Out of scope (4-GPU, 2×2, symmetric, chi_I<χ) → not in any task. ✓
+
+**Placeholder scan:** The findings-doc template `<…>` are data slots filled from `frontier_scan.txt` at Task 4 (measured values unknown until run), not unspecified logic. All code and commands are complete and runnable. The χ grid in Task 3 is an explicit starting grid with a stated reach-search rule (step χ until OOM), not a vague "sweep as needed".
+
+**Type/name consistency:** `frontier_energy_and_grad(path, D, chi, chi_I, device_mesh, ctm_chunk_size, seed, well_conditioned, max_iter)` — identical signature in Task 1 definition, Task 2 harness call, and tests. `skip_reason(D, mesh_n, shard)` — identical in Task 2 definition and `test_frontier_bench_guard.py`. `_indices` / `_init_data` / `SINGLE_SITE_NEIGHBORS` match `_rung2_grad_probe.py` and `_ctm_tensor_convergence.py` (verified on the #668 branch). `ctm_energy_implicit(..., recipe, device_mesh, ctm_chunk_size)` and `ctm_energy_split_implicit(..., chi, chi_I, max_iter, conv_tol)` match the merged signatures (`_ctm_energy_ad.py:367`, `_split_ctm_energy_ad.py:205`).
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-01-632-largeD-largechi-multigpu-frontier.md`.

--- a/docs/superpowers/specs/2026-07-01-632-largeD-largechi-multigpu-frontier-design.md
+++ b/docs/superpowers/specs/2026-07-01-632-largeD-largechi-multigpu-frontier-design.md
@@ -1,0 +1,244 @@
+# Large-D × large-χ multi-GPU frontier benchmark (phase 1) — Design
+
+**Date:** 2026-07-01
+**Issue:** #632 (multi-GPU dense CTM-AD reach)
+**Status:** design approved, pending spec review → writing-plans
+
+## Goal
+
+Measure the reachable **(D, χ)** frontier of one iPEPS `value_and_grad` step
+(energy + gradient) across the paths and GPU counts tenax has **today**, to
+answer one question:
+
+> Does split-CTM on **1 GPU** reach larger (D, χ) than dense-CTM on **2 GPUs**,
+> and where is each wall?
+
+This is a **characterization** study — **no `src/` change**. It establishes the
+current ground truth (and confirms the path-composition gap, below) before any
+decision to build a new capability in a later phase.
+
+## Motivating crux (why this study exists)
+
+tenax has two relevant CTM paths, and they **do not compose**:
+
+- **split-CTM** (`_split_ctm_*`, `ctm_energy_split_implicit`): χ²·D⁴ absorption —
+  the memory-efficient large-χ/large-D forward+AD lever (productized as
+  `--path split` / `fuse_virtual_legs=False`, #650). It has **no `device_mesh`**
+  anywhere → **single-GPU only**, single-site (`recipe="1x1"`).
+- **dense CTM** (`ctm_energy_implicit`): χ²·D⁶ absorption. Has the multi-GPU
+  machinery (GSPMD `device_mesh` sharding + the `ctm_chunk_size` knob from Inc1,
+  #668), but the sharding relief is weak — SVD-replication-bound, ~1.2–2× and
+  D-fading (the shard-reach benchmark, `2026-07-01-632-shard-only-reach-grad-D10-12`).
+
+So "large D + large χ on multiple GPUs" today forces a choice of **one** lever,
+not both: split's χ²·D⁴ savings on 1 GPU, *or* dense's weak multi-GPU sharding on
+the χ²·D⁶ path. This benchmark quantifies that trade so phase 2 can decide
+whether building split × multi-GPU is worth it.
+
+## Scope
+
+- **Operation:** `value_and_grad` — one optimize step (energy + gradient of the
+  implicit-AD CTM energy). This is the "running a ground-state calculation"
+  metric and where the backward wall lives.
+- **Recipe:** fixed at **1×1** for *all* configs — split IS 1×1, and
+  `ctm_chunk_size` (Inc1) is 1×1-only, so 1×1 is the common ground that makes the
+  four configs apples-to-apples.
+- **GPU count:** 1-GPU and 2-GPU, on the two clean cards (GPUs 1,2). 4-GPU is
+  **deferred** to a follow-up (needs GPUs 0 and 4 freed).
+- **State:** 1-site dense iPEPS, Heisenberg gate, well-conditioned tensor (same
+  init as the trusted rung-2 / shard-reach probe), x64.
+
+## Prerequisites / branch base
+
+Phase 1 **must branch off fresh `origin/main` (f9b8f6e, #668 "Increment 1 —
+chunked dense-CTM absorption")**, not the current `bench/632-shard-reach-D10-12`
+branch, which predates #668. Two of the four configs depend on #668:
+
+- **config 4 (dense + chunk):** `ctm_energy_implicit` gains the
+  `ctm_chunk_size: int | None = None` param (`_ctm_energy_ad.py:367`), threaded
+  into the forward as `partial(jit_step_raw, chunk_size=ctm_chunk_size)` (`:577`).
+  Merged behavior is **forward-chunk + monolith-backward** (exact grads; Inc2
+  backward-chunk was gated NO-GO and reverted).
+- **config 3 (dense-1×1 + shard):** #668 hoisted `_shard_a` into the **1×1** sweep
+  branch (previously 2×2-only), so `device_mesh` sharding only affects the 1×1
+  forward *after* #668. Before it, a 1×1 `device_mesh` run was silently unsharded.
+
+`ctm_energy_split_implicit` (config 1) and the base dense path (config 2) predate
+#668 and are already present. The current branch's one uncommitted edit (the
+shard-reach handoff's buffer-level OOM section) belongs to the shard-reach PR, not
+phase 1 — handle it separately so it is not lost.
+
+## Comparison matrix
+
+All at recipe=1×1; **one config per process** (peak memory is cumulative
+in-process, so isolation gives a clean per-device peak — the shard-reach method).
+
+| # | config                    | path / entry                             | GPUs | knobs                          |
+|---|---------------------------|------------------------------------------|------|--------------------------------|
+| 1 | split-CTM, 1-GPU          | `ctm_energy_split_implicit` (χ²·D⁴)      | 1    | `chi_I = chi`                  |
+| 2 | dense, 1-GPU              | `ctm_energy_implicit` recipe=1×1 (χ²·D⁶) | 1    | —                              |
+| 3 | dense, 2-GPU shard        | dense + `device_mesh`                     | 2    | GSPMD (N=2)                    |
+| 4 | dense, 2-GPU shard+chunk  | dense + `device_mesh` + `ctm_chunk_size`  | 2    | GSPMD (N=2) + chunk (Inc1)     |
+
+**The gap this documents:** split has **no column 3/4** — it is 1-GPU only. The
+study makes that concrete by showing where split-1GPU lands relative to
+dense-2GPU on the same (D, χ).
+
+**Metric per cell:** per-device peak (GB), outcome (`OK` / `OOM` / autotuner-fail),
+wall time, and an energy / ‖g‖ sanity value. The frontier = the largest (D, χ)
+that returns `OK` for each config.
+
+**Grid:** D ∈ {6, 8, 10, 12}; a per-D χ list, **pushed higher on the split path**
+(χ²·D⁴ ≪ χ²·D⁶, so split should reach much larger χ before OOM). Concrete χ values
+are chosen at run time to bracket each config's wall (start where the prior
+shard-reach numbers land and step χ up until OOM).
+
+## Components
+
+### Component 1 — `tests/_frontier_grad_probe.py` (new)
+
+A single dispatcher that leaves the trusted `_rung2_grad_probe.py` **pristine**
+(it is still used by the rung-2 gate tests). It reuses that probe's `_indices` /
+`_init_data` helpers (imported) for an identical 1-site dense iPEPS + Heisenberg
+gate + well-conditioned init.
+
+```python
+def frontier_energy_and_grad(
+    *, path, D, chi, chi_I=None, device_mesh=None, ctm_chunk_size=None,
+    seed=0, well_conditioned=True, max_iter=30,
+):
+    """Return (energy: float, grad: (D,D,D,D,2) array) of one value_and_grad step.
+
+    path="dense": ctm_energy_implicit(..., recipe="1x1", device_mesh=device_mesh,
+                  ctm_chunk_size=ctm_chunk_size,
+                  forward_gauge="phase", adjoint_method="fixed_point")
+    path="split": ctm_energy_split_implicit(..., chi_I=chi_I or chi)   # no mesh (1-GPU)
+    """
+    ...
+    e, g = jax.value_and_grad(loss)(data0)
+    return float(e), np.asarray(g)
+```
+
+- **dense** branch mirrors the rung-2 probe but at `recipe="1x1"` and additionally
+  threads `ctm_chunk_size`.
+- **split** branch calls `ctm_energy_split_implicit({(0,0): A}, SINGLE_SITE_NEIGHBORS,
+  gate, chi=chi, chi_I=chi_I or chi, max_iter=..., conv_tol=..., renormalize=True)`.
+  It **does not** accept `device_mesh` (single-GPU); passing one is a caller error
+  the harness guards against.
+
+Peak memory is ~independent of `max_iter` (implicit-AD stores the fixed point, not
+the unrolled trajectory), so `max_iter=30` is enough for a faithful peak.
+
+### Component 2 — `examples/bench_ctm_frontier_grad.py` (new)
+
+CLI harness in the shard-reach style. Args:
+`--path {dense,split}  --D <ints...>  --chi <int>  --chi-I <int|None>
+ --shard  --chunk <int>  --max-iter <int>  --seed <int>`.
+
+Builds the mesh via `build_ctm_mesh()` when `--shard`. Runs **one (path, D, χ) per
+process** for a clean peak. Reports one line per D:
+
+```
+path=split D=10 chi=48 OK  E=-0.601234  |g|=1.2e-02  per_device_peak=NN.NN GB  wall=NN.Ns
+path=dense D=10 chi=24 FAILED(XlaRuntimeError: RESOURCE_EXHAUSTED ... 30.5GiB)  wall=NN.Ns
+```
+
+`peak_gb()` reads `jax.devices()[0].memory_stats()["peak_bytes_in_use"]` (the
+per-device peak; on a 2-GPU sharded run every device holds the same replicated +
+sharded mix, so device 0's peak is representative — matches shard-reach).
+
+## Guards (two orthogonal walls: divisibility vs memory)
+
+There are **two independent** reasons a sharded config can fail to run. The
+harness distinguishes them explicitly.
+
+1. **Divisibility (the shard guard).** GSPMD shards the **D² leg** of the
+   double-layer tensor and the CTM edges (`ctm_sharding.py`:
+   `edge_partition_spec()` → `PartitionSpec(None, "d", None)`;
+   `double_layer_partition_spec()` → shard a D² axis). So a config is *shardable
+   at all* iff **`D² % N == 0`**. The harness **skips** (prints `SKIP`) a `--shard`
+   config when `D² % mesh_n != 0`, before ever building the computation.
+
+   At **N=2** all four grid D values pass (D² ∈ {36, 64, 100, 144} are all even):
+   - D=10 → 100 → 100 % 2 = 0 ✓
+   - D=12 → 144 → 144 % 2 = 0 ✓
+
+   D²=100 and 144 are **not** impossible to shard — they are fine at N=2. They
+   would only be blocked at an N that does not divide them (e.g., N=3 divides 144
+   but not 100), or for odd D² such as D=11 → 121 (un-shardable by any even N).
+   For the deferred 4-GPU follow-up, **N=4** also passes all four D (36, 64, 100,
+   144 are all divisible by 4); it is N=3 that would break D²=64 and 100.
+
+2. **Memory (OOM).** Passing the divisibility guard does **not** mean the config
+   fits. A shardable config can still exceed device RAM — e.g., shard-reach's
+   D=10/12 were *attempted* (they passed the guard) and then hit the memory wall
+   at those χ. This is caught at run time as `RESOURCE_EXHAUSTED` and reported as
+   `FAILED(...)`, distinct from `SKIP`.
+
+The `--chunk` guard: `ctm_chunk_size` is dense-1×1 only, so `--chunk` on
+`--path split` is a caller error → the harness warns and ignores it. `--shard` on
+`--path split` likewise warns and is ignored (split has no `device_mesh`).
+
+## Data flow / the sweep
+
+A documented bash matrix (in the findings doc's Reproduce block) drives the four
+configs across the grid, one process each, appending stdout to a scratch file;
+the frontier table is assembled from those lines. Per-process isolation is the
+trusted method (in-process peak is cumulative and would contaminate a multi-config
+loop). Example rows:
+
+```bash
+# split, 1-GPU, push chi high:
+CUDA_VISIBLE_DEVICES=1 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+  uv run python examples/bench_ctm_frontier_grad.py --path split --D 10 --chi 48
+# dense, 2-GPU shard+chunk:
+CUDA_VISIBLE_DEVICES=1,2 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+  uv run python examples/bench_ctm_frontier_grad.py --path dense --D 10 --chi 24 --shard --chunk 8
+```
+
+## Error handling
+
+`value_and_grad` is wrapped in try/except. Catch `RESOURCE_EXHAUSTED` (OOM) and
+XLA autotuner failures; print `FAILED(<ExcType>: <message[:110]>)` plus the
+attempted-allocation size when the BFC dump exposes it. A `SKIP` (divisibility) is
+printed *without* running. Everything else re-raises (a real bug should not be
+silently swallowed as `FAILED`).
+
+## Validation
+
+Before the GPU sweep, a **CPU sanity check** at D=2 χ=6 for both paths:
+
+- assert finite `E` and finite `‖g‖` for `path="dense"` and `path="split"`;
+- assert that at fixed D the split and dense energies **move toward each other as
+  χ grows** (they truncate differently, so they are *not* equal at small χ — that
+  is expected physics, not a bug; the check is monotone-approach, not equality).
+
+No `src/` is touched, so the default dense path stays byte-identical and existing
+CI (`-m core`) continues to cover it.
+
+## Deliverable
+
+`docs/superpowers/handoffs/2026-07-01-632-largeD-largechi-multigpu-frontier-findings.md`:
+
+- the 4-config × grid frontier table (per-device peak + OK/OOM/SKIP per cell);
+- the reachable frontier per config (largest (D, χ) that fits);
+- the headline verdict: **split-1GPU vs dense-2GPU** — which reaches larger (D, χ);
+- the confirmed composition gap (split has no multi-GPU column);
+- a recommendation feeding a possible **phase 2** (build split × multi-GPU, or not).
+
+## Out of scope (phase 1)
+
+- **4-GPU** runs (deferred until GPUs 0 and 4 are free).
+- Any **`src/` change** (this is a measurement study).
+- The **2×2** recipe (chunk is 1×1-only; split is 1×1-only).
+- **Symmetric / fermionic** envs (large-D symmetric is YASTN territory).
+- Reducing **`chi_I` below χ** on the split path (held `chi_I = chi` for a clean
+  frontier; `chi_I < χ` is a further split-only memory lever, measured later).
+- **Forward-only** reach (this study is `value_and_grad`; forward-only is a cheaper
+  secondary map that can be added later).
+
+## Reproduce (validated methodology anchor)
+
+The dense-1×1 probe should reproduce the shard-reach anchor within recipe
+differences; the harness prints the same `per_device_peak` field the shard-reach
+benchmark used, so numbers are directly comparable across the two studies.

--- a/examples/bench_ctm_frontier_grad.py
+++ b/examples/bench_ctm_frontier_grad.py
@@ -1,0 +1,110 @@
+"""#632 large-D x large-chi multi-GPU frontier benchmark — value_and_grad reach.
+
+Per-device peak of ONE value_and_grad step across (all at recipe=1x1):
+  --path split               1-GPU  ctm_energy_split_implicit (chi^2 * D^4)
+  --path dense               1-GPU  ctm_energy_implicit recipe=1x1 (chi^2 * D^6)
+  --path dense --shard       N-GPU  + GSPMD device_mesh
+  --path dense --shard --chunk K   N-GPU  + device_mesh + ctm_chunk_size
+
+One (path, D, chi) per process for a clean cumulative peak (shard-reach method).
+
+Two orthogonal walls (see the design spec):
+  divisibility : --shard needs D^2 % mesh_n == 0  -> SKIP (decided before running)
+  memory (OOM) : a shardable config can still exceed RAM -> FAILED(RESOURCE_EXHAUSTED)
+
+Usage (PREALLOCATE=false for a faithful peak; one config per process):
+    CUDA_VISIBLE_DEVICES=1   XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        uv run python examples/bench_ctm_frontier_grad.py --path split --D 10 --chi 48
+    CUDA_VISIBLE_DEVICES=1,2 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        uv run python examples/bench_ctm_frontier_grad.py --path dense --D 10 --chi 24 --shard --chunk 8
+"""
+import argparse
+import os
+import sys
+import time
+
+
+def skip_reason(D, mesh_n, shard):
+    """SKIP reason iff a sharded config is un-shardable (D^2 not divisible by N)."""
+    if shard and (D * D) % mesh_n != 0:
+        return f"D^2={D * D} % mesh_n={mesh_n} != 0"
+    return None
+
+
+def peak_gb():
+    import jax
+
+    try:
+        return jax.devices()[0].memory_stats()["peak_bytes_in_use"] / 1e9
+    except Exception:  # noqa: BLE001
+        return float("nan")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--path", choices=["dense", "split"], required=True)
+    ap.add_argument("--D", type=int, nargs="+", default=[6, 8, 10, 12])
+    ap.add_argument("--chi", type=int, default=24)
+    ap.add_argument("--chi-I", type=int, default=None, dest="chi_I")
+    ap.add_argument("--shard", action="store_true")
+    ap.add_argument("--chunk", type=int, default=0, help="ctm_chunk_size (0=off; dense only)")
+    ap.add_argument("--max-iter", type=int, default=30)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    from tenax.algorithms.ctm_sharding import build_ctm_mesh
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tests"))
+    from _frontier_grad_probe import frontier_energy_and_grad
+
+    n = jax.device_count()
+    shard = args.shard and args.path == "dense"
+    if args.shard and args.path == "split":
+        print("# WARN: --shard ignored on split path (single-GPU only)")
+    chunk = args.chunk if (args.chunk > 0 and args.path == "dense") else None
+    if args.chunk > 0 and args.path == "split":
+        print("# WARN: --chunk ignored on split path")
+    mesh = build_ctm_mesh() if shard else None
+    mesh_n = n if shard else 1
+    print(
+        f"# path={args.path} devices={n} shard={shard} mesh_n={mesh_n} "
+        f"chi={args.chi} chi_I={args.chi_I} chunk={chunk} max_iter={args.max_iter} "
+        f"recipe=1x1 x64=True"
+    )
+    for D in args.D:
+        reason = skip_reason(D, mesh_n, shard)
+        if reason is not None:
+            print(f"path={args.path} D={D} chi={args.chi}: SKIP ({reason})")
+            continue
+        t0 = time.perf_counter()
+        try:
+            e, g = frontier_energy_and_grad(
+                path=args.path,
+                D=D,
+                chi=args.chi,
+                chi_I=args.chi_I,
+                device_mesh=mesh,
+                ctm_chunk_size=chunk,
+                seed=args.seed,
+                well_conditioned=True,
+                max_iter=args.max_iter,
+            )
+            gnorm = float((g ** 2).sum() ** 0.5)
+            dt = time.perf_counter() - t0
+            print(
+                f"path={args.path} D={D} chi={args.chi} OK  E={e:.6f}  |g|={gnorm:.3e}  "
+                f"per_device_peak={peak_gb():.2f} GB  wall={dt:.1f}s"
+            )
+        except Exception as ex:  # noqa: BLE001
+            dt = time.perf_counter() - t0
+            print(
+                f"path={args.path} D={D} chi={args.chi} "
+                f"FAILED({type(ex).__name__}: {str(ex)[:110]})  wall={dt:.1f}s"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/bench_ctm_frontier_grad.py
+++ b/examples/bench_ctm_frontier_grad.py
@@ -18,6 +18,7 @@ Usage (PREALLOCATE=false for a faithful peak; one config per process):
     CUDA_VISIBLE_DEVICES=1,2 XLA_PYTHON_CLIENT_PREALLOCATE=false \
         uv run python examples/bench_ctm_frontier_grad.py --path dense --D 10 --chi 24 --shard --chunk 8
 """
+
 import argparse
 import os
 import sys
@@ -47,7 +48,9 @@ def main():
     ap.add_argument("--chi", type=int, default=24)
     ap.add_argument("--chi-I", type=int, default=None, dest="chi_I")
     ap.add_argument("--shard", action="store_true")
-    ap.add_argument("--chunk", type=int, default=0, help="ctm_chunk_size (0=off; dense only)")
+    ap.add_argument(
+        "--chunk", type=int, default=0, help="ctm_chunk_size (0=off; dense only)"
+    )
     ap.add_argument("--max-iter", type=int, default=30)
     ap.add_argument("--seed", type=int, default=0)
     args = ap.parse_args()
@@ -92,7 +95,7 @@ def main():
                 well_conditioned=True,
                 max_iter=args.max_iter,
             )
-            gnorm = float((g ** 2).sum() ** 0.5)
+            gnorm = float((g**2).sum() ** 0.5)
             dt = time.perf_counter() - t0
             print(
                 f"path={args.path} D={D} chi={args.chi} OK  E={e:.6f}  |g|={gnorm:.3e}  "

--- a/tests/_frontier_grad_probe.py
+++ b/tests/_frontier_grad_probe.py
@@ -1,0 +1,86 @@
+"""Frontier benchmark probe: value_and_grad of the CTM-AD energy across paths.
+
+Dispatches the dense (``ctm_energy_implicit``, recipe="1x1", optionally sharded
++ chunked) and split (``ctm_energy_split_implicit``, single-GPU, chi^2 * D^4)
+paths to a common ``jax.value_and_grad`` for the large-D x large-chi multi-GPU
+frontier study (phase 1, #632). Reuses the rung-2 probe's 1-site dense iPEPS +
+gate + well-conditioned init so per-device peaks are directly comparable to the
+shard-reach benchmark.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from _rung2_grad_probe import _indices, _init_data  # pristine helpers (do not edit)
+
+from tenax.algorithms._ctm_energy_ad import ctm_energy_implicit
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
+from tenax.algorithms._split_ctm_energy_ad import ctm_energy_split_implicit
+from tenax.core.tensor import DenseTensor
+
+_HEISENBERG = jnp.diag(jnp.array([0.25, -0.25, -0.25, 0.25])).reshape(2, 2, 2, 2)
+
+
+def frontier_energy_and_grad(
+    *,
+    path,
+    D,
+    chi,
+    chi_I=None,
+    device_mesh=None,
+    ctm_chunk_size=None,
+    seed=0,
+    well_conditioned=True,
+    max_iter=30,
+):
+    """Return (energy: float, grad: (D,D,D,D,2) array) of one value_and_grad step.
+
+    path="dense": ctm_energy_implicit(recipe="1x1", device_mesh=..., ctm_chunk_size=...)
+    path="split": ctm_energy_split_implicit(chi_I=chi_I or chi)  # single-GPU only
+    """
+    idx = _indices(D)
+    data0 = _init_data(D, seed, well_conditioned)
+
+    if path == "dense":
+
+        def loss(data):
+            A = DenseTensor(data, idx)
+            return ctm_energy_implicit(
+                {(0, 0): A},
+                SINGLE_SITE_NEIGHBORS,
+                _HEISENBERG,
+                chi=chi,
+                max_iter=max_iter,
+                conv_tol=1e-10,
+                forward_gauge="phase",
+                adjoint_method="fixed_point",
+                recipe="1x1",
+                device_mesh=device_mesh,
+                ctm_chunk_size=ctm_chunk_size,
+            )
+
+    elif path == "split":
+        if device_mesh is not None:
+            raise ValueError("split path is single-GPU only (no device_mesh)")
+        if ctm_chunk_size is not None:
+            raise ValueError("split path does not support ctm_chunk_size")
+
+        def loss(data):
+            A = DenseTensor(data, idx)
+            return ctm_energy_split_implicit(
+                {(0, 0): A},
+                SINGLE_SITE_NEIGHBORS,
+                _HEISENBERG,
+                chi=chi,
+                chi_I=chi_I or chi,
+                max_iter=max_iter,
+                conv_tol=1e-10,
+            )
+
+    else:
+        raise ValueError(f"unknown path {path!r} (expected 'dense' or 'split')")
+
+    e, g = jax.value_and_grad(loss)(data0)
+    return float(e), np.asarray(g)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,9 @@ _FILE_MARKERS = {
     # #632 Increment 2 gate byproduct: forward-chunk grads through the (monolith)
     # implicit-AD backward stay exact. Tiny D=2 CPU value_and_grad parity.
     "test_ctm_chunk_backward_grad.py": "core",
+    # #632 frontier benchmark (phase 1): tiny D=2 CPU value_and_grad finite +
+    # path-guard checks. Fast; core so CI required checks run them.
+    "test_frontier_probe.py": "core",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,7 @@ _FILE_MARKERS = {
     # #632 frontier benchmark (phase 1): tiny D=2 CPU value_and_grad finite +
     # path-guard checks. Fast; core so CI required checks run them.
     "test_frontier_probe.py": "core",
+    "test_frontier_bench_guard.py": "core",
 }
 
 

--- a/tests/test_frontier_bench_guard.py
+++ b/tests/test_frontier_bench_guard.py
@@ -7,15 +7,15 @@ from bench_ctm_frontier_grad import skip_reason
 
 def test_skip_divisibility_n2():
     # N=2: all even D^2 shard; odd D^2 does not.
-    assert skip_reason(10, 2, True) is None   # 100 % 2 == 0
-    assert skip_reason(12, 2, True) is None   # 144 % 2 == 0
+    assert skip_reason(10, 2, True) is None  # 100 % 2 == 0
+    assert skip_reason(12, 2, True) is None  # 144 % 2 == 0
     assert skip_reason(11, 2, True) is not None  # 121 % 2 != 0
 
 
 def test_skip_divisibility_n3():
     # N=3: 144 shards; 64 and 100 do not.
-    assert skip_reason(12, 3, True) is None      # 144 % 3 == 0
-    assert skip_reason(8, 3, True) is not None   # 64 % 3 != 0
+    assert skip_reason(12, 3, True) is None  # 144 % 3 == 0
+    assert skip_reason(8, 3, True) is not None  # 64 % 3 != 0
     assert skip_reason(10, 3, True) is not None  # 100 % 3 != 0
 
 

--- a/tests/test_frontier_bench_guard.py
+++ b/tests/test_frontier_bench_guard.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "examples"))
+from bench_ctm_frontier_grad import skip_reason
+
+
+def test_skip_divisibility_n2():
+    # N=2: all even D^2 shard; odd D^2 does not.
+    assert skip_reason(10, 2, True) is None   # 100 % 2 == 0
+    assert skip_reason(12, 2, True) is None   # 144 % 2 == 0
+    assert skip_reason(11, 2, True) is not None  # 121 % 2 != 0
+
+
+def test_skip_divisibility_n3():
+    # N=3: 144 shards; 64 and 100 do not.
+    assert skip_reason(12, 3, True) is None      # 144 % 3 == 0
+    assert skip_reason(8, 3, True) is not None   # 64 % 3 != 0
+    assert skip_reason(10, 3, True) is not None  # 100 % 3 != 0
+
+
+def test_no_shard_never_skips():
+    assert skip_reason(11, 2, False) is None
+    assert skip_reason(8, 1, False) is None

--- a/tests/test_frontier_probe.py
+++ b/tests/test_frontier_probe.py
@@ -1,0 +1,30 @@
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import numpy as np
+import pytest
+from _frontier_grad_probe import frontier_energy_and_grad
+
+
+@pytest.mark.parametrize("path", ["dense", "split"])
+def test_frontier_probe_finite(path):
+    e, g = frontier_energy_and_grad(path=path, D=2, chi=6, max_iter=15)
+    assert np.isfinite(e), e
+    assert np.all(np.isfinite(g)), path
+    assert g.shape == (2, 2, 2, 2, 2), g.shape
+
+
+def test_frontier_split_rejects_mesh():
+    with pytest.raises(ValueError):
+        frontier_energy_and_grad(path="split", D=2, chi=6, device_mesh=object())
+
+
+def test_frontier_split_rejects_chunk():
+    with pytest.raises(ValueError):
+        frontier_energy_and_grad(path="split", D=2, chi=6, ctm_chunk_size=4)
+
+
+def test_frontier_unknown_path():
+    with pytest.raises(ValueError):
+        frontier_energy_and_grad(path="nope", D=2, chi=6)


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, opened by @Ying-Jer Kao.

## What

Phase 1 of the #632 large-D × large-χ multi-GPU study: a **measurement benchmark** (no `src/` change) characterizing the reachable `(D, χ)` frontier of one iPEPS `value_and_grad` step across four configs, all at recipe=1×1:

1. split-CTM **1-GPU** (χ²·D⁴)
2. dense **1-GPU** (χ²·D⁶)
3. dense **2-GPU** shard (GSPMD `device_mesh`)
4. dense **2-GPU** shard + `ctm_chunk_size` chunk

## Deliverables

- `tests/_frontier_grad_probe.py` — path-dispatching `value_and_grad` probe (dense `ctm_energy_implicit` recipe=1×1 + `device_mesh`/`ctm_chunk_size`; split `ctm_energy_split_implicit`), reusing the trusted rung-2 probe's state.
- `examples/bench_ctm_frontier_grad.py` — CLI harness with the divisibility guard; reports per-device peak, separating the two orthogonal walls (divisibility SKIP vs memory OOM).
- `tests/test_frontier_probe.py`, `tests/test_frontier_bench_guard.py` — `core`-marked.
- Design spec, implementation plan, and findings handoff under `docs/superpowers/`.

## Result (2× A100, GPUs 1,2)

| | split-CTM **1-GPU** | dense **2-GPU** shard(+chunk) |
|---|---|---|
| D=8 | χ≥128 @ 16.9 GB | χ32 @ 16.5 GB |
| D=10 | χ≥128 @ 39.9 GB | **χ16** (χ24 OOMs) |
| D=12 | χ96 @ 46 GB | **can't compile χ16** (autotuner) |

**The memory-efficient algorithm on ONE GPU dominates the multi-GPU dense apparatus on TWO, everywhere on the frontier.** Multi-GPU dense sharding is weak (1.1–1.4×) and never extends the D-reach; chunk adds exactly 0 GB to the `value_and_grad` peak (confirms the Increment-2 NO-GO from the pipeline side). Split/dense energies agree to ~4 digits (probe validated).

**Phase-2 implication:** multi-GPU *dense* is a dead end for large (D,χ); the real lever is sharding the *split* path (`device_mesh` into `_split_ctm_*`).

## Tests

- `uv run pytest -m core` → **1086 passed, 8 skipped, 0 failed**.
- No `src/tenax/**` change (measurement study). New tests are `core`-marked.
- Subagent-driven: each task spec+quality reviewed; whole-branch review = ready to merge (0 Critical/Important; Minor harness follow-ups recorded in the findings doc for phase-2 reuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)