### PR TITLE
feat(hotrg): GSPMD multi-GPU sharding for dense HOTRG (HOTRGConfig.device_mesh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ print(f"Exact: {f_exact:.8f}")
 See `examples/ising_trg.py` and `examples/ising_hotrg.py` for full TRG and HOTRG
 examples at multiple temperatures compared against the Onsager exact solution.
 
+For large-χ dense HOTRG, set `HOTRGConfig(device_mesh=mesh)` (a 1-D
+`jax.sharding.Mesh`) to shard the dominant χ⁶ intermediate across multiple GPUs —
+~1/N per-device peak memory and a higher reachable χ, at the same free energy.
+Since HOTRG is forward-only there is no autodiff-through-SVD barrier, so GSPMD
+sharding is effective here (unlike the CTM-AD path). See
+`examples/probe_hotrg_multigpu.py`.
+
 ## AutoMPO Example
 
 ```python

--- a/docs/superpowers/handoffs/2026-07-03-hotrg-trg-multigpu-feasibility.md
+++ b/docs/superpowers/handoffs/2026-07-03-hotrg-trg-multigpu-feasibility.md
@@ -54,6 +54,40 @@ HOTRG, unlike every CTM-AD multi-GPU attempt.
   so the largest intermediate is χ⁵/χ⁴) — that raises the single-GPU ceiling directly and is
   orthogonal to sharding.
 
+## Productized (same PR)
+
+`HOTRGConfig(device_mesh=<1-D Mesh>)` now shards dense HOTRG. Implementation
+(`src/tenax/algorithms/hotrg.py`):
+
+- Each step re-shards its input `up` leg via `with_sharding_constraint`
+  (`_shard_leg`); `up` is present in both the horizontal and vertical χ⁶
+  `T_merged`, so the eager contractions produce a sharded χ⁶ **without ever
+  materializing it replicated**. Re-sharding each step handles the leg rotation
+  across the horizontal/vertical alternation.
+- **Eager, not jit.** `truncated_svd` does host-side rank truncation
+  (`linalg.py:1793`, `np.array(s)`) and is **not jit-safe** — jitting the step
+  crashes (`reshape (4,4)->(2,2,8)` on the first rank-deficient SVD). Eager
+  `with_sharding_constraint` works and keeps χ⁶ sharded; the trade-off is ~49 GB
+  vs a jitted ~33 GB at χ=40 (eager keeps extra copies), still a clear win.
+- Guards: no-op for `device_mesh=None`, for non-`DenseTensor` (block-sparse HOTRG
+  is small), and when a leg dim isn't divisible by the device count (early
+  small-bond steps — no memory pressure there anyway).
+
+Measured on the **full productized** `hotrg()` (2×A100, real high-water, β=0.3):
+
+| χ (num_steps=8) | nomesh | mesh | note |
+|---|---|---|---|
+| 32 | 2.17 GB | **1.10 GB (2.0×)** | identical free energy |
+| 40 | **FAILS** (autotuner RESOURCE_EXHAUSTED on the χ⁶ transpose) | **49 GB, fits, f=−2.6339** | **ceiling extension** |
+| 44+ | fails | autotuner wall (even sharded) | compile-level cap |
+
+So multi-GPU extends the reachable χ (single-GPU wall ~χ=40 → reachable with 2
+GPUs) at 2× per-device relief and the same free energy. **Caveat:** beyond ~χ=44
+an XLA autotuner wall on the giant `(χ³×χ³)` gemm/transpose caps *both* paths
+(same class as the split-CTM D=12 wall; `--xla_gpu_autotune_level=0` may push it).
+Tests: `tests/test_hotrg_sharding.py` (parity on fake CPU devices) + 22 existing
+hotrg tests still pass.
+
 ## Artifacts
 
 - `examples/probe_hotrg_multigpu.py` — real high-water shard probe (HOTRG/TRG, per leg/χ/mode).

--- a/src/tenax/algorithms/hotrg.py
+++ b/src/tenax/algorithms/hotrg.py
@@ -25,10 +25,39 @@ from dataclasses import dataclass
 
 import jax
 import jax.numpy as jnp
+from jax.lax import with_sharding_constraint
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 from tenax.algorithms._tensor_utils import max_abs_normalize
 from tenax.contraction.contractor import contract, truncated_svd
-from tenax.core.tensor import Tensor
+from tenax.core.tensor import DenseTensor, Tensor
+
+
+def _shard_leg(T: Tensor, label: str, device_mesh: Mesh | None) -> Tensor:
+    """Constrain ``T``'s ``label`` leg to be sharded over ``device_mesh``.
+
+    A pure layout hint (``with_sharding_constraint``) — never changes numerics.
+    Applied to the dominant chi^6 ``T_merged`` intermediate inside the HOTRG
+    steps so it stays at ~1/N per device (dense large-chi multi-GPU HOTRG;
+    HOTRG is forward-only so there is no backward SVD-VJP replication wall).
+
+    No-op when ``device_mesh is None``, for non-``DenseTensor`` inputs (dense
+    large-chi is the target regime; block-sparse HOTRG is small), or when the
+    leg dimension is not divisible by the device count (the early small-bond
+    steps, which carry no memory pressure).
+    """
+    if device_mesh is None or not isinstance(T, DenseTensor):
+        return T
+    n = device_mesh.devices.size
+    axis = T.labels().index(label)
+    leaves, treedef = jax.tree_util.tree_flatten(T)
+    if not leaves or leaves[0].shape[axis] % n != 0:
+        return T
+    spec = [None] * len(T.labels())
+    spec[axis] = device_mesh.axis_names[0]
+    sharding = NamedSharding(device_mesh, PartitionSpec(*spec))
+    leaves = [with_sharding_constraint(x, sharding) for x in leaves]
+    return jax.tree_util.tree_unflatten(treedef, leaves)
 
 
 @dataclass
@@ -43,12 +72,20 @@ class HOTRGConfig:
                          "horizontal": horizontal only.
                          "vertical": vertical only.
         svd_trunc_err:   Optional maximum truncation error per HOSVD.
+        device_mesh:     Optional 1-D ``jax.sharding.Mesh`` for multi-GPU dense
+                         HOTRG. When set, each step shards the dominant chi^6
+                         ``T_merged`` intermediate over the mesh (~1/N per-device
+                         peak, extends the chi ceiling). Pure layout hint —
+                         same free energy as single-device. Opt-in; ``None``
+                         (default) is unchanged single-device behaviour. Only
+                         affects the dense path (block-sparse HOTRG is small).
     """
 
     max_bond_dim: int = 16
     num_steps: int = 10
     direction_order: str = "alternating"
     svd_trunc_err: float | None = None
+    device_mesh: Mesh | None = None
 
 
 def hotrg(
@@ -63,7 +100,10 @@ def hotrg(
     Args:
         tensor: Initial site tensor (DenseTensor or SymmetricTensor) with
                 4 legs labeled ("up", "down", "left", "right").
-        config: HOTRGConfig parameters.
+        config: HOTRGConfig parameters. Set ``config.device_mesh`` to a 1-D
+                ``jax.sharding.Mesh`` to shard the dominant chi^6 intermediate
+                over multiple GPUs (~1/N per-device peak, higher chi ceiling;
+                dense path only). See ``examples/probe_hotrg_multigpu.py``.
 
     Returns:
         Scalar JAX array: estimated log(Z)/N (free energy per site).
@@ -80,25 +120,24 @@ def hotrg(
 
     T = tensor
     log_norm_total = jnp.zeros((), dtype=T.dtype)
+    # Runs eager (``truncated_svd`` does host-side rank truncation and is not
+    # jit-safe). When ``device_mesh`` is set, each step re-shards its input
+    # ``up`` leg (see ``_hotrg_step_*``); eager contractions over sharded inputs
+    # keep the dominant chi^6 ``T_merged`` sharded (~1/N per device) without ever
+    # materializing it replicated.
+    mesh = config.device_mesh
 
     for step in range(config.num_steps):
         if config.direction_order == "alternating":
-            if step % 2 == 0:
-                T, log_norm = _hotrg_step_horizontal(
-                    T, config.max_bond_dim, config.svd_trunc_err
-                )
-            else:
-                T, log_norm = _hotrg_step_vertical(
-                    T, config.max_bond_dim, config.svd_trunc_err
-                )
+            step_fn = _hotrg_step_horizontal if step % 2 == 0 else _hotrg_step_vertical
         elif config.direction_order == "horizontal":
-            T, log_norm = _hotrg_step_horizontal(
-                T, config.max_bond_dim, config.svd_trunc_err
-            )
+            step_fn = _hotrg_step_horizontal
         else:
-            T, log_norm = _hotrg_step_vertical(
-                T, config.max_bond_dim, config.svd_trunc_err
-            )
+            step_fn = _hotrg_step_vertical
+
+        T, log_norm = step_fn(
+            T, config.max_bond_dim, config.svd_trunc_err, device_mesh=mesh
+        )
 
         # Each HOTRG step halves the number of tensors.
         log_norm_total = log_norm_total + log_norm / (2.0 ** (step + 1))
@@ -110,6 +149,7 @@ def _hotrg_step_horizontal(
     T: Tensor,
     max_bond_dim: int,
     svd_trunc_err: float | None = None,
+    device_mesh: Mesh | None = None,
 ) -> tuple[Tensor, jax.Array]:
     """Single horizontal HOTRG coarse-graining step (polymorphic).
 
@@ -124,6 +164,11 @@ def _hotrg_step_horizontal(
     Returns:
         (T_new, log_norm) where T_new has compressed up/down bonds.
     """
+    # Multi-GPU: shard the input "up" leg so the eager contractions below keep
+    # the dominant chi^6 T_merged at ~1/N per device. "up" is present in T_merged
+    # (up,down,left,U,D,right) and in every step's input, so re-sharding it here
+    # each step handles the leg rotation across horizontal/vertical alternation.
+    T = _shard_leg(T, "up", device_mesh)
     # Step 1: Form environment M by contracting T with itself over (left, right).
     # T has labels (up, down, left, right). Second copy relabeled to avoid collision.
     T_copy = T.relabels({"up": "U", "down": "D", "left": "right", "right": "left"})
@@ -167,6 +212,7 @@ def _hotrg_step_vertical(
     T: Tensor,
     max_bond_dim: int,
     svd_trunc_err: float | None = None,
+    device_mesh: Mesh | None = None,
 ) -> tuple[Tensor, jax.Array]:
     """Single vertical HOTRG coarse-graining step (polymorphic).
 
@@ -180,6 +226,9 @@ def _hotrg_step_vertical(
     Returns:
         (T_new, log_norm) where T_new has compressed left/right bonds.
     """
+    # Multi-GPU: shard the input "up" leg (present in T_merged
+    # (up,left,right,down,L,R)) so the eager contractions keep chi^6 at ~1/N.
+    T = _shard_leg(T, "up", device_mesh)
     # Step 1: Form environment M by contracting T with itself over (up, down).
     T_copy = T.relabels({"left": "L", "right": "R", "up": "down", "down": "up"})
     # T_copy: (down, up, L, R) — shares "up" and "down" with T

--- a/tests/_hotrg_sharding_parity_subproc.py
+++ b/tests/_hotrg_sharding_parity_subproc.py
@@ -1,0 +1,43 @@
+"""HOTRG free energy under a GSPMD device mesh must equal the single-device
+result. Invoked by tests/test_hotrg_sharding.py under
+XLA_FLAGS=--xla_force_host_platform_device_count=N. Exits 0 on parity.
+
+Usage: _hotrg_sharding_parity_subproc.py [beta] [chi] [steps] [thresh]
+"""
+
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms.ctm_sharding import build_ctm_mesh
+from tenax.algorithms.hotrg import HOTRGConfig, hotrg
+from tenax.algorithms.trg import compute_ising_tensor
+
+
+def main() -> int:
+    beta = float(sys.argv[1]) if len(sys.argv) > 1 else 0.3
+    chi = int(sys.argv[2]) if len(sys.argv) > 2 else 8
+    steps = int(sys.argv[3]) if len(sys.argv) > 3 else 6
+    thresh = float(sys.argv[4]) if len(sys.argv) > 4 else 1e-8
+
+    T = compute_ising_tensor(beta)
+    f_single = float(hotrg(T, HOTRGConfig(max_bond_dim=chi, num_steps=steps)))
+    mesh = build_ctm_mesh()  # fake devices from XLA_FLAGS
+    f_shard = float(
+        hotrg(T, HOTRGConfig(max_bond_dim=chi, num_steps=steps, device_mesh=mesh))
+    )
+    err = abs(f_single - f_shard)
+    print(
+        f"devices={jax.device_count()} beta={beta} chi={chi} steps={steps} "
+        f"f_single={f_single:.10f} f_shard={f_shard:.10f} |delta|={err:.2e}"
+    )
+    return 0 if err < thresh else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_hotrg_sharding.py
+++ b/tests/test_hotrg_sharding.py
@@ -1,0 +1,63 @@
+"""GSPMD multi-GPU sharding for dense HOTRG (large-chi coarse-graining).
+
+HOTRG is forward-only (no AD-through-SVD backward), and it forms a chi^6
+``T_merged`` intermediate that dominates memory while the HOSVD operand is only
+chi^4. Sharding a free leg of ``T_merged`` keeps that chi^6 wall at ~1/N per
+device -> ideal per-device memory relief and a higher chi ceiling (measured
+2.00x on 2xA100; see docs/.../2026-07-03-hotrg-trg-multigpu-feasibility.md).
+
+Sharding is a pure layout hint: ``HOTRGConfig(device_mesh=mesh)`` must give the
+same free energy as single-device. Parity runs on fake CPU devices via a
+subprocess (matching tests/test_ctm_sharding_parity.py); the per-device memory
+relief itself is a GPU high-water measurement (examples/probe_hotrg_multigpu.py).
+"""
+
+import os
+import subprocess
+import sys
+
+
+def _run_subproc(n_dev, *args):
+    env = dict(
+        os.environ,
+        XLA_FLAGS=f"--xla_force_host_platform_device_count={n_dev}",
+        JAX_PLATFORMS="cpu",
+    )
+    return subprocess.run(
+        [sys.executable, "tests/_hotrg_sharding_parity_subproc.py", *[str(a) for a in args]],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
+def test_hotrg_sharded_matches_single_device():
+    """HOTRG free energy under a 2-device GSPMD mesh equals single-device to
+    <1e-9 on a well-conditioned state (beta=0.6, chi=16: measured ~2e-16).
+
+    Sharding is exact up to floating-point reassociation. On a hard state
+    (small chi near Tc) the sharded HOSVD can pick a marginally different but
+    equally-valid truncation among near-degenerate singular values, so the gap
+    grows to O(1e-4) — but it collapses with chi (chi=32 at beta=0.3 is
+    bit-identical). This case exercises the truncation regime while staying in
+    the tight-parity regime, so it still catches a real sharding bug.
+    """
+    r = _run_subproc(2, 0.6, 16, 6, 1e-9)
+    assert r.returncode == 0, (
+        f"HOTRG sharded parity failed:\nSTDOUT:{r.stdout}\nSTDERR:{r.stderr}"
+    )
+
+
+def test_hotrg_flag_off_is_unchanged():
+    """device_mesh=None (default) is a literal no-op: bit-identical to omitting
+    it. Single device, no fake-device env needed."""
+    from tenax.algorithms.hotrg import HOTRGConfig, hotrg
+    from tenax.algorithms.trg import compute_ising_tensor
+
+    T = compute_ising_tensor(0.3)
+    f_default = float(hotrg(T, HOTRGConfig(max_bond_dim=8, num_steps=6)))
+    f_none = float(
+        hotrg(T, HOTRGConfig(max_bond_dim=8, num_steps=6, device_mesh=None))
+    )
+    assert f_default == f_none


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Productizes the HOTRG multi-GPU feasibility GO from #681. HOTRG is **forward-only** (no autodiff-through-SVD backward — the wall that made CTM-AD multi-GPU a NO-GO), and its **χ⁶ `T_merged`** intermediate dominates memory while the HOSVD operand is only χ⁴. Sharding a free leg gives ideal per-device relief.

## API
`HOTRGConfig(device_mesh=<1-D jax.sharding.Mesh>)` — opt-in; `None` (default) is unchanged single-device behaviour. Dense path only (block-sparse HOTRG is small).

## Mechanism
- Each step re-shards its input `up` leg (`_shard_leg` → `with_sharding_constraint`). `up` is present in **both** the horizontal and vertical χ⁶ `T_merged`, so the eager contractions produce a **sharded χ⁶ without ever materializing it replicated**; re-sharding each step handles the H/V leg rotation.
- **Eager, not jit:** `truncated_svd` does host-side rank truncation (`linalg.py`, `np.array(s)`) and is not jit-safe (jitting crashes on the first rank-deficient SVD). Eager costs ~49 GB vs a jitted ~33 GB at χ=40 — still a clear win.
- Guards: no-op for `device_mesh=None`, non-`DenseTensor`, or a leg dim not divisible by the device count (early small-bond steps).

## Measured (2×A100, real `peak_bytes_in_use`, full `hotrg()`, β=0.3)
| χ (num_steps=8) | nomesh | mesh |
|---|---|---|
| 32 | 2.17 GB | **1.10 GB (2.0×)**, identical free energy |
| 40 | **fails** (autotuner OOM on the χ⁶ transpose) | **49 GB, fits**, f=−2.6339 — extends reachable χ |
| 44+ | fails | XLA autotuner wall on the `(χ³×χ³)` gemm caps both (compile-level, cf. split-CTM D=12) |

## Tests / docs
- `tests/test_hotrg_sharding.py`: sharded == single-device parity (fake CPU devices, well-conditioned → ~2e-16) + `device_mesh=None` flag-off no-op. 22 existing hotrg tests still pass.
- Parity is exact up to FP reassociation; only small-χ-near-Tc shows O(1e-4) from HOSVD truncation-ties (collapses with χ — bit-identical at χ=32).
- README + docstrings updated; full write-up in `docs/superpowers/handoffs/2026-07-03-hotrg-trg-multigpu-feasibility.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)