### PR TITLE
fix(#463): address Codex review on split-CTM PRs #684/#685/#690

### DIFF
--- a/src/tenax/__init__.py
+++ b/src/tenax/__init__.py
@@ -129,6 +129,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
         "compute_energy_split_ctm_tensor_multisite",
     ),
     "ctm_split_tensor": ("tenax.algorithms._split_ctm_tensor", "ctm_split_tensor"),
+    "ctm_split_tensor_2site": (
+        "tenax.algorithms._split_ctm_tensor",
+        "ctm_split_tensor_2site",
+    ),
     # _tensor_utils
     "fuse_indices": ("tenax.algorithms._tensor_utils", "fuse_indices"),
     "split_index": ("tenax.algorithms._tensor_utils", "split_index"),
@@ -503,6 +507,7 @@ __all__ = [
     # Split CTM (Tensor protocol)
     "SplitCTMTensorEnv",
     "ctm_split_tensor",
+    "ctm_split_tensor_2site",
     "compute_energy_split_ctm_tensor",
     "compute_energy_split_ctm_tensor_2site",
     "compute_energy_split_ctm_tensor_multisite",

--- a/src/tenax/algorithms/_split_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_convergence.py
@@ -357,8 +357,14 @@ def _split_ctm_sweep_multisite_2x2_via_fused(
     neighbors: dict[Coord, dict[str, Coord]],
     chi: int,
     chi_I: int,
+    renormalize: bool = True,
 ) -> dict[Coord, SplitCTMTensorEnv]:
-    """One fermionic 2×2 split sweep via ``merge → fused sweep → resplit``."""
+    """One fermionic 2×2 split sweep via ``merge → fused sweep → resplit``.
+
+    ``renormalize`` is honored on the merged (fused) representation so a caller
+    disabling per-sweep normalization gets the same raw fixed-point map as the
+    dense/bosonic split path — it is *not* hard-coded on (#690).
+    """
     from tenax.algorithms._ctm_tensor_convergence import (
         _ctm_tensor_sweep_multisite,
     )
@@ -370,7 +376,7 @@ def _split_ctm_sweep_multisite_2x2_via_fused(
     fused_envs = {c: _split_env_to_tensor_standard(e) for c, e in envs.items()}
     double_layers = {c: _build_double_layer_tensor(A) for c, A in site_tensors.items()}
     new_fused, _eps, _sS = _ctm_tensor_sweep_multisite(
-        fused_envs, double_layers, neighbors, chi, True, recipe="2x2"
+        fused_envs, double_layers, neighbors, chi, renormalize, recipe="2x2"
     )
     return {
         c: _tensor_env_to_split_standard(fe, site_tensors[c], chi_I)
@@ -390,6 +396,7 @@ def _split_ctm_sweep_multisite_2x2(
     neighbors: dict[Coord, dict[str, Coord]],
     chi: int,
     chi_I: int,
+    renormalize: bool = True,
 ) -> dict[Coord, SplitCTMTensorEnv]:
     """One 2x2-recipe split sweep — twin of the fused 2x2 branch of
     :func:`_ctm_tensor_sweep_multisite`.
@@ -404,10 +411,15 @@ def _split_ctm_sweep_multisite_2x2(
     (see ``_split_ctm_sweep_multisite_2x2_via_fused``), since the split
     double-layer kernels below do not yet carry the order-dependent Koszul
     signs (#463 Phase 4 / #641).
+
+    ``renormalize`` is forwarded to the fermionic fused route so its internal
+    normalization matches the caller's flag (#690).  The bosonic branch does not
+    normalize here; :func:`_split_ctm_sweep_multisite` applies the post-sweep
+    ``renormalize`` for it.
     """
     if _split_env_is_fermionic(next(iter(envs.values()))):
         return _split_ctm_sweep_multisite_2x2_via_fused(
-            envs, site_tensors, neighbors, chi, chi_I
+            envs, site_tensors, neighbors, chi, chi_I, renormalize=renormalize
         )
     # Function-local import: _split_ctm_tensor_moves imports from this module,
     # so importing the absorb helpers at module scope would form a cycle.
@@ -566,7 +578,7 @@ def _split_ctm_sweep_multisite(
                 )
     elif recipe == "2x2":
         envs = _split_ctm_sweep_multisite_2x2(
-            envs, site_tensors, bars, neighbors, chi, chi_I
+            envs, site_tensors, bars, neighbors, chi, chi_I, renormalize=renormalize
         )
     else:
         raise ValueError(

--- a/src/tenax/algorithms/ipeps_ad_policy.py
+++ b/src/tenax/algorithms/ipeps_ad_policy.py
@@ -272,6 +272,29 @@ def make_ctm_energy_fn(
         """
         validate_split_ctm_config(ctm_cfg, recipe)
         if len(site_tensors) == 2:
+            # The 2-site split forward is the genuine joint 2×2 plaquette CTM
+            # (#463 Phase 2); every 2-site split AD call hard-codes
+            # ``recipe="2x2"`` downstream.  ``recipe="1x1"`` is only wired for
+            # the single-site split path, so accept-then-silently-run-2x2 would
+            # mislabel the experiment — reject it instead of threading a recipe
+            # the 2-site kernels do not implement.
+            if recipe != "2x2":
+                raise NotImplementedError(
+                    "The 2-site split-CTM AD path only supports gs_recipe='2x2'; "
+                    f"got recipe={recipe!r}. Use unit_cell='1x1' for the '1x1' "
+                    "(single-site) split recipe."
+                )
+            # TBPTT (#506): the single-site split and fused explicit paths honor
+            # ``gs_explicit_ad_backward_steps``, but ``ctm_energy_split_explicit_2site``
+            # does not thread it (and swallows unknown kwargs), so forwarding it
+            # would silently backprop through every step and defeat the memory
+            # cap.  Reject rather than ignore until the 2-site path implements it.
+            if use_explicit and explicit_backward_steps is not None:
+                raise NotImplementedError(
+                    "Truncated backprop (gs_explicit_ad_backward_steps / TBPTT) "
+                    "is not wired into the 2-site split explicit-AD path; unset "
+                    "it, or use the single-site split / fused explicit path."
+                )
             if use_explicit:
                 return ctm_energy_split_explicit_2site(
                     site_tensors,

--- a/tests/test_split_ctm_2site.py
+++ b/tests/test_split_ctm_2site.py
@@ -433,6 +433,24 @@ def test_split_2x2_sweep_runs_and_preserves_uniform():
     assert np.all(np.isfinite(C1)) and np.max(np.abs(C1)) > 0
 
 
+def test_ctm_split_tensor_2site_is_publicly_exported():
+    """``ctm_split_tensor_2site`` is importable from the top-level ``tenax``.
+
+    Its energy sibling ``compute_energy_split_ctm_tensor_2site`` is already a
+    public export; a user who obtains the coupled 2-site split environment via
+    ``ctm_split_tensor_2site`` must be able to import it the same way rather than
+    reach into the private ``_split_ctm_tensor`` shim (#684).
+    """
+    import tenax
+    from tenax.algorithms._split_ctm_tensor_convergence import (
+        ctm_split_tensor_2site as _canonical,
+    )
+
+    assert "ctm_split_tensor_2site" in tenax.__all__
+    assert hasattr(tenax, "ctm_split_tensor_2site")
+    assert tenax.ctm_split_tensor_2site is _canonical
+
+
 def test_ctm_split_tensor_2site_returns_two_envs():
     from tenax.algorithms._split_ctm_tensor_convergence import ctm_split_tensor_2site
 

--- a/tests/test_split_ctm_2site_fermionic.py
+++ b/tests/test_split_ctm_2site_fermionic.py
@@ -209,3 +209,67 @@ def test_fermionic_edge_resplit_roundtrip():
         assert _one_minus_fidelity(got, exp) < 1e-12, (
             f"{field}: 1-F={_one_minus_fidelity(got, exp):.3e}"
         )
+
+
+def _rel_corner_gap(merged_env, ref_env):
+    """Max relative-norm gap over the four corners (scale-SENSITIVE).
+
+    Corners are not resplit in the split representation, so the merge-back
+    preserves their absolute scale exactly — unlike edges, whose SVD resplit is
+    only scale/direction-faithful (see ``test_fermionic_edge_resplit_roundtrip``,
+    which checks fidelity, not magnitude).  Corners are therefore the honest
+    probe of whether the fused env was normalized.
+    """
+    worst = 0.0
+    for field in ("C1", "C2", "C3", "C4"):
+        got_t, exp_t = getattr(merged_env, field), getattr(ref_env, field)
+        perm = tuple(list(got_t.labels()).index(lbl) for lbl in exp_t.labels())
+        got = np.asarray(got_t.transpose(perm).todense()).ravel()
+        exp = np.asarray(exp_t.todense()).ravel()
+        worst = max(worst, np.linalg.norm(got - exp) / np.linalg.norm(exp))
+    return worst
+
+
+def test_fermionic_split_sweep_honors_renormalize_false():
+    """The fermionic ``merge → fused → resplit`` sweep honors ``renormalize=False``.
+
+    Regression for the hard-coded ``renormalize=True`` in the fused routing
+    (#690): a caller passing ``renormalize=False`` must get the *raw* fixed-point
+    map — identical to a raw (``renormalize=False``) fused sweep on the merged
+    environment — not a fused env that was silently normalized before resplit.
+
+    Scale-sensitive on purpose: the bug leaves *direction* unchanged (the fused
+    sweep runs either way) and only rescales, so the fidelity-based parity test
+    above cannot see it.  We key on the corners, whose absolute scale survives
+    the resplit round-trip exactly, and additionally assert the flag genuinely
+    toggles behaviour (``renormalize=True`` does *not* reproduce the raw oracle).
+    """
+    chi = 6
+    site_tensors, bars, split_envs, fused_envs = _build_shared_fermionic_envs(chi)
+
+    # Oracle: one RAW (renormalize=False) fused sweep on the merged env.
+    dls = {c: _build_double_layer_tensor(A) for c, A in site_tensors.items()}
+    fused_raw, _eps, _sS = _ctm_tensor_sweep_multisite(
+        fused_envs, dls, NB, chi, False, recipe="2x2"
+    )
+
+    # renormalize=False must reproduce the raw fused sweep (scale included).
+    split_raw = _split_ctm_sweep_multisite_2x2(
+        split_envs, site_tensors, bars, NB, chi, 4 * chi, renormalize=False
+    )
+    # renormalize=True must NOT — proving the flag is actually consulted.
+    split_norm = _split_ctm_sweep_multisite_2x2(
+        split_envs, site_tensors, bars, NB, chi, 4 * chi, renormalize=True
+    )
+
+    for c in site_tensors:
+        gap_raw = _rel_corner_gap(_split_env_to_tensor_standard(split_raw[c]), fused_raw[c])
+        gap_norm = _rel_corner_gap(_split_env_to_tensor_standard(split_norm[c]), fused_raw[c])
+        assert gap_raw < 1e-9, (
+            f"cell {c}: renormalize=False corner gap {gap_raw:.3e} vs the raw "
+            "fused oracle (fused env was normalized despite the flag)"
+        )
+        assert gap_norm > 1e-3, (
+            f"cell {c}: renormalize=True corner gap {gap_norm:.3e} — the "
+            "renormalize flag has no effect on the fused routing"
+        )

--- a/tests/test_split_ctm_fuse_flag.py
+++ b/tests/test_split_ctm_fuse_flag.py
@@ -338,6 +338,66 @@ def test_make_ctm_energy_fn_split_rejects_unsupported_recipe():
         fn({(0, 0): A})
 
 
+def test_make_ctm_energy_fn_2site_split_rejects_1x1_recipe():
+    """The 2-site split AD branch rejects ``gs_recipe='1x1'`` instead of
+    silently running the 2×2 plaquette CTM (#685/#463).
+
+    Config validation permits ``recipe='1x1'`` (it is legal for the single-site
+    split path), but every 2-site split AD call hard-codes ``recipe='2x2'``
+    downstream.  Rather than mislabel such a run, the 2-site branch must reject
+    the unsupported recipe up front.
+    """
+    from tenax.algorithms.ipeps_ad_policy import make_ctm_energy_fn
+
+    A = _make_site(2, 2, seed=0)
+    gate = _heisenberg_gate()
+    cfg = CTMConfig(chi=4, fuse_virtual_legs=False)
+
+    fn = make_ctm_energy_fn(
+        neighbors=SINGLE_SITE_NEIGHBORS,
+        gate=gate,
+        get_ctm_cfg=lambda: cfg,
+        env_cache={},
+        use_explicit=False,
+        explicit_warmup=2,
+        explicit_steps=3,
+        recipe="1x1",
+    )
+    with pytest.raises(NotImplementedError, match="2-site split.*recipe"):
+        fn({(0, 0): A, (1, 0): A})
+
+
+def test_make_ctm_energy_fn_2site_split_explicit_rejects_tbptt():
+    """The 2-site split *explicit* AD branch rejects the TBPTT cap instead of
+    silently backpropagating through every step (#685/#506).
+
+    The single-site split and fused explicit paths forward
+    ``explicit_backward_steps`` (``gs_explicit_ad_backward_steps``); the 2-site
+    split explicit path dropped it, so ``ctm_energy_split_explicit_2site``
+    (which swallows unknown kwargs) would differentiate all steps and defeat the
+    requested memory cap.  It must reject the setting rather than ignore it.
+    """
+    from tenax.algorithms.ipeps_ad_policy import make_ctm_energy_fn
+
+    A = _make_site(2, 2, seed=0)
+    gate = _heisenberg_gate()
+    cfg = CTMConfig(chi=4, fuse_virtual_legs=False)
+
+    fn = make_ctm_energy_fn(
+        neighbors=SINGLE_SITE_NEIGHBORS,
+        gate=gate,
+        get_ctm_cfg=lambda: cfg,
+        env_cache={},
+        use_explicit=True,
+        explicit_warmup=2,
+        explicit_steps=4,
+        explicit_backward_steps=2,
+        recipe="2x2",
+    )
+    with pytest.raises(NotImplementedError, match="TBPTT"):
+        fn({(0, 0): A, (1, 0): A})
+
+
 def test_split_implicit_raises_for_multisite():
     """ctm_energy_split_implicit raises NotImplementedError for >1 site."""
     from tenax.algorithms._split_ctm_energy_ad import ctm_energy_split_implicit


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Addresses four **verified P2** Codex review findings on the merged #463 split-CTM phase PRs. Each was a documented knob silently ignored (no crashes); all fixed with TDD (red→green), `ruff` clean.

| Finding | Fix |
|---|---|
| **#684** — `ctm_split_tensor_2site` in the split-CTM shim `__all__` but not top-level `tenax` (its energy sibling is) → `from tenax import ctm_split_tensor_2site` raised | Add to `__init__.py` lazy-import table + `__all__`. |
| **#685a** — 2-site split AD accepted `gs_recipe='1x1'` then silently ran the hard-coded 2×2 CTM | Reject `recipe != '2x2'` in the 2-site split branch (`NotImplementedError`). |
| **#685b** — 2-site split *explicit* AD dropped `gs_explicit_ad_backward_steps` (TBPTT); callee swallows unknown kwargs → backprops through all steps, defeating the memory cap | Reject the TBPTT cap on the 2-site split explicit path (single-site/fused already honor-or-reject it). |
| **#690** — fermionic `merge→fused→resplit` sweep hard-coded `renormalize=True`, so `renormalize=False` still normalized the fused env before resplit | Thread the caller's `renormalize` through `_split_ctm_sweep_multisite_2x2` → `_via_fused` → `_ctm_tensor_sweep_multisite`. |

### Tests
- `test_split_ctm_fuse_flag.py` (**core**): 2-site split rejects `recipe='1x1'` and rejects TBPTT.
- `test_split_ctm_2site.py`: `ctm_split_tensor_2site` is publicly exported and identity-equal to the canonical symbol.
- `test_split_ctm_2site_fermionic.py`: scale-sensitive **corner-oracle** regression for #690 — `renormalize=False` reproduces a raw fused sweep on the corners (whose absolute scale survives the resplit round-trip, unlike edges, which are only fidelity-faithful), and `renormalize=True` provably does not.

All new + adjacent existing split-CTM tests pass locally (CPU). Fermionic/2-site tests run in the `algorithm` bucket, so I've added the `run-full-tests` label.