### PR TITLE
fix: address Codex review on #686/#691 (GPU regularized_svd unpack + Potts β=0 zero-mode)

### DIFF
--- a/src/tenax/algorithms/_ad_primitives.py
+++ b/src/tenax/algorithms/_ad_primitives.py
@@ -339,13 +339,13 @@ def regularized_svd(M: jax.Array) -> tuple[jax.Array, jax.Array, jax.Array]:
 
     Returns a plain ``(U, s, Vh)`` tuple (not ``SVDResult``).
     """
-    result = _dense_svd(M, full_matrices=False)
-    return _fix_svd_signs(result.U, result.S, result.Vh)
+    U0, s0, Vh0 = _dense_svd(M, full_matrices=False)
+    return _fix_svd_signs(U0, s0, Vh0)
 
 
 def _regularized_svd_fwd(M):
-    result = _dense_svd(M, full_matrices=False)
-    U, s, Vh = _fix_svd_signs(result.U, result.S, result.Vh)
+    U0, s0, Vh0 = _dense_svd(M, full_matrices=False)
+    U, s, Vh = _fix_svd_signs(U0, s0, Vh0)
     return (U, s, Vh), (U, s, Vh)
 
 

--- a/src/tenax/algorithms/trg.py
+++ b/src/tenax/algorithms/trg.py
@@ -287,10 +287,12 @@ def compute_potts_tensor(
     # Q[a, b] = exp(beta*J) on the diagonal, 1 off-diagonal.
     Q = jnp.asarray(np.ones((q, q)) + (np.exp(beta * J) - 1.0) * np.eye(q))
 
-    # Matrix square root of Q (NOT element-wise). Q is symmetric
-    # positive-definite for beta*J > 0, so sqrtQ @ sqrtQ = Q.
+    # Matrix square root of Q (NOT element-wise). Q is symmetric positive-
+    # definite for beta*J > 0 and only positive *semi*-definite at the
+    # beta*J -> 0 (infinite-temperature) limit, where eigh returns tiny negative
+    # zero-mode eigenvalues; clip to >= 0 so sqrt stays finite (else all-NaN).
     evals, evecs = jnp.linalg.eigh(Q)
-    sqrtQ = evecs @ jnp.diag(jnp.sqrt(evals)) @ evecs.T
+    sqrtQ = evecs @ jnp.diag(jnp.sqrt(jnp.clip(evals, 0.0, None))) @ evecs.T
 
     # T_{udlr} = sum_s sqrtQ[u,s] sqrtQ[d,s] sqrtQ[l,s] sqrtQ[r,s]
     T = jnp.einsum("us,ds,ls,rs->udlr", sqrtQ, sqrtQ, sqrtQ, sqrtQ)

--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -43,7 +43,11 @@ def _dense_svd(
     """Dense SVD that avoids the cuSOLVER ``gesvdj`` NaN on GPU.
 
     Drop-in replacement for ``jnp.linalg.svd(matrix, full_matrices=...,
-    compute_uv=...)`` (returns ``(U, s, Vh)`` when ``compute_uv`` else ``s``).
+    compute_uv=...)``. Always returns a plain ``(U, s, Vh)`` tuple when
+    ``compute_uv`` (else ``s``) on *both* backends: ``jnp.linalg.svd`` returns an
+    ``SVDResult`` namedtuple but ``jax.lax.linalg.svd`` returns a bare tuple, so
+    we normalise to a bare tuple to keep the two paths interchangeable (callers
+    must unpack, not use ``.U/.S/.Vh``).
 
     On CUDA, jaxlib>=0.10.2 lowers ``jnp.linalg.svd`` to ``cusolver_gesvdj_ffi``
     (the Jacobi SVD), whose iteration fails to converge (``info != 0`` -> the
@@ -57,15 +61,20 @@ def _dense_svd(
     result on ``info != 0`` (jax-ml/jax gesvdj non-convergence issue).
     """
     if jax.default_backend() == "gpu":
-        return _lax_svd(
+        result = _lax_svd(
             matrix,
             full_matrices=full_matrices,
             compute_uv=compute_uv,
             algorithm=_SvdAlgorithm.QR,
         )
-    return jnp.linalg.svd(
-        matrix, full_matrices=full_matrices, compute_uv=compute_uv
-    )
+    else:
+        result = jnp.linalg.svd(
+            matrix, full_matrices=full_matrices, compute_uv=compute_uv
+        )
+    if compute_uv:
+        u, s, vh = result  # SVDResult (CPU) or tuple (GPU) -> bare tuple
+        return u, s, vh
+    return result
 
 
 def _has_nonstandard_blocks(tensor: SymmetricTensor) -> bool:

--- a/tests/test_trg.py
+++ b/tests/test_trg.py
@@ -626,6 +626,19 @@ class TestComputePottsTensor:
         permuted = arr[np.ix_(perm, perm, perm, perm)]
         assert np.allclose(arr, permuted, atol=1e-12)
 
+    def test_infinite_temperature_limit_is_finite(self):
+        """At beta*J -> 0, Q is only positive *semi*-definite (a single nonzero
+        uniform mode). eigh returns tiny negative zero-modes, so the matrix
+        square root must clip them to avoid an all-NaN tensor.
+        """
+        for beta in (0.0, 1e-13):
+            arr = np.asarray(compute_potts_tensor(beta=beta, q=3).todense())
+            assert np.isfinite(arr).all(), f"non-finite Potts tensor at beta={beta}"
+        # at beta=0 the tensor is the uniform rank-1 mode: every entry ~ 1/3
+        # (sum_s (1/sqrt(q))^4 = q / q^2 = 1/q).
+        arr0 = np.asarray(compute_potts_tensor(beta=0.0, q=3).todense())
+        assert np.allclose(arr0, 1.0 / 3.0, atol=1e-6)
+
 
 class TestPottsCriticalBeta:
     """The self-dual critical point beta_c = ln(1 + sqrt(q)) / J."""


### PR DESCRIPTION
Addresses the two automated (Codex) review findings on the just-merged #691 and #686.

## P1 (from #691) — GPU `regularized_svd` `AttributeError`
`_dense_svd`'s GPU branch returns `jax.lax.linalg.svd`'s **bare `(U, s, Vh)` tuple**, whereas `jnp.linalg.svd` returns an `SVDResult` **namedtuple**. `regularized_svd` / `_regularized_svd_fwd` accessed `result.U/.S/.Vh`, so on **GPU** (the reduced-corner QR/SVD projector AD path, `gs_projector_method="qr"`) they raised `AttributeError` — i.e. #691 fixed the gesvdj NaN but broke a different GPU path.

**Fix:** normalise `_dense_svd` to always return a bare tuple on both backends (it already documented "returns `(U, s, Vh)`"), and unpack at the two call sites instead of attribute access. Because the return is now a bare tuple on CPU too, the existing `test_regularized_svd.py` tests exercise the exact path GPU hits — so CI now guards this (verified: those tests go red before the unpack fix, green after).

## P2 (from #686) — `compute_potts_tensor(0.0)` all-NaN
At `beta*J → 0` the weight matrix `Q = ones(q, q)` is only positive **semi**-definite; `eigh` returns tiny **negative** zero-modes (e.g. `-4.5e-16`), so `jnp.sqrt` produced an all-NaN tensor at the valid infinite-temperature point (and for very small `beta*J`).

**Fix:** clip eigenvalues to `>= 0` before the matrix square root. New test `test_infinite_temperature_limit_is_finite` (β=0 and 1e-13 finite; β=0 tensor → uniform 1/q mode).

## Verification (CPU)
- `regularized_svd` forward/gradient/degeneracy tests: red→green (74 passed in the ad/regularized-svd suite).
- Potts: 13 passed incl. the new β=0 test; SVD ill-conditioned regression from #691 still green.
- `ruff check` clean. The `_dense_svd` normalisation is a no-op for the 45 unpacking call sites; only the 2 attribute-access sites changed (grep-confirmed exhaustive).

> 🤖 **AI-generated PR** — investigated and written by Claude Code, posted by @yingjerkao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)