### PR TITLE
fix(#463): 2-site split TBPTT guard rejects only real truncation (#694 review)

### DIFF
--- a/src/tenax/algorithms/ipeps_ad_policy.py
+++ b/src/tenax/algorithms/ipeps_ad_policy.py
@@ -284,16 +284,25 @@ def make_ctm_energy_fn(
                     f"got recipe={recipe!r}. Use unit_cell='1x1' for the '1x1' "
                     "(single-site) split recipe."
                 )
-            # TBPTT (#506): the single-site split and fused explicit paths honor
-            # ``gs_explicit_ad_backward_steps``, but ``ctm_energy_split_explicit_2site``
-            # does not thread it (and swallows unknown kwargs), so forwarding it
-            # would silently backprop through every step and defeat the memory
-            # cap.  Reject rather than ignore until the 2-site path implements it.
-            if use_explicit and explicit_backward_steps is not None:
+            # TBPTT (#506): the 2-site split explicit path always backprops
+            # through every step (``ctm_energy_split_explicit_2site`` does not
+            # thread ``backward_steps`` and swallows unknown kwargs).  Full
+            # backward — ``K is None`` or ``K == explicit_steps`` — is therefore
+            # already correct and must be allowed; only genuine truncation
+            # (``K < explicit_steps``) would be silently ignored and defeat the
+            # memory cap, so reject only that until the 2-site path implements
+            # truncation.
+            if (
+                use_explicit
+                and explicit_backward_steps is not None
+                and explicit_backward_steps < explicit_steps
+            ):
                 raise NotImplementedError(
-                    "Truncated backprop (gs_explicit_ad_backward_steps / TBPTT) "
-                    "is not wired into the 2-site split explicit-AD path; unset "
-                    "it, or use the single-site split / fused explicit path."
+                    "Truncated backprop (gs_explicit_ad_backward_steps < "
+                    "gs_explicit_ad_steps / TBPTT) is not wired into the 2-site "
+                    "split explicit-AD path; set gs_explicit_ad_backward_steps to "
+                    "None or gs_explicit_ad_steps (full backward), or use the "
+                    "single-site split / fused explicit path."
                 )
             if use_explicit:
                 return ctm_energy_split_explicit_2site(

--- a/tests/test_split_ctm_fuse_flag.py
+++ b/tests/test_split_ctm_fuse_flag.py
@@ -398,6 +398,46 @@ def test_make_ctm_energy_fn_2site_split_explicit_rejects_tbptt():
         fn({(0, 0): A, (1, 0): A})
 
 
+def test_make_ctm_energy_fn_2site_split_explicit_allows_full_backward():
+    """``explicit_backward_steps == explicit_steps`` is full backward, not TBPTT.
+
+    ``gs_explicit_ad_backward_steps`` is validated in ``1..gs_explicit_ad_steps``;
+    the maximum ``K == steps`` differentiates every sweep (leading
+    ``steps - K == 0`` under ``stop_gradient``) — identical to the ``None``
+    default, which the 2-site split explicit path already does.  The TBPTT guard
+    must reject only genuine truncation (``K < steps``), not this valid
+    full-backward setting (#694 follow-up: Codex over-rejection).
+    """
+    import jax.numpy as jnp
+
+    from tenax.algorithms._ctm_tensor_convergence import CHECKERBOARD_NEIGHBORS
+    from tenax.algorithms.ipeps_ad_policy import make_ctm_energy_fn
+
+    D = 2
+    chi = D * D  # lossless interlayer bond
+    A = _make_site(D, 2, seed=1)
+    B = _make_site(D, 2, seed=2)
+    gate = _heisenberg_gate()
+    cfg = CTMConfig(chi=chi, chi_I=chi, fuse_virtual_legs=False)
+
+    steps = 2
+    fn = make_ctm_energy_fn(
+        neighbors=CHECKERBOARD_NEIGHBORS,
+        gate=gate,
+        get_ctm_cfg=lambda: cfg,
+        env_cache={},
+        use_explicit=True,
+        explicit_warmup=2,
+        explicit_steps=steps,
+        explicit_backward_steps=steps,  # == steps → full backward (valid)
+        recipe="2x2",
+    )
+    # Must NOT raise the TBPTT guard; runs the full-backward 2-site path.
+    e = fn({(0, 0): A, (1, 0): B})
+    assert jnp.isfinite(jnp.real(e))
+    assert abs(float(jnp.imag(e))) < 1e-8
+
+
 def test_split_implicit_raises_for_multisite():
     """ctm_energy_split_implicit raises NotImplementedError for >1 site."""
     from tenax.algorithms._split_ctm_energy_ad import ctm_energy_split_implicit


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Follow-up on a **Codex P2** review comment on the (merged) #694 — a correction to the #685b guard I added there.

### The over-rejection
The #685b guard rejected **any** non-`None` `gs_explicit_ad_backward_steps` on the 2-site split explicit path. But `gs_explicit_ad_backward_steps` is validated in `1..gs_explicit_ad_steps` (`iPEPSConfig.__post_init__`), and `K == gs_explicit_ad_steps` means **full backward** — the leading `steps − K == 0` sweeps are stopped, so every step is differentiated, identical to the `None` default. The 2-site split explicit path already backprops through every step (`ctm_energy_split_explicit_2site` swallows unknown kwargs and never truncates), so that configuration was already correct — yet the guard raised `NotImplementedError`.

### Fix
Reject only **genuine truncation** (`K < explicit_steps`); allow `K is None` and `K == explicit_steps`. (`K > explicit_steps` can't occur — config caps it.)

```python
if (use_explicit
        and explicit_backward_steps is not None
        and explicit_backward_steps < explicit_steps):
    raise NotImplementedError(...)
```

### Tests (`test_split_ctm_fuse_flag.py`, core)
- **New**: `K == explicit_steps` (full backward) is allowed and runs the 2-site explicit path to a finite energy — red before the fix (raised the TBPTT guard), green after.
- Unchanged: `K < explicit_steps` still rejected; `recipe='1x1'` still rejected.

`ruff` clean. Adds the `run-full-tests` label (2-site tests span the algorithm bucket).