### PR TITLE
fix(#670): symmetric 2x2 CTM direction-dependent bond bookkeeping (unblocks #667)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-670-symmetric-2x2-carried-bond.md
+++ b/docs/superpowers/plans/2026-07-01-670-symmetric-2x2-carried-bond.md
@@ -1,0 +1,506 @@
+# #670 Symmetric 2×2 CTM carried-bond threading fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the symmetric (block-sparse U(1)) `ctm_tensor_2site(..., recipe="2x2")` sweep run to convergence on a genuine multi-charge U(1)-Sz environment (currently it raises a per-sector block mismatch), match the dense result, and un-xfail the #667 acceptance test.
+
+**Architecture:** Approach A from `docs/superpowers/specs/2026-07-01-670-symmetric-2x2-carried-bond-design.md`. The 2×2 absorption already has the correct one-carried/one-compressed corner structure (confirmed against variPEPS). The bug is that the *carried* corner leg and the edge leg the enlarged corner glues it to are not the same bond. **Task 1 is a diagnostic gate** that pins the exact divergent bond using a variPEPS numerical oracle; **Task 3's fix content is chosen from Task 1's finding** (the leading candidate is given, with a decision rule). TDD throughout; the dense path must stay a bit-for-bit no-op.
+
+**Tech Stack:** JAX (float64), Tenax `SymmetricTensor` (U(1)-Sz block-sparse), `opt_einsum`; variPEPS 1.4.2 (GPL, importable in `.venv`) as a **read-only test/diagnostic oracle only — never imported by `src/`**.
+
+---
+
+## Background the engineer needs (read before starting)
+
+The failure: `ctm_tensor_2site(recipe="2x2")` on any multi-charge U(1) env raises
+`ValueError: Size of label ... does not match previous terms` inside
+`_build_enlarged_corner` (e.g. `bottom_left`'s `C4.c4_u ↔ T4.t4_u`). Dense
+(trivial-charge) does not crash (single block of size χ).
+
+Three facts already established (do NOT re-derive; cited in the spec):
+
+1. **Env-consumption ground truth** (energy/RDM path, production-validated) —
+   which env legs share a bond:
+   ```
+   C1.c1_r↔T1.t1_l   C1.c1_d↔T4.t4_d
+   C2.c2_l↔T1.t1_r   C2.c2_d↔T2.t2_u
+   C3.c3_l↔T3.t3_l   C3.c3_u↔T2.t2_d
+   C4.c4_u↔T3.t3_r   C4.c4_r↔T4.t4_u
+   ```
+2. **Enlarged-corner pairing** (`_build_enlarged_corner`) agrees with (1) for
+   C1/C2/C3 but **disagrees for C4**: `bottom_left` uses `C4.c4_u↔T4.t4_u`,
+   `C4.c4_r↔T3.t3_r` (C4's two legs swapped vs the ground truth).
+3. **Left absorption** (`_ctm_tensor_absorb_left_2plaq`) produces
+   `new C4.c4_r` = projector-compressed (`P_top_curr`), `new C4.c4_u` = carried
+   relabel of the old edge leg `T3.t3_l` (`{"chi_new": "c4_r", "t3_l": "c4_u"}`,
+   `src/tenax/algorithms/_ctm_tensor_moves.py:506`).
+
+A localized swap of *only* the `bottom_left` pairing was already tried and
+**refuted** — it relocates the crash to the other C4 leg. So the diagnostic (Task
+1) must pin whether the divergence is the carried leg's source cell, its
+`t3_l`/`t3_r` end, the enlarged-corner pairing, or a combination, before editing.
+
+variPEPS oracle finding (the anchor): variPEPS's `new C4` after a left move is
+also `(carried_old_T3_chi, compressed_new_chi)`; it works because the carried leg
+is a **verbatim copy of the unmodified edge tensor the consumer later glues to**.
+The Tenax fix must make the carried leg equal that same unmodified edge leg.
+
+---
+
+## File Structure
+
+- `tests/oracle_varipeps.py` (new) — test-only helper that runs variPEPS 2-site
+  CTMRG and extracts env / post-absorption bond structure. Guarded by
+  `pytest.importorskip("varipeps")`. **Never imported by `src/`.**
+- `scripts/diag_670_bond_divergence.py` (new, throwaway — deleted in Task 6) —
+  the Task 1 diagnostic that diffs Tenax vs variPEPS post-`left`-move bonds.
+- `src/tenax/algorithms/_ctm_tensor_projector_2x2.py` — `_build_enlarged_corner`
+  (the C4 pairing in `bottom_left`, and by symmetry check the other positions).
+- `src/tenax/algorithms/_ctm_tensor_moves.py` — the four
+  `_ctm_tensor_absorb_*_2plaq` (carried-leg relabels).
+- `tests/test_ctm_670_symmetric_2x2.py` (new) — the red→green unit test for
+  post-absorption enlarged-corner consistency on a multi-charge env.
+- `tests/test_ctm_direction_dependent_bonds.py` — un-xfail + retarget the
+  acceptance test (Task 5).
+
+---
+
+## Task 1: variPEPS oracle + pin the exact divergent bond (DIAGNOSTIC GATE)
+
+**This task writes no `src/` code. Its deliverable is (a) a reusable oracle
+helper and (b) a recorded, exact statement of the divergent bond that Task 3
+implements against.** Do not start Task 3 until this is done.
+
+**Files:**
+- Create: `tests/oracle_varipeps.py`
+- Create: `scripts/diag_670_bond_divergence.py` (throwaway)
+
+- [ ] **Step 1: Write the variPEPS oracle helper**
+
+Create `tests/oracle_varipeps.py`. It must import variPEPS lazily and expose one
+function that runs variPEPS dense 2-site CTMRG and returns the converged env
+corner/edge tensor shapes + axis meaning. Use the working recipe already proven
+in the investigation: build a 2-site checkerboard unit cell
+(`structure=[[0,1],[1,0]]`, D=2, d=2) via `varipeps.PEPS_Unit_Cell.random(...)`
+and converge with `varipeps.ctmrg.routine.calc_ctmrg_env(peps_arrays, uc)`.
+
+```python
+"""variPEPS 2-site CTMRG oracle (test/diagnostic only). GPL reference — NEVER
+import this from src/. Skips cleanly if variPEPS is not installed."""
+from __future__ import annotations
+import numpy as np
+
+def varipeps_available() -> bool:
+    try:
+        import varipeps  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+def run_varipeps_2site_ctmrg(D: int = 2, d: int = 2, chi: int = 8, seed: int = 0):
+    """Run dense 2-site checkerboard CTMRG; return {'C1':shape,...,'T4':shape}
+    for unit-cell site 0 plus a short axis-convention note. Raises if variPEPS
+    is unavailable (callers guard with varipeps_available())."""
+    import jax
+    jax.config.update("jax_enable_x64", True)
+    import varipeps
+    from varipeps import PEPS_Unit_Cell
+    from varipeps.ctmrg.routine import calc_ctmrg_env
+    uc = PEPS_Unit_Cell.random(
+        structure=[[0, 1], [1, 0]], d=d, D=D, chi=chi, chi_max=chi,
+        seed=seed, dtype=np.complex128,
+    )
+    peps_arrays = [t.tensor for t in uc.get_unique_tensors()]
+    conv_uc = calc_ctmrg_env(peps_arrays, uc)
+    site0 = conv_uc[0, 0][0][0]
+    return {
+        name: tuple(getattr(site0, name).shape)
+        for name in ("C1", "C2", "C3", "C4", "T1", "T2", "T3", "T4")
+    }
+```
+
+Note: the exact variPEPS constructor/env accessor names were verified working in
+the 2026-07-01 investigation; if a name differs in the installed version, consult
+`.venv/lib/python3.11/site-packages/varipeps/` examples and adjust — the goal is
+"a converged env whose tensor shapes/axis order you can print", nothing more.
+
+- [ ] **Step 2: Smoke-run the oracle**
+
+Run: `uv run python -c "from tests.oracle_varipeps import run_varipeps_2site_ctmrg as r; print(r())"`
+Expected: prints a dict of 8 shapes (corners `(chi,chi)`, edges rank-4). If
+variPEPS errors, fix the constructor/accessor names per the installed package
+before proceeding.
+
+- [ ] **Step 3: Write the Tenax-vs-variPEPS divergence diagnostic**
+
+Create `scripts/diag_670_bond_divergence.py`. It must:
+1. Build a *direction-uniform multi-charge* U(1)-Sz pair (normal SU, `base_charges`
+   kept) at D=3 (reuse `/tmp/su667_uniform.pkl` if present, else regenerate via
+   the `_su_direction_dependent_pair`-style helper with `base_charges` kept — see
+   `tests/test_ctm_direction_dependent_bonds.py` for the SU driver).
+2. Run ONE Tenax `left` absorption on the init env (replicate the `left` branch
+   of `_ctm_tensor_sweep_multisite`: `_compute_plaquette_projector_pair` for each
+   anchor, then `_ctm_tensor_absorb_left_2plaq`, store at `s_dst`).
+3. For the resulting env at each `s_dst`, print the per-sector charge Counter of
+   `C4.c4_u`, `C4.c4_r`, `T4.t4_u`, `T4.t4_d`, `T3.t3_l`, `T3.t3_r`, and the
+   `env_src` (neighbor) `T3.t3_l`/`t3_r`.
+4. Explicitly test each candidate identity and print HOLDS/BROKEN:
+   - `C4.c4_r (s_dst) == T4.t4_u (s_dst)`  (compressed↔compressed; expected HOLD)
+   - `C4.c4_u (s_dst) == s_dst.T3.t3_r`     (carried↔own-T3 ground-truth glue)
+   - `C4.c4_u (s_dst) == env_src.T3.t3_l`   (what is currently carried)
+   - `C4.c4_u (s_dst) == env_src.T3.t3_r`
+5. Print which single identity, if enforced, would make the `bottom_left`
+   enlarged corner (energy/RDM pairing `c4_u↔t3_r`, `c4_r↔t4_u`) consistent.
+
+- [ ] **Step 4: Run the diagnostic and RECORD the finding**
+
+Run: `uv run python scripts/diag_670_bond_divergence.py`
+Record, in a new "## Task 1 outcome" section appended to
+`docs/superpowers/specs/2026-07-01-670-symmetric-2x2-carried-bond-design.md`:
+- the exact divergent bond (which `C4` leg, which cell's `T3`, which end),
+- which identity HOLDS vs BROKEN,
+- the concrete correction it implies (carried-leg source/end and/or
+  enlarged-corner pairing). This is the target Task 3 implements.
+
+- [ ] **Step 5: Commit (oracle + finding; diagnostic script stays uncommitted)**
+
+```bash
+git add tests/oracle_varipeps.py docs/superpowers/specs/2026-07-01-670-symmetric-2x2-carried-bond-design.md
+git commit -m "diag(#670): variPEPS oracle + pinned exact carried-bond divergence
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Red test — post-absorption enlarged corners on a multi-charge env
+
+**Files:**
+- Create: `tests/test_ctm_670_symmetric_2x2.py`
+
+- [ ] **Step 1: Write the failing test**
+
+This asserts that after ONE `left` sweep-direction on a multi-charge U(1) env, the
+four enlarged corners for the NEXT direction all build (i.e. the env is internally
+bond-consistent). It currently raises the `ValueError` block mismatch.
+
+```python
+"""Symmetric 2x2 must stay bond-consistent after absorption (#670)."""
+from __future__ import annotations
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+import tenax.algorithms.ipeps_simple_update as SU
+from tenax.algorithms._ctm_tensor_convergence import (
+    CHECKERBOARD_NEIGHBORS as NB,
+    _sort_coords_for_direction,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    _build_double_layer_tensor,
+    initialize_ctm_tensor_env,
+)
+from tenax.algorithms._ctm_tensor_moves import (
+    _compute_plaquette_projector_pair,
+    _ctm_tensor_absorb_left_2plaq,
+)
+from tenax.algorithms._ctm_tensor_projector_2x2 import _build_enlarged_corner
+from tenax.algorithms.ipeps import heisenberg_gate_u1sz, heisenberg_u1sz_init_pair
+
+CHI = 12
+
+
+def _uniform_multicharge_pair(D=3, steps=40, dt=0.1):
+    """Normal U(1)-Sz SU (base_charges kept) -> direction-uniform multi-charge."""
+    A, B = heisenberg_u1sz_init_pair(D=D, key=jax.random.PRNGKey(0))
+    H = heisenberg_gate_u1sz()
+    gate = SU._make_trotter_gate_tensor(H, dt, site_tensor=A)
+    lh, lv = jnp.ones(D), jnp.ones(D)
+    for s in range(steps):
+        if s % 2 == 0:
+            A, B, lh = SU._simple_update_2site_horizontal_tensor(A, B, gate, lh, lv, D)
+        else:
+            A, B, lv = SU._simple_update_2site_vertical_tensor(A, B, gate, lh, lv, D)
+    return A, B
+
+
+def _one_left(A, B):
+    site = {(0, 0): A, (1, 0): B}
+    dl = {c: _build_double_layer_tensor(t) for c, t in site.items()}
+    envs = {c: initialize_ctm_tensor_env(t, CHI) for c, t in site.items()}
+    projectors = {}
+    for s_anchor in envs:
+        s_TR = NB[s_anchor]["right"]; s_BL = NB[s_anchor]["bottom"]; s_BR = NB[s_TR]["bottom"]
+        Pt, Pb, _, _ = _compute_plaquette_projector_pair(
+            envs[s_anchor], envs[s_TR], envs[s_BL], envs[s_BR],
+            dl[s_anchor], dl[s_TR], dl[s_BL], dl[s_BR], CHI, "left")
+        projectors[s_anchor] = (Pt, Pb)
+    new = {}
+    for s_dst in _sort_coords_for_direction(list(envs), "left"):
+        s_src = NB[s_dst]["left"]; sa = NB[s_src]["top"]
+        Pta, Pba = projectors[sa]; Ptc, Pbc = projectors[s_src]
+        C1, T4, C4 = _ctm_tensor_absorb_left_2plaq(envs[s_src], dl[s_src], Pta, Pba, Ptc, Pbc)
+        new[s_dst] = envs[s_dst]._replace(C1=C1, T4=T4, C4=C4)
+    return new, dl
+
+
+def test_enlarged_corners_build_after_left_absorption_multicharge():
+    A, B = _uniform_multicharge_pair()
+    new, dl = _one_left(A, B)
+    for s_dst, env in new.items():
+        for pos, (C, Th, Tv) in {
+            "top_left": (env.C1, env.T1, env.T4),
+            "top_right": (env.C2, env.T1, env.T2),
+            "bottom_left": (env.C4, env.T3, env.T4),
+            "bottom_right": (env.C3, env.T3, env.T2),
+        }.items():
+            Q = _build_enlarged_corner(C, Th, Tv, dl[s_dst], position=pos)
+            assert Q is not None, f"{pos} failed to build at {s_dst}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_ctm_670_symmetric_2x2.py -o addopts="" -q`
+Expected: FAIL with `ValueError: Size of label ... does not match previous terms`
+(the block mismatch, most likely in `bottom_left`).
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add tests/test_ctm_670_symmetric_2x2.py
+git commit -m "test(#670): red — enlarged corners must build after 2x2 left absorption on multi-charge env
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Apply the carried-bond correction (content from Task 1)
+
+**Files:**
+- Modify: `src/tenax/algorithms/_ctm_tensor_moves.py` and/or
+  `src/tenax/algorithms/_ctm_tensor_projector_2x2.py` — per the Task 1 finding.
+
+**Decision rule (from Task 1 outcome):**
+- If Task 1 shows `C4.c4_r == T4.t4_u` HOLDS and the break is
+  `C4.c4_u` vs `s_dst.T3.t3_r`, the fix has two coupled parts: (a) make
+  `_build_enlarged_corner(bottom_left)` use the energy/RDM pairing
+  (`c4_r↔t4_u`, `c4_u↔t3_r`), and (b) make the absorption carry onto `c4_u` the
+  edge leg that equals `s_dst.T3.t3_r` (correct cell/end). Apply BOTH; a
+  half-fix only relocates the crash (already observed).
+- If Task 1 shows a different divergence (e.g. wrong source cell only), apply the
+  minimal relabel/source correction it names instead.
+
+**Leading-candidate edit (apply only if Task 1 confirms the pairing half).** The
+current `bottom_left` in `_build_enlarged_corner` (~lines 235-244) is:
+
+```python
+    if position == "bottom_left":
+        # C4.c4_u <-> T4.t4_u
+        C_r = C.relabel("c4_u", "t4_u")
+        CT_v = contract(C_r, T_v)  # -> (c4_r, t4_d, l2)
+        # C4.c4_r <-> T3.t3_r
+        T_h_r = T_h.relabel("t3_r", "c4_r")
+        CTT = contract(CT_v, T_h_r)  # -> (t4_d, l2, d2, t3_l)
+        Q = contract(CTT, a)  # -> (t4_d, t3_l, u2, r2) free legs
+        return Q.relabels({"t4_d": "chi_T", "t3_l": "chi_R"})
+```
+
+Correct it to the energy/RDM pairing (matches C1/C2/C3 and the RDM path):
+
+```python
+    if position == "bottom_left":
+        # C4.c4_r <-> T4.t4_u  (energy/RDM convention; #670)
+        C_r = C.relabel("c4_r", "t4_u")
+        CT_v = contract(C_r, T_v)  # -> (c4_u, t4_d, l2)
+        # C4.c4_u <-> T3.t3_r
+        T_h_r = T_h.relabel("t3_r", "c4_u")
+        CTT = contract(CT_v, T_h_r)  # -> (t4_d, l2, d2, t3_l)
+        Q = contract(CTT, a)  # -> (t4_d, t3_l, u2, r2) free legs
+        return Q.relabels({"t4_d": "chi_T", "t3_l": "chi_R"})
+```
+
+Plus the absorption half named by Task 1 (the exact `_ctm_tensor_absorb_*_2plaq`
+carried-leg source/end correction). Mirror the same correction across all four
+directions where the analogous asymmetry exists (Task 1 confirms which).
+
+- [ ] **Step 1: Apply the correction(s) named by the Task 1 outcome** (the
+  leading-candidate `bottom_left` edit above + the absorption carried-leg fix).
+
+- [ ] **Step 2: Run the Task 2 red test → green**
+
+Run: `uv run pytest tests/test_ctm_670_symmetric_2x2.py -o addopts="" -q`
+Expected: PASS (all enlarged corners build after the left absorption).
+
+- [ ] **Step 3: Run a full symmetric 2×2 sweep smoke check**
+
+Run:
+```bash
+uv run python -c "
+import jax; jax.config.update('jax_enable_x64', True)
+from tests.test_ctm_670_symmetric_2x2 import _uniform_multicharge_pair
+from tenax.algorithms._ctm_tensor_convergence import ctm_tensor_2site
+A,B=_uniform_multicharge_pair()
+eA,eB=ctm_tensor_2site(A,B,chi=12,max_iter=6,recipe='2x2')
+import jax.numpy as jnp; print('C1 norm', float(jnp.linalg.norm(eA.C1.todense())))
+"
+```
+Expected: completes without a block mismatch; prints a finite C1 norm.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tenax/algorithms/_ctm_tensor_projector_2x2.py src/tenax/algorithms/_ctm_tensor_moves.py
+git commit -m "fix(#670): correct 2x2 carried-bond threading so symmetric multi-charge env stays consistent
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Dense no-op guard (fix must not change the dense path)
+
+**Files:**
+- Add to: `tests/test_ctm_670_symmetric_2x2.py`
+
+- [ ] **Step 1: Write the dense-parity test**
+
+The direction-dependent *dense* 2×2 energy was −0.542116 before the fix and must
+be unchanged (the fix is a relabel that is a no-op for trivial charges).
+
+```python
+def test_dense_2x2_energy_unchanged_by_fix():
+    from tenax import compute_energy_ctm_tensor_2site, ctm_tensor_2site
+    from tenax.algorithms.ipeps import heisenberg_gate
+    from tenax.core.tensor import DenseTensor
+    # direction-dependent pair (base_charges-free), same as the #667 fixture
+    from tests.test_ctm_direction_dependent_bonds import _su_direction_dependent_pair
+    A, B = _su_direction_dependent_pair()
+    Ad = DenseTensor(np.array(A.todense()), A.indices)
+    Bd = DenseTensor(np.array(B.todense()), B.indices)
+    eA, eB = ctm_tensor_2site(Ad, Bd, chi=12, max_iter=60, conv_tol=1e-9, recipe="2x2")
+    E = float(compute_energy_ctm_tensor_2site(Ad, Bd, eA, eB, heisenberg_gate()))
+    assert abs(E - (-0.542116)) < 1e-5, f"dense 2x2 energy drifted: {E}"
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `uv run pytest tests/test_ctm_670_symmetric_2x2.py::test_dense_2x2_energy_unchanged_by_fix -o addopts="" -q`
+Expected: PASS (dense energy still −0.542116).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_ctm_670_symmetric_2x2.py
+git commit -m "test(#670): guard dense 2x2 energy unchanged by carried-bond fix
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Un-xfail + retarget the #667 acceptance test to recipe="2x2"
+
+**Files:**
+- Modify: `tests/test_ctm_direction_dependent_bonds.py`
+
+- [ ] **Step 1: Remove the `@pytest.mark.xfail(...)` decorator** from
+  `test_symmetric_2site_ctm_matches_dense_on_direction_dependent_bonds` and change
+  BOTH `ctm_tensor_2site(...)` calls in it from `recipe="1x1"` to `recipe="2x2"`.
+  Update the docstring comment to cite #670 as fixed and this plan.
+
+The two calls become:
+```python
+    eAd, eBd = ctm_tensor_2site(Ad, Bd, chi=12, max_iter=60, conv_tol=1e-9, recipe="2x2")
+    ...
+    eA, eB = ctm_tensor_2site(A, B, chi=12, max_iter=60, conv_tol=1e-9, recipe="2x2")
+```
+
+- [ ] **Step 2: Run the acceptance test**
+
+Run: `uv run pytest tests/test_ctm_direction_dependent_bonds.py -o addopts="" -q`
+Expected: all pass (no xfail). `abs(E_sym - E_dense) < 1e-6`, `C1 norm > 1e-8`,
+`E_sym < -0.3` (dense reference ≈ −0.542 for recipe="2x2").
+If `E_sym < -0.3` fails because the fixture SU state is degenerate (per the Phase
+2 note), relax that one bound to match the dense reference and document why — the
+load-bearing assertion is `abs(E_sym - E_dense) < 1e-6`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_ctm_direction_dependent_bonds.py
+git commit -m "test(#667): un-xfail direction-dependent 2-site CTM (fixed via #670), retarget to recipe=2x2
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Regression sweep, cleanup, PR
+
+**Files:**
+- Delete: `scripts/diag_670_bond_divergence.py`
+
+- [ ] **Step 1: Delete the throwaway diagnostic**
+
+```bash
+git rm -f scripts/diag_670_bond_divergence.py 2>/dev/null || rm -f scripts/diag_670_bond_divergence.py
+```
+
+- [ ] **Step 2: Run the CTM/iPEPS regression suite**
+
+Run:
+```bash
+uv run pytest -m core -q
+uv run pytest tests/test_ctm_tensor.py tests/test_ctm_tensor_projector_2x2.py tests/test_ipeps_u1sz.py tests/test_ctm_670_symmetric_2x2.py tests/test_ctm_direction_dependent_bonds.py -o addopts="" -q
+```
+Expected: all green. In particular the 2×2 projector closure test
+(`P_bot · P_top = I`) and the u1sz suite must be unchanged.
+
+- [ ] **Step 3: Confirm no fermionic regression / scope note**
+
+Run: `uv run pytest tests/ -k "fermion" -o addopts="" -q`
+Expected: unchanged (the fix targets the non-fused path). If the same
+carried-bond bug is visible on the fused path, open a follow-up issue rather than
+expanding scope here.
+
+- [ ] **Step 4: Update memory + close-out docs**
+
+Update `MEMORY.md` note `project_667_direction_dependent_ctm.md` to record #670
+FIXED (mechanism: carried-bond threading correction) and the #667 test un-xfailed.
+Append the final mechanism to the design spec's "Task 1 outcome" section.
+
+- [ ] **Step 5: Commit, push, PR, close #670**
+
+```bash
+git add -A
+git commit -m "chore(#670): cleanup + memory/docs update; direction-dependent 2x2 CTM works
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+git push -u origin fix/670-symmetric-2x2-carried-bond
+gh pr create --title "fix(#670): symmetric 2x2 CTM carried-bond threading (unblocks #667)" \
+  --body "$(printf '> 🤖 **AI-generated PR** — written by Claude Code, posted by @yjkao.\n\nFixes #670. Corrects the 2x2 absorption carried-bond threading so the symmetric block-sparse CTM stays bond-consistent on genuine multi-charge U(1) envs. Anchored on a variPEPS numerical oracle. Un-xfails the #667 direction-dependent acceptance test (retargeted to recipe=2x2). Dense path is a bit-for-bit no-op (dense 2x2 energy unchanged at -0.542116).\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)')"
+```
+Merge per CLAUDE.md (auto-merge; CI must pass).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** oracle harness = Task 1 Step 1; diagnostic/pin = Task 1
+  Steps 3-4; fix = Task 3; acceptance (`|E_sym-E_dense|<1e-6`, un-xfail #667) =
+  Task 5; dense no-op = Task 4; regression/closure/fermionic-scope = Task 6.
+- **Diagnosis-gated honesty:** Task 3's exact content is chosen by Task 1's
+  measured outcome (leading candidate + decision rule given). This is deliberate,
+  not a placeholder — the localized-swap refutation proved guessing the fix blind
+  is wrong; Task 1 removes the guess.
+- **Names verified:** `_build_enlarged_corner`, `_ctm_tensor_absorb_left_2plaq`,
+  `_compute_plaquette_projector_pair`, `_sort_coords_for_direction`,
+  `initialize_ctm_tensor_env`, `_build_double_layer_tensor`,
+  `CHECKERBOARD_NEIGHBORS`, `ctm_tensor_2site`,
+  `compute_energy_ctm_tensor_2site` are current symbols.
+- **No-op invariant:** Task 4 locks the dense path; Task 6 locks core/closure/
+  fermionic — the fix must not regress the production (dense/trivial-charge) path.

--- a/docs/superpowers/plans/2026-07-01-670-symmetric-2x2-carried-bond.md
+++ b/docs/superpowers/plans/2026-07-01-670-symmetric-2x2-carried-bond.md
@@ -504,3 +504,35 @@ Merge per CLAUDE.md (auto-merge; CI must pass).
   `compute_energy_ctm_tensor_2site` are current symbols.
 - **No-op invariant:** Task 4 locks the dense path; Task 6 locks core/closure/
   fermionic — the fix must not regress the production (dense/trivial-charge) path.
+
+---
+
+## Outcome (2026-07-01) — DONE
+
+The fix was **bounded** (Approach A held; not structural), but the scope grew from
+the planned single site to **three**, because Task 1's diagnostic only ran one
+`left` absorption and never exercised the full sweep. The scope-mapping (fix-forward
+diagnostic) found every crash mapped cleanly to the production energy/RDM
+convention:
+
+1. `_build_enlarged_corner` `bottom_left` — C4 legs were swapped; now
+   `c4_u↔t3_r`, `c4_r↔t4_u` (commit `805757e`).
+2. `_ctm_tensor_absorb_bottom_2plaq` — C3·T2 paired `c3_l↔t2_d`; now `c3_u↔t2_d`.
+3. `_ctm_sv_diff` — zero-pads SV vectors so warmup block-structure growth on
+   asymmetric states reports not-converged instead of crashing (eager/non-AD
+   call sites, so gradient-safe).
+
+Result: direction-dependent symmetric 2×2 CTM matches dense to **4e-14**
+(E = −0.5421160718). Dense path is a true no-op (the swap is a benign gauge
+choice on a single block; a fatal charge-sector mismatch only for block-sparse
+`A.l != A.r`), so the plan's dense-no-op assumption (Task 4) held after all.
+
+Stale unit test `test_build_enlarged_corner_bottom_left_numerical` (its einsum
+encoded the old swapped C4 pairing) updated. #667 acceptance test un-xfailed and
+retargeted to `recipe="2x2"` (commit `07fa9ac`); dense guard added (commit
+`0523818`).
+
+**Out-of-scope follow-ups filed:** #674 (fermionic/fused twin
+`_ctm_tensor_absorb_bottom_2plaq_fused` has the same latent C3 bug), #675
+(compiled `_ctm_compiled_moves.py` uses the same pre-fix `c3_l↔t2_d` convention).
+Both are no-ops on uniform states so production is unaffected.

--- a/docs/superpowers/specs/2026-07-01-670-symmetric-2x2-carried-bond-design.md
+++ b/docs/superpowers/specs/2026-07-01-670-symmetric-2x2-carried-bond-design.md
@@ -150,3 +150,117 @@ carried / how it's paired*, not the contraction topology or the projector math.
 - **variPEPS index-convention mapping** to Tenax is nontrivial; the oracle is a
   guide, and the primary acceptance is dense-parity + block-consistency, which
   hold independent of variPEPS.
+
+## Task 1 outcome
+
+**Recorded 2026-07-01 from `scripts/diag_670_bond_divergence.py` (throwaway) on
+the cached direction-*uniform* multi-charge U(1)-Sz D=3 pair
+`/tmp/su667_uniform.pkl` (`A.l == A.r`, both `{−1:1, 0:1, 1:1}`), χ=12, after
+ONE `left` 2×2 absorption via the exact `left` branch of
+`_ctm_tensor_sweep_multisite`.** The finding is identical for both `s_dst`
+cells `(0,0)` and `(1,0)`, so it is a genuine per-move property, not a
+cell-specific accident.
+
+### The exact divergent bond
+
+The divergence is in the `bottom_left` **enlarged-corner pairing** inside
+`_build_enlarged_corner` (`src/tenax/algorithms/_ctm_tensor_projector_2x2.py`,
+lines 235–244), **not** in the carried leg's source cell or its `t3_l`/`t3_r`
+end. After a `left` absorption the new `C4` (stored at `s_dst`) has:
+
+- `C4.c4_r` — projector-**compressed** (via `P_top_curr`), flow `+1`,
+  charge→dim map `{−2:1, −1:3, 0:4, 1:3, 2:1}`.
+- `C4.c4_u` — **carried** relabel of the old `env_src.T3.t3_l`, flow `+1`,
+  charge→dim map `{−2:2, −1:4, 0:3, 1:2, 2:1}`.
+
+These two `C4` legs have **different** charge→dim maps (`{…,0:4,1:3,…}` vs
+`{…,0:3,1:2,…}`), which is why swapping them matters. The `s_dst`-own edges the
+enlarged corner glues them to are:
+
+- `s_dst.T4.t4_u` — flow `−1`, `{−2:1, −1:3, 0:4, 1:3, 2:1}`
+  (matches `C4.c4_r`).
+- `s_dst.T3.t3_r` — flow `−1`, `{−2:2, −1:4, 0:3, 1:2, 2:1}`
+  (matches `C4.c4_u`).
+
+### HOLDS vs BROKEN (charge→dim maps; "==" = identical map)
+
+GROUND-TRUTH pairing (energy/RDM path):
+
+- `[1] C4.c4_r == s_dst.T4.t4_u` → **HOLDS**
+  (`{−2:1, −1:3, 0:4, 1:3, 2:1}` == `{−2:1, −1:3, 0:4, 1:3, 2:1}`)
+- `[2] C4.c4_u == s_dst.T3.t3_r` → **HOLDS**
+  (`{−2:2, −1:4, 0:3, 1:2, 2:1}` == `{−2:2, −1:4, 0:3, 1:2, 2:1}`)
+
+CURRENT `_build_enlarged_corner` `bottom_left` pairing (C4's two legs SWAPPED,
+lines 237 + 240 — `c4_u`↔`t4_u`, `c4_r`↔`t3_r`):
+
+- `[3] C4.c4_u == s_dst.T4.t4_u` → **BROKEN**
+  (`{−2:2, −1:4, 0:3, 1:2, 2:1}` != `{−2:1, −1:3, 0:4, 1:3, 2:1}`)
+- `[4] C4.c4_r == s_dst.T3.t3_r` → **BROKEN**
+  (`{−2:1, −1:3, 0:4, 1:3, 2:1}` != `{−2:2, −1:4, 0:3, 1:2, 2:1}`)
+
+Carried-leg provenance (all **HOLD** — the carried leg is sourced correctly):
+
+- `[5] C4.c4_u == env_src.T3.t3_l` → **HOLDS** (this is literally the relabel
+  performed by `_ctm_tensor_absorb_left_2plaq` line 513).
+- `[6] C4.c4_u == env_src.T3.t3_r` → **HOLDS**
+- `[7] C4.c4_u == s_dst.T3.t3_l` → **HOLDS**
+
+Because the direction-uniform state has the same charge→dim map on every T3 end
+(`env_src` and `s_dst`, `t3_l` and `t3_r` all `{−2:2, −1:4, 0:3, 1:2, 2:1}`),
+identities [2],[5],[6],[7] are all satisfied simultaneously — i.e. the carried
+leg's **source cell** and its **`t3_l`/`t3_r` end** are NOT the divergent
+variable on the uniform state. The single divergent variable is the
+enlarged-corner **pairing** of `C4`'s two legs.
+
+### Direct crash reproduction (decisive)
+
+Building `_build_enlarged_corner(env.C4, env.T3, env.T4, a, "bottom_left")` on
+the post-absorption env:
+
+- CURRENT pairing (`c4_u`↔`t4_u`, `c4_r`↔`t3_r`):
+  **CRASH** `ValueError: Size of label 'd' for operand 1 (4) does not match
+  previous terms (3).` — this is exactly the #670 error.
+- GROUND-TRUTH pairing (`c4_u`↔`t3_r`, `c4_r`↔`t4_u`, obtained by relabel-
+  swapping only `C4`'s two legs before the same builder): **OK** — the enlarged
+  corner builds with no mismatch.
+
+Flows are consistent with the ground-truth pairing: `c4_u`(+1)↔`t3_r`(−1) and
+`c4_r`(+1)↔`t4_u`(−1) are both opposite-flow (contractible); the current
+swapped pairing crashes on the dim mismatch before flow even matters.
+
+### The concrete correction the fix task must implement
+
+In `_build_enlarged_corner`, `position == "bottom_left"` branch
+(`src/tenax/algorithms/_ctm_tensor_projector_2x2.py`, lines 235–244), the two
+`C4` legs are paired to the wrong edges. Change the pairing to the energy/RDM
+ground truth:
+
+- pair `C4.c4_u` with the **horizontal** edge `T3.t3_r` (currently line 240
+  wrongly relabels `t3_r → c4_r`);
+- pair `C4.c4_r` with the **vertical** edge `T4.t4_u` (currently line 237
+  wrongly relabels `c4_u → t4_u`).
+
+Concretely, the branch's first two relabels must become `C.relabel("c4_r",
+"t4_u")` (glue the compressed leg to the vertical edge) and `T_h.relabel(
+"t3_r", "c4_u")` (glue the carried leg to the horizontal edge), and the free-leg
+`Q.relabels` targets updated to keep the same output seams (`chi_T`, `chi_R`).
+The carried-leg absorption (`_ctm_tensor_absorb_left_2plaq` relabel `t3_l →
+c4_u`, moves-file line 513) is **correct and must NOT change**.
+
+### Caveat for the fix task (why the earlier localized swap was "refuted")
+
+A prior session swapped *only* this `bottom_left` pairing and the crash merely
+relocated. The diagnostic explains why: the projector-construction path
+(`_compute_2x2_projector` / `_compute_plaquette_projector_pair`) and the other
+three enlarged-corner positions must read `C4`'s legs with a convention
+**consistent** with the corrected `bottom_left`. The `left`-move enlarged corner
+that feeds the projector for the *next* direction also consumes `C4`, so the
+`C4`-leg convention must be fixed **everywhere `C4` is consumed** (projector
+build + all four enlarged-corner uses that touch `C4`), not only in the
+`bottom_left` builder. The fix is small (a `C4`-leg convention correction) but
+must be applied at every `C4` consumption site, then validated by re-running the
+full `left` sweep + `_build_enlarged_corner` for the *next* direction without a
+crash, and finally by the dense-parity acceptance test. The divergence is
+confirmed to be the carried-bond/pairing story (a `C4`-leg pairing bug), **not**
+a broader storage-target or absorption-provenance defect.

--- a/docs/superpowers/specs/2026-07-01-670-symmetric-2x2-carried-bond-design.md
+++ b/docs/superpowers/specs/2026-07-01-670-symmetric-2x2-carried-bond-design.md
@@ -1,0 +1,152 @@
+# #670 — Symmetric 2×2 CTM carried-bond threading fix (design)
+
+**Date:** 2026-07-01
+**Issue:** [#670](https://github.com/tenax-lab/tenax/issues/670)
+**Branch:** `fix/670-symmetric-2x2-carried-bond`
+**Approach:** A — oracle-anchored minimal correction (approved 2026-07-01)
+
+## Goal
+
+Make the symmetric (block-sparse U(1)) **2×2** forward CTM sweep
+(`ctm_tensor_2site(..., recipe="2x2")` / `_ctm_tensor_sweep_multisite`) run to
+convergence on a genuine multi-charge U(1)-Sz environment without the
+per-sector block-size mismatch it currently raises, matching the dense result.
+On success, un-xfail
+`tests/test_ctm_direction_dependent_bonds.py::test_symmetric_2site_ctm_matches_dense_on_direction_dependent_bonds`
+(retargeting it to `recipe="2x2"`).
+
+## Background — confirmed root cause
+
+The symmetric 2×2 sweep crashes for **any** genuine multi-charge U(1) env (not
+just direction-dependent `A.l != A.r`; reproduced on a direction-uniform
+multi-charge pair). The crash is in the enlarged-corner build inside the
+plaquette projector, e.g. `bottom_left`'s `C4.c4_u ↔ T4.t4_u` contraction, with a
+per-sector count mismatch.
+
+Established by investigation (`docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md`
+Phase 2 + follow-up, and #670):
+
+- After a `left` absorption `_ctm_tensor_absorb_left_2plaq` produces `new C4` with
+  one **projector-compressed** leg (`c4_r`, via `P_top_curr`) and one
+  **carried-over** leg (`c4_u`, a relabel of the old edge leg `T3.t3_l`).
+- The next move's enlarged corner glues that carried leg to an edge leg whose
+  charge structure differs → mismatch. Dense (trivial-charge) tolerates it
+  because there is a single block of size χ.
+- A localized swap of `bottom_left`'s C4 pairing was tried and **refuted**: it
+  merely relocates the crash to the other C4 leg. So both the pairing *and* the
+  carried leg's bond identity are involved.
+
+### variPEPS oracle finding (the design anchor)
+
+variPEPS 1.4.2 is importable in `.venv` (GPL — reference/test only). Its
+`do_left_absorption` produces `new C4 = (carried_old_T3_chi, compressed_new_chi)`
+— **the same one-carried/one-compressed structure Tenax already has**. It does
+*not* crash because the carried leg is a **verbatim copy of an *unmodified* edge
+tensor's leg**, and the env consumer glues it back to that *same unmodified
+tensor* (the left sweep does not recompute `T3`; `replace_left_env_tensors` keeps
+it). So the carried leg needs no per-sector reconciliation — it is bit-identical
+to the tensor it later contracts.
+
+**Conclusion:** Tenax's absorption *structure* is correct. The bug is that
+Tenax's carried leg and the leg the enlarged corner glues it to are **not the
+same bond** — a bookkeeping error (which cell's edge is carried, which
+`t3_l`/`t3_r` end, and/or the enlarged-corner pairing), not a structural
+redesign.
+
+## Approach A — oracle-anchored minimal correction
+
+Treat this as a bond-bookkeeping bug. Use variPEPS as a **numerical oracle** to
+pin the exact divergence, then apply the minimal correction, and verify Tenax's
+whole sweep reproduces the correct env bond structure.
+
+### Components
+
+1. **variPEPS oracle harness (test-only, `scripts/` or `tests/` helper).**
+   A thin wrapper that builds a 2-site unit cell in variPEPS from the *same*
+   site tensors Tenax uses (or an equivalent random D=2 pair), runs variPEPS
+   dense CTMRG to convergence, and exposes: (a) the converged corner/edge tensor
+   bond dimensions and axis meaning, and (b) — where feasible — the intermediate
+   post-`left`-absorption `C4`/`T4`/`T3` bond structure. variPEPS is GPL and is
+   **never imported by `src/`**; it lives only in test/diagnostic code, guarded
+   by an import skip if unavailable (so CI without variPEPS still passes the rest
+   of the suite).
+
+2. **Diagnostic (red) step — pin the exact divergent bond.**
+   With Tenax and variPEPS both run on the same/equivalent pair, numerically diff
+   the post-`left`-move `C4` (and `T4`, `T3`) bond charge structure to identify
+   the precise leg where Tenax diverges from the reference: is the carried leg
+   sourced from the wrong cell's `T3`, the wrong (`t3_l`/`t3_r`) end, or does the
+   enlarged corner glue the wrong pair? This converts the current guesswork into
+   a concrete, quoted target. Output: a written note of the exact divergence.
+
+3. **Fix — minimal carried-leg/pairing correction.**
+   In `_ctm_tensor_absorb_*_2plaq` and/or `_build_enlarged_corner`, correct the
+   carried leg's source/relabel (and, if needed, the enlarged-corner pairing) so
+   the carried leg is the verbatim unmodified edge leg the enlarged corner glues
+   to — mirroring variPEPS's convention. The fix must be symmetric across all
+   four directions (left/right/top/bottom) and internally consistent with the
+   env-consumption convention already used by the energy/RDM path
+   (`C4.c4_u↔T3.t3_r`, `C4.c4_r↔T4.t4_u`, etc.).
+
+4. **Scope guard.** The non-fused (dense + bosonic-U(1)) absorption path only.
+   The fermionic `_ctm_tensor_absorb_*_2plaq_fused` path is **out of scope**
+   (separate follow-up if needed) — but if the same bookkeeping bug exists there,
+   note it in a follow-up issue.
+
+### Data flow (unchanged shape; corrected labels)
+
+`initialize_ctm_tensor_env` → `_ctm_tensor_sweep_multisite(recipe="2x2")`
+→ per direction: `_compute_plaquette_projector_pair` (builds 4 enlarged corners
+→ `_compute_2x2_projector`) → `_ctm_tensor_absorb_*_2plaq` (applies projector
+halves, carries the unmodified edge leg). The fix changes only *which leg is
+carried / how it's paired*, not the contraction topology or the projector math.
+
+## Testing strategy
+
+- **Unit (red→green):** a test that builds the post-`left`-move env on a
+  multi-charge (direction-uniform first, then direction-dependent) pair and
+  asserts the enlarged corners for the *next* direction all build without a block
+  mismatch (extends the existing Phase 1
+  `test_2x2_enlarged_corners_build_on_direction_dependent_init` to post-absorption
+  envs).
+- **Oracle parity (where variPEPS available):** assert Tenax's converged 2×2
+  symmetric env bond structure matches variPEPS's (dimensions/charges), skipped
+  when variPEPS is absent.
+- **Acceptance:** un-xfail + retarget
+  `test_symmetric_2site_ctm_matches_dense_on_direction_dependent_bonds` to
+  `recipe="2x2"`; require `abs(E_sym - E_dense) < 1e-6`, `C1 norm > 1e-8`.
+- **Regression / no-op for the working paths:**
+  - Dense parity: the direction-dependent *dense* 2×2 energy stays −0.542116.
+  - `uv run pytest -m core -q` plus `tests/test_ctm_tensor.py`,
+    `tests/test_ctm_tensor_projector_2x2.py`, `tests/test_ipeps_u1sz.py` green.
+  - The 2×2 projector closure test (`P_bot · P_top = I`) unchanged.
+
+## Acceptance criteria
+
+1. `ctm_tensor_2site(recipe="2x2")` completes on a direction-uniform multi-charge
+   U(1) env (the general #670 repro) — no block mismatch.
+2. `abs(E_sym − E_dense) < 1e-6` on the direction-dependent pair with
+   `recipe="2x2"`; corner norm > 1e-8.
+3. The #667 acceptance test is **un-xfailed** and retargeted to `recipe="2x2"`
+   and passes.
+4. Dense and direction-uniform-dense results and all existing core/CTM/projector
+   tests are unchanged (fix is a no-op for the dense path).
+5. #670 closed; fermionic path scoped to a follow-up if the same bug exists there.
+
+## Non-goals
+
+- Fermionic (`FermionParity`/`FermionicU1`) 2×2 absorption (separate follow-up).
+- The `1x1` recipe (has a distinct fundamental edge-orientation wall; the #667
+  test moves to `2x2`).
+- Any projector-math change (`_compute_2x2_projector` SVD/closure stays as is).
+- Copying variPEPS code — it is a read-only GPL reference/oracle only.
+
+## Risks
+
+- **The divergence may span more than the carried leg** (e.g. multi-site storage
+  target). Mitigation: the diagnostic step pins it before coding; if it turns out
+  structural after all, we stop and re-scope with evidence rather than guessing
+  (as we did when the localized swap was refuted).
+- **variPEPS index-convention mapping** to Tenax is nontrivial; the oracle is a
+  guide, and the primary acceptance is dense-parity + block-consistency, which
+  hold independent of variPEPS.

--- a/src/tenax/algorithms/_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_ctm_tensor_convergence.py
@@ -541,7 +541,20 @@ def _ctm_tensor_sweep_multisite(
 
 
 def _ctm_sv_diff(sv_new: jax.Array, sv_old: jax.Array) -> jax.Array:
-    """Compute max absolute difference between normalized singular value vectors."""
+    """Compute max absolute difference between normalized singular value vectors.
+
+    On direction-dependent (asymmetric-bond) states the corner block
+    structure fills out empty charge sectors during CTM warmup, so the
+    concatenated per-sector SV vector can have a different length from one
+    iteration to the next (#670).  Zero-pad the shorter vector to the common
+    length: newly-appearing singular values then register as a nonzero diff,
+    which correctly reports the env as *not yet converged* while it is still
+    changing shape.  Once the block structure stabilises the lengths match
+    and the diff reduces to the usual element-wise comparison.
+    """
+    n = max(sv_new.shape[0], sv_old.shape[0])
+    sv_new = jnp.pad(sv_new, (0, n - sv_new.shape[0]))
+    sv_old = jnp.pad(sv_old, (0, n - sv_old.shape[0]))
     sv1 = sv_new / (jnp.sum(sv_new) + 1e-15)
     sv2 = sv_old / (jnp.sum(sv_old) + 1e-15)
     return jnp.max(jnp.abs(sv1 - sv2))

--- a/src/tenax/algorithms/_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_ctm_tensor_moves.py
@@ -151,10 +151,7 @@ def _env_is_fermionic(env_src: CTMTensorEnv) -> bool:
     asymmetric-conjugate), fermionic envs keep the proven fused path.
     """
     C1 = env_src.C1
-    return (
-        isinstance(C1, SymmetricTensor)
-        and C1.indices[0].symmetry.is_fermionic
-    )
+    return isinstance(C1, SymmetricTensor) and C1.indices[0].symmetry.is_fermionic
 
 
 def _phase_fix_normalize_tensor(T: Tensor) -> Tensor:
@@ -514,7 +511,9 @@ def _ctm_tensor_absorb_left_2plaq(
 
     # ---- T4: sandwiched by P_top_above (top face, t4_d⊕u2) and
     #          P_bot_curr (bottom face, t4_u⊕d2) ----
-    step = _apply_proj_unfused(P_top_above, T4_with_a, "t4_d", "u2")  # (chi_new, t4_u, d2, r2)
+    step = _apply_proj_unfused(
+        P_top_above, T4_with_a, "t4_d", "u2"
+    )  # (chi_new, t4_u, d2, r2)
     # ``env_first`` matches the fused path's ``contract(step, P_right)`` order
     # (Koszul-correct for fermions) and yields canonical leg order directly.
     T4_new = _apply_proj_unfused(
@@ -599,7 +598,9 @@ def _ctm_tensor_absorb_right_2plaq(
     C3_new = C3_new.relabels({"chi_new": "c3_u", "t3_r": "c3_l"})
 
     # ---- T2: sandwiched by P_bot_above (fl, t2_u⊕u2) and P_top_curr (fr, t2_d⊕d2) ----
-    step = _apply_proj_unfused(P_bot_above, T2_with_a, "t2_u", "u2")  # (chi_new, t2_d, d2, l2)
+    step = _apply_proj_unfused(
+        P_bot_above, T2_with_a, "t2_u", "u2"
+    )  # (chi_new, t2_d, d2, l2)
     T2_new = _apply_proj_unfused(
         P_top_curr, step, "t2_d", "d2", chi_new="chi_new_r", env_first=True
     )
@@ -670,7 +671,9 @@ def _ctm_tensor_absorb_top_2plaq(
     C2_new = C2_new.relabels({"chi_new": "c2_l", "t2_d": "c2_d"})
 
     # ---- T1: sandwiched by P_bot_left (fl, t1_l⊕l2) and P_top_curr (fr, t1_r⊕r2) ----
-    step = _apply_proj_unfused(P_bot_left, T1_with_a, "t1_l", "l2")  # (chi_new, t1_r, d2, r2)
+    step = _apply_proj_unfused(
+        P_bot_left, T1_with_a, "t1_l", "l2"
+    )  # (chi_new, t1_r, d2, r2)
     T1_new = _apply_proj_unfused(
         P_top_curr, step, "t1_r", "r2", chi_new="chi_new_r", env_first=True
     )
@@ -706,8 +709,9 @@ def _ctm_tensor_absorb_bottom_2plaq(
     C4g = contract(C4_r, env_src.T4)  # (c4_u, t4_d, l2)
 
     # ---- C3·T2 (both at s_src) ----
-    C3_l = env_src.C3.relabel("c3_l", "t2_d")
-    C3g = contract(C3_l, env_src.T2)  # (c3_u, t2_u, r2)
+    # C3.c3_u <-> T2.t2_d  (energy/RDM convention; #670)
+    C3_u = env_src.C3.relabel("c3_u", "t2_d")
+    C3g = contract(C3_u, env_src.T2)  # (c3_l, t2_u, r2)  # #670
 
     # ---- T3·ket (both at s_src) ----
     T3_with_a = contract(env_src.T3, a_src)  # (t3_r, t3_l, u2, l2, r2)
@@ -717,11 +721,13 @@ def _ctm_tensor_absorb_bottom_2plaq(
     C4_new = C4_new.relabels({"chi_new": "c4_r", "t4_d": "c4_u"})
 
     # ---- C3: project with P_top_curr ----
-    C3_new = _apply_proj_unfused(P_top_curr, C3g, "c3_u", "r2")
+    C3_new = _apply_proj_unfused(P_top_curr, C3g, "c3_l", "r2")  # #670
     C3_new = C3_new.relabels({"chi_new": "c3_u", "t2_u": "c3_l"})
 
     # ---- T3: sandwiched by P_top_left (fl, t3_r⊕l2) + P_bot_curr (fr, t3_l⊕r2) ----
-    step = _apply_proj_unfused(P_top_left, T3_with_a, "t3_r", "l2")  # (chi_new, t3_l, u2, r2)
+    step = _apply_proj_unfused(
+        P_top_left, T3_with_a, "t3_r", "l2"
+    )  # (chi_new, t3_l, u2, r2)
     T3_new = _apply_proj_unfused(
         P_bot_curr, step, "t3_l", "r2", chi_new="chi_new_r", env_first=True
     )
@@ -786,7 +792,9 @@ def _ctm_tensor_absorb_left_2plaq_fused(
 
     # ---- T4: sandwiched by P_top_above (top face, t4_d⊕u2) and
     #          P_bot_curr (bottom face, t4_u⊕d2) ----
-    step = _apply_proj_unfused(P_top_above, T4_with_a, "t4_d", "u2")  # (chi_new, t4_u, d2, r2)
+    step = _apply_proj_unfused(
+        P_top_above, T4_with_a, "t4_d", "u2"
+    )  # (chi_new, t4_u, d2, r2)
     T4_new = _apply_proj_unfused(
         P_bot_curr, step, "t4_u", "d2", chi_new="chi_new_r"
     )  # (chi_new, r2, chi_new_r)
@@ -871,7 +879,9 @@ def _ctm_tensor_absorb_right_2plaq_fused(
     C3_new = C3_new.relabels({"chi_new": "c3_u", "t3_r": "c3_l"})
 
     # ---- T2: sandwiched by P_bot_above (fl, t2_u⊕u2) and P_top_curr (fr, t2_d⊕d2) ----
-    step = _apply_proj_unfused(P_bot_above, T2_with_a, "t2_u", "u2")  # (chi_new, t2_d, d2, l2)
+    step = _apply_proj_unfused(
+        P_bot_above, T2_with_a, "t2_u", "u2"
+    )  # (chi_new, t2_d, d2, l2)
     T2_new = _apply_proj_unfused(P_top_curr, step, "t2_d", "d2", chi_new="chi_new_r")
     T2_new = T2_new.relabels({"chi_new": "t2_u", "chi_new_r": "t2_d", "l2": "r2"})
     T2_new = T2_new.transpose(
@@ -939,7 +949,9 @@ def _ctm_tensor_absorb_top_2plaq_fused(
     C2_new = C2_new.relabels({"chi_new": "c2_l", "t2_d": "c2_d"})
 
     # ---- T1: sandwiched by P_bot_left (fl, t1_l⊕l2) and P_top_curr (fr, t1_r⊕r2) ----
-    step = _apply_proj_unfused(P_bot_left, T1_with_a, "t1_l", "l2")  # (chi_new, t1_r, d2, r2)
+    step = _apply_proj_unfused(
+        P_bot_left, T1_with_a, "t1_l", "l2"
+    )  # (chi_new, t1_r, d2, r2)
     T1_new = _apply_proj_unfused(P_top_curr, step, "t1_r", "r2", chi_new="chi_new_r")
     T1_new = T1_new.relabels({"chi_new": "t1_l", "chi_new_r": "t1_r", "d2": "u2"})
     T1_new = T1_new.transpose(
@@ -987,7 +999,9 @@ def _ctm_tensor_absorb_bottom_2plaq_fused(
     C3_new = C3_new.relabels({"chi_new": "c3_u", "t2_u": "c3_l"})
 
     # ---- T3: sandwiched by P_top_left (fl, t3_r⊕l2) + P_bot_curr (fr, t3_l⊕r2) ----
-    step = _apply_proj_unfused(P_top_left, T3_with_a, "t3_r", "l2")  # (chi_new, t3_l, u2, r2)
+    step = _apply_proj_unfused(
+        P_top_left, T3_with_a, "t3_r", "l2"
+    )  # (chi_new, t3_l, u2, r2)
     T3_new = _apply_proj_unfused(P_bot_curr, step, "t3_l", "r2", chi_new="chi_new_r")
     T3_new = T3_new.relabels({"chi_new": "t3_r", "chi_new_r": "t3_l", "u2": "d2"})
     T3_new = T3_new.transpose(
@@ -1002,8 +1016,17 @@ def _ctm_tensor_absorb_bottom_2plaq_fused(
 
 
 def _chunked_T_new_apply(
-    edge, a, P_1, P_2, C1g, C4g,
-    edge_label_order, chi_leg, surv_leg, chunked_fn, chunk_size,
+    edge,
+    a,
+    P_1,
+    P_2,
+    C1g,
+    C4g,
+    edge_label_order,
+    chi_leg,
+    surv_leg,
+    chunked_fn,
+    chunk_size,
 ):
     """Chunked edge absorption for a 1x1 dense move.
 
@@ -1041,7 +1064,9 @@ def _chunked_T_new_apply(
     C4_new = contract(P_2.bar(), C4g)
     chi_new_idx = P1_bar.indices[list(P1_bar.labels()).index("chi_new")]
     surv_idx = a.indices[list(a.labels()).index(surv_leg)]
-    chi_new_r_idx = P_2.indices[list(P_2.labels()).index("chi_new")].relabel("chi_new_r")
+    chi_new_r_idx = P_2.indices[list(P_2.labels()).index("chi_new")].relabel(
+        "chi_new_r"
+    )
     T_new = DenseTensor(T_arr, (chi_new_idx, surv_idx, chi_new_r_idx))
     return C1_new, C4_new, T_new
 
@@ -1089,13 +1114,22 @@ def _ctm_tensor_move_left(
 
     if chunk_size is not None and isinstance(env_self.T4, DenseTensor):
         C1_new, C4_new, T4_new = _chunked_T_new_apply(
-            env_self.T4, a, P_1, P_2, C1g, C4g,
-            ["t4_d", "l2", "t4_u"], "t4_d", "r2",
-            _chunked_T_new_left, chunk_size,
+            env_self.T4,
+            a,
+            P_1,
+            P_2,
+            C1g,
+            C4g,
+            ["t4_d", "l2", "t4_u"],
+            "t4_d",
+            "r2",
+            _chunked_T_new_left,
+            chunk_size,
         )
     else:
         if chunk_size is not None:
             import warnings
+
             warnings.warn(
                 "chunk_size is set but env is not dense (SymmetricTensor); "
                 "falling back to the standard fused-index CTM path.",
@@ -1166,13 +1200,22 @@ def _ctm_tensor_move_right(
 
     if chunk_size is not None and isinstance(env_self.T2, DenseTensor):
         C2_new, C3_new, T2_new = _chunked_T_new_apply(
-            env_self.T2, a, P_1, P_2, C2g, C3g,
-            ["t2_u", "r2", "t2_d"], "t2_u", "l2",
-            _chunked_T_new_right, chunk_size,
+            env_self.T2,
+            a,
+            P_1,
+            P_2,
+            C2g,
+            C3g,
+            ["t2_u", "r2", "t2_d"],
+            "t2_u",
+            "l2",
+            _chunked_T_new_right,
+            chunk_size,
         )
     else:
         if chunk_size is not None:
             import warnings
+
             warnings.warn(
                 "chunk_size is set but env is not dense (SymmetricTensor); "
                 "falling back to the standard fused-index CTM path.",
@@ -1242,13 +1285,22 @@ def _ctm_tensor_move_top(
 
     if chunk_size is not None and isinstance(env_self.T1, DenseTensor):
         C1_new, C2_new, T1_new = _chunked_T_new_apply(
-            env_self.T1, a, P_1, P_2, C1g, C2g,
-            ["t1_l", "u2", "t1_r"], "t1_l", "d2",
-            _chunked_T_new_top, chunk_size,
+            env_self.T1,
+            a,
+            P_1,
+            P_2,
+            C1g,
+            C2g,
+            ["t1_l", "u2", "t1_r"],
+            "t1_l",
+            "d2",
+            _chunked_T_new_top,
+            chunk_size,
         )
     else:
         if chunk_size is not None:
             import warnings
+
             warnings.warn(
                 "chunk_size is set but env is not dense (SymmetricTensor); "
                 "falling back to the standard fused-index CTM path.",
@@ -1318,13 +1370,22 @@ def _ctm_tensor_move_bottom(
 
     if chunk_size is not None and isinstance(env_self.T3, DenseTensor):
         C4_new, C3_new, T3_new = _chunked_T_new_apply(
-            env_self.T3, a, P_1, P_2, C4g, C3g,
-            ["t3_r", "d2", "t3_l"], "t3_r", "u2",
-            _chunked_T_new_bottom, chunk_size,
+            env_self.T3,
+            a,
+            P_1,
+            P_2,
+            C4g,
+            C3g,
+            ["t3_r", "d2", "t3_l"],
+            "t3_r",
+            "u2",
+            _chunked_T_new_bottom,
+            chunk_size,
         )
     else:
         if chunk_size is not None:
             import warnings
+
             warnings.warn(
                 "chunk_size is set but env is not dense (SymmetricTensor); "
                 "falling back to the standard fused-index CTM path.",

--- a/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
+++ b/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
@@ -233,11 +233,11 @@ def _build_enlarged_corner(
         return Q.relabels({"t1_l": "chi_L", "t2_d": "chi_B"})
 
     if position == "bottom_left":
-        # C4.c4_u <-> T4.t4_u
-        C_r = C.relabel("c4_u", "t4_u")
-        CT_v = contract(C_r, T_v)  # -> (c4_r, t4_d, l2)
-        # C4.c4_r <-> T3.t3_r
-        T_h_r = T_h.relabel("t3_r", "c4_r")
+        # C4.c4_r <-> T4.t4_u  (energy/RDM convention; #670)
+        C_r = C.relabel("c4_r", "t4_u")
+        CT_v = contract(C_r, T_v)  # -> (c4_u, t4_d, l2)
+        # C4.c4_u <-> T3.t3_r
+        T_h_r = T_h.relabel("t3_r", "c4_u")
         CTT = contract(CT_v, T_h_r)  # -> (t4_d, l2, d2, t3_l)
         # T3.d2 <-> a.d2 ; T4.l2 <-> a.l2
         Q = contract(CTT, a)  # -> (t4_d, t3_l, u2, r2) free legs

--- a/tests/oracle_varipeps.py
+++ b/tests/oracle_varipeps.py
@@ -1,0 +1,78 @@
+"""variPEPS 2-site CTMRG oracle (test/diagnostic only). GPL reference — NEVER
+import this from src/. Skips cleanly if variPEPS is not installed.
+
+variPEPS is GPL-licensed. It is used here purely as a read-only numerical
+oracle for cross-checking Tenax's dense 2-site CTMRG environment axis
+conventions. It must never be imported from anything under ``src/``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def varipeps_available() -> bool:
+    """Return True iff variPEPS can be imported in this environment."""
+    try:
+        import varipeps  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def run_varipeps_2site_ctmrg(
+    D: int = 2, d: int = 2, chi: int = 8, seed: int = 0
+) -> dict:
+    """Run dense 2-site checkerboard CTMRG and report converged env shapes.
+
+    Returns a dict with the shapes of the eight environment tensors
+    (``C1``..``C4`` corners, ``T1``..``T4`` edges) for unit-cell site 0,
+    plus an ``_axis_note`` string documenting variPEPS' axis convention.
+
+    Raises if variPEPS is unavailable (callers should guard with
+    ``varipeps_available()``).
+    """
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+
+    from varipeps.ctmrg.routine import calc_ctmrg_env
+    from varipeps.peps import PEPS_Unit_Cell
+
+    uc = PEPS_Unit_Cell.random(
+        structure=[[0, 1], [1, 0]],
+        d=d,
+        D=D,
+        chi=chi,
+        max_chi=chi,
+        seed=seed,
+        dtype=np.complex128,
+    )
+    peps_arrays = [t.tensor for t in uc.get_unique_tensors()]
+    # calc_ctmrg_env returns (converged_unitcell, norm_smallest_S)
+    conv_uc = calc_ctmrg_env(peps_arrays, uc)[0]
+    site0 = conv_uc[0, 0][0][0]
+
+    shapes = {
+        name: tuple(getattr(site0, name).shape)
+        for name in ("C1", "C2", "C3", "C4", "T1", "T2", "T3", "T4")
+    }
+    shapes["_axis_note"] = (
+        "variPEPS square-PEPS env convention (varipeps.peps.tensor.PEPS_Tensor): "
+        "corners C1..C4 are rank-2 (chi, chi); edges are rank-4. "
+        "T1 (top): (chi_left, D_ket_up, D_bra_up, chi_right); "
+        "T2 (right): (D_ket_right, D_bra_right, chi_up, chi_down); "
+        "T3 (bottom): (chi_left, chi_right, D_ket_down, D_bra_down); "
+        "T4 (left): (chi_up, D_ket_left, D_bra_left, chi_down). "
+        "PEPS tensor axes: (D_left, D_up, phys, D_right, D_down)."
+    )
+    return shapes
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke run
+    if not varipeps_available():
+        print("variPEPS not available")
+    else:
+        for k, v in run_varipeps_2site_ctmrg().items():
+            print(k, v)

--- a/tests/test_ctm_670_symmetric_2x2.py
+++ b/tests/test_ctm_670_symmetric_2x2.py
@@ -1,0 +1,116 @@
+"""Symmetric 2x2 must stay bond-consistent after absorption (#670)."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+import tenax.algorithms.ipeps_simple_update as SU
+from tenax.algorithms._ctm_tensor_convergence import (
+    CHECKERBOARD_NEIGHBORS as NB,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    _sort_coords_for_direction,
+)
+from tenax.algorithms._ctm_tensor_init import (
+    _build_double_layer_tensor,
+    initialize_ctm_tensor_env,
+)
+from tenax.algorithms._ctm_tensor_moves import (
+    _compute_plaquette_projector_pair,
+    _ctm_tensor_absorb_left_2plaq,
+)
+from tenax.algorithms._ctm_tensor_projector_2x2 import _build_enlarged_corner
+from tenax.algorithms.ipeps import heisenberg_gate_u1sz, heisenberg_u1sz_init_pair
+
+CHI = 12
+
+
+def _uniform_multicharge_pair(D=3, steps=40, dt=0.1):
+    """Normal U(1)-Sz SU (base_charges kept) -> direction-uniform multi-charge."""
+    A, B = heisenberg_u1sz_init_pair(D=D, key=jax.random.PRNGKey(0))
+    H = heisenberg_gate_u1sz()
+    gate = SU._make_trotter_gate_tensor(H, dt, site_tensor=A)
+    lh, lv = jnp.ones(D), jnp.ones(D)
+    for s in range(steps):
+        if s % 2 == 0:
+            A, B, lh = SU._simple_update_2site_horizontal_tensor(A, B, gate, lh, lv, D)
+        else:
+            A, B, lv = SU._simple_update_2site_vertical_tensor(A, B, gate, lh, lv, D)
+    return A, B
+
+
+def _direction_dependent_pair(D=3, steps=40, dt=0.1):
+    """base_charges-free U(1)-Sz SU -> A.l != A.r (direction-dependent bonds)."""
+    A, B = heisenberg_u1sz_init_pair(D=D, key=jax.random.PRNGKey(0))
+    H = heisenberg_gate_u1sz()
+    gate = SU._make_trotter_gate_tensor(H, dt, site_tensor=A)
+    lh, lv = jnp.ones(D), jnp.ones(D)
+    orig = SU.truncated_svd
+    SU.truncated_svd = lambda *a, **k: orig(*a, **{**k, "base_charges": None})
+    try:
+        for s in range(steps):
+            if s % 2 == 0:
+                A, B, lh = SU._simple_update_2site_horizontal_tensor(
+                    A, B, gate, lh, lv, D
+                )
+            else:
+                A, B, lv = SU._simple_update_2site_vertical_tensor(
+                    A, B, gate, lh, lv, D
+                )
+    finally:
+        SU.truncated_svd = orig
+    return A, B
+
+
+def _one_left(A, B):
+    site = {(0, 0): A, (1, 0): B}
+    dl = {c: _build_double_layer_tensor(t) for c, t in site.items()}
+    envs = {c: initialize_ctm_tensor_env(t, CHI) for c, t in site.items()}
+    projectors = {}
+    for s_anchor in envs:
+        s_TR = NB[s_anchor]["right"]
+        s_BL = NB[s_anchor]["bottom"]
+        s_BR = NB[s_TR]["bottom"]
+        Pt, Pb, _, _ = _compute_plaquette_projector_pair(
+            envs[s_anchor],
+            envs[s_TR],
+            envs[s_BL],
+            envs[s_BR],
+            dl[s_anchor],
+            dl[s_TR],
+            dl[s_BL],
+            dl[s_BR],
+            CHI,
+            "left",
+        )
+        projectors[s_anchor] = (Pt, Pb)
+    new = {}
+    for s_dst in _sort_coords_for_direction(list(envs), "left"):
+        s_src = NB[s_dst]["left"]
+        sa = NB[s_src]["top"]
+        Pta, Pba = projectors[sa]
+        Ptc, Pbc = projectors[s_src]
+        C1, T4, C4 = _ctm_tensor_absorb_left_2plaq(
+            envs[s_src], dl[s_src], Pta, Pba, Ptc, Pbc
+        )
+        new[s_dst] = envs[s_dst]._replace(C1=C1, T4=T4, C4=C4)
+    return new, dl
+
+
+def test_enlarged_corners_build_after_left_absorption_multicharge():
+    A, B = _direction_dependent_pair()
+    new, dl = _one_left(A, B)
+    for s_dst, env in new.items():
+        for pos, (C, Th, Tv) in {
+            "top_left": (env.C1, env.T1, env.T4),
+            "top_right": (env.C2, env.T1, env.T2),
+            "bottom_left": (env.C4, env.T3, env.T4),
+            "bottom_right": (env.C3, env.T3, env.T2),
+        }.items():
+            Q = _build_enlarged_corner(C, Th, Tv, dl[s_dst], position=pos)
+            assert Q is not None, f"{pos} failed to build at {s_dst}"

--- a/tests/test_ctm_670_symmetric_2x2.py
+++ b/tests/test_ctm_670_symmetric_2x2.py
@@ -114,3 +114,20 @@ def test_enlarged_corners_build_after_left_absorption_multicharge():
         }.items():
             Q = _build_enlarged_corner(C, Th, Tv, dl[s_dst], position=pos)
             assert Q is not None, f"{pos} failed to build at {s_dst}"
+
+
+def test_dense_2x2_energy_unchanged_by_fix():
+    """The direction-dependent DENSE 2x2 energy is a no-op invariant of the
+    #670 fix (the corrected leg pairing is a benign gauge choice on the
+    single-block dense path). Locks it at the measured -0.5421160718."""
+    from tenax import compute_energy_ctm_tensor_2site, ctm_tensor_2site
+    from tenax.algorithms.ipeps import heisenberg_gate
+    from tenax.core.tensor import DenseTensor
+    from tests.test_ctm_direction_dependent_bonds import _su_direction_dependent_pair
+
+    A, B = _su_direction_dependent_pair()
+    Ad = DenseTensor(np.array(A.todense()), A.indices)
+    Bd = DenseTensor(np.array(B.todense()), B.indices)
+    eA, eB = ctm_tensor_2site(Ad, Bd, chi=12, max_iter=60, conv_tol=1e-9, recipe="2x2")
+    E = float(compute_energy_ctm_tensor_2site(Ad, Bd, eA, eB, heisenberg_gate()))
+    assert abs(E - (-0.5421160718)) < 1e-6, f"dense 2x2 energy drifted: {E}"

--- a/tests/test_ctm_direction_dependent_bonds.py
+++ b/tests/test_ctm_direction_dependent_bonds.py
@@ -64,19 +64,13 @@ def test_su_output_is_direction_dependent_but_cell_consistent():
     assert _charges(A, "l") == _charges(B, "r"), "A.l must match B.r (cell-consistent)"
 
 
-@pytest.mark.xfail(
-    reason="Blocked by #670: the symmetric block-sparse 2x2 CTM sweep is broken "
-    "for ANY multi-charge U(1) env (enlarged-corner carried-vs-compressed bond "
-    "mismatch), not just direction-dependent bonds. See "
-    "docs/superpowers/plans/2026-07-01-direction-dependent-symmetric-ctm.md "
-    "(Phase 2 outcome). Phase 0 (canonical tiling) + Phase 1 (init corner "
-    "consistency) landed and are correct; the 2x2 absorption fix is #670. The "
-    "1x1 recipe used here also has a fundamental edge-orientation wall (plan "
-    "Background).",
-    strict=False,
-)
 def test_symmetric_2site_ctm_matches_dense_on_direction_dependent_bonds():
-    """ctm_tensor_2site on A.l!=A.r must not error and must match the dense result."""
+    """ctm_tensor_2site on A.l!=A.r must not error and must match the dense result.
+
+    Fixed by #670 (carried-bond leg-pairing in the 2x2 enlarged-corner projector).
+    Uses recipe="2x2"; the 1x1 recipe has a separate fundamental edge-orientation
+    wall and is not targeted here.  Both paths should converge to E ≈ -0.5421.
+    """
     A, B = _su_direction_dependent_pair()
     Hd = heisenberg_gate()
 
@@ -84,12 +78,12 @@ def test_symmetric_2site_ctm_matches_dense_on_direction_dependent_bonds():
     Ad = DenseTensor(np.array(A.todense()), A.indices)
     Bd = DenseTensor(np.array(B.todense()), B.indices)
     eAd, eBd = ctm_tensor_2site(
-        Ad, Bd, chi=12, max_iter=60, conv_tol=1e-9, recipe="1x1"
+        Ad, Bd, chi=12, max_iter=60, conv_tol=1e-9, recipe="2x2"
     )
     E_dense = float(compute_energy_ctm_tensor_2site(Ad, Bd, eAd, eBd, Hd))
 
     # Symmetric block-sparse path (the one that used to crash with 7 vs 4).
-    eA, eB = ctm_tensor_2site(A, B, chi=12, max_iter=60, conv_tol=1e-9, recipe="1x1")
+    eA, eB = ctm_tensor_2site(A, B, chi=12, max_iter=60, conv_tol=1e-9, recipe="2x2")
     c1 = float(jnp.linalg.norm(eA.C1.todense()))
     E_sym = float(compute_energy_ctm_tensor_2site(A, B, eA, eB, Hd))
 

--- a/tests/test_ctm_tensor_projector_2x2.py
+++ b/tests/test_ctm_tensor_projector_2x2.py
@@ -255,8 +255,8 @@ def test_build_enlarged_corner_bottom_left_numerical():
       T4: (t4_d, l2, t4_u)     a:  (u2,   d2, l2,   r2)
 
     Shared bonds in the contraction:
-      C4.c4_u — T4.t4_u   (chi)
-      C4.c4_r — T3.t3_r   (chi)
+      C4.c4_r — T4.t4_u   (chi)
+      C4.c4_u — T3.t3_r   (chi)
       T3.d2   — a.d2      (D^2)
       T4.l2   — a.l2      (D^2)
     Remaining open legs: T4.t4_d (chi_T), T3.t3_l (chi_R), a.u2, a.r2.
@@ -288,13 +288,13 @@ def test_build_enlarged_corner_bottom_left_numerical():
     )
     Q_dense = np.asarray(Q.todense())
 
-    # Index legend:
-    #   a = c4_r / t3_r (chi)             b = c4_u / t4_u (chi)
+    # Index legend (corrected to production energy/RDM convention; #670):
+    #   a = c4_r / t4_u (chi)             b = c4_u / t3_r (chi)
     #   c = d2 (D^2)                      e = l2 (D^2)
     #   f = t4_d (chi_T)                  g = t3_l (chi_R)
     #   h = u2 (D^2)                      k = r2 (D^2)
     Q_ref = np.einsum(
-        "ab,acg,feb,hcek->fghk",
+        "ab,bcg,fea,hcek->fghk",
         C4_arr,
         T3_arr,
         T4_arr,


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yjkao.

Fixes #670. Unblocks #667.

## What

The block-sparse U(1)-Sz `ctm_tensor_2site(..., recipe="2x2")` sweep crashed with per-sector block mismatches on genuine **direction-dependent** (`A.l != A.r`, cell-consistent) states. Three localized bond-bookkeeping fixes, each anchored on the production energy/RDM convention in `_ctm_tensor_energy.py` and cross-checked against a variPEPS numerical oracle:

1. **`_build_enlarged_corner` (`bottom_left`)** — C4's two legs were glued to the wrong edges; now `c4_u↔t3_r`, `c4_r↔t4_u`.
2. **`_ctm_tensor_absorb_bottom_2plaq`** — C3·T2 paired `c3_l↔t2_d`; corrected to `c3_u↔t2_d`.
3. **`_ctm_sv_diff`** — asymmetric-bond states grow charge sectors during CTM warmup, so the concatenated per-sector SV vector changes length between iterations and crashed the convergence check; now zero-pads the shorter vector (eager, non-AD call sites → gradient-safe).

## Why it hid until now

All three are **no-ops on uniform/dense** states: for a leg-symmetric corner the swap is a benign gauge choice (single block, same energy), and the SV vector length is stable. The bug only bites block-sparse envs with `A.l != A.r`. Existing 2x2 tests only covered symmetric-corner states, so it was never exercised.

## Validation

- Direction-dependent symmetric 2x2 now matches dense to **4e-14** (E = −0.5421160718).
- Dense 2x2 energy **unchanged** (guard test locks it).
- #667 acceptance test un-xfailed and retargeted to `recipe="2x2"` — passes.
- Stale unit test `test_build_enlarged_corner_bottom_left_numerical` (its einsum reference encoded the old swapped C4 pairing) updated to the correct convention.
- Targeted CTM/iPEPS + u1sz suites green; full core suite gates via CI.

## Out of scope (follow-ups filed)

Same latent `c3_l↔t2_d` bug exists in two other code paths that are no-ops on the production (uniform) path:
- #674 — fermionic/fused twin `_ctm_tensor_absorb_bottom_2plaq_fused`.
- #675 — compiled path `_ctm_compiled_moves.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)