### PR TITLE
feat(#463): 2-site split-CTM SymmetricTensor forward (Phase 3)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-2site-split-ctm-symmetric.md
+++ b/docs/superpowers/plans/2026-07-04-2site-split-ctm-symmetric.md
@@ -1,0 +1,573 @@
+# 2-site Split-CTM SymmetricTensor (Phase 3) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the coupled 2-site checkerboard split-CTM path (forward + explicit/implicit AD) work for bosonic SymmetricTensor (trivial and nontrivial U(1)/Zₙ), mirroring the proven single-site symmetric path — closing #463 Phase 3. Fermionic is Phase 4.
+
+**Architecture:** The 2plaq split path is already substantially polymorphic — enlarged corners are label-based `contract` + invertible `_fuse_ket_bra`, the projector already dispatches to the block-sparse symmetric kernel (`_compute_2x2_projector_symmetric`), and projectors are applied via the #605-safe `_apply_proj_unfused`. The one real gap is per-sector interlayer-SVD truncation: `_svd_split_edge_tensor` only takes the symmetric branch when it receives `base_charges`, which the 2plaq path currently never derives (driver hard-codes `None`; absorbs never derive it). Following the codebase's *un-plumbing* direction (`base_charges` is vestigial in `_apply_projector`), we derive it **locally at the two points of use** — each absorb reads the `A` it already holds; the driver reads `site_tensors[s]` — via a small local helper, adding **no** parameter to any sweep/absorb signature. The AD `custom_vjp` machinery is pure `jax.tree` over the env pytree and symmetry-agnostic; it is verified, not rewritten.
+
+**Tech Stack:** Python 3.11/3.12, JAX (float64), Tenax `Tensor`/`DenseTensor`/`SymmetricTensor`/`U1Symmetry`/`TensorIndex`, `jax.custom_vjp`, pytest (`-m core` + `slow`).
+
+---
+
+## Critical validation lessons (read before writing any test)
+
+1. **Trivial-U(1) parity is a *forward-correctness* guard, not a `base_charges` guard.** For trivial (all-zero) charges there is a single charge sector, so per-sector truncation is *identical* to global truncation — the trivial-U(1) energy/AD parity tests (Task 2/3) pass with or without the `base_charges` fix. They validate that the polymorphic symmetric path is *correct* (symmetric == dense). The `base_charges` fix is exercised only by **nontrivial** charges (multiple sectors competing for the `chi_I` budget), so the red→green test for the source fix is the **nontrivial-charge sector-preservation smoke** (Task 1) — the 2-site analogue of the single-site `test_fermionic_u1_charges_preserved_across_sweeps` regression.
+
+2. **Never use random tensors for tight energy/AD parity.** The fused 2-site CTM oscillates on random input (see [[feedback_ctm_parity_needs_convergent_input]]), so every tight parity test uses a **physical convergent** Heisenberg Néel checkerboard from 2-site simple update via `_build_su_neel` (`tests/test_split_ctm_2site.py:859`), wrapped as a trivial-U(1) SymmetricTensor. The nontrivial-charge smoke (Task 1) is the *only* place a random SymmetricTensor is acceptable — it asserts structure (finite + sectors preserved), never an energy value.
+
+3. **The trusted AD gate is `implicit == explicit`, not `implicit == finite-difference`.** The split energy_fn carries a pre-existing Wirtinger gap that AD-vs-FD inherits. Use the **XXZ Δ=0.3** clean-regime gate for the machine-exact assertion (`cos > 1−1e-9`, `rel < 1e-6`); the Heisenberg point is floored at `rel ~ 5e-4` by the degenerate-SV SVD backward (a known limitation, not a bug — see [[feedback_ad_parity_degenerate_svd_floor]]) and gets only a loose companion assertion.
+
+---
+
+## File Structure
+
+- **`src/tenax/algorithms/_split_ctm_tensor_moves.py`** (MODIFY) — owns the 2plaq absorbs. Add one small module-level helper `_split_base_charges(A)`; call it at the top of each of the four `_split_ctm_absorb_*_2plaq` and pass the result to that function's `_svd_split_edge_tensor` call(s). No signature changes.
+- **`src/tenax/algorithms/_split_ctm_tensor_convergence.py`** (MODIFY) — owns the 2-site sweep driver. Replace the hard-coded `base_charges=None` at the `_compute_split_plaquette_projector_pair` call with `_split_base_charges(site_tensors[s])`.
+- **`tests/test_split_ctm_2site_symmetric.py`** (CREATE) — owns the Phase-3 symmetric suite: nontrivial-charge sector-preservation smoke (Task 1), trivial-U(1) energy parity (Task 2), symmetric AD parity (Task 3). Local helpers `_to_trivial_u1`, `_build_nontrivial_u1_pair`, `_xxz_gate`; reuses `_build_su_neel` / `_heisenberg_gate` from `tests/test_split_ctm_2site.py`.
+
+### Key reference signatures (already on the branch; do not modify)
+
+```python
+# _split_ctm_tensor_moves.py
+def _svd_split_edge_tensor(T, left_labels, right_labels, chi_I, ket_relabels,
+                           bra_relabels, base_charges=None) -> tuple[Tensor, Tensor]
+#   symmetric branch at line 852: `if isinstance(T, SymmetricTensor) and base_charges is not None:`
+def _split_ctm_absorb_bottom_2plaq(env_src, A, A_bar, P_top_left, P_bot_left,
+                                   P_top_curr, P_bot_curr, chi_I)   # + left/right/top twins
+
+# _split_ctm_tensor_convergence.py
+def _split_ctm_sweep_multisite_2x2(envs, site_tensors, bars, neighbors, chi, chi_I)
+def _initialize_split_multisite_env(site_tensors, chi, chi_I) -> dict[Coord, SplitCTMTensorEnv]
+def ctm_split_tensor_2site(A, B, chi, max_iter=100, conv_tol=1e-8, chi_I=None,
+                           renormalize=True, recipe="2x2") -> tuple[SplitCTMTensorEnv, SplitCTMTensorEnv]
+
+# _split_ctm_tensor_energy.py
+def compute_energy_split_ctm_tensor_2site(A, B, env_A, env_B, gate, d=None) -> jax.Array
+
+# _split_ctm_energy_ad.py  (Phase-2, on this branch)
+def ctm_energy_split_explicit_2site(site_tensors, neighbors, gate, *, chi, warmup_steps,
+                                    backprop_steps, chi_I=None, renormalize=True, **_)
+def ctm_energy_split_implicit_2site(site_tensors, neighbors, gate, *, chi, max_iter,
+                                    conv_tol, chi_I=None, renormalize=True, min_iter=2, **_)
+
+# _ctm_tensor_convergence.py
+CHECKERBOARD_NEIGHBORS   # {(0,0): {...}, (1,0): {...}} bipartite neighbor map
+```
+
+The single-site precedent this mirrors: `_split_ctm_tensor_moves.py:1363/1451/1539/1627`
+(each single-site move derives `A.indices[0].charges if isinstance(A, SymmetricTensor) else None`
+locally); tests `tests/test_split_ctm_tensor.py::TestSplitCTMSymmetric` (lines 495-660).
+
+---
+
+## Task 1: `base_charges` local derivation (source fix) + nontrivial-charge sector-preservation
+
+**Files:**
+- Modify: `src/tenax/algorithms/_split_ctm_tensor_moves.py` (add `_split_base_charges`; edit 4 absorbs)
+- Modify: `src/tenax/algorithms/_split_ctm_tensor_convergence.py` (driver line ~272)
+- Test: `tests/test_split_ctm_2site_symmetric.py` (create)
+
+The core source change: engage per-sector interlayer-SVD truncation on the 2-site symmetric path so charge sectors survive across sweeps, driving it with the nontrivial-charge smoke.
+
+- [ ] **Step 1: Write the failing sector-preservation smoke test**
+
+Create `tests/test_split_ctm_2site_symmetric.py`:
+
+```python
+"""#463 Phase 3 — 2-site split-CTM SymmetricTensor support (bosonic U(1)/Zn).
+
+Trivial-U(1) parity (Tasks 2/3) validates the polymorphic symmetric path is
+correct (symmetric == dense). The nontrivial-charge sector-preservation smoke
+(Task 1) is the red->green gate for per-sector interlayer-SVD truncation: without
+base_charges the 2plaq path uses GLOBAL truncation, which starves a charge sector
+across sweeps. Mirrors the single-site regression
+test_fermionic_u1_charges_preserved_across_sweeps.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tenax.algorithms._ctm_tensor_convergence import CHECKERBOARD_NEIGHBORS
+from tenax.algorithms._split_ctm_tensor_convergence import (
+    _initialize_split_multisite_env,
+    _split_ctm_sweep_multisite_2x2,
+)
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import U1Symmetry
+from tenax.core.tensor import DenseTensor, SymmetricTensor
+from tests.test_split_ctm_2site import _build_su_neel, _heisenberg_gate
+
+
+def _bond_sector_count(env_tensor, interlayer_label):
+    """Number of distinct charge sectors on a tensor's interlayer bond leg."""
+    pos = env_tensor.labels().index(interlayer_label)
+    return len(np.unique(np.asarray(env_tensor.indices[pos].charges)))
+
+
+def _build_nontrivial_u1_pair(D=2, d=2):
+    """Direction-dependent (A != B) nontrivial bosonic-U(1) checkerboard pair.
+
+    Virtual/phys charges [0, 1] give two competing sectors, so global vs
+    per-sector interlayer truncation differ. Requires D == 2 and d == 2.
+    """
+    assert D == 2 and d == 2, "helper hard-codes the [0,1] two-sector layout"
+    sym = U1Symmetry()
+    vc = np.array([0, 1], dtype=np.int32)
+    pc = np.array([0, 1], dtype=np.int32)
+    flows = (
+        FlowDirection.OUT, FlowDirection.IN, FlowDirection.OUT,
+        FlowDirection.IN, FlowDirection.IN,
+    )
+    labels = ("u", "d", "l", "r", "phys")
+    charge_sets = (vc, vc, vc, vc, pc)
+    indices = tuple(
+        TensorIndex.from_charges(sym, c.copy(), f, label=lbl)
+        for c, f, lbl in zip(charge_sets, flows, labels)
+    )
+    kA, kB = jax.random.split(jax.random.PRNGKey(7))
+    A = SymmetricTensor.random_normal(indices, kA)
+    B = SymmetricTensor.random_normal(indices, kB)
+    return A, B
+
+
+def test_2site_symmetric_charge_sectors_preserved():
+    """Nontrivial-charge 2-site split sweeps stay finite, remain SymmetricTensor,
+    and preserve both interlayer charge sectors (no sector starvation)."""
+    A, B = _build_nontrivial_u1_pair(D=2, d=2)
+    site_tensors = {(0, 0): A, (1, 0): B}
+    bars = {c: t.bar() for c, t in site_tensors.items()}
+    chi, chi_I = 6, 4
+
+    envs = _initialize_split_multisite_env(site_tensors, chi, chi_I)
+    for _ in range(3):
+        envs = _split_ctm_sweep_multisite_2x2(
+            envs, site_tensors, bars, CHECKERBOARD_NEIGHBORS, chi, chi_I
+        )
+
+    for coord, env in envs.items():
+        for t in env:
+            assert isinstance(t, SymmetricTensor), (
+                f"{coord} env tensor collapsed to non-symmetric type"
+            )
+            assert jnp.all(jnp.isfinite(t.todense())), (
+                f"{coord} env tensor non-finite after sweeps"
+            )
+        # The T1 ket interlayer bond must retain BOTH input sectors.
+        assert _bond_sector_count(env.T1_ket, "t1k_I") >= 2, (
+            f"{coord}: interlayer bond starved to a single charge sector "
+            "(global truncation dropped a sector — base_charges not engaged)"
+        )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/test_split_ctm_2site_symmetric.py::test_2site_symmetric_charge_sectors_preserved -x -q`
+
+Expected: FAIL — the interlayer bond starves to a single sector (assertion on `_bond_sector_count`), because `_split_ctm_sweep_multisite_2x2` passes `base_charges=None`, so `_svd_split_edge_tensor` takes the global-truncation branch.
+
+If instead it PASSES (this random state happened not to starve a sector), tighten the competition before implementing: raise `chi_I` toward `chi` and/or add a second `_build_nontrivial_u1_pair` seed, so the two sectors genuinely compete for the `chi_I` budget. Do not implement the fix until the test is red — a green-without-fix test proves nothing about `base_charges`.
+
+- [ ] **Step 3: Add the local `base_charges` helper + engage it (source fix)**
+
+In `src/tenax/algorithms/_split_ctm_tensor_moves.py`, add a module-level helper near the other private helpers (e.g. just above `_svd_split_edge_tensor`, ~line 826). `SymmetricTensor` is already imported in this module (used at line 852).
+
+```python
+def _split_base_charges(A: Tensor) -> np.ndarray | None:
+    """Charges of a site tensor's first leg, for per-sector interlayer-SVD
+    truncation on the symmetric split path.
+
+    Returns ``None`` for a DenseTensor (global truncation). Derived locally at
+    the point of use — mirrors the single-site moves and the fused
+    ``_get_base_charges``; deliberately NOT a plumbed cross-call parameter
+    (``base_charges`` is being un-plumbed — see ``_apply_projector``).
+    """
+    return A.indices[0].charges if isinstance(A, SymmetricTensor) else None
+```
+
+Then in each of the four `_split_ctm_absorb_{bottom,left,right,top}_2plaq`, derive
+`base_charges` at the top of the function (right after the `def`/docstring) and pass
+it to every `_svd_split_edge_tensor` call in that function. For
+`_split_ctm_absorb_bottom_2plaq` the edit is:
+
+```python
+def _split_ctm_absorb_bottom_2plaq(
+    env_src, A, A_bar, P_top_left, P_bot_left, P_top_curr, P_bot_curr, chi_I
+):
+    """..."""  # unchanged docstring
+    base_charges = _split_base_charges(A)
+    # ... unchanged corner/edge growth + projector application ...
+    T3_ket_new, T3_bra_new = _svd_split_edge_tensor(
+        T3g,
+        left_labels=["chi_new", "u"],
+        right_labels=["u_bra", "chi_new_r"],
+        chi_I=chi_I,
+        ket_relabels={"chi_new": "t3k_r", "u": "d_ket", "_svd_bond": "t3k_I"},
+        bra_relabels={"_svd_bond": "t3b_I", "u_bra": "d_bra", "chi_new_r": "t3b_l"},
+        base_charges=base_charges,   # <-- add this line
+    )
+    # ... unchanged flow-fixups + return ...
+```
+
+Apply the identical two-line change (derive `base_charges = _split_base_charges(A)`
+at the top; add `base_charges=base_charges` to the `_svd_split_edge_tensor` call) to
+`_split_ctm_absorb_left_2plaq`, `_split_ctm_absorb_right_2plaq`, and
+`_split_ctm_absorb_top_2plaq`. Confirm each absorb has exactly one
+`_svd_split_edge_tensor` call:
+
+Run: `grep -n "_svd_split_edge_tensor" src/tenax/algorithms/_split_ctm_tensor_moves.py`
+
+Every call site *inside* an absorb gets `base_charges=base_charges`; the definition
+(line ~827) is unchanged.
+
+Then in `src/tenax/algorithms/_split_ctm_tensor_convergence.py`, import the helper
+and replace the hard-coded `None` at the projector call (~line 272):
+
+```python
+from tenax.algorithms._split_ctm_tensor_moves import _split_base_charges
+```
+
+(add to the existing function-local import block in `_split_ctm_sweep_multisite_2x2`
+that already pulls the absorb helpers — keep it function-local to avoid the module
+import cycle noted at line 234), and:
+
+```python
+            Pt, Pb, _eps, _sS = _compute_split_plaquette_projector_pair(
+                envs_old[s],
+                envs_old[s_TR],
+                envs_old[s_BL],
+                envs_old[s_BR],
+                site_tensors[s],
+                bars[s],
+                site_tensors[s_TR],
+                bars[s_TR],
+                site_tensors[s_BL],
+                bars[s_BL],
+                site_tensors[s_BR],
+                bars[s_BR],
+                chi,
+                direction,
+                base_charges=_split_base_charges(site_tensors[s]),  # <-- was None
+            )
+```
+
+- [ ] **Step 4: Run the smoke test to verify it passes**
+
+Run: `uv run pytest tests/test_split_ctm_2site_symmetric.py::test_2site_symmetric_charge_sectors_preserved -x -q`
+Expected: PASS — per-sector truncation now preserves both interlayer sectors across sweeps.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tenax/algorithms/_split_ctm_tensor_moves.py \
+        src/tenax/algorithms/_split_ctm_tensor_convergence.py \
+        tests/test_split_ctm_2site_symmetric.py
+git commit -m "feat(#463): 2-site split-CTM per-sector interlayer truncation (Phase 3 Task 1)"
+```
+
+---
+
+## Task 2: Trivial-U(1) forward + energy parity (Tier 1/2)
+
+**Files:**
+- Test: `tests/test_split_ctm_2site_symmetric.py` (append)
+
+Validate the polymorphic symmetric 2-site forward is *correct*: on a physical
+convergent Néel checkerboard wrapped as trivial-U(1), the symmetric energy matches
+the dense energy. This is a regression guard (single-sector → sector-independent of
+Task 1), across D∈{2,3}, χ∈{4,8}.
+
+- [ ] **Step 1: Write the energy-parity test**
+
+Append to `tests/test_split_ctm_2site_symmetric.py`:
+
+```python
+def _to_trivial_u1(A):
+    """Wrap a dense iPEPS site (shape (D,D,D,D,d), labels u,d,l,r,phys) as a
+    trivial-U(1) SymmetricTensor with the same data — robust to whatever indices
+    the SU builder attached."""
+    data = A.todense()
+    sym = U1Symmetry()
+    flows = (
+        FlowDirection.OUT, FlowDirection.IN, FlowDirection.OUT,
+        FlowDirection.IN, FlowDirection.IN,
+    )
+    labels = ("u", "d", "l", "r", "phys")
+    indices = tuple(
+        TensorIndex.from_charges(sym, np.zeros(n, dtype=np.int32), f, label=lbl)
+        for n, f, lbl in zip(data.shape, flows, labels)
+    )
+    return SymmetricTensor.from_dense(data, indices)
+
+
+@pytest.mark.parametrize("D,chi", [(2, 4), (2, 8), (3, 8)])
+def test_2site_symmetric_energy_matches_dense(D, chi):
+    """Trivial-U(1) symmetric split energy == dense split energy on a convergent
+    Neel checkerboard. The D=3 case is also the design-§10 hard-fusion guard."""
+    from tenax.algorithms._split_ctm_tensor_convergence import ctm_split_tensor_2site
+    from tenax.algorithms._split_ctm_tensor_energy import (
+        compute_energy_split_ctm_tensor_2site,
+    )
+
+    A, B = _build_su_neel(D=D)
+    gate = _heisenberg_gate()
+
+    envA_d, envB_d = ctm_split_tensor_2site(
+        A, B, chi, max_iter=60, conv_tol=1e-10, chi_I=chi
+    )
+    E_dense = float(compute_energy_split_ctm_tensor_2site(A, B, envA_d, envB_d, gate, d=2))
+
+    As, Bs = _to_trivial_u1(A), _to_trivial_u1(B)
+    envA_s, envB_s = ctm_split_tensor_2site(
+        As, Bs, chi, max_iter=60, conv_tol=1e-10, chi_I=chi
+    )
+    E_sym = float(compute_energy_split_ctm_tensor_2site(As, Bs, envA_s, envB_s, gate, d=2))
+
+    assert np.isfinite(E_sym), f"symmetric energy not finite: {E_sym}"
+    assert abs(E_sym - E_dense) < 1e-6, f"sym={E_sym} dense={E_dense} (D={D}, chi={chi})"
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `uv run pytest tests/test_split_ctm_2site_symmetric.py::test_2site_symmetric_energy_matches_dense -q`
+Expected: PASS (all 3 parametrizations).
+
+This is a *regression guard*, so PASS on the first run is the expected outcome (the
+polymorphic path already handles trivial-U(1); Task 1's fix is sector-independent
+here). If it FAILS, the failure is a genuine dense-only assumption on the 2plaq
+symmetric forward — diagnose the specific op (look for a `.todense()`, a raw
+`reshape`, or a `DenseTensor`-typed constructor on the path the test exercises) and
+fix it minimally in `_split_ctm_tensor_moves.py`, then re-run. A D=2 pass with a D=3
+fail specifically implicates a hard-fusion charge-conjugation clash in the enlarged
+corner (design §10) — inspect `_build_split_enlarged_corner`'s `_fuse_ket_bra` seams.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_split_ctm_2site_symmetric.py
+git commit -m "test(#463): 2-site trivial-U(1) split energy parity vs dense (Phase 3 Task 2)"
+```
+
+---
+
+## Task 3: Symmetric AD parity (Tier 3)
+
+**Files:**
+- Test: `tests/test_split_ctm_2site_symmetric.py` (append)
+
+Validate autodiff through the coupled 2-site symmetric fixed point: on the trivial-
+U(1) wrapped convergent state, symmetric `implicit == explicit` and symmetric-grad
+== dense-grad, using the XXZ Δ=0.3 clean-regime gate. These tests run the CTM to
+convergence with AD → mark them `slow` (out of `-m core`, matching the Phase-2 AD
+tests).
+
+- [ ] **Step 1: Write the symmetric AD parity test (XXZ clean-regime gate)**
+
+Append to `tests/test_split_ctm_2site_symmetric.py`:
+
+```python
+def _xxz_gate(delta=0.3, d=2):
+    """XXZ 2-site gate H = delta*Sz.Sz + 0.5(Sp.Sm + Sm.Sp). delta=0.3 avoids the
+    degenerate-SV SVD-backward floor that Heisenberg (delta=1) hits."""
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]], dtype=jnp.float64)
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=jnp.float64)
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]], dtype=jnp.float64)
+    H = delta * jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+    return H.reshape(d, d, d, d)
+
+
+@pytest.mark.slow
+def test_2site_symmetric_ad_matches_explicit_and_dense():
+    """PRIMARY Tier-3 gate: trivial-U(1) symmetric split AD gradient (w.r.t.
+    sublattice A) matches BOTH the symmetric explicit (unrolled) gradient and the
+    dense implicit gradient, on the convergent state with the XXZ Delta=0.3 gate.
+
+    implicit==explicit / sym==dense, NOT implicit==FD: the split energy_fn carries a
+    pre-existing Wirtinger gap (see feedback_ad_parity_degenerate_svd_floor).
+    """
+    from tenax.algorithms._split_ctm_energy_ad import (
+        ctm_energy_split_explicit_2site,
+        ctm_energy_split_implicit_2site,
+    )
+
+    A_d, B_d = _build_su_neel(D=2)
+    A_s, B_s = _to_trivial_u1(A_d), _to_trivial_u1(B_d)
+    gate = _xxz_gate(0.3)
+    chi = 4  # chi = D*D lossless on the physical low-interlayer-rank state
+
+    def _flat_grad(g):
+        return jnp.concatenate([x.ravel() for x in jax.tree.leaves(g)])
+
+    def loss_imp(a, b):
+        return ctm_energy_split_implicit_2site(
+            {(0, 0): a, (1, 0): b}, CHECKERBOARD_NEIGHBORS, gate,
+            chi=chi, chi_I=chi, max_iter=80, conv_tol=1e-13, min_iter=2,
+        ).real
+
+    def loss_exp(a, b):
+        return ctm_energy_split_explicit_2site(
+            {(0, 0): a, (1, 0): b}, CHECKERBOARD_NEIGHBORS, gate,
+            chi=chi, chi_I=chi, warmup_steps=40, backprop_steps=40,
+        ).real
+
+    # symmetric implicit vs symmetric explicit
+    e_i, g_i = jax.value_and_grad(loss_imp)(A_s, B_s)
+    e_e, g_e = jax.value_and_grad(loss_exp)(A_s, B_s)
+    gi, ge = _flat_grad(g_i), _flat_grad(g_e)
+    assert jnp.allclose(e_i, e_e, atol=1e-9), f"sym energy mismatch: {e_i} vs {e_e}"
+    cos_ie = float(jnp.real(jnp.vdot(gi, ge)) / (jnp.linalg.norm(gi) * jnp.linalg.norm(ge)))
+    rel_ie = float(jnp.linalg.norm(gi - ge) / jnp.linalg.norm(ge))
+    assert cos_ie > 1 - 1e-9, f"sym implicit vs explicit direction: cos={cos_ie}"
+    assert rel_ie < 1e-6, f"sym implicit vs explicit magnitude: rel={rel_ie}"
+
+    # symmetric implicit vs dense implicit (same wrapped data)
+    e_d, g_d = jax.value_and_grad(loss_imp)(A_d, B_d)
+    gd = _flat_grad(g_d)
+    assert jnp.allclose(e_i, e_d, atol=1e-8), f"sym vs dense energy: {e_i} vs {e_d}"
+    cos_sd = float(jnp.real(jnp.vdot(gi, gd)) / (jnp.linalg.norm(gi) * jnp.linalg.norm(gd)))
+    rel_sd = float(jnp.linalg.norm(gi - gd) / jnp.linalg.norm(gd))
+    assert cos_sd > 1 - 1e-9, f"sym vs dense direction: cos={cos_sd}"
+    assert rel_sd < 1e-6, f"sym vs dense magnitude: rel={rel_sd}"
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `uv run pytest tests/test_split_ctm_2site_symmetric.py::test_2site_symmetric_ad_matches_explicit_and_dense -x -q`
+Expected: PASS.
+
+Expected outcome is PASS: the `custom_vjp` is `jax.tree`-generic, so SymmetricTensor
+leaves flow through unchanged. If it FAILS on a *direction* mismatch (`cos` far below
+1), there is a genuine dense-only assumption on the AD path — localize it (a
+`.todense()` / dense reshape reachable from `_split_ctm_converge_multisite`'s fwd/bwd
+or `_phase_fix_split_ctm_tensor`) and fix it minimally; do NOT restructure the Neumann
+backward. If it fails only on `rel` (magnitude, direction fine), the symmetric
+explicit reference is under-converged — bump `warmup_steps`/`backprop_steps` to 60 or
+tighten implicit `conv_tol` to `1e-14`.
+
+- [ ] **Step 3: Add the Heisenberg companion (documents the degenerate-SV floor)**
+
+Append:
+
+```python
+@pytest.mark.slow
+def test_2site_symmetric_ad_heisenberg_floor():
+    """Heisenberg (Delta=1) companion: symmetric implicit vs explicit gradient agree
+    in DIRECTION but the magnitude is floored at ~5e-4 by the degenerate-SV SVD
+    backward (a known limitation, NOT a bug — the machine-exact gate is XXZ Delta=0.3,
+    see test_2site_symmetric_ad_matches_explicit_and_dense)."""
+    from tenax.algorithms._split_ctm_energy_ad import (
+        ctm_energy_split_explicit_2site,
+        ctm_energy_split_implicit_2site,
+    )
+
+    A_d, B_d = _build_su_neel(D=2)
+    A_s, B_s = _to_trivial_u1(A_d), _to_trivial_u1(B_d)
+    gate = _heisenberg_gate()
+    chi = 4
+
+    def loss_imp(a):
+        return ctm_energy_split_implicit_2site(
+            {(0, 0): a, (1, 0): B_s}, CHECKERBOARD_NEIGHBORS, gate,
+            chi=chi, chi_I=chi, max_iter=80, conv_tol=1e-13, min_iter=2,
+        ).real
+
+    def loss_exp(a):
+        return ctm_energy_split_explicit_2site(
+            {(0, 0): a, (1, 0): B_s}, CHECKERBOARD_NEIGHBORS, gate,
+            chi=chi, chi_I=chi, warmup_steps=40, backprop_steps=40,
+        ).real
+
+    _, g_i = jax.value_and_grad(loss_imp)(A_s)
+    _, g_e = jax.value_and_grad(loss_exp)(A_s)
+    gi = jnp.concatenate([x.ravel() for x in jax.tree.leaves(g_i)])
+    ge = jnp.concatenate([x.ravel() for x in jax.tree.leaves(g_e)])
+    cos = float(jnp.real(jnp.vdot(gi, ge)) / (jnp.linalg.norm(gi) * jnp.linalg.norm(ge)))
+    rel = float(jnp.linalg.norm(gi - ge) / jnp.linalg.norm(ge))
+    assert cos > 1 - 1e-6, f"direction should still agree: cos={cos}"
+    assert rel < 5e-3, f"magnitude should be near the ~5e-4 floor, got rel={rel}"
+```
+
+- [ ] **Step 4: Run both AD tests + commit**
+
+Run: `uv run pytest tests/test_split_ctm_2site_symmetric.py -q -m slow`
+Expected: PASS (both AD tests).
+
+```bash
+git add tests/test_split_ctm_2site_symmetric.py
+git commit -m "test(#463): 2-site symmetric split AD parity — XXZ machine-exact + Heisenberg floor (Phase 3 Task 3)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full Phase-3 suite:**
+
+Run: `uv run pytest tests/test_split_ctm_2site_symmetric.py -q`
+Expected: PASS (all — smoke, 3 energy-parity params, 2 AD tests).
+
+- [ ] **Guard against dense/single-site regression** (the source fix touched shared
+  files):
+
+Run: `uv run pytest tests/test_split_ctm_2site.py tests/test_split_ctm_2site_ad.py tests/test_split_ctm_tensor.py -q`
+Expected: PASS (all pre-existing dense 2-site + single-site symmetric suites — the
+`base_charges=None`→`_split_base_charges(A)` change is a no-op for DenseTensor, which
+returns `None`).
+
+- [ ] **Run the core marker (CI-required):**
+
+Run: `uv run pytest -m core -q`
+Expected: PASS.
+
+- [ ] **Docs:** the new functions are all private (`_split_base_charges`) or tests —
+  no public API change. Confirm no README/`__init__` update is needed:
+
+Run: `grep -rn "_split_base_charges\|ctm_energy_split" README.md src/tenax/__init__.py`
+Expected: no matches (these stay internal).
+
+  Update the `#463` status memory ([[project_463_2site_forward_phase2_handoff]] /
+  [[project_463_split_ctm_canonical]]) to mark Phase 3 complete (bosonic symmetric)
+  and Phase 4 (fermionic) as next.
+
+- [ ] **Open / update the PR** per CLAUDE.md workflow. This branch already hosts
+  Phase 2 (PR #685, open); Phase 3 stacks on it. Push and either add commits to #685
+  or open a stacked PR retargeted to `main` after #685 merges:
+
+```bash
+git push origin design/463-2site-split-ctm-ad
+```
+
+  Apply the `run-full-tests` label so the `slow` AD tests run in CI.
+
+---
+
+## Self-review notes (spec coverage)
+
+- Spec "Core change: derive `base_charges` locally, not plumbed" → Task 1
+  (`_split_base_charges` helper; driver + 4 absorbs derive locally; zero signature
+  changes). ✅
+- Spec §2 Tier-1/2 energy parity (trivial-U(1) wrap, D∈{2,3}, χ∈{4,8}, direction-
+  dependent A≠B) → Task 2 (`_build_su_neel` gives A≠B via Néel bias; parametrized). ✅
+- Spec §2 Tier-3 AD parity (symmetric implicit==explicit + symmetric==dense; XXZ
+  Δ=0.3 machine-exact + Heisenberg floor companion) → Task 3. ✅
+- Spec §2 nontrivial-charge structural smoke (finite + SymmetricTensor + sectors
+  preserved; no convergent-charged oracle) → Task 1 smoke. ✅
+- Spec "AD verified, not rewritten" → Task 3 expects PASS with no AD-code change;
+  contingency only fixes a genuine dense assumption minimally. ✅
+- Spec risk "hard fusion at D≥3" → Task 2 D=3 energy-parity param is the guard, with
+  a targeted diagnosis note. ✅
+- Spec risk "trivial-charge short-circuit" → Task 1 validation lesson #1 documents
+  that trivial-U(1) is sector-independent, so the smoke (nontrivial) is the real
+  `base_charges` gate. ✅
+- Out of scope (fermionic, convergent charged state, chi-bump/schedule) → not in this
+  plan; deferred to Phase 4. ✅
+
+**Genuine execution-time risk:** the nontrivial-charge smoke's red-first depends on
+the random state actually starving a sector under global truncation. Task 1 Step 2
+gives the concrete tightening (raise `chi_I`, add a seed) if it is green-without-fix —
+never implement against a green test. The trivial-U(1) energy/AD tests are expected
+PASS-first (regression guards); their contingency notes cover the low-probability case
+of a real dense-only assumption surviving on the 2plaq symmetric path.
+```

--- a/docs/superpowers/specs/2026-07-04-2site-split-ctm-symmetric-design.md
+++ b/docs/superpowers/specs/2026-07-04-2site-split-ctm-symmetric-design.md
@@ -36,11 +36,31 @@ per-block rewrite:
   single-site move path only — a red herring for Phase 3).
 
 **The actual gap:** `_split_ctm_sweep_multisite_2x2` hard-codes `base_charges=None`
-(`_split_ctm_tensor_convergence.py:272`) and never forwards it into the four
-`_split_ctm_absorb_*_2plaq` → their `_svd_split_edge_tensor` calls. Without it the
-per-sector-truncation symmetric branch never engages. The single-site moves derive
-it (`A.indices[0].charges if isinstance(A, SymmetricTensor) else None`, moves lines
-1363/1451/1539/1627); the 2-site path must do the same.
+(`_split_ctm_tensor_convergence.py:272`) and the four `_split_ctm_absorb_*_2plaq`
+never derive charges for their `_svd_split_edge_tensor` calls, so the
+per-sector-truncation symmetric branch never engages.
+
+**`base_charges` is a locally-derived value, NOT a plumbed parameter — the fix must
+respect that.** The codebase is actively *un*-plumbing `base_charges`: it is already
+vestigial in projector *application* (`_apply_projector`, "kept for API compat
+during transition" — charges recovered intrinsically via
+`_reembed_target_for_projector`). Where the *value* is still required — the
+interlayer-SVD split (`_svd_split_edge_tensor` → `_truncate_svd_per_sector` →
+`_derive_charges`) and the symmetric 2×2 projector — the convention is to derive it
+**locally at the point of use** from a site tensor already in hand:
+
+- Fused path: the `_get_base_charges(a)` helper reads the double-layer `"u2"` leg
+  charges and returns `None` when all charges are zero (trivial symmetry → the
+  global-truncation path).
+- Split single-site moves: inline
+  `A.indices[0].charges if isinstance(A, SymmetricTensor) else None`
+  (moves lines 1363/1451/1539/1627).
+
+The 2-site path already carries the needed site tensors at both call sites — the
+driver holds `site_tensors[s]` (convergence line 262) and each absorb receives its
+`A` (`_split_ctm_absorb_bottom_2plaq(env_src, A, A_bar, ...)`). So the fix derives
+charges locally at those two points; it does **not** add a `base_charges` parameter
+threaded through the sweep signatures.
 
 ## Requirements (pinned)
 
@@ -55,28 +75,38 @@ it (`A.indices[0].charges if isinstance(A, SymmetricTensor) else None`, moves li
 
 ## Chosen approach
 
-Thread `base_charges` through the 2-site sweep and the four absorbs so per-sector
-SVD truncation engages, then mirror the single-site symmetric test methodology on
-the 2-site path. The AD `custom_vjp` machinery is pure `jax.tree` over the env
-pytree and symmetry-agnostic — it is **verified**, not rewritten.
+Derive `base_charges` **locally at the two points of use** — the projector call in
+the driver and the interlayer-SVD split inside each absorb — from a site tensor
+already in hand, matching how the fused path (`_get_base_charges`) and the split
+single-site moves already do it. Do **not** add a `base_charges` parameter to the
+sweep/absorb signatures (that runs against the codebase's un-plumbing direction).
+Then mirror the single-site symmetric test methodology on the 2-site path. The AD
+`custom_vjp` machinery is pure `jax.tree` over the env pytree and symmetry-agnostic
+— it is **verified**, not rewritten.
 
 ## Design
 
 ### 1. Source changes
 
 **`_split_ctm_tensor_convergence.py`** (`_split_ctm_sweep_multisite_2x2`, ~line 272):
-- Derive per-sublattice `base_charges` from each site tensor:
-  `base_charges = A.indices[0].charges if isinstance(A, SymmetricTensor) else None`
-  (mirroring single-site moves). Pass it to
-  `_compute_split_plaquette_projector_pair` (replacing the hard-coded `None`) **and**
-  into each of the four `_split_ctm_absorb_*_2plaq` calls.
+- Replace the hard-coded `base_charges=None` in the
+  `_compute_split_plaquette_projector_pair` call with a value derived locally from
+  the anchor site tensor already in scope (`site_tensors[s]`, line 262), using the
+  split single-site convention (`indices[0].charges`, or the shared helper if one is
+  factored out). Only this one call site changes here; the absorb calls are unchanged.
 
 **`_split_ctm_tensor_moves.py`** (the four `_split_ctm_absorb_{bottom,left,right,top}_2plaq`):
-- Add a `base_charges` parameter (default `None` to preserve dense call sites) and
-  forward it to their internal `_svd_split_edge_tensor` calls so the symmetric
-  per-sector-truncation branch (`_truncate_svd_per_sector` → `_select_bond_entries`)
-  engages. The enlarged-corner assembly, projector dispatch, and
-  `_apply_proj_unfused` application are unchanged — already polymorphic / #605-safe.
+- **No signature change.** Each absorb already receives its `A`; derive
+  `base_charges = A.indices[0].charges if isinstance(A, SymmetricTensor) else None`
+  locally inside the function (mirroring single-site moves) and pass it to that
+  function's own `_svd_split_edge_tensor` call(s), engaging the symmetric
+  per-sector-truncation branch (`_truncate_svd_per_sector` → `_derive_charges`). The
+  enlarged-corner assembly, projector dispatch, and `_apply_proj_unfused` application
+  are unchanged — already polymorphic / #605-safe.
+- **Optional tidy (consistency, not required):** if a single shared derivation helper
+  reads better than four inline copies, factor a small local `_split_base_charges(A)`
+  — but keep it local to the split module; do not resurrect a plumbed cross-call
+  parameter.
 
 **`_split_ctm_energy_ad.py`** (2-site AD wrappers):
 - **Verify only.** The multisite `custom_vjp` (`_split_ctm_converge_multisite` +
@@ -137,10 +167,15 @@ Stack on `design/463-2site-split-ctm-ad` (PR #685 still open; a fresh branch off
   degenerate-singular-value floor at the Heisenberg point (same as dense/fused). The
   machine-exact gate is XXZ Δ=0.3; the Heisenberg companion asserts only the
   documented `~5e-4` floor. This is a known limitation, not a Phase-3 bug.
-- **`base_charges` per-sublattice:** on the checkerboard A and B may carry different
-  index charges; each absorb must receive the charges of the correct site tensor, not
-  a single global value. Thread per-coord, matching how the single-site moves read
-  `A.indices[0].charges` for the site being absorbed.
+- **`base_charges` locality + per-sublattice:** on the checkerboard A and B may carry
+  different index charges, so charges must come from the *correct* site tensor. This
+  is handled naturally by deriving locally (each absorb reads its own `A`; the driver
+  reads `site_tensors[s]`) — do not re-introduce a single plumbed value. The trivial-
+  U(1) parity input has all-zero charges: the fused `_get_base_charges` short-circuits
+  that to `None` (global truncation), while the split single-site inline form passes
+  `[0,…]` and takes the single-sector per-sector path. Both give the same result;
+  pick one convention and apply it consistently on the split 2-site path (the Tier-1/2
+  energy-parity test is the guard that the choice is correct).
 - **AD leaf-type surprise:** the expectation is zero AD-code change. If a
   dense-only assumption surfaces on the VJP path, fix it minimally and note it — do
   not restructure the Neumann backward.

--- a/docs/superpowers/specs/2026-07-04-2site-split-ctm-symmetric-design.md
+++ b/docs/superpowers/specs/2026-07-04-2site-split-ctm-symmetric-design.md
@@ -1,0 +1,167 @@
+# 2-site split-CTM — SymmetricTensor support (Phase 3) — design
+
+> Issue #463, Phase 3. Extends the coupled 2-site checkerboard split-CTM path
+> (forward + AD) from DenseTensor to **bosonic SymmetricTensor** (trivial and
+> nontrivial U(1)/Zₙ). Fermionic (FermionParity / FermionicU1 with Koszul signs)
+> is **Phase 4** and explicitly out of scope here.
+
+## Problem
+
+Phases 0–2 landed the dense joint 2-site split-CTM forward (`ctm_split_tensor_2site`,
+PR #684) and its explicit + implicit AD (`_split_ctm_energy_ad.py`, PR #685 on
+`design/463-2site-split-ctm-ad`). Both are exercised **only** by DenseTensor tests.
+The single-site split path is already fully SymmetricTensor-capable and tested
+(`tests/test_split_ctm_tensor.py::TestSplitCTMSymmetric` — trivial-U(1)
+energy-matches-dense to 1e-6, FermionicU1 charge preservation across sweeps), so a
+symmetric 2-site path is the natural next increment and the design §9 Phase-3 item.
+
+## Key finding (scope is narrower than design §9's wording)
+
+Design §9 phrased Phase 3 as "per-block layout for split enlarged corners + the
+four absorbs." A code audit shows the 2plaq path is **already substantially
+polymorphic**, so the real work is one threaded argument plus test coverage, not a
+per-block rewrite:
+
+- The 2-site **enlarged-corner assembly** (`_build_split_enlarged_corner`,
+  `_split_ctm_tensor_moves.py:103`) is pure label-based `contract` + invertible
+  `_fuse_ket_bra` (which carries `FuseInfo` via `fuse_indices`). Feed SymmetricTensor
+  `C`/`T`/`A` and you get a SymmetricTensor `Q` — no type branching needed.
+- The **projector** already dispatches on type: `_compute_split_plaquette_projector_pair`
+  → `_compute_2x2_projector` → `_compute_2x2_projector_symmetric` (block-sparse,
+  tracer-safe, Issue #435). Comes for free once the split `Q`s are symmetric.
+- **Projector application is already #605-safe.** The 2plaq absorbs use
+  `_apply_proj_unfused` (splits the projector's fused leg before contracting — the
+  YASTN-style fix for the D≥3 hard-fusion charge-conjugation clash). They do **not**
+  touch the DenseTensor-only `_unfuse_projector_fused` reshape (that lives on the
+  single-site move path only — a red herring for Phase 3).
+
+**The actual gap:** `_split_ctm_sweep_multisite_2x2` hard-codes `base_charges=None`
+(`_split_ctm_tensor_convergence.py:272`) and never forwards it into the four
+`_split_ctm_absorb_*_2plaq` → their `_svd_split_edge_tensor` calls. Without it the
+per-sector-truncation symmetric branch never engages. The single-site moves derive
+it (`A.indices[0].charges if isinstance(A, SymmetricTensor) else None`, moves lines
+1363/1451/1539/1627); the 2-site path must do the same.
+
+## Requirements (pinned)
+
+- Bosonic SymmetricTensor (trivial-U(1) and nontrivial-charge U(1)/Zₙ) works
+  end-to-end on the 2-site checkerboard split forward **and** AD.
+- No change to the DenseTensor path behaviour (byte-identical fast paths).
+- Fermionic is **out of scope** (Phase 4): no `_env_is_fermionic` bifurcation is
+  added here. Bosonic charges are reachable through the existing unfused-projector
+  application without a Koszul-sign branch.
+- `chi_I = chi` (lossless) as in the single-site and dense-2-site paths;
+  smaller-`chi_I` truncation stays out of scope.
+
+## Chosen approach
+
+Thread `base_charges` through the 2-site sweep and the four absorbs so per-sector
+SVD truncation engages, then mirror the single-site symmetric test methodology on
+the 2-site path. The AD `custom_vjp` machinery is pure `jax.tree` over the env
+pytree and symmetry-agnostic — it is **verified**, not rewritten.
+
+## Design
+
+### 1. Source changes
+
+**`_split_ctm_tensor_convergence.py`** (`_split_ctm_sweep_multisite_2x2`, ~line 272):
+- Derive per-sublattice `base_charges` from each site tensor:
+  `base_charges = A.indices[0].charges if isinstance(A, SymmetricTensor) else None`
+  (mirroring single-site moves). Pass it to
+  `_compute_split_plaquette_projector_pair` (replacing the hard-coded `None`) **and**
+  into each of the four `_split_ctm_absorb_*_2plaq` calls.
+
+**`_split_ctm_tensor_moves.py`** (the four `_split_ctm_absorb_{bottom,left,right,top}_2plaq`):
+- Add a `base_charges` parameter (default `None` to preserve dense call sites) and
+  forward it to their internal `_svd_split_edge_tensor` calls so the symmetric
+  per-sector-truncation branch (`_truncate_svd_per_sector` → `_select_bond_entries`)
+  engages. The enlarged-corner assembly, projector dispatch, and
+  `_apply_proj_unfused` application are unchanged — already polymorphic / #605-safe.
+
+**`_split_ctm_energy_ad.py`** (2-site AD wrappers):
+- **Verify only.** The multisite `custom_vjp` (`_split_ctm_converge_multisite` +
+  fwd/bwd) and the Γ phase-fix (`_phase_fix_split_ctm_tensor`) are `jax.tree`-generic
+  and should carry SymmetricTensor leaves unchanged. If a leaf-type assumption
+  surfaces (e.g. a `.todense()` or dense-only reshape on the AD path), fix it
+  minimally; do not restructure the VJP.
+
+### 2. Testing strategy
+
+New file `tests/test_split_ctm_2site_symmetric.py` (or an extension of
+`tests/test_split_ctm_2site_ad.py`), mirroring `TestSplitCTMSymmetric`. All tight
+parity tests use a **convergent, direction-dependent** state (A ≠ B), never random
+tensors (the fused 2-site CTM oscillates on random input — see
+`feedback_ctm_parity_needs_convergent_input`). Reuse the `_build_su_neel(D=...)` /
+`_heisenberg_gate` helpers from `tests/test_split_ctm_2site.py`.
+
+- **Tier 1/2 — energy parity (trivial-U(1) wrap of dense):** build the convergent
+  dense Néel checkerboard `(A, B)`, wrap each as a trivial-U(1) SymmetricTensor with
+  `SymmetricTensor.from_dense(A.todense(), A.indices)`, converge
+  `ctm_split_tensor_2site` in both dense and symmetric form, assert
+  `|E_sym − E_dense| < 1e-6`. Across D∈{2,3}, χ∈{4,8}. (Direct 2-site analogue of
+  `test_symmetric_energy_matches_dense`; the D=3 case is also the §10 hard-fusion
+  guard.)
+
+- **Tier 3 — AD parity (trivial-U(1) wrap):** on the wrapped state,
+  - symmetric `implicit == explicit` gradient: `cos > 1 − 1e-9`, `rel < 1e-6`;
+  - symmetric-grad == dense-grad (same wrapped data) to `rel < 1e-6`.
+  Use the **XXZ Δ=0.3 clean-regime** gate for the machine-exact assertion; keep a
+  Heisenberg companion that only asserts the looser degenerate-SV floor
+  (`rel ~ 5e-4`, see `feedback_ad_parity_degenerate_svd_floor`). Gradient taken
+  w.r.t. sublattice A only for a clean scalar parity, mirroring the dense Task-2 test.
+
+- **Structural smoke (nontrivial charges):** build a nontrivial-charge 2-site pair
+  (FermionicU1 or Zₙ charges, `SymmetricTensor.random_normal`), run a few
+  `_split_ctm_sweep_multisite_2x2` sweeps, assert all env tensors stay finite,
+  remain SymmetricTensor, and keep ≥1 block (charge sectors survive). This exercises
+  real block structure and per-sector truncation without needing a convergent charged
+  oracle (mirrors `test_fermionic_u1_charges_preserved_across_sweeps`). No energy or
+  variational assertion here — a genuinely-charged convergent state (symmetric SU)
+  is out of scope; the trivial-U(1) parity carries the correctness weight.
+
+### 3. Branch / PR
+
+Stack on `design/463-2site-split-ctm-ad` (PR #685 still open; a fresh branch off
+`main` would lack the Phase-2 AD code). Own commits, own green suite. Retarget to
+`main` after #685 merges. Follows CLAUDE.md git workflow (PR, `--squash`,
+`run-full-tests` label for the AD/slow tests).
+
+## Risks & open questions
+
+- **Hard fusion at D≥3 (design §10):** the split enlarged-corner assembly must stay
+  clear of raw-reshape HARD fusion. Audit confirms it currently does (`_fuse_ket_bra`
+  is invertible; projectors applied via `_apply_proj_unfused`). The Tier-1/2 D=3
+  energy-parity test is the guard — if it fails at D=3 but passes at D=2, suspect a
+  charge-conjugation clash in the corner seams.
+- **Symmetric AD degenerate-SV floor:** the block-sparse SVD backward has a
+  degenerate-singular-value floor at the Heisenberg point (same as dense/fused). The
+  machine-exact gate is XXZ Δ=0.3; the Heisenberg companion asserts only the
+  documented `~5e-4` floor. This is a known limitation, not a Phase-3 bug.
+- **`base_charges` per-sublattice:** on the checkerboard A and B may carry different
+  index charges; each absorb must receive the charges of the correct site tensor, not
+  a single global value. Thread per-coord, matching how the single-site moves read
+  `A.indices[0].charges` for the site being absorbed.
+- **AD leaf-type surprise:** the expectation is zero AD-code change. If a
+  dense-only assumption surfaces on the VJP path, fix it minimally and note it — do
+  not restructure the Neumann backward.
+
+## Acceptance
+
+- [ ] Tier-1/2 energy parity: split-symmetric == split-dense to `< 1e-6` on a
+  convergent Néel checkerboard (trivial-U(1) wrap), D∈{2,3}, χ∈{4,8}.
+- [ ] Tier-3 AD parity: symmetric `implicit == explicit` and symmetric == dense
+  gradient to `rel < 1e-6` (XXZ Δ=0.3 clean-regime gate; Heisenberg companion at the
+  `~5e-4` floor).
+- [ ] Structural smoke: nontrivial-charge 2-site sweep stays finite, SymmetricTensor,
+  charge sectors preserved.
+- [ ] DenseTensor 2-site path unchanged (existing dense suites green:
+  `test_split_ctm_2site.py`, `test_split_ctm_2site_ad.py`).
+- [ ] `-m core` green; slow AD tests green under the `run-full-tests` label.
+
+## Out of scope
+
+- Fermionic (FermionParity / FermionicU1 Koszul signs) — Phase 4.
+- A convergent nontrivial-charge 2-site state (symmetric SU) — smoke only here.
+- chi-auto-bump / chi-schedule / smaller-than-`chi` interlayer truncation on the
+  split path (stays guarded off).
+- General multisite (>2 sites).

--- a/src/tenax/algorithms/_split_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_convergence.py
@@ -239,6 +239,7 @@ def _split_ctm_sweep_multisite_2x2(
     # so importing the absorb helpers at module scope would form a cycle.
     from tenax.algorithms._split_ctm_tensor_moves import (
         _compute_split_plaquette_projector_pair,
+        _split_base_charges,
         _split_ctm_absorb_bottom_2plaq,
         _split_ctm_absorb_left_2plaq,
         _split_ctm_absorb_right_2plaq,
@@ -269,7 +270,7 @@ def _split_ctm_sweep_multisite_2x2(
                 bars[s_BR],
                 chi,
                 direction,
-                base_charges=None,
+                base_charges=_split_base_charges(site_tensors[s]),
             )
             projectors[s] = (Pt, Pb)
         # Phase 2: absorb per destination cell using two plaquettes' halves.

--- a/src/tenax/algorithms/_split_ctm_tensor_init.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_init.py
@@ -155,12 +155,15 @@ def _init_symmetric_corner(
 
     idx_a = TensorIndex.from_charges(sym, charges.copy(), flow_a, label=label_a)
     idx_b = TensorIndex.from_charges(sym, charges.copy(), flow_b, label=label_b)
-    # Match dense reference: eye(min(chi, D)) padded to chi,
-    # which initializes fewer diagonal entries when chi > D.
-    D = A.indices[ref_axis].dim
-    C = jnp.eye(min(chi, D), dtype=A.dtype)
-    C_pad = jnp.zeros((chi, chi), dtype=A.dtype)
-    C_pad = C_pad.at[: C.shape[0], : C.shape[1]].set(C)
+    # Match the dense reference :func:`_make_dense_corner` EXACTLY: a rank-1
+    # corner with only entry ``(0, 0) = 1``.  The previous ``eye(min(chi, D))``
+    # seed diverged from the dense path — at D>=3 it drives the split CTM onto
+    # an *artificially* degenerate corner fixed point whose degenerate subspace
+    # rotates every sweep, so the symmetric env never converges element-wise
+    # (and, compounded with the leg-order SVD bug below, collapsed the energy to
+    # exactly 0.0).  Rank-1 converges element-wise to the non-degenerate
+    # ``[1, 0, ...]`` corner, matching dense.  (#463 Phase 3.)
+    C_pad = jnp.zeros((chi, chi), dtype=A.dtype).at[0, 0].set(1.0)
     return SymmetricTensor.from_dense(C_pad, (idx_a, idx_b), tol=float("inf"))
 
 

--- a/src/tenax/algorithms/_split_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_moves.py
@@ -100,6 +100,28 @@ def _fuse_ket_bra(
     return fuse_indices(T, 0, 1, fused_label, fused_flow)
 
 
+# Fused enlarged-corner leg order per position (``chi`` seams first, then the
+# ``D²`` seams) — see :func:`_build_split_enlarged_corner`.  The split corner is
+# transposed to this order so the block-sparse ``tensor_svd`` in
+# :func:`_compute_2x2_projector` groups the ``(chi, d2)`` left legs correctly.
+_FUSED_CORNER_LEG_ORDER = {
+    "top_left": ("chi_R", "chi_B", "d2", "r2"),
+    "top_right": ("chi_L", "chi_B", "d2", "l2"),
+    "bottom_left": ("chi_T", "chi_R", "u2", "r2"),
+    "bottom_right": ("chi_L", "chi_T", "u2", "l2"),
+}
+
+
+def _canonical_split_corner(Q: Tensor, position: str) -> Tensor:
+    """Transpose a split enlarged corner to the fused corner's leg order."""
+    order = _FUSED_CORNER_LEG_ORDER[position]
+    labels = Q.labels()
+    perm = tuple(labels.index(lbl) for lbl in order)
+    if perm == tuple(range(len(labels))):
+        return Q
+    return Q.transpose(perm)
+
+
 def _build_split_enlarged_corner(
     C: Tensor,
     T_h_ket: Tensor,
@@ -115,12 +137,27 @@ def _build_split_enlarged_corner(
     :func:`_build_enlarged_corner`, assembled from ket/bra split edges + a
     physical double layer (A ket, A_bar bra) with the phys index traced.
 
-    Output free legs match the fused recipe's LABEL SET exactly (axis order is
-    not significant — ``_compute_2x2_projector`` indexes by label):
-      top_left     -> {chi_R, r2, chi_B, d2}
-      top_right    -> {chi_L, l2, chi_B, d2}
-      bottom_left  -> {chi_T, u2, chi_R, r2}
-      bottom_right -> {chi_L, l2, chi_T, u2}
+    Output free legs match the fused recipe's LABEL SET **and axis order**
+    exactly (``chi`` seams first, then the ``D²`` seams):
+      top_left     -> (chi_R, chi_B, d2, r2)
+      top_right    -> (chi_L, chi_B, d2, l2)
+      bottom_left  -> (chi_T, chi_R, u2, r2)
+      bottom_right -> (chi_L, chi_T, u2, l2)
+
+    Axis order **is** significant for the SymmetricTensor path (#463 Phase 3).
+    The block-sparse ``tensor_svd`` inside :func:`_compute_2x2_projector`
+    assembles each charge sector's matrix by reshaping every block *in its
+    native axis order* into ``(left_rows, right_cols)`` — it does NOT transpose
+    the block to the requested ``left_labels`` order first.  Its ``left_labels``
+    for the plaquette are ``(chi, d2)`` (chi slow), so if the corner were
+    returned with the ``d2`` seam *before* the ``chi`` seam (as the raw
+    ``_fuse_ket_bra`` output is), the reshape would flatten the row index in
+    ``(d2, chi)`` = d2-slow order.  That transposes the SVD's row basis, so
+    ``U·S·Vh`` reconstructs a *permuted* matrix — the projector then keeps a
+    different (wrong) subspace and the env drifts every sweep (energy wobbles /
+    collapses at D>=3, masked at D=2 where D²=4 and the seam is nearly
+    self-dual).  Matching the fused corner's ``(chi…, d2…)`` layout keeps the
+    split path byte-consistent with the working fused reference.
 
     The physical double layer is built by contracting the ket edges with the
     ket virtual legs of ``A`` and the bra edges with the bra virtual legs of
@@ -144,7 +181,8 @@ def _build_split_enlarged_corner(
         Q = contract(ket, A_bra)  # (t1b_r, t4b_u, d, r, D_bra, R_bra)
         Q = _fuse_ket_bra(Q, "d", "D_bra", "d2", FlowDirection.OUT)
         Q = _fuse_ket_bra(Q, "r", "R_bra", "r2", FlowDirection.OUT)
-        return Q.relabels({"t1b_r": "chi_R", "t4b_u": "chi_B"})
+        Q = Q.relabels({"t1b_r": "chi_R", "t4b_u": "chi_B"})
+        return _canonical_split_corner(Q, position)
 
     if position == "top_right":
         # C2.c2_l <-> T1's right = t1b_r (BRA) ; C2.c2_d <-> T2's top = t2k_u (KET).
@@ -162,7 +200,8 @@ def _build_split_enlarged_corner(
         Q = contract(ket, A_bra)  # (t1k_l, d, l, t2b_d, D_bra, L_bra)
         Q = _fuse_ket_bra(Q, "d", "D_bra", "d2", FlowDirection.OUT)
         Q = _fuse_ket_bra(Q, "l", "L_bra", "l2", FlowDirection.IN)
-        return Q.relabels({"t1k_l": "chi_L", "t2b_d": "chi_B"})
+        Q = Q.relabels({"t1k_l": "chi_L", "t2b_d": "chi_B"})
+        return _canonical_split_corner(Q, position)
 
     if position == "bottom_left":
         # C4.c4_r <-> T4's up = t4b_u (BRA) ; C4.c4_u <-> T3's right = t3k_r (KET).
@@ -179,7 +218,8 @@ def _build_split_enlarged_corner(
         Q = contract(ket, A_bra)  # (t4k_d, u, r, t3b_l, U_bra, R_bra)
         Q = _fuse_ket_bra(Q, "u", "U_bra", "u2", FlowDirection.IN)
         Q = _fuse_ket_bra(Q, "r", "R_bra", "r2", FlowDirection.OUT)
-        return Q.relabels({"t4k_d": "chi_T", "t3b_l": "chi_R"})
+        Q = Q.relabels({"t4k_d": "chi_T", "t3b_l": "chi_R"})
+        return _canonical_split_corner(Q, position)
 
     if position == "bottom_right":
         # C3.c3_l <-> T3's left = t3b_l (BRA) ; C3.c3_u <-> T2's bottom = t2b_d (BRA).
@@ -198,7 +238,8 @@ def _build_split_enlarged_corner(
         Q = contract(ket, A_bra)  # (t3k_r, t2k_u, u, l, U_bra, L_bra)
         Q = _fuse_ket_bra(Q, "u", "U_bra", "u2", FlowDirection.IN)
         Q = _fuse_ket_bra(Q, "l", "L_bra", "l2", FlowDirection.IN)
-        return Q.relabels({"t3k_r": "chi_L", "t2k_u": "chi_T"})
+        Q = Q.relabels({"t3k_r": "chi_L", "t2k_u": "chi_T"})
+        return _canonical_split_corner(Q, position)
 
     raise ValueError(f"unsupported position={position!r}")
 

--- a/src/tenax/algorithms/_split_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_moves.py
@@ -837,9 +837,9 @@ def _split_base_charges(A: Tensor) -> np.ndarray | None:
     truncation on the symmetric split path.
 
     Returns ``None`` for a DenseTensor (global truncation). Derived locally at
-    the point of use — mirrors the single-site moves and the fused
-    ``_get_base_charges``; deliberately NOT a plumbed cross-call parameter
-    (``base_charges`` is being un-plumbed — see ``_apply_projector``).
+    the point of use — a clean extraction of the single-site split-move inline
+    derivation (``A.indices[0].charges``); deliberately NOT a plumbed cross-call
+    parameter (``base_charges`` is being un-plumbed — see ``_apply_projector``).
     """
     return A.indices[0].charges if isinstance(A, SymmetricTensor) else None
 

--- a/src/tenax/algorithms/_split_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_moves.py
@@ -927,9 +927,11 @@ def _svd_split_edge_tensor(
         # (split-CTM at small D after PR #399 flipped the projector default
         # to "svd"). Route through truncated_svd_symmetric_ad, whose backward
         # is the Lorentzian-regularized + rank-aware kernel from _ad_primitives.
-        # TODO(#463 Phase 2-4): add SymmetricTensor block-sparse regularized SVD
-        # as a follow-up so the SymmetricTensor branches below also get a finite
-        # adjoint on rank-deficient blocks.
+        # TODO(#687): add SymmetricTensor block-sparse regularized SVD so the
+        # SymmetricTensor branch above gets the same regularized adjoint. Its
+        # absence floors symmetric CTM AD (implicit==explicit) at ~1e-2 vs the
+        # dense path's 1e-6 — even on a non-degenerate spectrum, so it is more
+        # than missing regularization; see issue #687.
         from tenax.algorithms._ad_primitives import truncated_svd_symmetric_ad
 
         U_t, s, Vh_t = truncated_svd_symmetric_ad(

--- a/src/tenax/algorithms/_split_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_moves.py
@@ -373,6 +373,7 @@ def _split_ctm_absorb_bottom_2plaq(
     convention, #670/#674): projector halves applied via ``_apply_proj_unfused``,
     ket/bra edge halves grown then SVD-split over ``chi_I``.
     """
+    base_charges = _split_base_charges(A)
     C4g = _grow_split_corner_2x2(
         env_src.C4,
         "c4_r",
@@ -432,6 +433,7 @@ def _split_ctm_absorb_bottom_2plaq(
         chi_I=chi_I,
         ket_relabels={"chi_new": "t3k_r", "u": "d_ket", "_svd_bond": "t3k_I"},
         bra_relabels={"_svd_bond": "t3b_I", "u_bra": "d_bra", "chi_new_r": "t3b_l"},
+        base_charges=base_charges,
     )
     C4_new = _ensure_corner_flows(C4_new, "C4")
     C3_new = _ensure_corner_flows(C3_new, "C3")
@@ -443,6 +445,7 @@ def _split_ctm_absorb_left_2plaq(
     env_src, A, A_bar, P_top_above, P_bot_above, P_top_curr, P_bot_curr, chi_I
 ):
     """Split LEFT absorption -> (C1_new, T4_ket_new, T4_bra_new, C4_new)."""
+    base_charges = _split_base_charges(A)
     C1g = _grow_split_corner_2x2(
         env_src.C1,
         "c1_r",
@@ -502,6 +505,7 @@ def _split_ctm_absorb_left_2plaq(
         chi_I=chi_I,
         ket_relabels={"chi_new": "t4k_d", "r": "l_ket", "_svd_bond": "t4k_I"},
         bra_relabels={"_svd_bond": "t4b_I", "r_bra": "l_bra", "chi_new_r": "t4b_u"},
+        base_charges=base_charges,
     )
     C1_new = _ensure_corner_flows(C1_new, "C1")
     C4_new = _ensure_corner_flows(C4_new, "C4")
@@ -513,6 +517,7 @@ def _split_ctm_absorb_right_2plaq(
     env_src, A, A_bar, P_top_above, P_bot_above, P_top_curr, P_bot_curr, chi_I
 ):
     """Split RIGHT absorption -> (C2_new, T2_ket_new, T2_bra_new, C3_new)."""
+    base_charges = _split_base_charges(A)
     C2g = _grow_split_corner_2x2(
         env_src.C2,
         "c2_l",
@@ -572,6 +577,7 @@ def _split_ctm_absorb_right_2plaq(
         chi_I=chi_I,
         ket_relabels={"chi_new": "t2k_u", "l": "r_ket", "_svd_bond": "t2k_I"},
         bra_relabels={"_svd_bond": "t2b_I", "l_bra": "r_bra", "chi_new_r": "t2b_d"},
+        base_charges=base_charges,
     )
     C2_new = _ensure_corner_flows(C2_new, "C2")
     C3_new = _ensure_corner_flows(C3_new, "C3")
@@ -583,6 +589,7 @@ def _split_ctm_absorb_top_2plaq(
     env_src, A, A_bar, P_top_left, P_bot_left, P_top_curr, P_bot_curr, chi_I
 ):
     """Split TOP absorption -> (C1_new, T1_ket_new, T1_bra_new, C2_new)."""
+    base_charges = _split_base_charges(A)
     C1g = _grow_split_corner_2x2(
         env_src.C1,
         "c1_d",
@@ -642,6 +649,7 @@ def _split_ctm_absorb_top_2plaq(
         chi_I=chi_I,
         ket_relabels={"chi_new": "t1k_l", "d": "u_ket", "_svd_bond": "t1k_I"},
         bra_relabels={"_svd_bond": "t1b_I", "d_bra": "u_bra", "chi_new_r": "t1b_r"},
+        base_charges=base_charges,
     )
     C1_new = _ensure_corner_flows(C1_new, "C1")
     C2_new = _ensure_corner_flows(C2_new, "C2")
@@ -822,6 +830,18 @@ def _grow_edge_no_double_layer(
 # ------------------------------------------------------------------ #
 # SVD helper                                                            #
 # ------------------------------------------------------------------ #
+
+
+def _split_base_charges(A: Tensor) -> np.ndarray | None:
+    """Charges of a site tensor's first leg, for per-sector interlayer-SVD
+    truncation on the symmetric split path.
+
+    Returns ``None`` for a DenseTensor (global truncation). Derived locally at
+    the point of use — mirrors the single-site moves and the fused
+    ``_get_base_charges``; deliberately NOT a plumbed cross-call parameter
+    (``base_charges`` is being un-plumbed — see ``_apply_projector``).
+    """
+    return A.indices[0].charges if isinstance(A, SymmetricTensor) else None
 
 
 def _svd_split_edge_tensor(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,10 @@ _FILE_MARKERS = {
     "test_tensor_utils.py": "core",
     "test_split_ctm_tensor.py": "algorithm",
     "test_split_ctm_2site.py": "algorithm",
+    # 2-site split-CTM SymmetricTensor (#463 Phase 3): forward/energy-parity
+    # tests run in the algorithm bucket; the AD parity tests in this file carry
+    # their own explicit @pytest.mark.slow so they stay out of -m "not slow".
+    "test_split_ctm_2site_symmetric.py": "algorithm",
     # Dense 2-site split-CTM AD (#463 Phase 2): each parity test converges a
     # coupled fixed point + a full AD gradient (~5 min); slow-only so they stay
     # out of the -m core CI gate and the -m "not slow" bucket.

--- a/tests/test_split_ctm_2site_symmetric.py
+++ b/tests/test_split_ctm_2site_symmetric.py
@@ -226,3 +226,114 @@ def test_2site_symmetric_forward_converges_d3():
     assert abs(E_sym - E_dense) < 1e-6, (
         f"sym={E_sym} dense={E_dense} (D={D}, chi={chi})"
     )
+
+
+def _xxz_gate(delta=0.3, d=2):
+    """XXZ 2-site gate H = delta*Sz.Sz + 0.5(Sp.Sm + Sm.Sp).
+
+    delta=0.3 breaks the SU(2) degeneracy that floors the *dense* SVD-backward at
+    the Heisenberg point (delta=1); the dense path then reaches machine-exact
+    implicit==explicit AD parity.  The block-sparse (symmetric) SVD backward has a
+    separate, larger floor that delta=0.3 does NOT clear -- see issue #687.
+    """
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]], dtype=jnp.float64)
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=jnp.float64)
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]], dtype=jnp.float64)
+    H = delta * jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+    return H.reshape(d, d, d, d)
+
+
+@pytest.mark.slow
+def test_2site_symmetric_ad_direction_and_stability():
+    """Symmetric 2-site split-CTM AD (XXZ Delta=0.3) is finite, non-collapsing, and
+    direction-consistent -- but NOT machine-exact parity with the dense path.
+
+    Phase 3 lands the symmetric FORWARD (correct at all D); the block-sparse SVD
+    *backward* is a known accuracy limitation (issue #687 / the TODO in
+    ``_svd_split_edge_tensor``): it lacks the Lorentzian regularization the dense
+    path uses, so symmetric ``implicit == explicit`` floors at rel~1.3e-2 (dense
+    reaches 1e-6) even on the non-degenerate XXZ Delta=0.3 spectrum.
+
+    What this test DOES gate (all robustly true today):
+      * energy VALUE parity with dense is tight (the forward is correct);
+      * the AD gradient is finite and non-zero (regression against the D>=3
+        collapse, which drove gradients to 0);
+      * symmetric implicit and explicit gradients agree in DIRECTION (cos > 0.999)
+        and to rel < 5e-2 in magnitude (the documented block-sparse floor);
+      * the symmetric gradient agrees in direction with the dense gradient
+        (cos > 0.99) -- a different SVD backend, hence only a loose gate.
+
+    NOTE: AD-vs-finite-difference is deliberately NOT asserted -- the split
+    energy_fn carries a pre-existing Wirtinger gap that the dense path shares
+    (dense AD also disagrees with FD, incl. sign flips). The trusted gate is
+    implicit==explicit, and its tightening to ~1e-6 for the symmetric path is
+    tracked in #687.
+    """
+    from tenax.algorithms._split_ctm_energy_ad import (
+        ctm_energy_split_explicit_2site,
+        ctm_energy_split_implicit_2site,
+    )
+
+    A_d, B_d = _build_su_neel(D=2)
+    A_s, B_s = _to_trivial_u1(A_d), _to_trivial_u1(B_d)
+    gate = _xxz_gate(0.3)
+    chi = 4  # chi = D*D lossless on the physical low-interlayer-rank state
+
+    def _flat(g):
+        return jnp.concatenate([x.ravel() for x in jax.tree.leaves(g)])
+
+    def loss_imp(a, b):
+        return ctm_energy_split_implicit_2site(
+            {(0, 0): a, (1, 0): b},
+            CHECKERBOARD_NEIGHBORS,
+            gate,
+            chi=chi,
+            chi_I=chi,
+            max_iter=80,
+            conv_tol=1e-13,
+            min_iter=2,
+        ).real
+
+    def loss_exp(a, b):
+        return ctm_energy_split_explicit_2site(
+            {(0, 0): a, (1, 0): b},
+            CHECKERBOARD_NEIGHBORS,
+            gate,
+            chi=chi,
+            chi_I=chi,
+            warmup_steps=40,
+            backprop_steps=40,
+        ).real
+
+    e_si, g_si = jax.value_and_grad(loss_imp)(A_s, B_s)
+    e_se, g_se = jax.value_and_grad(loss_exp)(A_s, B_s)
+    e_di, g_di = jax.value_and_grad(loss_imp)(A_d, B_d)
+    gsi, gse, gdi = _flat(g_si), _flat(g_se), _flat(g_di)
+
+    # Forward is correct: symmetric energy == dense energy (both AD variants).
+    assert jnp.isfinite(e_si) and jnp.isfinite(e_se)
+    assert jnp.allclose(e_si, e_di, atol=1e-6), f"sym E {e_si} vs dense E {e_di}"
+    assert jnp.allclose(e_si, e_se, atol=1e-6), f"sym imp E {e_si} vs exp E {e_se}"
+
+    # Gradient finite + non-zero (D>=3 collapse regression: it drove grads to 0).
+    assert jnp.all(jnp.isfinite(gsi)) and float(jnp.linalg.norm(gsi)) > 1e-6
+
+    def _cos(a, b):
+        return float(
+            jnp.real(jnp.vdot(a, b)) / (jnp.linalg.norm(a) * jnp.linalg.norm(b))
+        )
+
+    def _rel(a, b):
+        return float(jnp.linalg.norm(a - b) / jnp.linalg.norm(b))
+
+    # Symmetric implicit vs explicit (same block-sparse backend): direction tight,
+    # magnitude at the documented block-sparse-backward floor (#687).
+    cos_ie, rel_ie = _cos(gsi, gse), _rel(gsi, gse)
+    assert cos_ie > 0.999, f"sym implicit/explicit direction: cos={cos_ie}"
+    assert rel_ie < 5e-2, (
+        f"sym implicit/explicit magnitude floor exceeded: rel={rel_ie}"
+    )
+
+    # Symmetric vs dense implicit (different SVD backend): loose direction gate.
+    cos_sd = _cos(gsi, gdi)
+    assert cos_sd > 0.99, f"sym-vs-dense gradient direction: cos={cos_sd}"

--- a/tests/test_split_ctm_2site_symmetric.py
+++ b/tests/test_split_ctm_2site_symmetric.py
@@ -1,0 +1,116 @@
+"""#463 Phase 3 — 2-site split-CTM SymmetricTensor support (bosonic U(1)/Zn).
+
+Trivial-U(1) parity (Tasks 2/3) validates the polymorphic symmetric path is
+correct (symmetric == dense). The nontrivial-charge sector-preservation smoke
+(Task 1) is the red->green gate for per-sector interlayer-SVD truncation: without
+base_charges the 2plaq path uses GLOBAL truncation, which starves a charge sector
+across sweeps. Mirrors the single-site regression
+test_fermionic_u1_charges_preserved_across_sweeps.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tenax.algorithms._ctm_tensor_convergence import CHECKERBOARD_NEIGHBORS
+from tenax.algorithms._split_ctm_tensor_convergence import (
+    _initialize_split_multisite_env,
+    _split_ctm_sweep_multisite_2x2,
+)
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import U1Symmetry
+from tenax.core.tensor import DenseTensor, SymmetricTensor
+from tests.test_split_ctm_2site import _build_su_neel, _heisenberg_gate
+
+
+def _bond_sector_count(env_tensor, interlayer_label):
+    """Number of distinct charge sectors on a tensor's interlayer bond leg."""
+    pos = env_tensor.labels().index(interlayer_label)
+    return len(np.unique(np.asarray(env_tensor.indices[pos].charges)))
+
+
+def _min_sector_count(env_tensor, interlayer_label):
+    """Minimum number of bond slots allocated to any charge sector."""
+    pos = env_tensor.labels().index(interlayer_label)
+    charges = np.asarray(env_tensor.indices[pos].charges)
+    _, counts = np.unique(charges, return_counts=True)
+    return int(np.min(counts)) if len(counts) > 0 else 0
+
+
+def _build_nontrivial_u1_pair(D=2, d=2):
+    """Direction-dependent (A != B) nontrivial bosonic-U(1) checkerboard pair.
+
+    Virtual/phys charges [0, 1] give two competing sectors, so global vs
+    per-sector interlayer truncation differ. Requires D == 2 and d == 2.
+    """
+    assert D == 2 and d == 2, "helper hard-codes the [0,1] two-sector layout"
+    sym = U1Symmetry()
+    vc = np.array([0, 1], dtype=np.int32)
+    pc = np.array([0, 1], dtype=np.int32)
+    flows = (
+        FlowDirection.OUT,
+        FlowDirection.IN,
+        FlowDirection.OUT,
+        FlowDirection.IN,
+        FlowDirection.IN,
+    )
+    labels = ("u", "d", "l", "r", "phys")
+    charge_sets = (vc, vc, vc, vc, pc)
+    indices = tuple(
+        TensorIndex.from_charges(sym, c.copy(), f, label=lbl)
+        for c, f, lbl in zip(charge_sets, flows, labels)
+    )
+    kA, kB = jax.random.split(jax.random.PRNGKey(7))
+    A = SymmetricTensor.random_normal(indices, kA)
+    B = SymmetricTensor.random_normal(indices, kB)
+    return A, B
+
+
+def test_2site_symmetric_charge_sectors_preserved():
+    """Nontrivial-charge 2-site split sweeps stay finite, remain SymmetricTensor,
+    and preserve per-sector interlayer-SVD budget (no sector starvation).
+
+    Global truncation (base_charges=None) allocates SVD slots to the sector
+    with the largest singular values, leaving the weaker sector with fewer than
+    chi_I // n_sectors slots.  Per-sector truncation (base_charges engaged)
+    guarantees each sector gets at least floor(chi_I / n_sectors) slots.
+
+    Red before the fix: global top-k gives 3 slots to sector 0 and 1 to
+    sector 1 (min_count=1 < chi_I//2=2). Green after: per-sector gives 2+2.
+    """
+    A, B = _build_nontrivial_u1_pair(D=2, d=2)
+    site_tensors = {(0, 0): A, (1, 0): B}
+    bars = {c: t.bar() for c, t in site_tensors.items()}
+    chi, chi_I = 6, 4
+
+    envs = _initialize_split_multisite_env(site_tensors, chi, chi_I)
+    for _ in range(3):
+        envs = _split_ctm_sweep_multisite_2x2(
+            envs, site_tensors, bars, CHECKERBOARD_NEIGHBORS, chi, chi_I
+        )
+
+    n_sectors = 2  # U(1) with charges [0, 1]
+    fair_share = chi_I // n_sectors  # 2
+
+    for coord, env in envs.items():
+        for t in env:
+            assert isinstance(t, SymmetricTensor), (
+                f"{coord} env tensor collapsed to non-symmetric type"
+            )
+            assert jnp.all(jnp.isfinite(t.todense())), (
+                f"{coord} env tensor non-finite after sweeps"
+            )
+        # The T1 ket interlayer bond must retain BOTH input sectors with a
+        # fair share of slots: per-sector truncation guarantees >= fair_share
+        # per sector; global truncation gives 3+1 (min=1 < fair_share=2).
+        assert _bond_sector_count(env.T1_ket, "t1k_I") >= 2, (
+            f"{coord}: interlayer bond collapsed to a single charge sector"
+        )
+        assert _min_sector_count(env.T1_ket, "t1k_I") >= fair_share, (
+            f"{coord}: interlayer bond sector starvation detected — "
+            f"min slots per sector = {_min_sector_count(env.T1_ket, 't1k_I')} "
+            f"< fair_share = {fair_share}. "
+            f"Global truncation dropped slots from the weaker charge sector "
+            "(base_charges not engaged for per-sector interlayer-SVD truncation)"
+        )

--- a/tests/test_split_ctm_2site_symmetric.py
+++ b/tests/test_split_ctm_2site_symmetric.py
@@ -114,3 +114,57 @@ def test_2site_symmetric_charge_sectors_preserved():
             f"Global truncation dropped slots from the weaker charge sector "
             "(base_charges not engaged for per-sector interlayer-SVD truncation)"
         )
+
+
+def _to_trivial_u1(A):
+    """Wrap a dense iPEPS site (shape (D,D,D,D,d), labels u,d,l,r,phys) as a
+    trivial-U(1) SymmetricTensor with the same data — robust to whatever indices
+    the SU builder attached."""
+    data = A.todense()
+    sym = U1Symmetry()
+    flows = (
+        FlowDirection.OUT,
+        FlowDirection.IN,
+        FlowDirection.OUT,
+        FlowDirection.IN,
+        FlowDirection.IN,
+    )
+    labels = ("u", "d", "l", "r", "phys")
+    indices = tuple(
+        TensorIndex.from_charges(sym, np.zeros(n, dtype=np.int32), f, label=lbl)
+        for n, f, lbl in zip(data.shape, flows, labels)
+    )
+    return SymmetricTensor.from_dense(data, indices)
+
+
+@pytest.mark.parametrize("D,chi", [(2, 4), (2, 8), (3, 8)])
+def test_2site_symmetric_energy_matches_dense(D, chi):
+    """Trivial-U(1) symmetric split energy == dense split energy on a convergent
+    Neel checkerboard. The D=3 case is also the design-§10 hard-fusion guard."""
+    from tenax.algorithms._split_ctm_tensor_convergence import ctm_split_tensor_2site
+    from tenax.algorithms._split_ctm_tensor_energy import (
+        compute_energy_split_ctm_tensor_2site,
+    )
+
+    A, B = _build_su_neel(D=D)
+    gate = _heisenberg_gate()
+
+    envA_d, envB_d = ctm_split_tensor_2site(
+        A, B, chi, max_iter=60, conv_tol=1e-10, chi_I=chi
+    )
+    E_dense = float(
+        compute_energy_split_ctm_tensor_2site(A, B, envA_d, envB_d, gate, d=2)
+    )
+
+    As, Bs = _to_trivial_u1(A), _to_trivial_u1(B)
+    envA_s, envB_s = ctm_split_tensor_2site(
+        As, Bs, chi, max_iter=60, conv_tol=1e-10, chi_I=chi
+    )
+    E_sym = float(
+        compute_energy_split_ctm_tensor_2site(As, Bs, envA_s, envB_s, gate, d=2)
+    )
+
+    assert np.isfinite(E_sym), f"symmetric energy not finite: {E_sym}"
+    assert abs(E_sym - E_dense) < 1e-6, (
+        f"sym={E_sym} dense={E_dense} (D={D}, chi={chi})"
+    )

--- a/tests/test_split_ctm_2site_symmetric.py
+++ b/tests/test_split_ctm_2site_symmetric.py
@@ -168,3 +168,61 @@ def test_2site_symmetric_energy_matches_dense(D, chi):
     assert abs(E_sym - E_dense) < 1e-6, (
         f"sym={E_sym} dense={E_dense} (D={D}, chi={chi})"
     )
+
+
+def test_2site_symmetric_forward_converges_d3():
+    """#463 Phase 3 root-cause regression: the D=3 trivial-U(1) 2-site split-CTM
+    forward must CONVERGE (finite, non-zero, == dense-split), not collapse.
+
+    Two bugs (both fixed) made the D=3 symmetric forward degenerate:
+
+    1. ``_init_symmetric_corner`` seeded ``eye(min(chi, D))`` instead of the
+       dense path's rank-1 ``(0, 0) = 1`` corner — an artificially degenerate
+       corner whose subspace rotates every sweep, so the env never converges
+       element-wise.
+
+    2. ``_build_split_enlarged_corner`` returned its legs in ``(d2, chi)`` order
+       while ``_build_enlarged_corner`` (fused reference) uses ``(chi, d2)``.
+       The block-sparse ``tensor_svd`` in ``_compute_2x2_projector`` reshapes
+       each sector block *in native axis order* into ``(left_rows, right_cols)``
+       without first transposing to ``left_labels=(chi, d2)`` order, so the
+       wrong-order corner transposed the SVD row basis → the projector kept a
+       different subspace → the env drifted and the energy collapsed to exactly
+       0.0 from ~iter 8 at D=3.
+
+    Together they collapsed the energy: ``-0.523 → -0.348 → … → 0.0``.  This
+    test is RED before either fix (energy is 0.0 / not close to dense) and
+    GREEN after both.
+    """
+    from tenax.algorithms._split_ctm_tensor_convergence import ctm_split_tensor_2site
+    from tenax.algorithms._split_ctm_tensor_energy import (
+        compute_energy_split_ctm_tensor_2site,
+    )
+
+    D, chi = 3, 8
+    A, B = _build_su_neel(D=D)
+    gate = _heisenberg_gate()
+
+    envA_d, envB_d = ctm_split_tensor_2site(
+        A, B, chi, max_iter=60, conv_tol=1e-10, chi_I=chi
+    )
+    E_dense = float(
+        compute_energy_split_ctm_tensor_2site(A, B, envA_d, envB_d, gate, d=2)
+    )
+
+    As, Bs = _to_trivial_u1(A), _to_trivial_u1(B)
+    envA_s, envB_s = ctm_split_tensor_2site(
+        As, Bs, chi, max_iter=60, conv_tol=1e-10, chi_I=chi
+    )
+    E_sym = float(
+        compute_energy_split_ctm_tensor_2site(As, Bs, envA_s, envB_s, gate, d=2)
+    )
+
+    # Finite, non-zero (the collapse drove it to exactly 0.0), and == dense.
+    assert np.isfinite(E_sym), f"symmetric energy not finite: {E_sym}"
+    assert abs(E_sym) > 1e-2, (
+        f"symmetric energy collapsed toward zero: {E_sym} (D={D}, chi={chi})"
+    )
+    assert abs(E_sym - E_dense) < 1e-6, (
+        f"sym={E_sym} dense={E_dense} (D={D}, chi={chi})"
+    )


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @Ying-Jer Kao.

Closes #463 Phase 3 (SymmetricTensor) for the **forward**; symmetric **AD** is landed with an honest scope + follow-up #687.

## What lands

**SymmetricTensor (bosonic U(1)/Zₙ) support for the 2-site checkerboard split-CTM forward** — correct at all D, mirroring the working single-site symmetric + fused-2×2 reference. Fermionic stays Phase 4.

- **Per-sector interlayer truncation** (`_split_base_charges`): each of the four `_split_ctm_absorb_*_2plaq` + the driver derive `base_charges` **locally** (not a plumbed param — `base_charges` is being un-plumbed), engaging `_svd_split_edge_tensor`'s symmetric per-sector branch. Regression: nontrivial-charge sector-preservation smoke.

- **Two D≥3 collapse bugs fixed** (found by the trivial-U(1) energy-parity test, which showed the symmetric env collapsing to E=0 at D≥3 while dense/single-site were fine):
  1. `_init_symmetric_corner` seeded `eye(min(chi,D))` instead of the dense path's rank-1 `(0,0)=1` (the same rank-1 fix the dense path got earlier, which the symmetric init missed) → D=2 oscillation.
  2. `_build_split_enlarged_corner` returned legs `(d2, chi)`, but the block-sparse `tensor_svd` reshapes each block in **native axis order** without transposing to `left_labels` → wrong SVD row basis → collapse (masked at D=2, D²=4). Fixed via `_canonical_split_corner` → the fused `(chi…, d2…)` layout.

## Tests (`tests/test_split_ctm_2site_symmetric.py`)
- Nontrivial-charge sector-preservation smoke (RED→GREEN gate for per-sector truncation).
- Trivial-U(1) symmetric == dense energy parity, D∈{2,3}, χ∈{4,8}.
- `test_2site_symmetric_forward_converges_d3` (RED→GREEN gate for the collapse fix).
- Honestly-scoped symmetric AD test (see below).

## Symmetric AD — scoped + follow-up #687
The symmetric **forward** is correct, but the block-sparse SVD **backward** lacks the dense path's Lorentzian regularization, so symmetric `implicit==explicit` AD floors at rel~1.3e-2 (dense: 1e-6) — and it floors even on a non-degenerate XXZ Δ=0.3 spectrum, so it's a real block-sparse VJP accuracy issue, not just missing regularization (**#687**; FD is not the arbiter — the split energy_fn has a documented Wirtinger gap the dense path shares). The Task-3 test gates what symmetric AD robustly delivers: tight energy parity with dense, finite/non-collapse gradient, direction agreement (cos>0.999 implicit-vs-explicit, cos>0.99 sym-vs-dense). Machine-exact symmetric AD is deferred to #687; the `_svd_split_edge_tensor` TODO points there.

## Verification (all green)
symmetric file 6/6 · dense 2-site forward 26 · single-site symmetric 49 · dense 2-site AD (Phase-2 regression) 9. Symmetric-file tests are `algorithm`-marked; the AD parity test is additionally `slow`.

## Notes
- Latent (not fixed here): the block-sparse `tensor_svd`/`qr`/`eigh` native-axis-order assumption in `linalg.py` (6 sites) — worked around at the caller; worth its own issue.

Design/plan: `docs/superpowers/{specs,plans}/2026-07-04-2site-split-ctm-symmetric*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)