### PR TITLE
test(#692): broaden checkerboard CTM plateau xfail guard

### DIFF
--- a/tests/test_ctm_python_loop.py
+++ b/tests/test_ctm_python_loop.py
@@ -138,15 +138,17 @@ class TestPythonLoopCtmConverge:
             conv_tol=1e-8,
         )
         # Known limitation (Issues #425/#426): same CTM-iter plateau as
-        # test_python_loop_converges, on the 2-site CHECKERBOARD path. Bails
-        # at iter ~12 with sv_diff~0.004 under plateau_patience=20. Narrow to
-        # that signature (codex P2 on PR #444): any other non-convergence
-        # outcome surfaces as a real failure.
-        if (
-            not info.converged
-            and 1e-5 < float(info.sv_diff) < 0.5
-            and info.iterations < max_iter
-        ):
+        # test_python_loop_converges, on the 2-site CHECKERBOARD path. The
+        # random-init fixed point oscillates without converging; depending on
+        # BLAS/XLA numerics it either trips the plateau_patience=20 early-bail
+        # (~iter 12, sv_diff~0.004) OR keeps oscillating for the full max_iter
+        # (sv_diff~0.017). Both are the same non-convergence, so the guard keys
+        # only on the *healthy-oscillation* signature (bounded sv_diff), not the
+        # iteration count — the earlier `iterations < max_iter` clause was
+        # platform-sensitive and hard-failed the full-run case in CI (#692).
+        # A genuinely broken CTM (diverging/NaN sv_diff, or a spurious
+        # zero-diff non-convergence) still falls outside the band and fails.
+        if not info.converged and 1e-5 < float(info.sv_diff) < 0.5:
             pytest.xfail(
                 f"CTM plateau on random init (#425/#426, 2-site checkerboard): "
                 f"converged={info.converged}, sv_diff={float(info.sv_diff):.3e}, "


### PR DESCRIPTION
## Summary

Fixes `test_python_loop_2site_checkerboard_converges` (second CI failure triaged in #692).

The test already `xfail`s the known random-init CTM plateau (#425/#426), but its guard required `info.iterations < max_iter`, so it only caught the case where the `plateau_patience=20` detector **early-bails** (~iter 12). Depending on BLAS/XLA numerics, the oscillating fixed point instead runs the **full `max_iter=50`** (`sv_diff≈0.017`, healthy oscillation) — which fell through the guard to `assert info.converged` and **hard-failed**. The author's machine early-bailed (< 50) → xfailed; CI ran full → failed.

Both outcomes are the *same* non-convergence limitation.

## Change

Drop the platform-sensitive `iterations < max_iter` clause; key the guard only on the healthy-oscillation signature:

```python
if not info.converged and 1e-5 < float(info.sv_diff) < 0.5:
    pytest.xfail(...)
```

A genuinely broken CTM (diverging / NaN `sv_diff`, or spurious zero-diff non-convergence) still falls outside the band and fails; a real convergence still runs the energy assertions.

## Verification

Was `FAILED` (`converged=False, iterations=50, sv_diff=1.74e-2`); now **xfails cleanly** (`1 xfailed`).

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.
