### PR TITLE
test(#692): fix flaky test_random_complex_ipeps_converges_to_physical_fp

### DIFF
--- a/tests/test_ctm_convergence_random_iPEPS.py
+++ b/tests/test_ctm_convergence_random_iPEPS.py
@@ -5,14 +5,20 @@ fixed point (corner SVs ~ [0.68, 0.68, 0.20, 0.20]) where variPEPS
 converges to the physical [0.95, 0.22, 0.19, 0.13] in ~10 iters.
 
 The post-fix SVs are ``[0.937, 0.302, 0.143, 0.102]`` (non-degenerate,
-hierarchical) — close to the variPEPS reference. At seed 0 the loop
-converges to ``sv_diff ≈ 9e-4`` in ~13 iterations under
-``conv_tol=1e-3``. The 1e-3 tolerance (vs the design-doc 1e-5) is
-chosen because a residual oscillation noted in
-``project_ctm_two_init_bugs_found.md`` is a separate downstream issue
-not in scope for bug 3a; the smoking-gun goal here is to *distinguish*
-the physical fp from the pre-fix paired-degenerate plateau
-(``sv_diff ~ 5e-2``), which 1e-3 does cleanly.
+hierarchical) — close to the variPEPS reference. At seed 0 the physical
+fixed point is reached in ~12 iterations, but its corner-SV metric has a
+residual oscillation floor (``sv_diff ~ 2.4e-3``) rather than driving
+cleanly to zero — a separate downstream issue noted in
+``project_ctm_two_init_bugs_found.md`` (#425), not in scope for bug 3a.
+
+The smoking-gun goal here is only to *distinguish* the physical fp from
+the pre-fix paired-degenerate plateau (``sv_diff ~ 5e-2``). The test
+therefore asserts the physical SV structure directly, plus a loose metric
+band (``sv_diff < 1e-2``) that separates the two robustly
+(``2.4e-3 << 1e-2 << 5e-2``). It deliberately does NOT assert
+``info.converged`` under a tight 1e-3 gate: the oscillation floor sits
+right at that gate and can fall either side across BLAS/XLA builds, which
+made the strict assertion flake in CI (issue #692).
 
 See ``project_ctm_two_init_bugs_found.md`` and
 ``docs/plans/2026-05-11-ctm-bug-3a-design.md``.
@@ -68,11 +74,20 @@ def test_random_complex_ipeps_converges_to_physical_fp():
         projector_method="svd",
     )
 
-    # Convergence reached. (1e-3 distinguishes physical fp from the
-    # paired-degenerate fp, which plateaus at sv_diff ~ 5e-2.)
-    assert info.converged, (
-        f"CTM did not converge in 50 iters at tol=1e-3; "
-        f"sv_diff={info.sv_diff}, iterations={info.iterations}"
+    # The physical fixed point is *reached* (see the SV assertions below), but
+    # its corner-SV metric has a residual oscillation floor (~2.4e-3 here) that
+    # is numerics/platform-sensitive and can sit either side of a tight 1e-3
+    # gate — so ``info.converged`` is NOT a robust assertion (it flakes across
+    # BLAS/XLA builds; see issue #692). The test's actual smoking-gun goal is to
+    # distinguish the physical fp from the pre-fix paired-degenerate plateau,
+    # whose metric floors ~5e-2. A loose band (``sv_diff < 1e-2``) separates the
+    # two robustly (2.4e-3 << 1e-2 << 5e-2) without depending on the oscillation
+    # dipping below 1e-3. The residual oscillation itself is a known limitation
+    # (project_ctm_two_init_bugs_found.md / #425), out of scope here.
+    assert info.sv_diff < 1e-2, (
+        f"corner-SV metric {info.sv_diff} did not drop below the 1e-2 band "
+        f"separating the physical fp from the paired-degenerate plateau "
+        f"(~5e-2); iterations={info.iterations}"
     )
 
     # Inspect leading C1 corner SVs.


### PR DESCRIPTION
## Summary

Fixes the flaky `test_random_complex_ipeps_converges_to_physical_fp` (one of the CI failures tracked in #692).

The test is **fully deterministic** (`numpy.RandomState(0)`, no JAX RNG) yet flaked across CI runs. Root cause (triaged locally):

- It asserted `info.converged` under a tight `conv_tol=1e-3`.
- The physical CTM fixed point for this seed has a **residual corner-SV oscillation floor (~2.4e-3)** that sits right at the 1e-3 gate and lands either side of it across BLAS/XLA builds. The plateau detector then bails at `converged=False` (stably, at iter 12 — verified at `max_iter` 50/100/200).
- **The fixed point is correctly reached:** final SVs `[0.9347, 0.3063, 0.1445, 0.1082]` ≈ the variPEPS reference `[0.937, 0.302, 0.143, 0.102]`. Both physical-SV assertions pass; only `info.converged` flaked.

The residual oscillation is a **known limitation** (`project_ctm_two_init_bugs_found.md` / #425), out of scope for this smoking-gun test — whose documented goal is only to *distinguish* the physical fp from the pre-fix paired-degenerate plateau (`sv_diff ~5e-2`).

## Change

- Replace the brittle `assert info.converged` with a loose metric band `assert info.sv_diff < 1e-2`, which separates physical (~2.4e-3) from paired-degenerate (~5e-2) robustly across platforms (`2.4e-3 << 1e-2 << 5e-2`).
- Keep the two physical-SV assertions unchanged (they are the real regression guard).
- Update the module docstring to reflect the actual behaviour (oscillation floor, not `9e-4` convergence).

This is a **test-assertion fix, not a code change** — the CTM converges to the correct physics; the assertion was mis-specified relative to the test's own stated intent.

## Verification

Previously `converged=False, sv_diff=2.38e-3` → **FAILED** locally; now **passes** (`1 passed in 7.75s`).

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.
