### PR TITLE
fix(linalg): route GPU SVD through QR algorithm to avoid cuSOLVER gesvdj NaN (jaxlib≥0.10.2)

### DIFF
--- a/src/tenax/algorithms/_ad_primitives.py
+++ b/src/tenax/algorithms/_ad_primitives.py
@@ -27,6 +27,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from tenax.linalg import _dense_svd
+
 
 class CTMRGGradientError(RuntimeError):
     """Raised when the CTM adjoint system is non-contractive (rho(J^T) >= 1)."""
@@ -120,7 +122,7 @@ def truncated_svd_ad(
     Returns:
         ``(U, s, Vh)`` truncated to *chi*.
     """
-    U, s_full, Vh = jnp.linalg.svd(M, full_matrices=False)
+    U, s_full, Vh = _dense_svd(M, full_matrices=False)
     k = min(chi, s_full.shape[0])
     s_trunc = s_full[:k]
     s_trunc = _zero_subrank_singular_values(s_trunc, s_full, k)
@@ -135,7 +137,7 @@ def _truncated_svd_ad_fwd(
     chi: int,
 ) -> tuple[tuple[jax.Array, jax.Array, jax.Array], tuple]:
     """Forward pass — store full SVD for backward."""
-    U_full, s_full, Vh_full = jnp.linalg.svd(M, full_matrices=False)
+    U_full, s_full, Vh_full = _dense_svd(M, full_matrices=False)
     U_full, s_full, Vh_full = _fix_svd_signs(U_full, s_full, Vh_full)
     k = min(chi, s_full.shape[0])
     s_trunc = s_full[:k]
@@ -286,7 +288,7 @@ def truncated_svd_ad_vh_only(
     Uses the same Lorentzian-regularized backward as ``truncated_svd_ad``
     but with ``dU=0``, saving memory by not storing U in residuals.
     """
-    U, s_full, Vh = jnp.linalg.svd(M, full_matrices=False)
+    U, s_full, Vh = _dense_svd(M, full_matrices=False)
     k = min(chi, s_full.shape[0])
     s_trunc = s_full[:k]
     s_trunc = _zero_subrank_singular_values(s_trunc, s_full, k)
@@ -297,7 +299,7 @@ def truncated_svd_ad_vh_only(
 
 def _truncated_svd_ad_vh_only_fwd(M, chi):
     """Forward pass — store full SVD for backward but return only (s, Vh)."""
-    U_full, s_full, Vh_full = jnp.linalg.svd(M, full_matrices=False)
+    U_full, s_full, Vh_full = _dense_svd(M, full_matrices=False)
     U_full, s_full, Vh_full = _fix_svd_signs(U_full, s_full, Vh_full)
     k = min(chi, s_full.shape[0])
     s_trunc = s_full[:k]
@@ -337,12 +339,12 @@ def regularized_svd(M: jax.Array) -> tuple[jax.Array, jax.Array, jax.Array]:
 
     Returns a plain ``(U, s, Vh)`` tuple (not ``SVDResult``).
     """
-    result = jnp.linalg.svd(M, full_matrices=False)
+    result = _dense_svd(M, full_matrices=False)
     return _fix_svd_signs(result.U, result.S, result.Vh)
 
 
 def _regularized_svd_fwd(M):
-    result = jnp.linalg.svd(M, full_matrices=False)
+    result = _dense_svd(M, full_matrices=False)
     U, s, Vh = _fix_svd_signs(result.U, result.S, result.Vh)
     return (U, s, Vh), (U, s, Vh)
 

--- a/src/tenax/algorithms/_ctm_compiled_moves.py
+++ b/src/tenax/algorithms/_ctm_compiled_moves.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import jax.numpy as jnp
 
 from tenax.algorithms.ad_utils import _fix_svd_signs, truncated_svd_ad
+from tenax.linalg import _dense_svd
 
 # ------------------------------------------------------------------ #
 # Helpers                                                              #
@@ -85,7 +86,7 @@ def _svd_projector_raw(
     if has_tracers:
         U_M, S_M, Vh_M = truncated_svd_ad(M, chi)
     else:
-        U_full, S_full, Vh_full = jnp.linalg.svd(M, full_matrices=False)
+        U_full, S_full, Vh_full = _dense_svd(M, full_matrices=False)
         U_full, S_full, Vh_full = _fix_svd_signs(U_full, S_full, Vh_full)
         k = min(chi, S_full.shape[0])
         S_M = S_full[:k]

--- a/src/tenax/algorithms/_ctm_honeycomb_convergence.py
+++ b/src/tenax/algorithms/_ctm_honeycomb_convergence.py
@@ -17,6 +17,7 @@ import jax.numpy as jnp
 
 from tenax.algorithms._ctm_honeycomb_env import HoneycombCTMEnv
 from tenax.algorithms._ctm_honeycomb_topology import Coord
+from tenax.linalg import _dense_svd
 
 __all__ = ["check_honeycomb_convergence"]
 
@@ -56,8 +57,8 @@ def _corner_sv_diff(
         for alpha in (0, 1, 2):
             C_old = getattr(env_old, f"C{alpha}").todense()
             C_new = getattr(env_new, f"C{alpha}").todense()
-            sv_old = jnp.linalg.svd(C_old, compute_uv=False)
-            sv_new = jnp.linalg.svd(C_new, compute_uv=False)
+            sv_old = _dense_svd(C_old, compute_uv=False)
+            sv_new = _dense_svd(C_new, compute_uv=False)
             sv_old = sv_old / (jnp.sum(sv_old) + 1e-15)
             sv_new = sv_new / (jnp.sum(sv_new) + 1e-15)
             diff = float(jnp.max(jnp.abs(sv_new - sv_old)))

--- a/src/tenax/algorithms/_ctm_honeycomb_projector.py
+++ b/src/tenax/algorithms/_ctm_honeycomb_projector.py
@@ -134,6 +134,7 @@ import numpy as np
 
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.tensor import DenseTensor, Tensor
+from tenax.linalg import _dense_svd
 
 __all__ = [
     "compute_honeycomb_corner_biorthogonal_projector",
@@ -320,7 +321,7 @@ def compute_honeycomb_projector(
         # For complex matrices it breaks the SVD identity.  We apply our
         # own per-column gauge fix below, with the inverse ``phase`` going
         # to V (so ``M = U_new S V_new^dagger`` is preserved exactly).
-        U_full, S_full, Vh_full = jnp.linalg.svd(M, full_matrices=False)
+        U_full, S_full, Vh_full = _dense_svd(M, full_matrices=False)
         # SVD truncation is bounded by the matrix rank: min(chi_in*d2, chi_out).
         k = min(chi, S_full.shape[0])
         U_k = U_full[:, :k]
@@ -573,7 +574,7 @@ def compute_honeycomb_corner_biorthogonal_projector(
     # The biorthogonality identity follows from this SVD: U_χ · diag(S) · #
     # V_χ^† == R_U · R_L^T (truncated).                                   #
     # ------------------------------------------------------------------ #
-    U_svd, S, Vh = jnp.linalg.svd(R_U @ R_L.T, full_matrices=False)
+    U_svd, S, Vh = _dense_svd(R_U @ R_L.T, full_matrices=False)
 
     k = int(min(chi, S.shape[0]))
     U_k = U_svd[:, :k]  # (n_qr_U, k)

--- a/src/tenax/algorithms/_ctm_projector.py
+++ b/src/tenax/algorithms/_ctm_projector.py
@@ -46,6 +46,7 @@ import numpy as np
 from tenax.algorithms._ctm_truncation_error import compute_truncation_error
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+from tenax.linalg import _dense_svd
 
 OUT = FlowDirection.OUT
 
@@ -704,7 +705,7 @@ def _svd_projector_symmetric(
         if M_q.size == 0:
             continue
 
-        U_M, S_M, Vh_M = jnp.linalg.svd(M_q, full_matrices=False)
+        U_M, S_M, Vh_M = _dense_svd(M_q, full_matrices=False)
         U_M, S_M, Vh_M = _fix_svd_signs(U_M, S_M, Vh_M)
         V_M = Vh_M.conj().T
 
@@ -987,7 +988,7 @@ def _compute_projector_tensor(
             # (not AD); return placeholder so backward stays clean.
             _eps_T = jnp.asarray(0.0)
         else:
-            U_M_full, S_full, Vh_full = jnp.linalg.svd(M, full_matrices=False)
+            U_M_full, S_full, Vh_full = _dense_svd(M, full_matrices=False)
             k = min(chi, S_full.shape[0])
             from tenax.algorithms._ad_primitives import _fix_svd_signs
 

--- a/src/tenax/algorithms/_ctm_tensor_c4v.py
+++ b/src/tenax/algorithms/_ctm_tensor_c4v.py
@@ -31,6 +31,7 @@ from tenax.algorithms._ctm_tensor_moves import _flip_leg_flow
 from tenax.contraction.contractor import contract
 from tenax.core.index import TensorIndex
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+from tenax.linalg import _dense_svd
 
 
 def _c4v_sweep(
@@ -224,7 +225,7 @@ def ctm_tensor_c4v(
     for _ in range(max_iter):
         C, T = _c4v_sweep(C, T, a, chi, projector_method)
 
-        current_sv = jnp.linalg.svd(C.todense(), compute_uv=False)
+        current_sv = _dense_svd(C.todense(), compute_uv=False)
         if prev_sv is not None:
             diff = _ctm_sv_diff(current_sv, prev_sv)
             if float(diff) < conv_tol:

--- a/src/tenax/algorithms/_ctm_tensor_c4v_reference_ad.py
+++ b/src/tenax/algorithms/_ctm_tensor_c4v_reference_ad.py
@@ -43,6 +43,7 @@ from tenax.algorithms._lorentzian_eigh import (
 )
 from tenax.algorithms.ipeps_config import CTMConfig
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+from tenax.linalg import _dense_svd
 
 __all__ = [
     "_truncated_eigh_lorentzian_backward",
@@ -100,7 +101,7 @@ def _ctm_tensor_c4v_reference_fixed_point_reduced(
     for it in range(int(config.max_iter)):
         C, T = _c4v_sweep(C, T, a, config.chi, config.projector_method)
         iters = it + 1
-        current_sv = jnp.linalg.svd(C.todense(), compute_uv=False)
+        current_sv = _dense_svd(C.todense(), compute_uv=False)
 
         if prev_sv is not None:
             residual = float(_ctm_sv_diff(current_sv, prev_sv))

--- a/src/tenax/algorithms/_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_ctm_tensor_convergence.py
@@ -52,6 +52,7 @@ from tenax.algorithms._ctm_tensor_paired_moves import (
 from tenax.core import EPS
 from tenax.core.lattice import Lattice
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+from tenax.linalg import _dense_svd
 
 # ------------------------------------------------------------------ #
 # Sweep + renormalize                                                  #
@@ -593,7 +594,7 @@ def _corner_singular_values(C):  # noqa: N802
         svs = []
         for key in C._block_keys:
             block = C.blocks[key]
-            s = jnp.linalg.svd(block, compute_uv=False)
+            s = _dense_svd(block, compute_uv=False)
             svs.append(s)
         if svs:
             all_svs = jnp.concatenate(svs)
@@ -601,7 +602,7 @@ def _corner_singular_values(C):  # noqa: N802
         return jnp.zeros(0)
     # DenseTensor or raw array
     data = _tensor_leaf_data(C)
-    return jnp.linalg.svd(data, compute_uv=False)
+    return _dense_svd(data, compute_uv=False)
 
 
 def ctm_tensor(

--- a/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
+++ b/src/tenax/algorithms/_ctm_tensor_projector_2x2.py
@@ -19,6 +19,7 @@ from tenax.contraction.contractor import contract
 from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.symmetry import U1Symmetry
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+from tenax.linalg import _dense_svd
 
 __all__ = ["_build_enlarged_corner", "_compute_2x2_projector"]
 
@@ -41,7 +42,7 @@ def _gauge_fixed_svd(
     mismatch, but it breaks the 2x2 closure ``P_bot @ P_top = I`` which
     has no intervening matrix.
     """
-    U, s, Vh = jnp.linalg.svd(M, full_matrices=False)
+    U, s, Vh = _dense_svd(M, full_matrices=False)
     max_idx = jnp.argmax(jnp.abs(U), axis=0)  # (k,)
     diag = U[max_idx, jnp.arange(U.shape[1])]
     phases = jnp.where(jnp.abs(diag) > 0, diag / jnp.abs(diag), 1.0)

--- a/src/tenax/algorithms/_padded_linalg.py
+++ b/src/tenax/algorithms/_padded_linalg.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 
+from tenax.linalg import _dense_svd
+
 # ------------------------------------------------------------------ #
 # Dense path                                                           #
 # ------------------------------------------------------------------ #
@@ -45,7 +47,7 @@ def padded_svd_dense(
     mat = theta.reshape(m, n)
 
     # Full (thin) SVD -- always returns min(m, n) singular values
-    U_full, s_full, Vh_full = jnp.linalg.svd(mat, full_matrices=False)
+    U_full, s_full, Vh_full = _dense_svd(mat, full_matrices=False)
     # U_full: (m, k), s_full: (k,), Vh_full: (k, n) where k = min(m, n)
     k = s_full.shape[0]
 
@@ -101,7 +103,7 @@ def padded_svd_blocks(
     # vmap SVD over all blocks
     # Each block is (M_max, N_max); SVD produces U (M_max, sv_per_block),
     # s (sv_per_block,), Vh (sv_per_block, N_max).
-    _, s_all, _ = jax.vmap(lambda m: jnp.linalg.svd(m, full_matrices=False))(pba.data)
+    _, s_all, _ = jax.vmap(lambda m: _dense_svd(m, full_matrices=False))(pba.data)
     # s_all: (num_blocks, sv_per_block)
 
     # Mask out padding: singular values from padded rows/cols are spurious.
@@ -183,7 +185,7 @@ def padded_svd_blocks_full(
     sv_per_block = min(M_max, N_max)
 
     # --- 1. vmap SVD over all blocks ---
-    U_all, s_all, Vh_all = jax.vmap(lambda m: jnp.linalg.svd(m, full_matrices=False))(
+    U_all, s_all, Vh_all = jax.vmap(lambda m: _dense_svd(m, full_matrices=False))(
         pba.data
     )
     # U_all:  (num_blocks, M_max, sv_per_block)

--- a/src/tenax/algorithms/ad_utils.py
+++ b/src/tenax/algorithms/ad_utils.py
@@ -59,6 +59,7 @@ from tenax.algorithms._split_ctm_tensor import (
     ctm_split_tensor,
 )
 from tenax.algorithms.ipeps_config import CTMConfig
+from tenax.linalg import _dense_svd
 
 _logger = logging.getLogger(__name__)
 
@@ -1116,7 +1117,7 @@ def _ctm_tensor_multisite_fixed_point(site_tensors, neighbors, config, envs_init
                 prev_env_arrays[c] = env_arrays
         else:
             for c in sorted(envs):
-                sv = jnp.linalg.svd(envs[c].C1.todense(), compute_uv=False)
+                sv = _dense_svd(envs[c].C1.todense(), compute_uv=False)
                 if c in prev_svs:
                     if float(_ctm_sv_diff_local(sv, prev_svs[c])) >= config.conv_tol:
                         converged = False

--- a/src/tenax/algorithms/dmrg3s.py
+++ b/src/tenax/algorithms/dmrg3s.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from tenax.core.index import TensorIndex
 from tenax.core.tensor import SymmetricTensor, Tensor
+from tenax.linalg import _dense_svd
 
 
 def build_expansion_tensor_dense(
@@ -102,7 +103,7 @@ def expand_and_truncate_dense(
         expanded = jnp.concatenate([site, P], axis=-1)
         chi_l, d, chi_exp = expanded.shape
         mat = expanded.reshape(chi_l * d, chi_exp)
-        U, S, Vh = jnp.linalg.svd(mat, full_matrices=False)
+        U, S, Vh = _dense_svd(mat, full_matrices=False)
 
         k = _truncation_bond_dim(S, max_bond_dim, svd_trunc_err)
         A = U[:, :k].reshape(chi_l, d, k)
@@ -123,7 +124,7 @@ def expand_and_truncate_dense(
         expanded = jnp.concatenate([P, site], axis=0)
         chi_exp, d, chi_r = expanded.shape
         mat = expanded.reshape(chi_exp, d * chi_r)
-        U, S, Vh = jnp.linalg.svd(mat, full_matrices=False)
+        U, S, Vh = _dense_svd(mat, full_matrices=False)
 
         k = _truncation_bond_dim(S, max_bond_dim, svd_trunc_err)
         B = Vh[:k, :].reshape(k, d, chi_r)
@@ -205,7 +206,7 @@ def _hybrid_ltr(site, neighbor, P, max_bond_dim, num_extra, hybrid, svd_trunc_er
     M_mat = site.reshape(chi_l * d, chi_r)
 
     # Full SVD of site tensor
-    U, S, Vh = jnp.linalg.svd(M_mat, full_matrices=False)
+    U, S, Vh = _dense_svd(M_mat, full_matrices=False)
 
     # Truncate to χ, compute truncation error
     k = _truncation_bond_dim(S, max_bond_dim, svd_trunc_err)
@@ -235,7 +236,7 @@ def _hybrid_ltr(site, neighbor, P, max_bond_dim, num_extra, hybrid, svd_trunc_er
 
         # Concatenate [M | Q_scaled] and re-SVD to smoothly mix
         expanded = jnp.concatenate([M_mat, Q_scaled], axis=1)
-        U2, S2, Vh2 = jnp.linalg.svd(expanded, full_matrices=False)
+        U2, S2, Vh2 = _dense_svd(expanded, full_matrices=False)
         k2 = _truncation_bond_dim(S2, max_bond_dim, svd_trunc_err)
         A = U2[:, :k2].reshape(chi_l, d, k2)
         remainder = jnp.diag(S2[:k2]) @ Vh2[:k2, :]
@@ -272,7 +273,7 @@ def _hybrid_rtl(site, neighbor, P, max_bond_dim, num_extra, hybrid, svd_trunc_er
     M_mat = site.reshape(chi_l, d * chi_r)
 
     # Full SVD of site tensor
-    U, S, Vh = jnp.linalg.svd(M_mat, full_matrices=False)
+    U, S, Vh = _dense_svd(M_mat, full_matrices=False)
 
     # Truncate, compute truncation error
     k = _truncation_bond_dim(S, max_bond_dim, svd_trunc_err)
@@ -301,7 +302,7 @@ def _hybrid_rtl(site, neighbor, P, max_bond_dim, num_extra, hybrid, svd_trunc_er
 
         # Concatenate [Q_scaled; M] along left bond (rows) and re-SVD
         expanded = jnp.concatenate([Q_scaled, M_mat], axis=0)
-        U2, S2, Vh2 = jnp.linalg.svd(expanded, full_matrices=False)
+        U2, S2, Vh2 = _dense_svd(expanded, full_matrices=False)
         k2 = _truncation_bond_dim(S2, max_bond_dim, svd_trunc_err)
         B = Vh2[:k2, :].reshape(k2, d, chi_r)
         remainder = U2[:, :k2] @ jnp.diag(S2[:k2])

--- a/src/tenax/algorithms/idmrg.py
+++ b/src/tenax/algorithms/idmrg.py
@@ -42,6 +42,7 @@ from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.mps import InfiniteMPS
 from tenax.core.symmetry import U1Symmetry
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+from tenax.linalg import _dense_svd
 
 # Optional Cython BLAS acceleration for hot loops.
 # Respect TENAX_DISABLE_CYTHON_BLAS env var consistently.
@@ -899,7 +900,7 @@ def _idmrg_sweep(
 
         chi_l, d_l, d_r, chi_r = theta_shape
         matrix = theta_opt.reshape(chi_l * d_l, d_r * chi_r)
-        U, s_full, Vt = jnp.linalg.svd(matrix, full_matrices=False)
+        U, s_full, Vt = _dense_svd(matrix, full_matrices=False)
 
         n_keep = min(config.max_bond_dim, len(s_full))
         U = U[:, :n_keep]
@@ -957,7 +958,7 @@ def _idmrg_sweep(
 
     chi_l, d_l, d_r, chi_r = theta_shape
     matrix = theta_opt.reshape(chi_l * d_l, d_r * chi_r)
-    U, s_full, Vt = jnp.linalg.svd(matrix, full_matrices=False)
+    U, s_full, Vt = _dense_svd(matrix, full_matrices=False)
     n_keep = min(config.max_bond_dim, len(s_full))
     U = U[:, :n_keep]
     s_center = s_full[:n_keep]
@@ -1008,7 +1009,7 @@ def _idmrg_sweep(
         # ---- SVD and truncate ----
         chi_l, d_l, d_r, chi_r = theta_shape
         matrix = theta_opt.reshape(chi_l * d_l, d_r * chi_r)
-        U, s_full, Vt = jnp.linalg.svd(matrix, full_matrices=False)
+        U, s_full, Vt = _dense_svd(matrix, full_matrices=False)
 
         n_keep = min(config.max_bond_dim, len(s_full))
         if config.svd_trunc_err is not None:
@@ -1530,7 +1531,7 @@ def _idmrg_1site_sweep(
         # ---- SVD to get A_L and A_R ----
         chi_l, d_l, d_r, chi_r = theta_shape
         matrix = theta_opt.reshape(chi_l * d_l, d_r * chi_r)
-        U, s_full, Vt = jnp.linalg.svd(matrix, full_matrices=False)
+        U, s_full, Vt = _dense_svd(matrix, full_matrices=False)
 
         n_keep = min(config.max_bond_dim, len(s_full))
         if config.svd_trunc_err is not None:
@@ -1568,7 +1569,7 @@ def _idmrg_1site_sweep(
         # new_A_R has s absorbed; extract s_center and right-canonical A_R
         chi_c = A_L.shape[2]
         mat_r = new_A_R.reshape(chi_c, d * chi_r)
-        U_r, s_r, Vt_r = jnp.linalg.svd(mat_r, full_matrices=False)
+        U_r, s_r, Vt_r = _dense_svd(mat_r, full_matrices=False)
         s_norm = jnp.linalg.norm(s_r)
         if s_norm > 1e-15:
             s_center = s_r / s_norm

--- a/src/tenax/algorithms/ipeps_ctm_convergence.py
+++ b/src/tenax/algorithms/ipeps_ctm_convergence.py
@@ -39,6 +39,7 @@ from tenax.algorithms.ipeps_ctm_moves import (
     _split_ctm_move,
 )
 from tenax.core import EPS
+from tenax.linalg import _dense_svd
 
 
 def _ctm_sweep(
@@ -131,7 +132,7 @@ def ctm(
     def body_fn(carry):
         env_i, prev_sv_i, iteration, _ = carry
         env_i = _ctm_sweep(env_i, a, chi, renormalize, projector_method)
-        current_sv = jnp.linalg.svd(env_i.C1, compute_uv=False)
+        current_sv = _dense_svd(env_i.C1, compute_uv=False)
         diff = _ctm_sv_diff(current_sv, prev_sv_i)
         converged = diff < conv_tol
         return (env_i, current_sv, iteration + 1, converged)
@@ -258,8 +259,8 @@ def ctm_2site(
     def body_fn(carry):
         eA, eB, psA, psB, iteration, _ = carry
         eA, eB = _ctm_2site_sweep(eA, eB, a_A, a_B, chi, renormalize)
-        sv_A = jnp.linalg.svd(eA.C1, compute_uv=False)
-        sv_B = jnp.linalg.svd(eB.C1, compute_uv=False)
+        sv_A = _dense_svd(eA.C1, compute_uv=False)
+        sv_B = _dense_svd(eB.C1, compute_uv=False)
         diff_A = _ctm_sv_diff(sv_A, psA)
         diff_B = _ctm_sv_diff(sv_B, psB)
         converged = jnp.maximum(diff_A, diff_B) < conv_tol
@@ -381,7 +382,7 @@ def ctm_split(
     for _ in range(config.max_iter):
         env = _split_ctm_sweep(env, A, chi, chi_I, config.renormalize)
 
-        current_sv = jnp.linalg.svd(env.C1, compute_uv=False)
+        current_sv = _dense_svd(env.C1, compute_uv=False)
         if prev_sv is not None:
             diff = _ctm_sv_diff(current_sv, prev_sv)
             if float(diff) < config.conv_tol:

--- a/src/tenax/algorithms/ipeps_ctm_moves.py
+++ b/src/tenax/algorithms/ipeps_ctm_moves.py
@@ -27,6 +27,7 @@ from tenax.algorithms.ipeps_config import (
     SplitCTMEnvironment,
 )
 from tenax.algorithms.ipeps_ctm_init import _build_double_layer
+from tenax.linalg import _dense_svd
 
 
 def _ctm_move_eigh(
@@ -392,7 +393,7 @@ def _svd_split_edge(
     T_4d = T_full.reshape(chi, D, D, chi)
     T_mat = T_4d.reshape(chi * D, D * chi)
 
-    U, s, Vh = jnp.linalg.svd(T_mat, full_matrices=False)
+    U, s, Vh = _dense_svd(T_mat, full_matrices=False)
     k = min(chi_I, len(s))
     sqrt_s = jnp.sqrt(s[:k])
     T_ket = (U[:, :k] * sqrt_s[None, :]).reshape(chi, D, k)

--- a/src/tenax/algorithms/pess.py
+++ b/src/tenax/algorithms/pess.py
@@ -10,6 +10,7 @@ import numpy as np
 from scipy.linalg import expm
 
 from tenax.algorithms.auto_mpo import spin_half_ops, spin_one_ops
+from tenax.linalg import _dense_svd
 
 D_PHYS_DEFAULT = 3  # spin-1
 
@@ -110,7 +111,7 @@ def hosvd_truncate(
 
     # Site a
     mat_a = theta_reordered.reshape(D_ext_a * d, D_ext_b * d * D_ext_c * d)
-    U_a, _, _ = jnp.linalg.svd(mat_a, full_matrices=False)
+    U_a, _, _ = _dense_svd(mat_a, full_matrices=False)
     D_int_a = min(D_max, U_a.shape[1])
     U_a = U_a[:, :D_int_a]
 
@@ -118,7 +119,7 @@ def hosvd_truncate(
     mat_b = theta_reordered.transpose(2, 3, 0, 1, 4, 5).reshape(
         D_ext_b * d, D_ext_a * d * D_ext_c * d
     )
-    U_b, _, _ = jnp.linalg.svd(mat_b, full_matrices=False)
+    U_b, _, _ = _dense_svd(mat_b, full_matrices=False)
     D_int_b = min(D_max, U_b.shape[1])
     U_b = U_b[:, :D_int_b]
 
@@ -126,7 +127,7 @@ def hosvd_truncate(
     mat_c = theta_reordered.transpose(4, 5, 0, 1, 2, 3).reshape(
         D_ext_c * d, D_ext_a * d * D_ext_b * d
     )
-    U_c, _, _ = jnp.linalg.svd(mat_c, full_matrices=False)
+    U_c, _, _ = _dense_svd(mat_c, full_matrices=False)
     D_int_c = min(D_max, U_c.shape[1])
     U_c = U_c[:, :D_int_c]
 
@@ -140,12 +141,12 @@ def hosvd_truncate(
 
     # Extract per-bond singular value vectors from the core. We only need the
     # singular values, so skip the U/V allocations via compute_uv=False.
-    sig_a = jnp.linalg.svd(core.reshape(D_int_a, D_int_b * D_int_c), compute_uv=False)
-    sig_b = jnp.linalg.svd(
+    sig_a = _dense_svd(core.reshape(D_int_a, D_int_b * D_int_c), compute_uv=False)
+    sig_b = _dense_svd(
         core.transpose(1, 0, 2).reshape(D_int_b, D_int_a * D_int_c),
         compute_uv=False,
     )
-    sig_c = jnp.linalg.svd(
+    sig_c = _dense_svd(
         core.transpose(2, 0, 1).reshape(D_int_c, D_int_a * D_int_b),
         compute_uv=False,
     )

--- a/src/tenax/algorithms/tdvp.py
+++ b/src/tenax/algorithms/tdvp.py
@@ -25,6 +25,7 @@ from tenax.core.index import FlowDirection, TensorIndex
 from tenax.core.mps import FiniteMPS
 from tenax.core.symmetry import U1Symmetry
 from tenax.core.tensor import DenseTensor, Tensor
+from tenax.linalg import _dense_svd
 from tenax.network.network import TensorNetwork
 
 
@@ -709,7 +710,7 @@ def _tdvp_step_2site(
         # SVD truncate
         chi_l_dim, dl, dr, chi_r_dim = theta_shape
         mat = evolved_4d.reshape(chi_l_dim * dl, dr * chi_r_dim)
-        U, s, Vh = jnp.linalg.svd(mat, full_matrices=False)
+        U, s, Vh = _dense_svd(mat, full_matrices=False)
 
         max_bond = config.max_bond_dim
         if config.svd_trunc_err is not None:
@@ -781,7 +782,7 @@ def _tdvp_step_2site(
 
         chi_l_dim, dl, dr, chi_r_dim = theta_shape
         mat = evolved_4d.reshape(chi_l_dim * dl, dr * chi_r_dim)
-        U, s, Vh = jnp.linalg.svd(mat, full_matrices=False)
+        U, s, Vh = _dense_svd(mat, full_matrices=False)
 
         max_bond = config.max_bond_dim
         if config.svd_trunc_err is not None:

--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -19,6 +19,8 @@ from collections.abc import Sequence
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax.lax.linalg import SvdAlgorithm as _SvdAlgorithm
+from jax.lax.linalg import svd as _lax_svd
 
 from tenax._rsvd_core import hmt_rsvd
 from tenax.core.index import FlowDirection, Label, TensorIndex
@@ -31,6 +33,39 @@ from tenax.core.tensor import (
 )
 
 # ---------- Shared helpers ----------
+
+
+def _dense_svd(
+    matrix: jax.Array,
+    full_matrices: bool = False,
+    compute_uv: bool = True,
+):
+    """Dense SVD that avoids the cuSOLVER ``gesvdj`` NaN on GPU.
+
+    Drop-in replacement for ``jnp.linalg.svd(matrix, full_matrices=...,
+    compute_uv=...)`` (returns ``(U, s, Vh)`` when ``compute_uv`` else ``s``).
+
+    On CUDA, jaxlib>=0.10.2 lowers ``jnp.linalg.svd`` to ``cusolver_gesvdj_ffi``
+    (the Jacobi SVD), whose iteration fails to converge (``info != 0`` -> the
+    output is filled with NaN) on ill-conditioned f64 matrices such as the HOTRG
+    HOSVD and CTM environment/projector tensors. The QR-based algorithm
+    (``gesvd``) always converges and matches the CPU/LAPACK result. CPU (LAPACK
+    ``gesdd``) is unaffected and faster, so only the GPU path is switched.
+
+    Ref: cuSOLVER 12.2.2.18 (jaxlib 0.10.1) -> 12.2.6.9 (jaxlib 0.10.2) regressed
+    ``gesvdj`` convergence on ill-conditioned inputs; JAX then NaN-fills the
+    result on ``info != 0`` (jax-ml/jax gesvdj non-convergence issue).
+    """
+    if jax.default_backend() == "gpu":
+        return _lax_svd(
+            matrix,
+            full_matrices=full_matrices,
+            compute_uv=compute_uv,
+            algorithm=_SvdAlgorithm.QR,
+        )
+    return jnp.linalg.svd(
+        matrix, full_matrices=full_matrices, compute_uv=compute_uv
+    )
 
 
 def _has_nonstandard_blocks(tensor: SymmetricTensor) -> bool:
@@ -317,12 +352,10 @@ def _truncated_svd_symmetric(
     if _batch:
         _svd_by_q = _grouped_decomp_by_shape(
             _mats_by_q,
-            lambda M: jnp.linalg.svd(M, full_matrices=False),
+            lambda M: _dense_svd(M),
         )
     else:
-        _svd_by_q = {
-            q: jnp.linalg.svd(M, full_matrices=False) for q, M in _mats_by_q.items()
-        }
+        _svd_by_q = {q: _dense_svd(M) for q, M in _mats_by_q.items()}
 
     for q in _mats_by_q:
         U_q, s_q, Vh_q = _svd_by_q[q]
@@ -1776,7 +1809,7 @@ def svd(
     matrix = dense_perm.reshape(left_dim, right_dim)
 
     # SVD (not JIT-able at this level due to dynamic truncation)
-    U, s, Vh = jnp.linalg.svd(matrix, full_matrices=False)
+    U, s, Vh = _dense_svd(matrix)
 
     # Preserve the full singular-value spectrum before truncation
     s_full = s
@@ -1876,7 +1909,7 @@ def _rsvd_matrix(
         n_power_iter=n_power_iter,
         key=key,
         qr_fn=jnp.linalg.qr,
-        svd_fn=lambda b: jnp.linalg.svd(b, full_matrices=False),
+        svd_fn=lambda b: _dense_svd(b),
     )
 
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -801,3 +801,53 @@ class TestBatchedTracedSvdAD:
         }
         T = SymmetricTensor(blocks, (idx_l, idx_r))
         self._check(T, do_fd=False)
+
+
+# ------------------------------------------------------------------ #
+# Ill-conditioned SVD must not NaN (jaxlib>=0.10.2 GPU gesvdj guard)  #
+# ------------------------------------------------------------------ #
+
+
+def _ill_conditioned_dense(n: int = 128):
+    """A finite, ill-conditioned (cond~1e16) symmetric DenseTensor.
+
+    Singular values decay smoothly 1e0 -> 1e-16. This is the regime of HOTRG /
+    CTM environment tensors that trips the cuSOLVER gesvdj (Jacobi) SVD.
+    """
+    rng = np.random.default_rng(0)
+    Q = np.linalg.qr(rng.standard_normal((n, n)))[0]
+    A = (Q * np.logspace(0, -16, n)) @ Q.T
+    sym = U1Symmetry()
+    ch = np.zeros(n, dtype=np.int32)
+    idx = (
+        TensorIndex.from_charges(sym, ch, IN, label="l"),
+        TensorIndex.from_charges(sym, ch, OUT, label="r"),
+    )
+    return DenseTensor(jnp.asarray(A), idx), A
+
+
+class TestSvdIllConditioned:
+    """Regression guard for the jaxlib>=0.10.2 GPU cuSOLVER ``gesvdj`` (Jacobi)
+    non-convergence NaN: on CUDA the default SVD returns all-NaN U/s/Vh for
+    ill-conditioned f64 matrices. On CPU (LAPACK gesdd) this is a robustness
+    baseline; on GPU it directly catches the NaN-filled decomposition.
+    """
+
+    def test_svd_no_nan_on_ill_conditioned(self):
+        from tenax.linalg import svd
+
+        T, A = _ill_conditioned_dense()
+        U, s, Vh, _ = svd(T, left_labels=["l"], right_labels=["r"])
+        assert not np.isnan(np.asarray(U.todense())).any(), "U has NaN"
+        assert not np.isnan(np.asarray(Vh.todense())).any(), "Vh has NaN"
+        assert not np.isnan(np.asarray(s)).any(), "s has NaN"
+
+    def test_svd_singular_values_match_numpy(self):
+        from tenax.linalg import svd
+
+        T, A = _ill_conditioned_dense()
+        _, s, _, _ = svd(T, left_labels=["l"], right_labels=["r"])
+        s_ref = np.linalg.svd(A, compute_uv=False)
+        k = 16  # top of the spectrum is well-determined
+        got = np.sort(np.asarray(s))[::-1][:k]
+        np.testing.assert_allclose(got, s_ref[:k], rtol=1e-6)


### PR DESCRIPTION
## Problem

On CUDA GPU with `jax_enable_x64`, **jaxlib ≥ 0.10.2 silently returns all-NaN from `jnp.linalg.svd` for ill-conditioned f64 matrices** (cond ≳ 1e15). These matrices arise every coarse-graining step in HOTRG/TRG (HOSVD) and every CTM move in iPEPS (environment & projector SVDs), so **GPU HOTRG, TRG, and CTM-AD produce NaN free energies / gradients on jaxlib 0.10.2** — while jaxlib 0.10.1 and host NumPy are fine.

### Root cause (bisected)
`jnp.linalg.svd` on CUDA lowers to `cusolver_gesvdj_ffi` (the cuSOLVER **Jacobi** SVD). The compiled HLO — including JAX's `select(info==0, result, NaN)` non-convergence guard — is byte-identical between 0.10.1 and 0.10.2. The only difference is the bundled cuSOLVER: **12.2.2.18 → 12.2.6.9**, whose `gesvdj` fails to converge (`info != 0`) on ill-conditioned inputs where the older one converged, so the guard NaN-fills the otherwise-usable decomposition. (Upstream report drafted for jax-ml/jax; workaround here is self-sufficient.)

## Fix

A shared `tenax.linalg._dense_svd()` helper routes SVD through the **QR-based algorithm** (`lax.linalg.svd(algorithm=SvdAlgorithm.QR)` == `gesvd`, which always converges) **on GPU**, and keeps `jnp.linalg.svd` (`gesdd`, faster) on **CPU** (LAPACK is unaffected). All 47 dense `jnp.linalg.svd` call sites across `linalg.py` and the algorithm modules route through it. Behavior is byte-identical on CPU; strictly more robust on GPU.

## Verification

**A100 / jaxlib 0.10.2 (the broken config), with this change:**

| Path | before | after |
|------|--------|-------|
| HOTRG Ising β=0.44 χ=32 | NaN | 0.928084 ✓ |
| HOTRG q=3 Potts β_c χ=32 | NaN | 2.068584235 ✓ (= 0.10.1 value) |
| CTM-AD `optimize_gs_ad` svd/vjp | NaN | −0.536478 ✓ |
| CTM-AD svd/gmres | NaN | −0.536518 ✓ |
| DMRG L=8 | −3.374933 | −3.374933 (unaffected) |

- New regression test (`tests/test_linalg.py::TestSvdIllConditioned`): SVDs an ill-conditioned (cond ~1e16) matrix through `tenax.linalg.svd`, asserts no NaN + spectrum matches NumPy. Red→green on GPU; baseline on CPU.
- Complex128 SVD via QR verified on GPU (recon 1.5e-14).
- `ruff check` clean; no import cycle.
- Full CPU suite (`pytest -m "not slow"`): **2456 passed**, same 5 pre-existing failures with **and** without this change (verified against clean `origin/main`) — zero regressions.

> 🤖 **AI-generated PR** — investigated and written by Claude Code, posted by @yingjerkao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)