### PR TITLE
feat(#463): fermionic 2-site split-CTM forward (Phase 4)

### DIFF
--- a/src/tenax/algorithms/_split_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_convergence.py
@@ -214,6 +214,171 @@ _SPLIT_DIRECTION_MOVES = {
 
 
 # ------------------------------------------------------------------ #
+# Fermionic (graded) routing — #463 Phase 4                            #
+# ------------------------------------------------------------------ #
+#
+# The split 2×2 grow/projector kernels build double-layer corners and edges
+# from graded ``A.bar()`` alone; they do NOT carry the order-dependent Koszul
+# signs that the *fused* 2-site path applies via its ``*_2plaq_fused`` variants
+# (gated by ``_env_is_fermionic``).  A raw fermionic split sweep therefore
+# diverges from the proven fused sweep — the corner GROW alone is already wrong
+# (#641).  Until a bounded (χ²·D⁴) Koszul-correct split kernel exists, fermionic
+# envs route through the fused sweep on the merged (χ²·D⁶) representation, then
+# the output edges are re-split back into ket/bra halves for storage.  The merge
+# (``_split_env_to_tensor_standard``) is a faithful inverse of the split, so this
+# is exact — see ``test_split_ctm_2site_fermionic``.
+
+
+def _split_env_is_fermionic(env: SplitCTMTensorEnv) -> bool:
+    """True when the split env tensors are graded (fermionic) SymmetricTensors."""
+    from tenax.core.tensor import SymmetricTensor
+
+    C1 = env.C1
+    return isinstance(C1, SymmetricTensor) and C1.indices[0].symmetry.is_fermionic
+
+
+# Per-edge spec to re-split a fused ``CTMTensorEnv`` edge into ket/bra halves.
+# Inverse of ``_split_env_to_tensor_standard._merge_edge``: the fused D² leg is
+# split back into its two parents (``d_ket``/``d_bra``), then an SVD over the
+# interlayer bond re-creates the ket ``(chi, D, chi_I)`` and bra ``(chi_I, D,
+# chi)`` halves with the standard split labels.
+_RESPLIT_SPEC = {
+    "T1": dict(
+        d2="u2",
+        left=("t1_l", "u_ket"),
+        right=("u_bra", "t1_r"),
+        ket_relabels={"t1_l": "t1k_l", "_svd_bond": "t1k_I"},
+        bra_relabels={"_svd_bond": "t1b_I", "t1_r": "t1b_r"},
+    ),
+    "T2": dict(
+        d2="r2",
+        left=("t2_u", "r_ket"),
+        right=("r_bra", "t2_d"),
+        ket_relabels={"t2_u": "t2k_u", "_svd_bond": "t2k_I"},
+        bra_relabels={"_svd_bond": "t2b_I", "t2_d": "t2b_d"},
+    ),
+    "T3": dict(
+        d2="d2",
+        left=("t3_r", "d_ket"),
+        right=("d_bra", "t3_l"),
+        ket_relabels={"t3_r": "t3k_r", "_svd_bond": "t3k_I"},
+        bra_relabels={"_svd_bond": "t3b_I", "t3_l": "t3b_l"},
+    ),
+    "T4": dict(
+        d2="l2",
+        left=("t4_d", "l_ket"),
+        right=("l_bra", "t4_u"),
+        ket_relabels={"t4_d": "t4k_d", "_svd_bond": "t4k_I"},
+        bra_relabels={"_svd_bond": "t4b_I", "t4_u": "t4b_u"},
+    ),
+}
+
+
+def _tensor_env_to_split_standard(
+    env, site_tensor: Tensor, chi_I: int
+) -> SplitCTMTensorEnv:
+    """Convert a fused ``CTMTensorEnv`` back to a ``SplitCTMTensorEnv``.
+
+    Inverse of ``_split_env_to_tensor_standard``: corners pass through
+    unchanged; each edge's fused D² leg is split into its two parents and an
+    SVD over the interlayer bond re-creates the ket/bra halves (truncated to
+    *chi_I*).
+
+    The fused edges produced by the fused CTM sweep carry no ``fuse_info`` on
+    their D² leg (it was built by projector application, not ``fuse_indices``),
+    so ``split_index`` cannot act on them directly.  Because the D² index
+    depends only on the site tensor (not the env), we transplant the
+    ``fuse_info``-bearing D² index from a freshly-initialised reference env of
+    the same site (sectors/multiplicities/flow are identical), then split.
+    """
+    from tenax.algorithms._split_ctm_tensor_energy import (
+        _split_env_to_tensor_standard,
+    )
+    from tenax.algorithms._split_ctm_tensor_moves import (
+        _split_base_charges,
+        _svd_split_edge_tensor,
+    )
+    from tenax.algorithms._tensor_utils import split_index
+    from tenax.core.tensor import SymmetricTensor
+
+    chi = env.C1.indices[0].dim
+    ref = _split_env_to_tensor_standard(
+        initialize_split_ctm_tensor_env(site_tensor, chi, chi_I)
+    )
+    base_charges = _split_base_charges(site_tensor)
+
+    halves = {}
+    for name, spec in _RESPLIT_SPEC.items():
+        edge = getattr(env, name)
+        ref_edge = getattr(ref, name)
+        d2 = spec["d2"]
+        ax = edge.labels().index(d2)
+        ref_d2 = ref_edge.indices[ref_edge.labels().index(d2)]
+        # Transplant the fuse_info-bearing D² index (shares block data).
+        new_indices = list(edge._indices)
+        new_indices[ax] = ref_d2.relabel(d2)
+        edge = SymmetricTensor._raw(
+            indices=tuple(new_indices),
+            data=edge._data,
+            block_keys=edge._block_keys,
+            block_shapes=edge._block_shapes,
+            block_offsets=edge._block_offsets,
+        )
+        edge = split_index(edge, ax)
+        halves[name] = _svd_split_edge_tensor(
+            edge,
+            left_labels=list(spec["left"]),
+            right_labels=list(spec["right"]),
+            chi_I=chi_I,
+            ket_relabels=spec["ket_relabels"],
+            bra_relabels=spec["bra_relabels"],
+            base_charges=base_charges,
+        )
+
+    return SplitCTMTensorEnv(
+        C1=env.C1,
+        C2=env.C2,
+        C3=env.C3,
+        C4=env.C4,
+        T1_ket=halves["T1"][0],
+        T1_bra=halves["T1"][1],
+        T2_ket=halves["T2"][0],
+        T2_bra=halves["T2"][1],
+        T3_ket=halves["T3"][0],
+        T3_bra=halves["T3"][1],
+        T4_ket=halves["T4"][0],
+        T4_bra=halves["T4"][1],
+    )
+
+
+def _split_ctm_sweep_multisite_2x2_via_fused(
+    envs: dict[Coord, SplitCTMTensorEnv],
+    site_tensors: dict[Coord, Tensor],
+    neighbors: dict[Coord, dict[str, Coord]],
+    chi: int,
+    chi_I: int,
+) -> dict[Coord, SplitCTMTensorEnv]:
+    """One fermionic 2×2 split sweep via ``merge → fused sweep → resplit``."""
+    from tenax.algorithms._ctm_tensor_convergence import (
+        _ctm_tensor_sweep_multisite,
+    )
+    from tenax.algorithms._ctm_tensor_init import _build_double_layer_tensor
+    from tenax.algorithms._split_ctm_tensor_energy import (
+        _split_env_to_tensor_standard,
+    )
+
+    fused_envs = {c: _split_env_to_tensor_standard(e) for c, e in envs.items()}
+    double_layers = {c: _build_double_layer_tensor(A) for c, A in site_tensors.items()}
+    new_fused, _eps, _sS = _ctm_tensor_sweep_multisite(
+        fused_envs, double_layers, neighbors, chi, True, recipe="2x2"
+    )
+    return {
+        c: _tensor_env_to_split_standard(fe, site_tensors[c], chi_I)
+        for c, fe in new_fused.items()
+    }
+
+
+# ------------------------------------------------------------------ #
 # Multisite sweep + driver                                             #
 # ------------------------------------------------------------------ #
 
@@ -234,7 +399,16 @@ def _split_ctm_sweep_multisite_2x2(
     Phase 2 absorbs the neighbour column/row into each ``s_dst`` and replaces
     the destination env's corner + ket/bra edge fields.  Neighbour/anchor
     lookups and the cascade order mirror the fused sweep exactly.
+
+    Fermionic (graded) envs take the ``merge → fused sweep → resplit`` route
+    (see ``_split_ctm_sweep_multisite_2x2_via_fused``), since the split
+    double-layer kernels below do not yet carry the order-dependent Koszul
+    signs (#463 Phase 4 / #641).
     """
+    if _split_env_is_fermionic(next(iter(envs.values()))):
+        return _split_ctm_sweep_multisite_2x2_via_fused(
+            envs, site_tensors, neighbors, chi, chi_I
+        )
     # Function-local import: _split_ctm_tensor_moves imports from this module,
     # so importing the absorb helpers at module scope would form a cycle.
     from tenax.algorithms._split_ctm_tensor_moves import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,9 @@ _FILE_MARKERS = {
     # tests run in the algorithm bucket; the AD parity tests in this file carry
     # their own explicit @pytest.mark.slow so they stay out of -m "not slow".
     "test_split_ctm_2site_symmetric.py": "algorithm",
+    # 2-site split-CTM fermionic (#463 Phase 4): block-sparse forward parity vs
+    # the fused sweep; algorithm bucket like its symmetric/split siblings.
+    "test_split_ctm_2site_fermionic.py": "algorithm",
     # Dense 2-site split-CTM AD (#463 Phase 2): each parity test converges a
     # coupled fixed point + a full AD gradient (~5 min); slow-only so they stay
     # out of the -m core CI gate and the -m "not slow" bucket.

--- a/tests/test_split_ctm_2site_fermionic.py
+++ b/tests/test_split_ctm_2site_fermionic.py
@@ -1,0 +1,211 @@
+"""Fermionic (graded) 2-site split-CTM forward parity — #463 Phase 4.
+
+The split 2×2 absorb kernels build double-layer corners / edges via graded
+``A.bar()`` alone; they do NOT carry the order-dependent Koszul signs that the
+*fused* 2-site path applies (the ``*_2plaq_fused`` variants gated by
+``_env_is_fermionic``).  As a result, a raw fermionic split sweep diverges from
+the proven fused sweep — the corner GROW alone is already wrong (not just the
+edge).  See the module docstring of ``_split_ctm_tensor_moves`` and #641.
+
+Phase 4 routes fermionic envs through the fused sweep on merged envs, then
+re-splits the output edges back to ket/bra halves (``merge → fused → resplit``).
+
+These tests pin that behaviour:
+
+* ``test_fermionic_split_sweep_matches_fused`` — one split sweep, merged to the
+  fused representation, must equal one fused sweep from the *same* shared env, to
+  machine precision, for every corner and edge.  Convergence- and
+  init-independent: the fused sweep is the trusted oracle (validated vs JW-ED in
+  #674), so per-sweep parity ⟹ (by induction) converged-env parity ⟹ correct
+  energy.
+* ``test_fermionic_edge_resplit_roundtrip`` — the load-bearing new primitive: a
+  fused edge, re-split into ket/bra halves and merged back, reproduces itself.
+"""
+
+from __future__ import annotations
+
+import jax
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+FermionParity = pytest.importorskip("tenax.core.symmetry").FermionParity
+
+from tenax.algorithms._ctm_tensor_convergence import (
+    CHECKERBOARD_NEIGHBORS as NB,
+)
+from tenax.algorithms._ctm_tensor_convergence import (
+    _ctm_tensor_sweep_multisite,
+)
+from tenax.algorithms._ctm_tensor_init import _build_double_layer_tensor
+from tenax.algorithms._split_ctm_tensor_convergence import (
+    _initialize_split_multisite_env,
+    _split_ctm_sweep_multisite_2x2,
+)
+from tenax.algorithms._split_ctm_tensor_energy import _split_env_to_tensor_standard
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.tensor import SymmetricTensor
+
+
+def _make_fp_site(D=2, seed=0):
+    """Uniform-compatible FermionParity iPEPS site (``A.l`` charges == ``A.r``)."""
+    sym = FermionParity()
+    ch = np.array(([0, 1] * D)[:D], dtype=np.int32)
+    phys = np.array([0, 1], dtype=np.int32)
+
+    def idx(c, flow, label):
+        return TensorIndex.from_charges(sym, c, flow, label=label)
+
+    return SymmetricTensor.random_normal(
+        (
+            idx(ch, FlowDirection.OUT, "u"),
+            idx(ch, FlowDirection.IN, "d"),
+            idx(ch, FlowDirection.OUT, "l"),
+            idx(ch, FlowDirection.IN, "r"),
+            idx(phys, FlowDirection.IN, "phys"),
+        ),
+        jax.random.PRNGKey(seed),
+    )
+
+
+def _one_minus_fidelity(x, y):
+    """1 − scale/phase-invariant overlap fidelity, aligning axes by label."""
+    lx = list(x.labels())
+    ly = list(y.labels())
+    assert sorted(lx) == sorted(ly), f"label sets differ:\n {lx}\n {ly}"
+    perm = tuple(lx.index(lbl) for lbl in ly)
+    ax = np.asarray(x.transpose(perm).todense()).ravel()
+    ay = np.asarray(y.todense()).ravel()
+    nx = np.linalg.norm(ax)
+    ny = np.linalg.norm(ay)
+    assert nx > 0 and ny > 0
+    return 1.0 - abs(np.vdot(ax, ay)) / (nx * ny)
+
+
+def _build_shared_fermionic_envs(chi, n_warmup=4):
+    """A generic (non-trivial) fermionic split env + its fused merge.
+
+    Uniform A=B checkerboard: enough to exercise the graded corner/edge grows
+    while keeping the block-sparse forward cheap.
+    """
+    from tenax.algorithms._split_ctm_tensor_convergence import (
+        _split_ctm_sweep_multisite,
+    )
+
+    A = _make_fp_site(seed=11)
+    site_tensors = {(0, 0): A, (1, 0): A}
+    bars = {c: T.bar() for c, T in site_tensors.items()}
+    split_envs = _initialize_split_multisite_env(site_tensors, chi, chi)
+    for _ in range(n_warmup):
+        split_envs = _split_ctm_sweep_multisite(
+            split_envs, site_tensors, bars, NB, chi, chi, True, "2x2"
+        )
+    fused_envs = {c: _split_env_to_tensor_standard(e) for c, e in split_envs.items()}
+    return site_tensors, bars, split_envs, fused_envs
+
+
+def test_fermionic_split_sweep_matches_fused():
+    """One fermionic split 2×2 sweep == one fused sweep on the same shared env."""
+    chi = 6
+    site_tensors, bars, split_envs, fused_envs = _build_shared_fermionic_envs(chi)
+
+    # One fused sweep (the trusted oracle).
+    dls = {c: _build_double_layer_tensor(A) for c, A in site_tensors.items()}
+    fused_new, _eps, _sS = _ctm_tensor_sweep_multisite(
+        fused_envs, dls, NB, chi, True, recipe="2x2"
+    )
+
+    # One split sweep (fermionic path); lossless interlayer bond.
+    split_new = _split_ctm_sweep_multisite_2x2(
+        split_envs, site_tensors, bars, NB, chi, 4 * chi
+    )
+
+    for c in site_tensors:
+        merged = _split_env_to_tensor_standard(split_new[c])
+        ref = fused_new[c]
+        for field in ("C1", "C2", "C3", "C4", "T1", "T2", "T3", "T4"):
+            got = getattr(merged, field)
+            exp = getattr(ref, field)
+            assert _one_minus_fidelity(got, exp) < 1e-10, (
+                f"cell {c} {field}: 1-F={_one_minus_fidelity(got, exp):.3e}"
+            )
+
+
+def test_fermionic_ctm_split_2site_public_path():
+    """End-to-end: ``ctm_split_tensor_2site`` runs for a fermionic pair and its
+    energy is finite/real.
+
+    Guards the public wiring for fermionic envs — the convergence loop, the
+    fermionic dispatch inside ``_split_ctm_sweep_multisite_2x2``, the post-sweep
+    ``_renormalize_split_env``, and the split energy path (which merges to
+    fused).  Rigorous per-move correctness is covered by
+    ``test_fermionic_split_sweep_matches_fused``; here we only assert the entry
+    point produces a valid graded environment and a sane energy.
+    """
+    import jax.numpy as jnp
+
+    from tenax.algorithms._split_ctm_tensor_convergence import ctm_split_tensor_2site
+    from tenax.algorithms._split_ctm_tensor_energy import (
+        compute_energy_split_ctm_tensor_2site,
+    )
+    from tenax.algorithms.fermionic_ipeps import FPEPSConfig, spinless_fermion_gate
+
+    A = _make_fp_site(seed=1)
+    B = _make_fp_site(seed=2)
+    chi = 6
+    gate = spinless_fermion_gate(FPEPSConfig(D=2, t=1.0, V=0.5))
+
+    env_A, env_B = ctm_split_tensor_2site(A, B, chi, max_iter=6, conv_tol=0.0)
+
+    # Graded environment preserved (fermionic SymmetricTensors, all fields set).
+    for env in (env_A, env_B):
+        assert _split_env_is_fermionic_ok(env)
+
+    E = compute_energy_split_ctm_tensor_2site(A, B, env_A, env_B, gate, d=2)
+    assert jnp.isfinite(E)
+    assert abs(float(jnp.imag(E))) < 1e-8
+
+
+def _split_env_is_fermionic_ok(env) -> bool:
+    from tenax.algorithms._split_ctm_tensor_convergence import (
+        _split_env_is_fermionic,
+    )
+
+    fields = (
+        env.C1,
+        env.C2,
+        env.C3,
+        env.C4,
+        env.T1_ket,
+        env.T1_bra,
+        env.T2_ket,
+        env.T2_bra,
+        env.T3_ket,
+        env.T3_bra,
+        env.T4_ket,
+        env.T4_bra,
+    )
+    return _split_env_is_fermionic(env) and all(f is not None for f in fields)
+
+
+def test_fermionic_edge_resplit_roundtrip():
+    """Fused edge → re-split into ket/bra halves → merge back == original."""
+    from tenax.algorithms._split_ctm_tensor_convergence import (
+        _tensor_env_to_split_standard,
+    )
+
+    chi = 6
+    site_tensors, _bars, split_envs, fused_envs = _build_shared_fermionic_envs(chi)
+    A = site_tensors[(0, 0)]
+    fused = fused_envs[(0, 0)]
+
+    resplit = _tensor_env_to_split_standard(fused, A, chi_I=4 * chi)
+    remerged = _split_env_to_tensor_standard(resplit)
+
+    for field in ("T1", "T2", "T3", "T4"):
+        got = getattr(remerged, field)
+        exp = getattr(fused, field)
+        assert _one_minus_fidelity(got, exp) < 1e-12, (
+            f"{field}: 1-F={_one_minus_fidelity(got, exp):.3e}"
+        )


### PR DESCRIPTION
## Summary

Phase 4 of #463: make the joint 2-site split-CTM forward correct for **fermionic (graded)** `SymmetricTensor` iPEPS.

The split 2×2 grow/projector kernels build double-layer corners and edges from graded `A.bar()` alone; they do **not** carry the order-dependent Koszul signs that the fused 2-site path applies via its `*_2plaq_fused` variants (gated by `_env_is_fermionic`). A raw fermionic split sweep therefore diverges from the proven fused sweep.

**Root cause (found by decomposition, not assumption):** the corner *grow* alone is already wrong (`C1` fidelity gap ~0.055–0.47), not just the edge's second projection as the Phase-4 handoff hypothesised. Multiple coupled Koszul sites → we route fermionic envs through the proven fused kernel rather than patching each sign.

## Approach — `merge → fused sweep → resplit`

- `_split_ctm_sweep_multisite_2x2` early-returns to `_split_ctm_sweep_multisite_2x2_via_fused` for graded envs: merges each split env to fused (`_split_env_to_tensor_standard`), runs the proven fused `_ctm_tensor_sweep_multisite`, then re-splits the output edges.
- New `_tensor_env_to_split_standard` inverts the merge. Fused-sweep edges carry no `fuse_info` on the D² leg (built by projector application, not `fuse_indices`), so the `fuse_info`-bearing D² index is transplanted from a fresh reference env of the same site before `split_index` + interlayer SVD.
- Dense / bosonic-symmetric paths are **untouched** (early return is fermionic-only). The split energy path already merges to fused, so it is correct once the forward env is. Convergence is corner-SV based, so no dependency on a fermionic split energy path.

This keeps fermionic at χ²·D⁶ (the documented Phase 2-4 state); bounded χ²·D⁴ fermionic split kernels remain future work.

## Tests (`tests/test_split_ctm_2site_fermionic.py`, algorithm bucket)

- `test_fermionic_split_sweep_matches_fused` — one fermionic split sweep, merged, equals one fused sweep on a shared env for all corners/edges (< 1e-10). The fused sweep is ED-validated (#674), so per-sweep parity ⟹ converged-env parity ⟹ energy parity.
- `test_fermionic_edge_resplit_roundtrip` — converter round-trips (< 1e-12; measured 1e-16).
- `test_fermionic_ctm_split_2site_public_path` — public entry point runs, finite/real t-V energy.

**No regressions:** dense+symmetric split-2site parity (31 passed) and existing fermionic/symmetric split tests (24 passed).

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.