### PR TITLE
docs(#570): reduced-corner 1x1 CTM GSPMD sharding — NO-GO characterization

### DIFF
--- a/docs/superpowers/handoffs/2026-07-02-570-qr-ctm-shardability-probe.md
+++ b/docs/superpowers/handoffs/2026-07-02-570-qr-ctm-shardability-probe.md
@@ -1,0 +1,103 @@
+# QR-CTMRG "re-open multi-GPU" — shardability probe (a): findings
+
+> **CORRECTION (2026-07-02, later same day):** the narrow HLO claim below (the
+> reduced-corner decomposition all-gathers only a small χD²×χ operand) is correct and
+> reproducible — but it does **NOT** translate into full-sweep per-device relief. The
+> follow-up gate found the full reduced-corner 1×1 *sweep* does not shard (real
+> high-water ~1.0×, NO-GO). See
+> `docs/superpowers/handoffs/2026-07-02-570-reduced-corner-shard-gate.md`. Read this
+> probe together with that correction, not as a standalone GO.
+
+
+**Date:** 2026-07-02
+**Trigger:** "explore QR-CTM" session. The QR-CTMRG kickoff brief flagged two payoffs
+for arXiv:2505.00494's reduced-corner scheme: (1) large-χ single-GPU speed, (2) *possibly
+re-open multi-GPU* by moving the decomposition off the dominant intermediate. This settles
+de-risk step **(a)**: *does `jnp.linalg.qr` on a sharded matrix shard, or replicate like SVD?*
+**Probe:** `examples/probe_qr_shard_reopen_570.py`. **Hardware:** 4× fake CPU device + 4× A100
+(compile-only; NCCL 4-way clique deadlocks on this box due to the DGX-Display GPU, but the
+GSPMD *partitioning* decision is a compile pass — CPU and GPU HLO agree exactly).
+
+## Verdict: payoff-2 is STRUCTURALLY ALIVE — but the lever is the reduced-corner SCHEME, not QR
+
+Two clean, GPU-confirmed facts:
+
+1. **Neither QR nor tall-skinny SVD is shardable in XLA.** Both all-gather their input to a
+   replicated copy before the (cuSOLVER) decomposition, then return a replicated output. The
+   literal question "(a) is `jnp.linalg.qr` shardable?" is **NO** — same replication barrier as
+   SVD. QR is *not* a sharding lever.
+
+2. **But the reduced-corner scheme shrinks the replicated operand by D².** The decomposition's
+   forced all-gather is confined to the *small* reduced corner; the dominant χ²D⁶ absorption
+   contraction (which #632 proved shards cleanly) never has to be replicated to feed it.
+
+### The decisive HLO (χ=128, D²=16 → χD²=2048; 4 devices; identical CPU & A100)
+
+Input sharded on the tall (χD²) axis; measure the biggest `all-gather` XLA inserts:
+
+| pattern | decomp operand | biggest all-gather | vs dense |
+|---|---|---:|---:|
+| `square-svd` (dense 2×2 analog) | χD² × χD² | **f64[2048,2048] = 33.55 MB** | 1× |
+| `tall-svd` (reduced 1×1, method=svd) | χD² × χ | f64[2048,128] = **2.10 MB** | **16× smaller** |
+| `tall-qr`  (reduced 1×1, method=qr) | χD² × 2χ | f64[2048,256] = 4.19 MB | 8× smaller |
+
+GPU HLO for `square-svd` literally shows `all-gather-done = f64[2048,2048]` feeding
+`custom-call(cusolver_gesvd)` on the full replicated matrix — this **is** the #632/#663/#672/#673
+NO-GO mechanism ("projector SVD forces the dominant operand replicated"). The reduced corner
+all-gathers only χD²×χ, which is **D²× smaller** (16× at D=4; 64× at D=8; 100× at D=10).
+
+### QR vs SVD is nearly irrelevant for sharding
+
+`tall-qr` all-gathers *more* than `tall-svd` (2χ-wide concat of both corners vs χ). So the
+favorable multi-GPU profile belongs to the **reduced-corner `recipe="1x1"` scheme** — which
+already exists with `projector_method="svd"` (#595/#597) — **not** to QR. This matches the
+2026-06-22 end-to-end finding (QR's only clean win is ~1.4× memory ceiling, not speed).
+
+## Why this dissolves the #632 multi-GPU NO-GO (in principle)
+
+- #632 rung-1 measured the CTM **contraction shards fine** (2.00× per-device without the SVD).
+- The SVD collapsed it to ~1.20× by all-gathering the dominant intermediate (dense χ²D⁶ or
+  split (χD)²). Root cause: the SVD operand *is* (a reshape of) the dominant intermediate.
+- The reduced-corner scheme makes the SVD/QR operand the **reduced** corner (χD²×χ), which is
+  D²× smaller than the dominant absorption. So the decomposition still replicates — but it now
+  replicates a *small* thing, leaving the χ²D⁶ absorption free to stay sharded.
+
+The obstacle that was declared *path-agnostic* (dense + split both replicate the dominant
+operand) is **not** scheme-agnostic: it depended on the decomposition operand *being* the
+dominant intermediate. The reduced-corner scheme breaks that identity.
+
+## What this does NOT prove (the real gate remains)
+
+- **No end-to-end per-device relief was demonstrated.** The probe's peak-memory metric was a
+  construction artifact: the toy producer materializes a replicated `(χ,D²,D²,χ)` buffer *before*
+  the sharded contraction with `a`, so that buffer set the peak (production threads the sharded
+  axis through the whole absorption via `ctm_sharding._MOVE_SURVIVING_AXIS`; the toy injects it
+  too late). The collective-operand evidence is robust; the peak number is not.
+- The reduced corner is still **all-gathered** (replicated χD²×χ per device) + a replicated tiny
+  SVD/eigh. At very large χ this fixed replicated cost grows ∝ χ²D²; whether it becomes the new
+  bottleneck vs the sharded χ²D⁶ absorption needs the real measurement.
+- A residual **all-reduce** forms the reduced corner when the reduction contracts the sharded
+  axis (cheap, χ²D²-class).
+
+## Recommendation / next gate
+
+**GO to the build gate (post-1.0; #663 defers multi-GPU).** The single structural obstacle that
+killed multi-GPU CTM-AD is removed by the reduced-corner scheme. Next, the concrete gate:
+
+1. Wire GSPMD sharding (reuse `ctm_sharding.py` `_MOVE_SURVIVING_AXIS` threading) through the
+   **actual reduced-corner `recipe="1x1"` move** (SVD variant first — simpler, better sharding
+   profile than QR), forward only.
+2. Measure per-device peak 1-GPU vs N-GPU at large D (D=8/10). GO if it recovers the ~2× rung-1
+   (no-SVD) profile — i.e. the reduced corner's replication does *not* re-collapse it.
+3. Only then: repeat for the backward (rung-2), and reconsider QR purely for its memory-ceiling
+   headroom on top.
+
+QR-specific work is **not** the lever. The lever is *reduced-corner scheme + GSPMD*.
+
+## Artifacts
+
+- `examples/probe_qr_shard_reopen_570.py` — pattern probe (`full`/`reduced-svd`/`reduced-qr`)
+  + isolated tall-vs-square decomposition (`--only-isolated`). CPU (fake devices) or GPU.
+- Ties to: [[qr-ctmrg-multigpu-largechi-lever]], [[632-gspmd-svd-replication-rootcause]],
+  [[632-frontier-split-vs-dense-multigpu]], #663 (v1.0 roadmap, multi-GPU deferred),
+  `2026-06-22-qr-vs-svd-projector-largechi-findings.md`.

--- a/docs/superpowers/handoffs/2026-07-02-570-reduced-corner-shard-gate.md
+++ b/docs/superpowers/handoffs/2026-07-02-570-reduced-corner-shard-gate.md
@@ -1,0 +1,82 @@
+# Reduced-corner 1×1 CTM move — GSPMD shard gate: **NO-GO** (corrected)
+
+**Date:** 2026-07-02.
+**Status:** This supersedes an earlier draft of this file that reported "GO, 4× relief".
+That verdict was **WRONG** — it came from a `memory_analysis` measurement artifact
+(dead-code elimination). The corrected verdict from **real multi-GPU high-water**
+measurement is **NO-GO**: the reduced-corner 1×1 CTM *sweep* does not achieve
+meaningful multi-GPU per-device relief (~1.0×), the same practical outcome as #632.
+
+## What happened (the methodology error)
+
+The gate `examples/gate_reduced_corner_shard_570.py` measured per-device peak via
+`compiled.memory_analysis().temp_size_in_bytes`, returning a **single leaf** (`T4`)
+from the move. XLA's DCE then pruned everything except the one sharded absorption that
+`T4` depends on, so the ratio looked like a clean 4× (and 2× on 2 devices). Returning
+the **full env** (so nothing is pruned), or measuring **real `peak_bytes_in_use`
+high-water** on GPU, both collapse the relief to ~1×.
+
+Lesson (again, cf. `[[570-svd-vjp-wall]]` "op-count ≠ HLO"): **`memory_analysis` +
+single-leaf return is not a faithful peak proxy — it is DCE-sensitive.** Use real
+`memory_stats()['peak_bytes_in_use']` high-water, one config per process, exactly as
+`examples/bench_ctm_sharding_memory.py` does. The isolated HLO collective scan
+(`probe_qr_shard_reopen_570.py`) was *correct* about its narrow claim (the reduced-corner
+decomposition all-gathers only a small operand) — but that narrow fact does **not**
+translate into full-sweep per-device relief.
+
+## The real numbers (2× A100, D=10 χ=32, `peak_bytes_in_use`, one mode/process)
+
+| layer | replicated | sharded | relief |
+|---|---:|---:|---:|
+| **absorb** (isolated χ²D⁶ contraction) | 9.83 GB | 5.71 GB | **1.72×** ✓ |
+| **move** (full `_ctm_tensor_move_left`, all env live) | 13.1 GB | 9.40 GB | **1.39×** |
+| **sweep** (full 4-direction 1×1 sweep) | 9.83 GB | 10.20 GB | **0.96×** ✗ |
+| sweep (double-layer committed replicated) | 9.80 GB | 9.80 GB | 1.00× ✗ |
+
+- The **isolated absorption shards** (1.72×, approaching the 2-device ideal) — the GSPMD
+  mechanism works at the contraction level (consistent with #632 rung-1's "contraction
+  shards 2.00× without SVD").
+- The win **erodes monotonically**: through the full move (projector + reembed) it drops
+  to 1.39×, and by the full sweep it is **gone** (0.96–1.00×). The sweep re-shards one
+  double-layer `a` to four different surviving axes per sweep; those reshards (plus the
+  move's post-absorption ops materializing replicated intermediates) cost as much as the
+  absorption sharding saves.
+- Even the *best* layer (single move) caps at ~1.4× — the same weak regime as #632's 2×2
+  (~1.2×). There is no N× multi-GPU reach here.
+
+## Why the premise looked good but fails
+
+The `probe_qr_shard_reopen_570.py` finding — reduced-corner decomposition all-gathers only
+a χD²×χ operand, not the χ²D⁶ intermediate — is **true and reproducible**. But the
+projector decomposition was never the *whole* story: the full move's `_apply_projector_
+with_reembed` + fuse/unfuse and the sweep's per-move `a` reshards reintroduce enough
+replicated/copied work that per-device peak does not drop. The #632 conclusion (projector
+SVD replicates the dominant operand → multi-GPU NO-GO) was framed around the 2×2 SVD, but
+the *practical* multi-GPU-doesn't-help outcome holds for the 1×1 reduced-corner path too,
+for a different (broader) reason.
+
+## Code state (no productization needed / warranted)
+
+`main` **already** applies `_shard_a` (`constrain_double_layer_for_move`) in the 1×1 branch
+of `_ctm_tensor_sweep_multisite` (added generically in #632 rung-1, `4ce7564`). So there is
+no hook to add — and it does not deliver relief. No production change is warranted.
+
+## Disposition
+
+- **NO-GO.** The reduced-corner 1×1 sweep is not a multi-GPU lever. Confirms #663's
+  "multi-GPU deferred post-1.0" and `[[632-frontier-split-vs-dense-multigpu]]`
+  (split-1GPU dominates). Large-D reach stays: **split-CTM on 1 GPU**.
+- If anyone revisits: the ceiling to beat is the **move-level 1.39×** (fix the projector/
+  reembed sharding loss first); the sweep additionally needs env-sharding persistence and
+  a way to avoid re-sharding `a` four ways. Given the 1.4× ceiling, low priority.
+
+## Artifacts (characterization; measure with real high-water, not memory_analysis)
+
+- `examples/probe_qr_shard_reopen_570.py` — isolated decomposition HLO collective scan
+  (correct narrow claim: reduced corner all-gathers small).
+- `examples/gate_reduced_corner_shard_570.py` — **memory_analysis-based; DCE-artifacted,
+  do not trust its relief number**; kept only with this caveat.
+- `examples/bench_1x1_shard_highwater.py` — the corrected real-high-water layered probe
+  (absorb / move / sweep). This is the faithful measurement.
+- Ties: `2026-07-02-570-qr-ctm-shardability-probe.md`, [[qr-ctmrg-multigpu-largechi-lever]],
+  [[632-gspmd-svd-replication-rootcause]], #663.

--- a/examples/bench_1x1_shard_highwater.py
+++ b/examples/bench_1x1_shard_highwater.py
@@ -1,0 +1,136 @@
+r"""Real per-device high-water peak of the reduced-corner 1×1 CTM path, at three
+granularities, to localize where GSPMD sharding is (or isn't) retained. (#570/#632)
+
+This is the FAITHFUL measurement that corrects the earlier
+``gate_reduced_corner_shard_570.py`` (which used ``memory_analysis`` + a single-leaf
+return and was fooled by dead-code elimination into reporting a spurious ~4× relief).
+Use ``memory_stats()['peak_bytes_in_use']`` — one mode per process — as
+``bench_ctm_sharding_memory.py`` does.
+
+Finding (2×A100, D=10 χ=32):
+  absorb (isolated χ²·D⁶ contraction) : 9.83 -> 5.71 GB  = 1.72x  (shards)
+  move   (full _ctm_tensor_move_left) : 13.1 -> 9.40 GB  = 1.39x  (partial)
+  sweep  (full 4-direction 1×1 sweep) : 9.83 -> 10.2 GB  = 0.96x  (NO relief)
+The relief erodes absorb -> move -> sweep: the projector/reembed materialize replicated
+intermediates and the sweep re-shards one double-layer to four surviving axes per sweep.
+=> reduced-corner 1×1 is NOT a multi-GPU lever (same ~1× outcome as #632). NO-GO.
+
+Run (one mode/process; NCCL 4-way deadlocks on the DGX-Display box, use 2 GPUs):
+    CUDA_VISIBLE_DEVICES=0,1 NCCL_P2P_DISABLE=1 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        uv run python examples/bench_1x1_shard_highwater.py 10 32 shard sweep
+"""
+
+from __future__ import annotations
+
+import sys
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import NamedSharding, PartitionSpec
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_tensor_convergence import (  # noqa: E402
+    SINGLE_SITE_NEIGHBORS,
+    _ctm_tensor_sweep_multisite,
+)
+from tenax.algorithms._ctm_tensor_init import (  # noqa: E402
+    _build_double_layer_tensor,
+    initialize_ctm_tensor_env,
+)
+from tenax.algorithms._ctm_tensor_moves import _ctm_tensor_move_left  # noqa: E402
+from tenax.algorithms.ctm_sharding import (  # noqa: E402
+    build_ctm_mesh,
+    commit_env,
+    constrain_double_layer_for_move,
+    double_layer_move_partition_spec,
+    double_layer_partition_spec,
+)
+from tenax.contraction.contractor import contract  # noqa: E402
+from tenax.core.index import FlowDirection, TensorIndex  # noqa: E402
+from tenax.core.symmetry import U1Symmetry  # noqa: E402
+from tenax.core.tensor import DenseTensor  # noqa: E402
+
+
+def _build_A(D, d=2, seed=42):
+    rng = np.random.RandomState(seed)
+    data = jnp.asarray(rng.standard_normal((D, D, D, D, d)))
+    data = data / (jnp.linalg.norm(data) + 1e-10)
+    sym = U1Symmetry()
+    ch = np.zeros(D, dtype=np.int32)
+    pch = np.zeros(d, dtype=np.int32)
+    idx = (
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(sym, pch.copy(), FlowDirection.IN, label="phys"),
+    )
+    return DenseTensor(data, idx)
+
+
+def _randomize(tree, seed):
+    leaves, treedef = jax.tree_util.tree_flatten(tree)
+    out = []
+    for i, x in enumerate(leaves):
+        r = np.random.RandomState(seed + i).standard_normal(x.shape)
+        r = jnp.asarray(r) / (float(np.linalg.norm(r)) + 1e-10)
+        out.append(r.astype(x.dtype))
+    return jax.tree_util.tree_unflatten(treedef, out)
+
+
+def _sc(*ts):  # keep every leaf live -> no DCE
+    return sum(jnp.sum(x * x) for t in ts for x in jax.tree_util.tree_leaves(t))
+
+
+def main():
+    D, chi, mode, layer = int(sys.argv[1]), int(sys.argv[2]), sys.argv[3], sys.argv[4]
+    mesh = build_ctm_mesh()
+    A = _build_A(D)
+    env = _randomize(initialize_ctm_tensor_env(A, chi), 1)
+    a = _randomize(_build_double_layer_tensor(A), 500)
+
+    if layer == "absorb":
+        def fn(env, a):
+            return _sc(contract(env.T4, constrain_double_layer_for_move(a, "left", mesh)))
+    elif layer == "move":
+        def fn(env, a):
+            e, _ = _ctm_tensor_move_left(
+                env, env, constrain_double_layer_for_move(a, "left", mesh), chi, "svd"
+            )
+            return _sc(e)
+    else:  # sweep
+        def fn(envs, dls):
+            e, _, _ = _ctm_tensor_sweep_multisite(
+                envs, dls, SINGLE_SITE_NEIGHBORS, chi, False, "svd",
+                recipe="1x1", device_mesh=mesh,
+            )
+            return _sc(e[(0, 0)])
+
+    if layer == "sweep":
+        if mode == "repl":
+            sh = NamedSharding(mesh, PartitionSpec())
+            A1 = jax.device_put({(0, 0): env}, sh)
+            A2 = jax.device_put({(0, 0): a}, sh)
+        else:
+            A1 = {(0, 0): commit_env(env, mesh)}
+            A2 = {(0, 0): jax.device_put(a, NamedSharding(mesh, double_layer_partition_spec()))}
+    else:
+        if mode == "repl":
+            sh = NamedSharding(mesh, PartitionSpec())
+            A1 = jax.device_put(env, sh)
+            A2 = jax.device_put(a, sh)
+        else:
+            A1 = commit_env(env, mesh)
+            A2 = jax.device_put(a, NamedSharding(mesh, double_layer_move_partition_spec("left")))
+
+    out = jax.jit(fn)(A1, A2)
+    jax.block_until_ready(out)
+    hw = jax.devices()[0].memory_stats()["peak_bytes_in_use"] / 1e9
+    print(f"LAYER={layer} MODE={mode} D={D} chi={chi} ndev={jax.device_count()} "
+          f"peak_dev0={hw:.4f}GB")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gate_reduced_corner_shard_570.py
+++ b/examples/gate_reduced_corner_shard_570.py
@@ -1,0 +1,245 @@
+r"""Gate: does the REAL reduced-corner 1×1 CTM move achieve ~1/N per-device peak
+memory when GSPMD-sharded?  (#570 payoff-2, follow-up to probe_qr_shard_reopen_570.)
+
+!!! WARNING — this script's RELIEF number is NOT trustworthy. !!!
+It uses ``memory_analysis().temp_size_in_bytes`` and returns a single leaf, so XLA's
+dead-code elimination prunes everything except the one sharded absorption and reports a
+spurious ~4× relief. The FAITHFUL measurement (real ``peak_bytes_in_use`` high-water,
+full env live) is ``examples/bench_1x1_shard_highwater.py`` and shows the full 1×1
+SWEEP does NOT shard (~1×, NO-GO). See
+``docs/superpowers/handoffs/2026-07-02-570-reduced-corner-shard-gate.md``. Kept only as
+a record of the methodology error.
+
+Background
+----------
+The #632 multi-GPU NO-GO was measured on the **dense 2×2** path (full χD²×χD² SVD),
+which XLA all-gathers -> replicates the dominant intermediate -> ~1.2× relief.
+`probe_qr_shard_reopen_570.py` showed (HLO) that the reduced-corner decomposition
+only touches a D²-smaller operand.  This gate tests the **real** move end-to-end:
+
+    _ctm_tensor_move_left(env, env, a, chi, projector_method="svd")
+
+with the double-layer's surviving D² leg sharded (as the production 2×2 path does via
+`constrain_double_layer_for_move`, which the 1×1 sweep branch does NOT yet call).
+
+The dense 1×1 SVD projector (`_ctm_projector.py:978-1018`) is:
+    M = C1g^H @ C4g        # (χ,χ) -- REDUCTION over the sharded χD² axis (all-reduce)
+    U,S,Vh = svd(M)        # tiny χ×χ, replicated
+    P = C4g @ (V S^-1/2)   # (χD²,χ) -- stays sharded on χD²
+so in principle the whole move stays sharded with only a ~χ² all-reduce.  The RISK:
+the fuse/reembed ops (merging a replicated χ axis with a sharded D² axis into χD²)
+may force an all-gather that re-replicates the χ²D⁶ absorption.  This gate measures
+which happens.
+
+GATE: reduced-corner 1×1 SVD move per-device peak should drop ~N× (recover the #632
+rung-1 no-SVD profile).  GO if relief >> the dense-2×2 ~1.2× baseline.
+
+Run
+---
+    # compile-only per-device peak estimate (cheap; D=8/10), fake devices:
+    XLA_FLAGS=--xla_force_host_platform_device_count=4 uv run python \
+        examples/gate_reduced_corner_shard_570.py --D 8 --chi 16
+
+    # real 2-GPU high-water validation (NCCL 4-way deadlocks on this box):
+    CUDA_VISIBLE_DEVICES=0,1 NCCL_P2P_DISABLE=1 uv run python \
+        examples/gate_reduced_corner_shard_570.py --D 8 --chi 16 --exec
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+
+from tenax.algorithms._ctm_tensor_init import (
+    _build_double_layer_tensor,
+    initialize_ctm_tensor_env,
+)
+from tenax.algorithms._ctm_tensor_moves import _ctm_tensor_move_left
+from tenax.algorithms.ctm_sharding import (
+    _AXIS,
+    build_ctm_mesh,
+    commit_env,
+    constrain_double_layer_for_move,
+    double_layer_move_partition_spec,
+)
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import U1Symmetry
+from tenax.core.tensor import DenseTensor
+
+_COLL = ("all-gather", "all-reduce", "all-to-all", "reduce-scatter", "collective-permute")
+_SHAPE_RE = re.compile(r"(?:f64|f32|c128|c64)\[[\d,]+\]")
+
+
+def _build_A(D, d=2, seed=42):
+    rng = np.random.RandomState(seed)
+    data = jnp.asarray(rng.standard_normal((D, D, D, D, d)))
+    data = data / (jnp.linalg.norm(data) + 1e-10)
+    sym = U1Symmetry()
+    ch = np.zeros(D, dtype=np.int32)
+    pch = np.zeros(d, dtype=np.int32)
+    idx = (
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(sym, pch.copy(), FlowDirection.IN, label="phys"),
+    )
+    return DenseTensor(data, idx)
+
+
+def _randomize(tree, seed=0):
+    """Replace every array leaf with a normalized random normal of the same shape,
+    so corners/edges are full-rank (realistic memory), keeping index structure."""
+    leaves, treedef = jax.tree_util.tree_flatten(tree)
+    out = []
+    for i, x in enumerate(leaves):
+        r = np.random.RandomState(seed + i).standard_normal(x.shape)
+        r = jnp.asarray(r) / (float(np.linalg.norm(r)) + 1e-10)
+        out.append(r.astype(x.dtype))
+    return jax.tree_util.tree_unflatten(treedef, out)
+
+
+def _bytes(tok):
+    dt, dims = tok.split("[")
+    n = 1
+    for x in dims.rstrip("]").split(","):
+        n *= int(x)
+    return n * {"f64": 8, "f32": 4, "c128": 16, "c64": 8}[dt]
+
+
+def scan_collectives(hlo):
+    found = []
+    for line in hlo.splitlines():
+        for op in _COLL:
+            if f"{op}(" in line or f"{op}-start(" in line or f"{op}-done" in line:
+                shapes = _SHAPE_RE.findall(line)
+                if shapes:
+                    biggest = max(shapes, key=_bytes)
+                    found.append((op, biggest, _bytes(biggest)))
+                break
+    return found
+
+
+def _mem(exe):
+    try:
+        ma = exe.memory_analysis()
+        temp = getattr(ma, "temp_size_in_bytes", 0)
+        out = getattr(ma, "output_size_in_bytes", 0)
+        arg = getattr(ma, "argument_size_in_bytes", 0)
+        return temp, out, arg
+    except Exception as e:  # noqa: BLE001
+        return -1, -1, str(e)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--D", type=int, default=8)
+    ap.add_argument("--chi", type=int, default=16)
+    ap.add_argument("--method", default="svd", choices=["svd", "qr"])
+    ap.add_argument("--exec", action="store_true", help="real multi-GPU high-water run")
+    ap.add_argument("--grad", action="store_true", help="also gate value_and_grad (backward)")
+    args = ap.parse_args()
+    jax.config.update("jax_enable_x64", True)
+    D, chi = args.D, args.chi
+    n = jax.device_count()
+    mesh = build_ctm_mesh()
+
+    A = _build_A(D)
+    env0 = _randomize(initialize_ctm_tensor_env(A, chi), seed=1)
+    a0 = _randomize(_build_double_layer_tensor(A), seed=500)
+
+    print(f"# gate_reduced_corner_shard  devices={n}  D={D} D2={D*D}  chi={chi}  "
+          f"method={args.method}")
+    print(f"#   dominant absorption χ²D⁶ = {chi*chi*D**6} elems "
+          f"= {chi*chi*D**6*8/1e9:.3f} GB (f64, single-device)")
+    print(f"#   reduced corner χD²×χ     = {chi*D*D*chi} elems "
+          f"= {chi*D*D*chi*8/1e6:.3f} MB")
+
+    def move(env, a, shard):
+        if shard:
+            a = constrain_double_layer_for_move(a, "left", mesh)
+        new_env, _eps = _ctm_tensor_move_left(env, env, a, chi, args.method)
+        # return the renormalized edge (biggest sharded output) as a raw array
+        leaves = jax.tree_util.tree_leaves(new_env.T4)
+        return leaves[0]
+
+    # ---- replicated (1-device-equivalent) baseline on the same mesh ----
+    repl = NamedSharding(mesh, PartitionSpec())  # fully replicated
+    env_r = jax.device_put(env0, repl)
+    a_r = jax.device_put(a0, repl)
+    exe_1 = jax.jit(lambda e, a: move(e, a, False)).lower(env_r, a_r).compile()
+    t1, o1, g1 = _mem(exe_1)
+
+    # ---- sharded: edges D²-sharded, corners replicated; a surviving-leg sharded ----
+    env_s = commit_env(env0, mesh)
+    a_s = jax.device_put(a0, NamedSharding(mesh, double_layer_move_partition_spec("left")))
+    exe_n = jax.jit(lambda e, a: move(e, a, True)).lower(env_s, a_s).compile()
+    tn, on, gn = _mem(exe_n)
+
+    colls = scan_collectives(exe_n.as_text())
+    maxb = max((b for _, _, b in colls), default=0)
+
+    def gb(x):
+        return x / 1e9 if x >= 0 else x
+
+    relief = (t1 / tn) if (tn and tn > 0) else float("nan")
+    print(f"\n  per-device TEMP peak (memory_analysis):")
+    print(f"     replicated (1-dev-equiv) = {gb(t1):.4f} GB")
+    print(f"     sharded  ({n}-dev)        = {gb(tn):.4f} GB")
+    print(f"     RELIEF = {relief:.2f}x   (ideal {n}x; dense-2×2 baseline ~1.2x)")
+    print(f"  output+arg (repl / shard): {gb(o1):.3f}/{gb(g1):.3f}  |  "
+          f"{gb(on):.3f}/{gb(gn):.3f} GB")
+
+    print(f"\n  collectives in the SHARDED move ({len(colls)}); "
+          f"biggest operand {maxb/1e6:.3f} MB "
+          f"[χ²D⁶={chi*chi*D**6*8/1e6:.1f}MB would = re-replication]:")
+    seen = set()
+    for op, shp, b in colls:
+        if (op, shp) in seen:
+            continue
+        seen.add((op, shp))
+        print(f"       {op:20s} {shp:26s} {b/1e6:.3f} MB")
+        if len(seen) >= 10:
+            break
+
+    if args.grad:
+        # Backward gate: value_and_grad through the move (traces the projector
+        # backward -> tracer SVD path).  Loss = sum(T4_new**2).
+        def loss(a, env, shard):
+            return jnp.sum(move(env, a, shard) ** 2)
+
+        vg = jax.value_and_grad(loss, argnums=0)
+        exe_g1 = jax.jit(lambda a, e: vg(a, e, False)).lower(a_r, env_r).compile()
+        exe_gn = jax.jit(lambda a, e: vg(a, e, True)).lower(a_s, env_s).compile()
+        tg1, _, _ = _mem(exe_g1)
+        tgn, _, _ = _mem(exe_gn)
+        gcolls = scan_collectives(exe_gn.as_text())
+        gmax = max((b for _, _, b in gcolls), default=0)
+        grelief = (tg1 / tgn) if (tgn and tgn > 0) else float("nan")
+        print(f"\n  BACKWARD (value_and_grad) per-device TEMP peak:")
+        print(f"     replicated = {gb(tg1):.4f} GB   sharded({n}) = {gb(tgn):.4f} GB   "
+              f"RELIEF = {grelief:.2f}x")
+        print(f"     biggest collective in backward = {gmax/1e6:.3f} MB "
+              f"[χ²D⁶={chi*chi*D**6*8/1e6:.1f}MB = re-replication]")
+
+    if args.exec and n > 1:
+        # real high-water validation + parity
+        jax.devices()  # ensure init
+        out_r = jax.jit(lambda e, a: move(e, a, False))(env_r, a_r)
+        out_s = jax.jit(lambda e, a: move(e, a, True))(env_s, a_s)
+        err = float(jnp.max(jnp.abs(jax.device_get(out_r) - jax.device_get(out_s))))
+        try:
+            hw = jax.devices()[0].memory_stats()["peak_bytes_in_use"] / 1e9
+        except Exception:
+            hw = float("nan")
+        print(f"\n  [--exec] parity |repl - shard|max = {err:.2e}  "
+              f"(cumulative high-water dev0 = {hw:.3f} GB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/probe_qr_shard_reopen_570.py
+++ b/examples/probe_qr_shard_reopen_570.py
@@ -1,0 +1,318 @@
+r"""Probe (a) for #570 QR-CTMRG "re-open multi-GPU" hypothesis.
+
+Question
+--------
+The multi-GPU CTM-AD NO-GO (#632/#663/#672/#673) is *path-agnostic*: XLA lowers the
+CTM projector SVD as **unshardable**, so it all-gathers whatever GSPMD sharded ->
+the dominant intermediate is replicated -> ~no per-device relief.
+
+But that verdict was measured on the **dense 2x2** (full ``chiD^2 x chiD^2`` SVD) and
+the **split** ``(chiD)^2`` paths, where the decomposition consumes a *large* operand.
+The reduced-corner ``recipe="1x1"`` scheme (#570) decomposes a *small* corner:
+``chiD^2 x chi`` (SVD) or ``chiD^2 x 2chi`` -> tiny ``2chi x 2chi`` (QR then SVD of R).
+
+So the structural question this probe settles:
+
+    When the decomposition consumes the *reduced* corner, does XLA still all-gather
+    the BIG absorption intermediate (chi^2 D^4) back to replicated (same NO-GO),
+    or does it keep the big contraction SHARDED and only touch the SMALL corner?
+
+If the big contraction stays sharded (per-device peak ~ 1/N), payoff-2 is
+structurally alive and worth a real build. If the reduced path replicates the big
+intermediate just like the dense path, it is the same path-agnostic NO-GO.
+
+Method
+------
+Three CTM-move-shaped patterns, identical producer contraction, differing only in
+the decomposition operand size:
+
+  * ``full``        : reshape X -> M_full (chiD^2 x chiD^2) -> svd          (dense 2x2 analog)
+  * ``reduced-svd`` : reduce  X -> M_red  (chiD^2 x chi)    -> svd          (recipe=1x1, method=svd)
+  * ``reduced-qr``  : reduce  X -> M_red  (chiD^2 x 2chi)   -> qr -> svd(R) (recipe=1x1, method=qr)
+
+For each: shard a *surviving* D^2 leg of the double-layer ``a`` (as the production
+sharding does), build the SPMD executable, and report
+  (1) parity of the gauge-invariant subspace projector P P^H vs single-device,
+  (2) every collective op XLA inserted + its largest operand (bytes),
+  (3) per-device peak temp memory (memory_analysis), 1-device vs N-device.
+
+Run
+---
+    # GSPMD partitioning decision (platform-agnostic), faked CPU devices:
+    XLA_FLAGS=--xla_force_host_platform_device_count=4 uv run python \
+        examples/probe_qr_shard_reopen_570.py --chi 16 --d2 16
+
+    # confirm on the real GPU mesh:
+    uv run python examples/probe_qr_shard_reopen_570.py --chi 16 --d2 64
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+
+import numpy as np
+
+_AXIS = "d"
+
+
+# --------------------------------------------------------------------------- #
+# Producer: the "big" absorption contraction (carries the sharded D^2 leg).
+# Mirrors examples/spike_ctm_sharding.enlarged_corner: X = (chi, D2, D2, chi).
+# --------------------------------------------------------------------------- #
+def _producer(C, Th, Tv, a):
+    x = jnp.einsum("ij,jkl->ikl", C, Th)  # (chi, D2, chi)
+    x = jnp.einsum("ikl,lmn->ikmn", x, Tv)  # (chi, D2, D2, chi)
+    x = jnp.einsum("ikmn,kmpq->ipqn", x, a)  # (chi, D2, D2, chi); axis p is a's survivor
+    return x  # (chi, D2_i-side, D2_p=SHARDED, chi)
+
+
+def _truncate_svd(M, chi):
+    U, _S, _Vh = jnp.linalg.svd(M, full_matrices=False)
+    return U[:, :chi]
+
+
+def _reduced_qr_proj(M, chi):
+    # mirrors _ctm_projector._reduced_qr_projector / the tracer qr branch:
+    # QR of the (chiD^2 x 2chi) reduced corner, then eigh/svd of the tiny R.
+    Q, R = jnp.linalg.qr(M)  # M: (chiD^2, 2chi) -> Q (chiD^2, 2chi), R (2chi, 2chi)
+    U_R, _S, _Vh = jnp.linalg.svd(R, full_matrices=False)  # tiny 2chi x 2chi
+    k = min(chi, U_R.shape[1])
+    return Q @ U_R[:, :k]  # (chiD^2, chi)
+
+
+def make_fns(chi, d2):
+    """Return {name: fn(C, Th, Tv, a, R0, R0b) -> P (chiD^2, chi)}."""
+
+    def full(C, Th, Tv, a, R0, R0b):
+        X = _producer(C, Th, Tv, a)  # (chi, D2, D2, chi)
+        M = X.reshape(chi * d2, d2 * chi)  # (chiD^2, chiD^2); sharded axis on COLS
+        return _truncate_svd(M, chi)  # svd of the FULL corner (the wall)
+
+    def reduced_svd(C, Th, Tv, a, R0, R0b):
+        X = _producer(C, Th, Tv, a)  # (chi, D2_k, D2_m=SHARDED, chi_n)
+        # reduce: contract the sharded (m) and chi (n) legs -> M_red (chi, D2_k, chi_j)
+        M = jnp.einsum("ikmn,mnj->ikj", X, R0)  # (chi, D2, chi); contracts sharded m
+        M = M.reshape(chi * d2, chi)  # (chiD^2, chi)
+        return _truncate_svd(M, chi)
+
+    def reduced_qr(C, Th, Tv, a, R0, R0b):
+        X = _producer(C, Th, Tv, a)
+        M1 = jnp.einsum("ikmn,mnj->ikj", X, R0).reshape(chi * d2, chi)
+        M2 = jnp.einsum("ikmn,mnj->ikj", X, R0b).reshape(chi * d2, chi)
+        M = jnp.concatenate([M1, M2], axis=1)  # (chiD^2, 2chi)  (both reduced corners)
+        return _reduced_qr_proj(M, chi)
+
+    return {"full": full, "reduced-svd": reduced_svd, "reduced-qr": reduced_qr}
+
+
+def make_inputs(chi, d2, seed=0):
+    k = jax.random.split(jax.random.PRNGKey(seed), 6)
+    C = jax.random.normal(k[0], (chi, chi))
+    Th = jax.random.normal(k[1], (chi, d2, chi))
+    Tv = jax.random.normal(k[2], (chi, d2, chi))
+    a = jax.random.normal(k[3], (d2, d2, d2, d2))
+    R0 = jax.random.normal(k[4], (d2, chi, chi))  # reducer (m, n) -> j
+    R0b = jax.random.normal(k[5], (d2, chi, chi))
+    return C, Th, Tv, a, R0, R0b
+
+
+# --------------------------------------------------------------------------- #
+# HLO collective inspection
+# --------------------------------------------------------------------------- #
+_COLLECTIVES = (
+    "all-gather",
+    "all-reduce",
+    "all-to-all",
+    "reduce-scatter",
+    "collective-permute",
+    "dynamic-slice",  # GSPMD sometimes materializes gathers as ds loops (rare)
+)
+_SHAPE_RE = re.compile(r"(?:f64|f32|c128|c64)\[[\d,]+\]")
+
+
+def _bytes_of(shape_tok):
+    dtype, dims = shape_tok.split("[")
+    dims = dims.rstrip("]")
+    n = 1
+    for d in dims.split(","):
+        n *= int(d)
+    width = {"f64": 8, "f32": 4, "c128": 16, "c64": 8}[dtype]
+    return n * width
+
+
+def scan_collectives(hlo_text):
+    """Return list of (op, biggest_operand_shape, bytes) for real cross-device ops."""
+    found = []
+    for line in hlo_text.splitlines():
+        for op in _COLLECTIVES:
+            if f" {op}(" in line or line.strip().startswith(op + "(") or f"= {op}" in line:
+                if op == "dynamic-slice":  # only count if it looks like a partition gather
+                    if "replica" not in line and "partition" not in line:
+                        continue
+                shapes = _SHAPE_RE.findall(line)
+                if not shapes:
+                    continue
+                biggest = max(shapes, key=_bytes_of)
+                found.append((op, biggest, _bytes_of(biggest)))
+                break
+    return found
+
+
+def subspace(P):
+    return P @ P.conj().T  # gauge-invariant projector onto column space
+
+
+def run_pattern(name, fn, args, chi, mesh, n):
+    # single-device reference
+    single = jax.jit(fn, static_argnums=())(*args)
+    G_single = subspace(single)
+
+    # sharded: shard a's surviving leg (axis 2 = the producer's p axis)
+    a_spec = PartitionSpec(None, None, _AXIS, None)
+    in_shardings = (
+        NamedSharding(mesh, PartitionSpec(None, None)),  # C
+        NamedSharding(mesh, PartitionSpec(None, None, None)),  # Th
+        NamedSharding(mesh, PartitionSpec(None, None, None)),  # Tv
+        NamedSharding(mesh, a_spec),  # a  (surviving D2 leg sharded)
+        NamedSharding(mesh, PartitionSpec(None, None, None)),  # R0
+        NamedSharding(mesh, PartitionSpec(None, None, None)),  # R0b
+    )
+    jf = jax.jit(fn, in_shardings=in_shardings)
+    args_sh = [jax.device_put(x, s) for x, s in zip(args, in_shardings)]
+    lowered = jf.lower(*args_sh)
+    compiled = lowered.compile()
+    sharded = compiled(*args_sh)
+    G_sh = subspace(jax.device_get(sharded))
+
+    err = float(jnp.max(jnp.abs(G_single - G_sh)))
+    hlo = compiled.as_text()
+    colls = scan_collectives(hlo)
+
+    # per-device peak temp memory
+    def peak(exe):
+        try:
+            ma = exe.memory_analysis()
+            return getattr(ma, "temp_size_in_bytes", 0) + getattr(
+                ma, "output_size_in_bytes", 0
+            )
+        except Exception:
+            return -1
+
+    single_exe = jax.jit(fn).lower(*args).compile()
+    peak_1 = peak(single_exe)
+    peak_n = peak(compiled)
+
+    return {
+        "name": name,
+        "err": err,
+        "collectives": colls,
+        "peak_1dev": peak_1,
+        "peak_ndev": peak_n,
+        "max_coll_bytes": max((b for _, _, b in colls), default=0),
+    }
+
+
+def isolated(chi, d2, mesh, n):
+    """Purest form of probe (a): a matrix already sharded on its tall (chiD^2) axis,
+    decomposed. Square (dense corner) vs tall-skinny (reduced corner).
+
+    A tall-skinny SVD is *mathematically* shardable (M^H M is chi x chi -> small
+    all-reduce; U = M V S^-1 stays sharded on the tall axis). A square SVD is not.
+    This checks whether XLA's lowering exploits that.
+    """
+    m = chi * d2
+    row_sh = NamedSharding(mesh, PartitionSpec(_AXIS, None))  # shard tall axis
+
+    cases = {
+        "square-svd  (chiD^2 x chiD^2)": (m, lambda M: _truncate_svd(M, chi)),
+        "tall-svd    (chiD^2 x chi)": (chi, lambda M: _truncate_svd(M, chi)),
+        "tall-qr     (chiD^2 x 2chi)": (2 * chi, lambda M: _reduced_qr_proj(M, chi)),
+    }
+    print(f"## isolated decomposition (input sharded on tall axis)  m={m}")
+    for label, (ncol, fn) in cases.items():
+        M = jax.random.normal(jax.random.PRNGKey(1), (m, ncol))
+        single = jax.jit(fn)(M)
+        G1 = subspace(single)
+        jf = jax.jit(fn, in_shardings=(row_sh,))
+        Ms = jax.device_put(M, row_sh)
+        compiled = jf.lower(Ms).compile()
+        out = compiled(Ms)
+        Gs = subspace(jax.device_get(out))
+        err = float(jnp.max(jnp.abs(G1 - Gs)))
+        out_shard = out.sharding.shard_shape(out.shape)
+        out_sharded = out_shard != out.shape
+        colls = scan_collectives(compiled.as_text())
+        maxb = max((b for _, _, b in colls), default=0)
+        print(f"  {label}")
+        print(f"     parity={err:.1e}  out_shape={out.shape} out_shard={out_shard} "
+              f"sharded={out_sharded}")
+        print(f"     collectives={len(colls)} biggest_operand={maxb/1e6:.3f}MB "
+              f"input={m*ncol*8/1e6:.3f}MB")
+        seen = set()
+        for op, shp, b in colls:
+            if (op, shp) in seen:
+                continue
+            seen.add((op, shp))
+            print(f"        {op:20s} {shp:24s} {b/1e6:.3f}MB")
+    print()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--chi", type=int, default=16)
+    ap.add_argument("--d2", type=int, default=16, help="D^2 (e.g. 16 for D=4, 64 for D=8)")
+    ap.add_argument("--only-isolated", action="store_true")
+    args_ns = ap.parse_args()
+    chi, d2 = args_ns.chi, args_ns.d2
+
+    jax.config.update("jax_enable_x64", True)
+    n = jax.device_count()
+    mesh = Mesh(np.asarray(jax.devices()), axis_names=(_AXIS,))
+
+    print(f"# probe_qr_shard_reopen_570  devices={n}  chi={chi}  D2={d2}  chiD2={chi*d2}")
+    print(f"#   X (big intermediate)  = chi^2 D^4 = {chi*chi*d2*d2} elems "
+          f"= {chi*chi*d2*d2*8/1e6:.2f} MB (f64)")
+    print(f"#   M_full (dense corner) = chiD^2 x chiD^2 = {(chi*d2)**2} elems "
+          f"= {(chi*d2)**2*8/1e6:.2f} MB")
+    print(f"#   M_red  (reduced)      = chiD^2 x chi    = {chi*d2*chi} elems "
+          f"= {chi*d2*chi*8/1e6:.2f} MB")
+    print()
+
+    isolated(chi, d2, mesh, n)
+    if args_ns.only_isolated:
+        return
+
+    fns = make_fns(chi, d2)
+    inp = make_inputs(chi, d2)
+    for name, fn in fns.items():
+        r = run_pattern(name, fn, inp, chi, mesh, n)
+        relief = (r["peak_1dev"] / r["peak_ndev"]) if r["peak_ndev"] > 0 else float("nan")
+        print(f"== {name} ==")
+        print(f"   parity |G_single - G_sharded|max = {r['err']:.2e}")
+        print(f"   per-device peak: 1dev={r['peak_1dev']/1e6:.2f}MB  "
+              f"{n}dev={r['peak_ndev']/1e6:.2f}MB  relief={relief:.2f}x  (ideal={n}x)")
+        if r["collectives"]:
+            print(f"   collectives ({len(r['collectives'])}); biggest operand "
+                  f"{r['max_coll_bytes']/1e6:.3f}MB:")
+            # show up to 6 distinct
+            seen = set()
+            for op, shp, b in r["collectives"]:
+                key = (op, shp)
+                if key in seen:
+                    continue
+                seen.add(key)
+                print(f"       {op:20s} {shp:24s} {b/1e6:.3f}MB")
+                if len(seen) >= 8:
+                    break
+        else:
+            print("   collectives: NONE")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

## Summary

Characterizes whether the reduced-corner `recipe="1x1"` CTM path re-opens **multi-GPU** for large-D iPEPS. The #632 dense-2×2 multi-GPU NO-GO was attributed to the projector SVD replicating the dominant `χD²×χD²` intermediate; the 1×1 path decomposes only a small `χD²×χ` corner, so the hypothesis was that its dominant `χ²D⁶` absorption could stay sharded.

**Verdict: NO-GO.** No `src/` changes.

## Evidence (real per-device high-water, 2×A100, D=10 χ=32)

| layer | replicated | sharded | relief |
|---|---:|---:|---:|
| isolated absorption (`χ²D⁶`) | 9.83 GB | 5.71 GB | **1.72×** ✓ |
| full move | 13.1 GB | 9.40 GB | 1.39× |
| **full 1×1 sweep** | 9.83 GB | 10.2 GB | **0.96×** ✗ |

The isolated absorption shards, but the relief **erodes through the move** (projector + reembed materialize replicated intermediates) and **vanishes in the full sweep** (which re-shards one double-layer to four surviving axes per pass). Net ~1× — the same practical outcome as #632. The isolated HLO claim (reduced-corner decomposition all-gathers only a small operand) is true but does **not** translate to full-sweep relief.

`main` already applies `_shard_a` in the 1×1 branch (#632 rung-1, `4ce7564`), so there is nothing to add — it just doesn't help. Confirms #663 (multi-GPU deferred post-1.0); split-CTM on 1 GPU stays the large-D lever.

## Methodology note (kept as a lesson)

An earlier `memory_analysis`-based gate reported a spurious **~4×** relief: returning a single leaf let XLA's dead-code elimination prune everything except the one sharded absorption. The faithful measurement is real `peak_bytes_in_use` high-water with the full env live — `examples/bench_1x1_shard_highwater.py`. (Same class of trap as the "op-count ≠ HLO" lessons in the #570/#566 line.)

## Contents (docs + examples only)

- `docs/superpowers/handoffs/2026-07-02-570-qr-ctm-shardability-probe.md` — isolated decomposition HLO probe (with correction banner).
- `docs/superpowers/handoffs/2026-07-02-570-reduced-corner-shard-gate.md` — NO-GO write-up.
- `examples/bench_1x1_shard_highwater.py` — **faithful** high-water probe (absorb/move/sweep).
- `examples/probe_qr_shard_reopen_570.py` — isolated decomposition HLO collective scan.
- `examples/gate_reduced_corner_shard_570.py` — kept, prominently caveated (DCE artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)