### PR TITLE
test(#692): triage 3 sharding parity/backward failures (regression xfail + tolerance loosen)

### DIFF
--- a/tests/test_ctm_sharding_backward.py
+++ b/tests/test_ctm_sharding_backward.py
@@ -14,20 +14,35 @@ import sys
 
 def test_sharded_backward_grad_matches_single_device():
     """value_and_grad under a 4-device GSPMD mesh equals the single-device
-    gradient to <1e-8 (well-conditioned state; fake CPU devices, subprocess)."""
+    gradient to a tight tolerance (well-conditioned state; fake CPU devices,
+    subprocess).
+
+    Tolerance (#692): sharding reassociates the D²-axis sums in both the forward
+    and the adjoint, so the sharded-vs-single gradient delta is O(eps*kappa).
+    On a well-conditioned state that floor is machine-precision (~1e-15)
+    locally, but **platform-dependent** — CI runners land at ~3e-7 on the
+    gradient (energy delta ~9e-10) on this same D=4 χ=8 state (measured on the
+    #692 Full-tests matrix), so the original 1e-8 gate was not portable. 1e-5
+    clears the observed CI gradient noise by ~36x (relative to |grad|~1.8e-2
+    that is ~5e-4 relative) while a real sharding/adjoint bug would give O(1)
+    relative error. The single-device fixed point is stable across PR #676, so
+    this is a tolerance-portability fix, not a masked regression.
+    """
     env = dict(
         os.environ,
         XLA_FLAGS="--xla_force_host_platform_device_count=4",
         JAX_PLATFORMS="cpu",
     )
     r = subprocess.run(
-        [sys.executable, "tests/_rung2_grad_parity_subproc.py", "4", "8", "1e-8"],
+        [sys.executable, "tests/_rung2_grad_parity_subproc.py", "4", "8", "1e-5"],
         env=env,
         capture_output=True,
         text=True,
         timeout=900,
     )
-    assert r.returncode == 0, f"grad parity failed:\nSTDOUT:{r.stdout}\nSTDERR:{r.stderr}"
+    assert r.returncode == 0, (
+        f"grad parity failed:\nSTDOUT:{r.stdout}\nSTDERR:{r.stderr}"
+    )
 
 
 def test_sharded_optimize_gs_ad_matches_single_device():
@@ -47,4 +62,6 @@ def test_sharded_optimize_gs_ad_matches_single_device():
         text=True,
         timeout=900,
     )
-    assert r.returncode == 0, f"optimize parity failed:\nSTDOUT:{r.stdout}\nSTDERR:{r.stderr}"
+    assert r.returncode == 0, (
+        f"optimize parity failed:\nSTDOUT:{r.stdout}\nSTDERR:{r.stderr}"
+    )

--- a/tests/test_ctm_sharding_parity.py
+++ b/tests/test_ctm_sharding_parity.py
@@ -52,7 +52,30 @@ def _run_parity_subproc(n_dev, D, chi, *, well_conditioned=False, thresh=1e-8):
     )
 
 
-@pytest.mark.parametrize("n_dev", [2, 4])
+@pytest.mark.parametrize(
+    "n_dev",
+    [
+        pytest.param(
+            2,
+            marks=pytest.mark.xfail(
+                reason=(
+                    "#702: PR #676 (direction-dependent 2x2 bond bookkeeping, "
+                    "bisected first-bad 7b8e5ad) moved the D=2 random single-site "
+                    "2x2 CTM fixed point into an ill-conditioned region "
+                    "(e_single -0.0083153747 -> -0.0075941887). Sharding "
+                    "reassociates the D²-axis sum, so the sharded-vs-single "
+                    "delta is O(eps*kappa): it blew from 5.55e-17 at 7b8e5ad^ to "
+                    "7.68e-5 here, >> thresh 1e-8. Same #676 root cause as the "
+                    "chi-bump regression; the well-conditioned probes below are "
+                    "unaffected (fixed point stable across #676). Flips green "
+                    "once #702 restores the fixed point."
+                ),
+                strict=False,
+            ),
+        ),
+        4,
+    ],
+)
 def test_sharded_forward_matches_single_device(n_dev):
     """Dense CTM energy under an N-device GSPMD mesh equals the single-device
     result to <1e-8 (subprocess with fake CPU devices)."""
@@ -63,19 +86,27 @@ def test_sharded_forward_matches_single_device(n_dev):
 
 def test_sharded_well_conditioned_tight_parity():
     """On a WELL-CONDITIONED state the sharded forward CTM matches single-device
-    to ~1e-10 even at a larger χ where the contracted D²-axis is reassociated
-    across 4 devices (D=4 → 4 elements/device).
+    to a tight tolerance even at a larger χ where the contracted D²-axis is
+    reassociated across 4 devices (D=4 → 4 elements/device).
 
     This guards the property that matters physically: sharding is exact up to
     floating-point reassociation, and on a well-separated CTM fixed point that
-    reassociation stays at machine precision. The companion random-state probe
-    at the SAME (D=4, χ=8) diverges by ~1e-4 (the reassociation noise is
-    amplified by the random state's large condition number), so this case
-    exercises a regime the small-χ ``test_sharded_forward_matches_single_device``
-    cases (bit-exact only because their fixed points happen to be
-    well-conditioned) do not reach.
+    reassociation stays small. The companion random-state probe at the SAME
+    (D=4, χ=8) diverges by ~1e-4 (the reassociation noise is amplified by the
+    random state's large condition number), so this case exercises a regime the
+    small-χ ``test_sharded_forward_matches_single_device`` cases do not reach.
+
+    Tolerance (#692): the reassociation floor is machine-precision (~1e-17)
+    locally but **platform-dependent** — CI runners (different CPU/XLA
+    reduction tree) land at ~9e-10 on this state (measured on the #692 Full-
+    tests matrix), so the original 1e-10 gate was not portable. 1e-6 clears the
+    observed CI noise by ~1000x while staying ~100x below the ill-conditioned
+    random regime (~1e-4), so it still catches a real sharding/fixed-point
+    regression. The single-device ``e_single`` is stable across PR #676
+    (0.0009211466 → 0.0009211468), i.e. this is a tolerance-portability fix,
+    not a masked regression.
     """
-    r = _run_parity_subproc(4, D=4, chi=8, well_conditioned=True, thresh=1e-10)
+    r = _run_parity_subproc(4, D=4, chi=8, well_conditioned=True, thresh=1e-6)
     assert r.returncode == 0, f"parity failed:\nSTDOUT:{r.stdout}\nSTDERR:{r.stderr}"
 
 


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

## What

Triages the **three** `#692` sharding failures. They split into **two root-cause classes**, verified against the real CI logs (Full-tests run `29156891969` @ `f88399b`, fetched via `gh api …/logs`) and the PR #676 boundary.

## Class 1 — real regression (xfail → #702)

**`test_sharded_forward_matches_single_device[2]`** (D=2 random state):

| commit | e_single | \|delta\| |
|---|---|---|
| `7b8e5ad^` (pre-#676) | −0.0083153747 | **5.55e-17** ✓ |
| `7b8e5ad` (#676) | −0.0075941887 | **7.68e-05** ✗ |

PR #676 (direction-dependent 2x2 bond bookkeeping) **moved** the D=2 random single-site 2x2 CTM fixed point into an ill-conditioned region. Sharding reassociates the D²-axis sum (O(eps·κ)), so the sharded-vs-single delta blew from machine precision to 7.68e-5. **Same #676 fixed-point drift as #702** (the chi-bump regression). xfail(strict=False) on the `n_dev=2` param only — `n_dev=4` still passes. Flips green once #702 restores the fixed point.

## Class 2 — fragile non-portable tolerance (loosen)

**`test_sharded_well_conditioned_tight_parity`** (1e-10 → **1e-6**) and **`test_sharded_backward_grad_matches_single_device`** (1e-8 → **1e-5**). Both run the **well-conditioned** D=4 χ=8 state.

- Its single-device fixed point is **stable across PR #676** (e_single 0.0009211466 → 0.0009211468) — *not* a regression.
- Locally it reassociates at machine precision (~1e-17 energy / ~1e-15 grad), but the **CI runners** (different CPU/XLA reduction tree) land at **~9e-10 energy / ~3e-7 grad** on the identical state. The original machine-precision-tuned gates were simply not portable across hardware.
- New gates clear the observed CI noise (~1000× energy, ~36× grad) while staying far below the ill-conditioned regime (~1e-4), so they still catch a real sharding/adjoint regression.

## Verified

`1 xfailed` (forward[2]) + `4 passed` (forward[4], well_conditioned@1e-6, flag_off, backward@1e-5). (`test_sharded_optimize_gs_ad_matches_single_device` — not in #692, untouched here, byte-identical to `main`, PASSES on CI — fails only locally with a JAX-version `IndivisibleError` at D=2×4-devices; out of scope.)

Part of #692. Root cause of Class 1: #702.
