### PR TITLE
test(#702): cover gs_recipe="2x2", the default CTM recipe, in CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,11 @@ _FILE_MARKERS = {
     # Chunked dense-CTM edge absorption (chunk x shard #632 Increment 1): fast
     # mechanism unit tests; collected as core so CI required checks run them.
     "test_ctm_chunked_absorb.py": "core",
+    # gs_recipe="2x2" (the iPEPSConfig default) production guard (#676 / #702).
+    # Only the forward-only cell-size consistency half is core; the end-to-end
+    # physical anchor lives in test_ctm_recipe_2x2_production_correctness.py so
+    # it does not inherit this marker and run in required CI (it is @slow).
+    "test_ctm_recipe_2x2_consistency.py": "core",
     # #632 Increment 2 gate byproduct: forward-chunk grads through the (monolith)
     # implicit-AD backward stay exact. Tiny D=2 CPU value_and_grad parity.
     "test_ctm_chunk_backward_grad.py": "core",

--- a/tests/test_ctm_recipe_2x2_consistency.py
+++ b/tests/test_ctm_recipe_2x2_consistency.py
@@ -1,0 +1,77 @@
+"""Multisite cell-size consistency of the CTM recipes (``core`` bucket).
+
+``gs_recipe`` selects the CTM projector scheme: ``"2x2"`` (Fishman plaquette,
+the :class:`iPEPSConfig` default) or ``"1x1"`` (reduced-corner single-site).
+Both are production paths, but only ``"1x1"`` had coverage --
+``test_split_ctm_production_correctness`` pins ``"1x1"`` energies, the kagome
+multisite tests skip without a saved ``logs/d4_ad_optimum.npz``, and the
+bipartite ``E < -0.66`` checks in ``test_ipeps.py`` exercise simple update
+rather than the AD path.  So the config *default* recipe had no green test.
+
+This module is the cheap, forward-only half of closing that gap; the
+end-to-end physical anchor lives in
+``test_ctm_recipe_2x2_production_correctness.py`` (slow bucket).  They are
+kept in separate files on purpose: ``conftest.py`` applies its file-level
+marker to every test in a file, so a ``slow`` test sharing this file would
+also inherit ``core`` and would then run in required CI.
+
+Context: issues #676 / #702.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from tenax.algorithms._ctm_energy_ad import ctm_energy_implicit
+from tenax.algorithms._ctm_tensor_convergence import (
+    CHECKERBOARD_NEIGHBORS,
+    SINGLE_SITE_NEIGHBORS,
+    make_neighbors,
+)
+from tenax.algorithms.ipeps import heisenberg_gate
+from tests.test_split_ctm_fuse_flag import _make_site
+
+
+@pytest.mark.parametrize("recipe", ["2x2", "1x1"])
+def test_uniform_tiling_consistency(recipe):
+    """A uniform tiling must give the same per-site energy at every cell size.
+
+    Uses a *direction-dependent* random ``A`` (``A.l != A.r``), not a C4v
+    tensor: a symmetric tensor can mask a left/right or up/down bond mix-up,
+    which is precisely the failure mode this guards.
+    """
+    # chi and max_iter are deliberately small: this asserts a *structural*
+    # invariant (cell-size independence), not an accurate energy, and all
+    # three cells run the identical fixed-point iteration, so the comparison
+    # is exact whether or not the CTM has fully converged.
+    D, d, chi = 2, 2, 4
+    A = _make_site(D, d, seed=0)
+    gate = heisenberg_gate()
+
+    def energy(site_tensors, neighbors):
+        e = ctm_energy_implicit(
+            site_tensors,
+            neighbors,
+            gate,
+            chi=chi,
+            max_iter=30,
+            conv_tol=1e-12,
+            recipe=recipe,
+        )
+        return float(jnp.real(e))
+
+    e1 = energy({(0, 0): A}, SINGLE_SITE_NEIGHBORS)
+    e2 = energy({(0, 0): A, (1, 0): A}, CHECKERBOARD_NEIGHBORS)
+    e4 = energy(
+        {(0, 0): A, (1, 0): A, (0, 1): A, (1, 1): A},
+        make_neighbors(2, 2),
+    )
+
+    worst = max(abs(e1 - e2), abs(e1 - e4), abs(e2 - e4))
+    assert worst < 1e-10, (
+        f"recipe={recipe!r}: uniform tiling is cell-size dependent -- "
+        f"multisite bond bookkeeping is broken. "
+        f"E(1-site)={e1:.12f} E(2-site)={e2:.12f} E(2x2)={e4:.12f} "
+        f"worst gap={worst:.3e}"
+    )

--- a/tests/test_ctm_recipe_2x2_production_correctness.py
+++ b/tests/test_ctm_recipe_2x2_production_correctness.py
@@ -1,0 +1,105 @@
+"""End-to-end physical anchor for the ``gs_recipe="2x2"`` CTM path (slow).
+
+``gs_recipe="2x2"`` (Fishman plaquette) is the :class:`iPEPSConfig` default,
+yet before this test no green test pinned a physical energy through it --
+``test_split_ctm_production_correctness`` uses ``"1x1"``, the kagome multisite
+tests skip without a saved ``logs/d4_ad_optimum.npz``, and the bipartite
+``E < -0.66`` checks in ``test_ipeps.py`` exercise simple update rather than
+the AD path.
+
+The cheap forward-only half of this coverage lives in
+``test_ctm_recipe_2x2_consistency.py`` (``core`` bucket).  That test proves
+the multisite machinery is *self-consistent* across cell sizes; it cannot
+catch a scheme that is self-consistent but converges to the wrong fixed
+point.  This test closes that hole by optimizing a genuine bipartite cell and
+pinning the result inside the QMC variational band.
+
+Kept in a separate file from the consistency test on purpose: ``conftest.py``
+applies its file-level marker to every test in a file, so a ``slow`` test
+sharing the ``core``-registered file would also inherit ``core`` and would
+then run in required CI.
+
+Reference values (D=2, chi=8, implicit AD, A100):
+  recipe="2x2": E/site = -0.658779   (634s)
+  recipe="1x1": E/site = -0.659967  (1997s)
+both with ``||A-B||/||A|| = sqrt(2)`` (orthogonal sublattices), against the
+Sandvik QMC ground state -0.6694 and the repo's ``fused+c4v = -0.6601``
+anchor.  The ~1e-3 spread between recipes is expected: they are different
+truncation schemes and need not agree exactly at finite chi.
+
+Runtime note: this takes ~100s on CPU, i.e. ~6x *faster* than the 634s A100
+run above.  At D=2 / chi=8 there is not enough work per kernel to amortize
+GPU launch overhead, so the step is host-orchestration-bound (same regime as
+#566 / #618).  CI runs the slow bucket on CPU, which is the fast path here.
+
+Context: issues #676 / #702.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from tenax.algorithms.ipeps import heisenberg_gate
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+from tests.test_split_ctm_fuse_flag import _make_site
+
+QMC_FLOOR = -0.6694
+ORDERED_CEIL = -0.60
+
+
+@pytest.mark.slow
+def test_bipartite_checkerboard_physical_energy():
+    """recipe="2x2" on a genuine bipartite cell must land in the QMC band.
+
+    ``unit_cell="2site"`` drives the real multisite production path: it builds
+    ``site_tensors={(0,0): A, (1,0): B}`` over ``CHECKERBOARD_NEIGHBORS`` with
+    ``recipe=config.gs_recipe``, so the CTM carries two *distinct* sublattice
+    tensors rather than a uniform tiling.  The gate stays unrotated -- with
+    ``gs_c4v=True`` the 2-site path derives B from A by sublattice rotation on
+    the physical leg, so Neel order lives in the A/B distinction.
+    """
+    D, d = 2, 2
+    config = iPEPSConfig(
+        max_bond_dim=D,
+        ctm=CTMConfig(
+            chi=8,
+            chi_I=8,
+            fuse_virtual_legs=True,
+            max_iter=60,
+            conv_tol=1e-9,
+            min_iter=4,
+        ),
+        unit_cell="2site",
+        gs_recipe="2x2",
+        gs_implicit_ad=True,
+        gs_c4v=True,
+        gs_metric_precond=False,
+        gs_conv_criterion="grad_norm",
+        gs_grad_norm_tol=1e-3,
+        gs_num_steps=40,
+        gs_log_interval=10,
+        su_init=False,
+    )
+
+    gate = heisenberg_gate()
+    AB = (_make_site(D, d, seed=3), _make_site(D, d, seed=11))
+    (A_opt, B_opt), _envs, E = optimize_gs_ad(gate, AB, config)
+    E = float(E)
+
+    # Guard against a vacuous pass: if the optimizer collapsed A and B onto
+    # each other this degenerates to a uniform tiling and proves nothing that
+    # the consistency test does not already cover.
+    A_d, B_d = A_opt.todense(), B_opt.todense()
+    distinctness = float(jnp.linalg.norm(A_d - B_d) / jnp.linalg.norm(A_d))
+    assert distinctness > 0.1, (
+        f"sublattices collapsed (||A-B||/||A||={distinctness:.3e}); "
+        "this is no longer a bipartite test"
+    )
+
+    assert QMC_FLOOR - 1e-3 <= E <= ORDERED_CEIL, (
+        f"recipe='2x2' bipartite energy {E:.6f}/site is outside the physical "
+        f"band [{QMC_FLOOR}, {ORDERED_CEIL}] -- either non-variational "
+        f"(below QMC) or not ordered (above {ORDERED_CEIL})"
+    )


### PR DESCRIPTION
## Why

`gs_recipe="2x2"` (Fishman plaquette) is the **`iPEPSConfig` default** (`ipeps_config.py:594`), but no green test pinned anything physical through it:

- `test_split_ctm_production_correctness` uses `gs_recipe="1x1"`
- the kagome multisite tests **skip** without a saved `logs/d4_ad_optimum.npz`
- the bipartite `E < -0.66` checks in `test_ipeps.py` exercise **simple update**, not the AD path

Found while validating that #676 did not regress the multisite 2×2 forward (#702). It hadn't — but the absence of coverage was the more actionable finding.

## What

Two layers, in two files, because they fail for different reasons.

**`test_ctm_recipe_2x2_consistency.py`** — `core`, **13.6s** CPU, forward-only.
A uniform tiling of one site into a 2-site checkerboard or a 2×2 four-site cell is the *same infinite state*, so per-site energy must agree across cell sizes. Any gap is a pure multisite bond-bookkeeping bug — the class of defect #676 touched — and it's independent of *which* fixed point the solver settles on. Uses a **direction-dependent** `A` (`A.l != A.r`); a C4v tensor would mask a left/right mix-up.

**`test_ctm_recipe_2x2_production_correctness.py`** — `slow`, **100s** CPU, end-to-end.
Consistency alone can't catch a scheme that is self-consistent but converges to the *wrong* fixed point. This optimizes a genuine bipartite cell (`unit_cell="2site"` → `site_tensors={(0,0):A, (1,0):B}` with two **distinct** sublattice tensors) and pins the result inside the QMC variational band.

## Measurements (D=2, χ=8, implicit AD)

| Check | Result |
|---|---|
| uniform tiling, 1- vs 2- vs 4-site (`2x2`) | gap **0.0** |
| uniform tiling (`1x1`) | gap **0.0** |
| bipartite `2x2` | **−0.658779**/site, `‖A−B‖/‖A‖ = √2` |
| bipartite `1x1` (cross-check, not committed) | **−0.659967**/site |

Both inside the physical band [−0.6694, −0.60] and consistent with the repo's `fused+c4v = -0.6601` anchor. The ~1e-3 spread between recipes is expected — different truncation schemes need not agree exactly at finite χ.

## Two things worth reviewer attention

**Separate files are load-bearing.** `conftest.py` applies its file-level marker to *every* test in a file, so a `@slow` test sharing the `core`-registered file would also inherit `core` and run in required CI. Routing verified:

```
-m core                    -> 2 selected (both fast)     1 deselected
-m slow                    -> 1 selected (the heavy one) 2 deselected
-m 'not core and not slow' -> 0 selected
```

Nothing leaks into required CI or the non-required `fast-other` bucket.

**The assertion is not vacuous.** Negative control (not committed) — if the multisite cell silently deduped to one site, all three energies would trivially agree:

| perturbation | gap | vs 1e-10 threshold |
|---|---|---|
| none (uniform 2×2) | 0.0 | passes |
| one of 4 sites, +1% | 5.4e-7 | **caught** |
| one of 2 checkerboard sites, +1% | 1.1e-5 | **caught** |

For scale, #702's own drift signature was 7e-5.

## Note on runtime

The slow test is ~100s on CPU vs **634s on an A100** — CPU is ~6× *faster*. At D=2/χ=8 there isn't enough work per kernel to amortize GPU launch overhead, so it's host-orchestration-bound (same regime as #566/#618). CI runs the slow bucket on CPU, which is the fast path here.

Tests only — no `src/` changes.

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yjkao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)