### PR TITLE
test(#692): xfail U(1)-Sz prototype guards on #700 env-collapse regression

### DIFF
--- a/tests/test_u1sz_defrag_prototype_610.py
+++ b/tests/test_u1sz_defrag_prototype_610.py
@@ -1,4 +1,5 @@
 """Faithfulness guard for the #610 C-lever prototype (Stage 2 prereq)."""
+
 import importlib.util
 import pathlib
 
@@ -12,6 +13,17 @@ from tenax.algorithms._ctm_tensor import ctm_tensor
 from tenax.algorithms.ipeps import heisenberg_gate_u1sz, heisenberg_u1sz_init_pair
 
 
+@pytest.mark.xfail(
+    reason=(
+        "#700: PR #671 sorted-tail chi-leg tiling collapses the U(1)-Sz "
+        "single-site CTM env to exact-zero (E=0) at D=3 chi=12 (bisected "
+        "regression, healthy env before 07e60c5 gave E=-0.0617). The energy "
+        "here is 0.0 because the underlying `ctm_tensor` returns a zero "
+        "environment, NOT because of this throwaway #610 prototype (baseline "
+        "`ctm_tensor` collapses identically). Flips green once #700 is fixed."
+    ),
+    strict=False,
+)
 def test_prototype_ctm_converges_and_energy_is_sane():
     jax.config.update("jax_enable_x64", True)
     A, _B = heisenberg_u1sz_init_pair(D=3, key=jax.random.PRNGKey(0))
@@ -37,6 +49,17 @@ def test_prototype_actually_drops_sectors():
     assert nblocks["C1"] <= 5, f"corner sectors not dropped: {nblocks}"
 
 
+@pytest.mark.xfail(
+    reason=(
+        "#700: PR #671 changed the D=3 chi=12 U(1)-Sz env-init chi-bond charge "
+        "structure (sorted-tail tiling), so the documented mixed-generation "
+        "chi-bond mismatch ('does not match previous') no longer trips — the "
+        "backward VJP now traces without raising. The #610 obstruction this "
+        "test pins is stale until the #700 env-init regression is resolved. "
+        "Flips green (or the obstruction message updates) once #700 is fixed."
+    ),
+    strict=False,
+)
 def test_backward_trace_does_not_survive_surgical_drop():
     """Gate-B Step-0 obstruction guard (#610): documents that the SURGICAL
     traced-path sector drop (filtered backward base_charges + greedy-backfill-


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

## What

xfails the two `test_u1sz_defrag_prototype_610.py` failures tracked in #692. Both are downstream of a **single real library regression**, now filed as **#700** — not the throwaway #610 prototype they nominally guard.

## Triage (systematic-debugging)

- Baseline `ctm_tensor` collapses **identically** with the prototype's sector-dropping disabled → the prototype is exonerated; the bug is in library `ctm_tensor`.
- The env is **healthy at init** (C1 norm 1.0) and zeroed on the **first** absorption sweep → `E = 0.0`.
- `git bisect` (good `07e60c5`, bad `main`) → first bad commit **`004fc89` (PR #671, `fix(#667): canonical env tiling`)**. Its sorted-tail chi-leg padding (`_tile_fused_to_chi`) collapses the U(1)-Sz single-site env at **D=3 χ=12** (χ=10 fine — padding-specific, not simply χ>D²).
- Energy on the reproducer: **−0.0617 at `07e60c5`** → **0.0 on `main`**. Clean regression.

| D | D² | χ | pad | result |
|---|----|----|-----|--------|
| 3 | 9  | 10 | 1 | ✓ nonzero |
| 3 | 9  | **12** | **3** | ✗ **collapse (E=0)** |
| 4 | 16 | 18 | 2 | ✓ nonzero |

The second test (`..._backward_trace_does_not_survive_surgical_drop`) fails because the same tiling change altered the χ-bond charge structure, so its documented `"does not match previous"` obstruction no longer trips.

## Why xfail (not fix here)

The real fix touches PR #671's direction-dependent tiling (whose own acceptance test is already xfailed pending #670). Per separate-branches-per-concern, that belongs in a focused PR under **#700**, not this test-greening branch. `xfail(strict=False)` with a #700 pointer keeps the suite honest and **auto-flips green** once #700 is fixed — turning the energy-sane test into a live regression guard.

## Verified

`tests/test_u1sz_defrag_prototype_610.py`: **1 passed, 2 xfailed** (the block-count test `test_prototype_actually_drops_sectors` is unaffected and still passes).

Part of #692. Root cause: #700.
