### PR TITLE
feat(trg): q-state Potts transfer tensor (compute_potts_tensor + potts_critical_beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,21 @@ Since HOTRG is forward-only there is no autodiff-through-SVD barrier, so GSPMD
 sharding is effective here (unlike the CTM-AD path). See
 `examples/probe_hotrg_multigpu.py`.
 
+The same coarse-graining works for the **q-state Potts model**
+(`compute_potts_tensor` produces any `q >= 2`; `q = 2` reduces to Ising):
+
+```python
+from tenax import HOTRGConfig, hotrg, compute_potts_tensor, potts_critical_beta
+
+q = 3
+beta_c = potts_critical_beta(q)  # ln(1 + sqrt(q)), the self-dual critical point
+T = compute_potts_tensor(beta_c, q=q)
+
+config = HOTRGConfig(max_bond_dim=16, num_steps=20)
+log_z_per_n = hotrg(T, config)
+print(f"Potts q={q} at beta_c={beta_c:.5f}:  ln(Z)/N = {float(log_z_per_n):.6f}")
+```
+
 ## AutoMPO Example
 
 ```python

--- a/src/tenax/__init__.py
+++ b/src/tenax/__init__.py
@@ -328,7 +328,9 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
         "compute_free_wilson_fermion_tensor",
     ),
     "compute_ising_tensor": ("tenax.algorithms.trg", "compute_ising_tensor"),
+    "compute_potts_tensor": ("tenax.algorithms.trg", "compute_potts_tensor"),
     "ising_free_energy_exact": ("tenax.algorithms.trg", "ising_free_energy_exact"),
+    "potts_critical_beta": ("tenax.algorithms.trg", "potts_critical_beta"),
     "trg": ("tenax.algorithms.trg", "trg"),
     "wilson_fermion_free_energy_exact": (
         "tenax.algorithms.trg",
@@ -417,8 +419,10 @@ __all__ = [
     "TRGConfig",
     "trg",
     "compute_ising_tensor",
+    "compute_potts_tensor",
     "compute_free_wilson_fermion_tensor",
     "ising_free_energy_exact",
+    "potts_critical_beta",
     "wilson_fermion_free_energy_exact",
     # HOTRG
     "HOTRGConfig",

--- a/src/tenax/algorithms/__init__.py
+++ b/src/tenax/algorithms/__init__.py
@@ -107,7 +107,9 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     ),
     "TRGConfig": ("tenax.algorithms.trg", "TRGConfig"),
     "compute_ising_tensor": ("tenax.algorithms.trg", "compute_ising_tensor"),
+    "compute_potts_tensor": ("tenax.algorithms.trg", "compute_potts_tensor"),
     "ising_free_energy_exact": ("tenax.algorithms.trg", "ising_free_energy_exact"),
+    "potts_critical_beta": ("tenax.algorithms.trg", "potts_critical_beta"),
     "trg": ("tenax.algorithms.trg", "trg"),
     # pess (kagome iPESS)
     "IPESSState": ("tenax.algorithms.pess", "IPESSState"),
@@ -185,7 +187,9 @@ __all__ = [
     "TRGConfig",
     "trg",
     "compute_ising_tensor",
+    "compute_potts_tensor",
     "ising_free_energy_exact",
+    "potts_critical_beta",
     # HOTRG
     "HOTRGConfig",
     "hotrg",

--- a/src/tenax/algorithms/trg.py
+++ b/src/tenax/algorithms/trg.py
@@ -242,6 +242,93 @@ def compute_ising_tensor(
     return DenseTensor(T, indices)
 
 
+def compute_potts_tensor(
+    beta: float,
+    q: int = 3,
+    J: float = 1.0,
+) -> Tensor:
+    """Build the initial transfer tensor for the 2D q-state Potts model.
+
+    The ferromagnetic q-state Potts model has energy
+    ``H = -J sum_<ij> delta(s_i, s_j)`` with ``s in {0, ..., q-1}``, giving the
+    per-bond Boltzmann weight matrix
+    ``Q[a, b] = exp(beta * J)`` if ``a == b`` else ``1``
+    (equivalently ``Q = ones(q, q) + (exp(beta*J) - 1) * I``).
+
+    As for the Ising tensor, we split ``Q = sqrtQ @ sqrtQ`` via its matrix
+    square root (``Q`` is symmetric positive-definite for ``beta*J > 0``) and
+    contract one factor onto each leg::
+
+        T_{udlr} = sum_s sqrtQ[u,s] sqrtQ[d,s] sqrtQ[l,s] sqrtQ[r,s]
+
+    so that ``Tr prod T`` reproduces the partition function ``Z``.
+
+    ``q = 2`` recovers the Ising model (up to a per-bond constant): its free
+    energy equals ``beta*J - beta * f_Ising(beta, J/2)``.
+
+    Args:
+        beta: Inverse temperature ``beta = 1/(k_B T)``.
+        q:    Number of Potts states (``q >= 2``). Default 3.
+        J:    Nearest-neighbor coupling (``J > 0`` ferromagnet).
+
+    Returns:
+        DenseTensor of shape ``(q, q, q, q)`` with legs
+        ``("up", "down", "left", "right")``.
+
+    Note:
+        The square-lattice Potts model is self-dual with a critical point at
+        ``beta_c = ln(1 + sqrt(q)) / J`` (see :func:`potts_critical_beta`),
+        continuous for ``q <= 4`` and first-order for ``q > 4``. Use HOTRG for
+        accurate free energies near ``beta_c``.
+    """
+    if q < 2:
+        raise ValueError(f"Potts model requires q >= 2, got q={q}")
+
+    # Q[a, b] = exp(beta*J) on the diagonal, 1 off-diagonal.
+    Q = jnp.asarray(np.ones((q, q)) + (np.exp(beta * J) - 1.0) * np.eye(q))
+
+    # Matrix square root of Q (NOT element-wise). Q is symmetric
+    # positive-definite for beta*J > 0, so sqrtQ @ sqrtQ = Q.
+    evals, evecs = jnp.linalg.eigh(Q)
+    sqrtQ = evecs @ jnp.diag(jnp.sqrt(evals)) @ evecs.T
+
+    # T_{udlr} = sum_s sqrtQ[u,s] sqrtQ[d,s] sqrtQ[l,s] sqrtQ[r,s]
+    T = jnp.einsum("us,ds,ls,rs->udlr", sqrtQ, sqrtQ, sqrtQ, sqrtQ)
+
+    sym = U1Symmetry()
+    bond_q = np.zeros(q, dtype=np.int32)
+    indices = (
+        TensorIndex.from_charges(sym, bond_q, FlowDirection.IN, label="up"),
+        TensorIndex.from_charges(sym, bond_q, FlowDirection.OUT, label="down"),
+        TensorIndex.from_charges(sym, bond_q, FlowDirection.IN, label="left"),
+        TensorIndex.from_charges(sym, bond_q, FlowDirection.OUT, label="right"),
+    )
+    return DenseTensor(T, indices)
+
+
+def potts_critical_beta(q: int = 3, J: float = 1.0) -> float:
+    """Self-dual critical inverse temperature of the 2D q-state Potts model.
+
+    On the square lattice the ferromagnetic Potts model is self-dual, fixing
+    the critical point at ``exp(beta_c * J) - 1 = sqrt(q)``, i.e.
+
+        beta_c = ln(1 + sqrt(q)) / J.
+
+    The transition is continuous for ``q <= 4`` and first-order for ``q > 4``.
+    For ``q = 2`` this is ``2x`` the Ising ``beta_c`` (since ``J_Ising = J/2``).
+
+    Args:
+        q: Number of Potts states (``q >= 2``). Default 3.
+        J: Nearest-neighbor coupling.
+
+    Returns:
+        The critical inverse temperature ``beta_c``.
+    """
+    if q < 2:
+        raise ValueError(f"Potts model requires q >= 2, got q={q}")
+    return float(np.log(1.0 + np.sqrt(q)) / J)
+
+
 def ising_free_energy_exact(beta: float, J: float = 1.0) -> float:
     """Compute the exact 2D Ising free energy per site via Onsager's formula.
 

--- a/tests/test_trg.py
+++ b/tests/test_trg.py
@@ -10,7 +10,9 @@ from tenax.algorithms.trg import (
     _trg_step,
     compute_free_wilson_fermion_tensor,
     compute_ising_tensor,
+    compute_potts_tensor,
     ising_free_energy_exact,
+    potts_critical_beta,
     trg,
     wilson_fermion_free_energy_exact,
 )
@@ -578,4 +580,98 @@ class TestFreeWilsonFermion:
         rel_err = abs(f_trg - f_exact) / abs(f_exact)
         assert rel_err < 0.02, (
             f"TRG ln(Z)/V={f_trg:.8f} vs exact={f_exact:.8f} (rel err={rel_err:.4f})"
+        )
+
+
+class TestComputePottsTensor:
+    """Structural tests for the q-state Potts local transfer tensor."""
+
+    def test_returns_dense_tensor(self):
+        T = compute_potts_tensor(beta=0.5)
+        assert isinstance(T, DenseTensor)
+
+    def test_default_q_is_3(self):
+        T = compute_potts_tensor(beta=0.5)
+        assert T.todense().shape == (3, 3, 3, 3)
+
+    def test_shape_matches_q(self):
+        for q in (2, 3, 4):
+            T = compute_potts_tensor(beta=0.5, q=q)
+            assert T.todense().shape == (q, q, q, q)
+
+    def test_labels_are_set(self):
+        T = compute_potts_tensor(beta=0.5)
+        labels = set(idx.label for idx in T.indices)
+        assert labels == {"up", "down", "left", "right"}
+
+    def test_tensor_is_symmetric_under_leg_swaps(self):
+        """T_{udlr} is built symmetrically, so u<->d and l<->r are no-ops."""
+        arr = np.asarray(compute_potts_tensor(beta=0.7, q=3).todense())
+        assert np.allclose(arr, arr.transpose(1, 0, 2, 3), atol=1e-12)
+        assert np.allclose(arr, arr.transpose(0, 1, 3, 2), atol=1e-12)
+
+    def test_matrix_sqrt_property(self):
+        """The internal sqrtQ must satisfy sqrtQ @ sqrtQ == Q (matrix sqrt)."""
+        beta, q, J = 0.6, 3, 1.0
+        Q = np.ones((q, q)) + (np.exp(beta * J) - 1.0) * np.eye(q)
+        ev, U = np.linalg.eigh(Q)
+        sqrtQ = U @ np.diag(np.sqrt(ev)) @ U.T
+        assert np.allclose(sqrtQ @ sqrtQ, Q, atol=1e-12)
+
+    def test_permutation_symmetry_of_states(self):
+        """S_q symmetry: permuting Potts state labels leaves the tensor fixed."""
+        arr = np.asarray(compute_potts_tensor(beta=0.8, q=3).todense())
+        # swap states 0<->1 on every leg
+        perm = np.array([1, 0, 2])
+        permuted = arr[np.ix_(perm, perm, perm, perm)]
+        assert np.allclose(arr, permuted, atol=1e-12)
+
+
+class TestPottsCriticalBeta:
+    """The self-dual critical point beta_c = ln(1 + sqrt(q)) / J."""
+
+    def test_q3_known_value(self):
+        assert np.isclose(potts_critical_beta(q=3), np.log(1 + np.sqrt(3)))
+
+    def test_q2_matches_twice_ising_beta_c(self):
+        """q=2 Potts beta_c equals 2x the Ising beta_c (J_Ising = J/2)."""
+        ising_bc = np.log(1 + np.sqrt(2)) / 2
+        assert np.isclose(potts_critical_beta(q=2), 2 * ising_bc)
+
+    def test_scales_inversely_with_J(self):
+        assert np.isclose(
+            potts_critical_beta(q=3, J=2.0), np.log(1 + np.sqrt(3)) / 2.0
+        )
+
+
+class TestPottsFreeEnergy:
+    """Convergence of TRG on Potts tensors against exact anchors."""
+
+    def test_q2_matches_ising_mapping(self):
+        """q=2 Potts is exactly Ising: Z_Potts = e^{beta*J*N} Z_Ising(J/2).
+
+        So ln(Z)/N = beta*J - beta * f_Ising(beta, J/2). This is a rigorous
+        end-to-end check of the Potts tensor construction.
+        """
+        beta, J = 0.2, 1.0
+        tensor = compute_potts_tensor(beta=beta, q=2, J=J)
+        config = TRGConfig(max_bond_dim=16, num_steps=20)
+        log_z_per_n = float(trg(tensor, config))
+        exact = beta * J - beta * ising_free_energy_exact(beta, J=J / 2)
+        rel_err = abs(log_z_per_n - exact) / abs(exact)
+        assert rel_err < 0.01, (
+            f"Potts(q=2) ln(Z)/N={log_z_per_n:.6f} vs Ising-mapped "
+            f"{exact:.6f} (rel err={rel_err:.4f})"
+        )
+
+    def test_q3_low_temperature_limit(self):
+        """At low T (large beta), ln(Z)/N -> 2*beta*J (2 bonds/site, aligned)."""
+        beta, J = 1.5, 1.0
+        tensor = compute_potts_tensor(beta=beta, q=3, J=J)
+        config = TRGConfig(max_bond_dim=16, num_steps=20)
+        log_z_per_n = float(trg(tensor, config))
+        # ln(Z)/N approaches 2*beta*J from above (small positive excitation term).
+        assert log_z_per_n >= 2 * beta * J - 1e-3
+        assert abs(log_z_per_n - 2 * beta * J) < 0.05, (
+            f"Potts(q=3) ln(Z)/N={log_z_per_n:.6f} vs 2*beta*J={2 * beta * J:.6f}"
         )


### PR DESCRIPTION
## Summary

Generalizes the Ising transfer-tensor builder to the **q-state Potts model**, so TRG and HOTRG (both accept any 4-leg tensor) work on Potts out of the box.

- **`compute_potts_tensor(beta, q=3, J=1.0)`** → `DenseTensor` of shape `(q,q,q,q)` with legs `("up","down","left","right")`. Same matrix-√ Boltzmann-weight recipe as `compute_ising_tensor`, with `Q = ones(q) + (e^{βJ}−1)·I`. `q=2` recovers Ising.
- **`potts_critical_beta(q=3, J=1.0)`** = `ln(1+√q)/J`, the square-lattice self-dual critical point (continuous transition for `q ≤ 4`).

Both are exported from `tenax` and `tenax.algorithms`; the README TRG section shows Potts + HOTRG usage.

## Validation

New tests in `tests/test_trg.py` check the construction against **exact anchors**, not just smoke:

- **q=2 Potts ≡ Ising**: TRG on `compute_potts_tensor(β, q=2)` matches `βJ − β·f_Ising(β, J/2)` within 1% (rigorous end-to-end check of the tensor).
- **q=3 low-T limit**: `ln(Z)/N → 2βJ` as `β→∞`.
- **`potts_critical_beta`**: `q=3` gives `ln(1+√3)`; `q=2` equals 2× the Ising `β_c`; scales as `1/J`.
- Structural: shape `(q,q,q,q)`, leg labels, leg-swap symmetry, matrix-√ property, and `S_q` state-permutation symmetry.

`pytest tests/test_trg.py` → **56 passed** (12 new Potts tests).

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)