### PR TITLE
feat(hotrg): multi-GPU sharding + TRG/HOTRG validation hardening

### DIFF
--- a/docs/superpowers/handoffs/2026-07-03-hotrg-trg-multigpu-feasibility.md
+++ b/docs/superpowers/handoffs/2026-07-03-hotrg-trg-multigpu-feasibility.md
@@ -1,0 +1,61 @@
+# HOTRG/TRG multi-GPU feasibility — **HOTRG = GO**, TRG = not useful
+
+**Date:** 2026-07-03.
+**Trigger:** #663 flagged TRG/HOTRG coarse-graining multi-GPU as the *one* multi-GPU lead
+NOT refuted by the CTM-AD NO-GO (TRG/HOTRG are forward-only — no AD-through-SVD backward,
+which was the wall that replicated the dominant CTM intermediate). This probe tests it.
+**Method:** real `peak_bytes_in_use` high-water, full output tensor live (no DCE — the
+mistake that produced a false CTM "GO" on 2026-07-02), one mode per process, 2×A100
+(NCCL 4-way deadlocks on the DGX-Display box). Probe: `examples/probe_hotrg_multigpu.py`.
+
+## Verdict
+
+| algorithm | χ=32 repl | χ=32 shard | relief | χ=40 repl | χ=40 shard |
+|---|---:|---:|---:|---:|---:|
+| **HOTRG** | 25.80 GB | 12.91 GB | **2.00×** ✓ | **OOM** | **32.9 GB (fits)** ✓ |
+| TRG | 0.084 GB | 0.113 GB | 0.75× (worse) | — | — |
+
+- **HOTRG multi-GPU = GO.** Sharding the `up` leg gives **ideal 2.00× per-device relief**
+  on 2 GPUs, numerically identical result, and **extends the χ ceiling**: χ=40 replicated
+  OOMs (RESOURCE_EXHAUSTED, 30.5 GiB alloc = χ⁶) but sharded fits at 32.9 GB/device.
+- **TRG = not a multi-GPU target.** Its peak is tiny (84 MB at χ=32) — TRG never forms a
+  χ⁶ intermediate (it is χ⁴/χ⁵-memory), so there is nothing to shard at practical χ, and
+  sharding adds overhead. (Plain TRG also has the CDL accuracy floor → use HOTRG anyway.)
+
+## Why HOTRG works where CTM-AD did not
+
+1. **Forward-only.** Free energy is a forward computation — no backward SVD-VJP. The CTM
+   NO-GO (2026-07-02) was caused by the *backward* projector-SVD replicating the dominant
+   operand; that mechanism is simply absent here.
+2. **χ⁶-dominant / χ⁴-tiny-SVD structure.** tenax HOTRG explicitly forms
+   `T_merged = (up,down,left,U,D,right) = χ⁶` (`_hotrg_step_horizontal` step 3) — the memory
+   wall. The HOSVD operand is only `χ²×χ² = χ⁴` (8 MB at χ=32 vs 8.6 GB for χ⁶). Sharding a
+   surviving leg (`up`) keeps the χ⁶ contraction at 1/N; the χ⁴ SVD replicates but is ~1000×
+   smaller, so its replication is free. No dominant-intermediate all-gather.
+3. **Single clean step** — no 4-direction sweep re-sharding one tensor to different axes
+   (which eroded the CTM sweep to ~1×).
+
+## Practical value
+
+HOTRG's single-GPU χ ceiling is set by χ⁶: ~χ=40 (33 GB) on an 80 GB A100, hard-capped ~χ=44
+(≈98 GB peak). Sharding across N GPUs multiplies the reachable χ⁶ by N → higher χ for
+high-accuracy critical-point / large-χ HOTRG studies. This is a **real** large-χ lever for
+HOTRG, unlike every CTM-AD multi-GPU attempt.
+
+## Caveats / next steps
+
+- Feasibility only (single step, `hotrg()` does not yet take a `device_mesh`). Productizing =
+  add a `device_mesh` to `HOTRGConfig` and apply a `with_sharding_constraint` on a surviving
+  leg inside `_hotrg_step_{horizontal,vertical}` (the alternating steps rotate which leg
+  survives — shard the one that carries into the χ⁶ merge each step).
+- 4-GPU untested (this box's DGX-Display GPU deadlocks 4-way NCCL); the clean 2.00×/N suggests
+  it scales, which would reach χ≈48 (χ⁶≈98 GB / 4 ≈ 25 GB/device).
+- A better long-term fix is to **not materialize χ⁶** (contract the isometries into the merge
+  so the largest intermediate is χ⁵/χ⁴) — that raises the single-GPU ceiling directly and is
+  orthogonal to sharding.
+
+## Artifacts
+
+- `examples/probe_hotrg_multigpu.py` — real high-water shard probe (HOTRG/TRG, per leg/χ/mode).
+- Ties: #663 (v1.0 roadmap: "TRG/HOTRG multi-GPU untested, post-1.0"),
+  `2026-07-02-570-reduced-corner-shard-gate.md` (the CTM NO-GO this contrasts with).

--- a/examples/probe_hotrg_multigpu.py
+++ b/examples/probe_hotrg_multigpu.py
@@ -1,0 +1,100 @@
+r"""Feasibility probe: can GSPMD shard a HOTRG (or TRG) coarse-graining step to
+cut per-device peak memory and extend the single-GPU chi ceiling? (#663 post-1.0)
+
+Why this might work where CTM multi-GPU did NOT:
+  * TRG/HOTRG free energy is a FORWARD-only computation — no AD-through-SVD
+    backward, which is exactly the wall that replicated the dominant CTM
+    intermediate (see 2026-07-02 reduced-corner-shard-gate NO-GO).
+  * tenax HOTRG explicitly forms T_merged = (up,down,left,U,D,right) = chi^6
+    (hotrg._hotrg_step_horizontal step 3). That chi^6 intermediate is the
+    single-GPU memory wall (chi=40 -> 33 GB, chi=48 -> 96 GB OOMs one 80GB GPU).
+    The HOSVD operand is only chi^2 x chi^2 = chi^4. So if sharding a surviving
+    leg keeps the chi^6 contraction at 1/N while only the chi^4 SVD replicates,
+    per-device peak drops ~N x and the chi ceiling extends.
+
+METHOD (learned the hard way on CTM): measure REAL peak_bytes_in_use high-water,
+full output tensor live (no DCE), ONE mode per process. Do NOT trust
+memory_analysis + single-leaf (DCE-inflates the ratio).
+
+Run (one mode/process; 2 GPUs — the DGX-Display box deadlocks 4-way NCCL):
+    CUDA_VISIBLE_DEVICES=0,1 NCCL_P2P_DISABLE=1 XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        uv run python examples/probe_hotrg_multigpu.py 40 up repl hotrg
+    ... shard  ...
+"""
+
+from __future__ import annotations
+
+import sys
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms.hotrg import _hotrg_step_horizontal  # noqa: E402
+from tenax.algorithms.trg import _trg_step  # noqa: E402
+from tenax.core.index import FlowDirection, TensorIndex  # noqa: E402
+from tenax.core.symmetry import U1Symmetry  # noqa: E402
+from tenax.core.tensor import DenseTensor  # noqa: E402
+
+_LABELS = ("up", "down", "left", "right")
+_FLOWS = (FlowDirection.IN, FlowDirection.OUT, FlowDirection.IN, FlowDirection.OUT)
+
+
+def _build_T(chi, seed=0):
+    rng = np.random.RandomState(seed)
+    data = jnp.asarray(rng.standard_normal((chi, chi, chi, chi)))
+    data = data / (jnp.linalg.norm(data) + 1e-10)
+    sym = U1Symmetry()
+    idx = tuple(
+        TensorIndex.from_charges(sym, np.zeros(chi, np.int32), fl, label=lb)
+        for lb, fl in zip(_LABELS, _FLOWS)
+    )
+    return DenseTensor(data, idx)
+
+
+def main():
+    chi = int(sys.argv[1])
+    shard_leg = sys.argv[2] if len(sys.argv) > 2 else "up"
+    mode = sys.argv[3] if len(sys.argv) > 3 else "repl"
+    algo = sys.argv[4] if len(sys.argv) > 4 else "hotrg"
+
+    mesh = Mesh(np.asarray(jax.devices()), axis_names=("d",))
+    n = jax.device_count()
+    T = _build_T(chi)
+
+    step = _hotrg_step_horizontal if algo == "hotrg" else _trg_step
+
+    def fn(T):
+        T_new, log_norm = step(T, chi, None)  # (T, max_bond_dim, svd_trunc_err)
+        # keep the FULL output tensor + scalar live (no DCE)
+        return jnp.sum(jax.tree_util.tree_leaves(T_new)[0] ** 2) + log_norm
+
+    axis = _LABELS.index(shard_leg)
+    if mode == "repl":
+        spec = PartitionSpec()
+    else:
+        p = [None, None, None, None]
+        p[axis] = "d"
+        spec = PartitionSpec(*p)
+    sh = NamedSharding(mesh, spec)
+    leaves, treedef = jax.tree_util.tree_flatten(T)
+    T = jax.tree_util.tree_unflatten(treedef, [jax.device_put(x, sh) for x in leaves])
+
+    out = jax.jit(fn)(T)
+    out.block_until_ready()
+    try:
+        hw = jax.devices()[0].memory_stats()["peak_bytes_in_use"] / 1e9
+    except Exception:
+        hw = float("nan")
+    chi6 = chi**6 * 8 / 1e9
+    chi4 = chi**4 * 8 / 1e9
+    print(f"ALGO={algo} chi={chi} shard_leg={shard_leg} MODE={mode} ndev={n} "
+          f"peak_dev0={hw:.4f}GB  [chi^6={chi6:.2f}GB chi^4={chi4:.4f}GB] "
+          f"result={float(out):.4e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hotrg.py
+++ b/tests/test_hotrg.py
@@ -202,6 +202,26 @@ class TestHOTRGRun:
             np.sign(result_hotrg) == np.sign(result_trg) or abs(result_hotrg) < 0.01
         ), f"HOTRG and TRG have different signs: {result_hotrg:.4f} vs {result_trg:.4f}"
 
+    def test_hotrg_converges_with_chi(self):
+        """HOTRG systematically improves with chi (unlike plain TRG's CDL
+        plateau): near criticality the free-energy error at chi=24 is well below
+        chi=8. Guards against a regression that stops using the larger bond dim.
+
+        Measured (beta=0.44, 20 steps): err(chi=8) ~ 3.7e-3, err(chi=24) ~ 1.5e-3
+        (ratio ~2.45).
+        """
+        beta = 0.44
+        tensor = compute_ising_tensor(beta=beta)
+        exact = ising_free_energy_exact(beta)
+        err = {}
+        for chi in (8, 24):
+            f = float(-hotrg(tensor, HOTRGConfig(max_bond_dim=chi, num_steps=20)) / beta)
+            err[chi] = abs(f - exact)
+        assert err[24] < 0.8 * err[8], (
+            f"HOTRG not converging in chi: err(chi=8)={err[8]:.3e} "
+            f"vs err(chi=24)={err[24]:.3e}"
+        )
+
     def test_hotrg_more_accurate_than_trg(self):
         """HOTRG should achieve better accuracy than TRG at the same chi."""
         from tenax.algorithms.trg import TRGConfig, trg

--- a/tests/test_trg.py
+++ b/tests/test_trg.py
@@ -250,7 +250,14 @@ class TestTRGRun:
         )
 
     def test_near_critical_free_energy(self):
-        """Near critical point (beta=0.44), TRG chi=16 should be within 5%."""
+        """Near critical point (beta=0.44), TRG chi=16 free energy is within 0.5%.
+
+        The measured rel err is ~2.4e-3 (plain Levin-Nave TRG plateaus at a
+        chi-independent CDL floor near criticality, so this is close to the best
+        TRG achieves at any chi). The 0.5% bound is a ~2x-margin regression guard
+        — much tighter than the old 5% placeholder — that still tolerates
+        platform floating-point variation.
+        """
         beta = 0.44
         tensor = compute_ising_tensor(beta=beta)
         config = TRGConfig(max_bond_dim=16, num_steps=20)
@@ -260,9 +267,31 @@ class TestTRGRun:
         relative_error = abs(trg_free_energy - exact_free_energy) / abs(
             exact_free_energy
         )
-        assert relative_error < 0.05, (
+        assert relative_error < 0.005, (
             f"TRG free energy {trg_free_energy:.6f} too far from "
             f"exact {exact_free_energy:.6f} (rel err={relative_error:.4f})"
+        )
+
+    def test_bond_dim_is_respected(self):
+        """TRG must actually use max_bond_dim: chi=2 is distinctly less accurate
+        than chi=4 (guards against a regression that silently ignores chi and
+        hides behind the chi-independent CDL plateau — the plateau only sets in
+        for chi >~ 6, so small chi still shows clear convergence).
+
+        Measured (beta=0.3, 20 steps): err(chi=2) ~ 1.8e-2, err(chi=4) ~ 8e-3
+        (ratio ~2.15). A broken truncation that pins the effective bond dim would
+        make these equal.
+        """
+        beta = 0.3
+        tensor = compute_ising_tensor(beta=beta)
+        exact = ising_free_energy_exact(beta)
+        err = {}
+        for chi in (2, 4):
+            f = float(-trg(tensor, TRGConfig(max_bond_dim=chi, num_steps=20)) / beta)
+            err[chi] = abs(f - exact)
+        assert err[2] > 1.3 * err[4], (
+            f"TRG not converging in chi (max_bond_dim ignored?): "
+            f"err(chi=2)={err[2]:.3e} vs err(chi=4)={err[4]:.3e}"
         )
 
     def test_low_temp_free_energy(self):


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Follow-up to the v1.0 TRG/HOTRG validation (both converge to the exact 2D Ising free energy; 65 existing tests pass). **No `src/` changes.**

## 1. Hardening the regression guards (test-only)

- **Tighten near-critical TRG tolerance** `5% → 0.5%`. Measured rel err at β=0.44, χ=16 is ~2.4e-3; the old 5% was a placeholder that would miss a 10× regression.
- **`test_bond_dim_is_respected` (TRG):** χ=2 must be distinctly worse than χ=4 (measured ratio ~2.15×). Guards against a truncation regression that silently ignores `max_bond_dim` and hides behind the Levin–Nave **CDL plateau** (plain TRG's error saturates at a χ-independent floor for χ≳6 — expected, not a bug).
- **`test_hotrg_converges_with_chi`:** near Tc, `err(χ=24) < err(χ=8)` (measured ratio ~2.45×). Guards HOTRG's systematic χ-convergence.

## 2. HOTRG multi-GPU feasibility — **GO** (the one #663 multi-GPU lead not refuted)

TRG/HOTRG are **forward-only** (no AD-through-SVD backward — the exact mechanism that replicated the dominant CTM intermediate and killed CTM multi-GPU). Measured with **real `peak_bytes_in_use` high-water, full output live** (not `memory_analysis`, which DCE-inflated the CTM shard gate):

| algorithm | χ=32 repl | χ=32 shard | relief | χ=40 repl | χ=40 shard |
|---|---:|---:|---:|---:|---:|
| **HOTRG** | 25.80 GB | 12.91 GB | **2.00×** | **OOM** | **32.9 GB (fits)** |
| TRG | 0.084 GB | 0.113 GB | 0.75× | — | — |

- **HOTRG = GO:** ideal 2.00× per-device relief on 2×A100, identical result, and it **extends the χ ceiling** — χ=40 replicated OOMs (χ⁶ = 33 GB alloc fails) but sharded fits. HOTRG explicitly forms `T_merged = χ⁶` (the memory wall) while the HOSVD operand is only `χ⁴` (~1000× smaller), so sharding a surviving leg keeps the χ⁶ contraction at 1/N. First positive multi-GPU result in this line.
- **TRG = not a target:** χ⁴/χ⁵-memory (84 MB peak at χ=32), nothing to shard at practical χ; use HOTRG for accuracy anyway.

Feasibility only (`hotrg()` has no `device_mesh` yet). Productization sketch + full analysis in `docs/superpowers/handoffs/2026-07-03-hotrg-trg-multigpu-feasibility.md`; probe in `examples/probe_hotrg_multigpu.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)