### PR TITLE
docs: drop --delete-branch from the documented merge command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Tenax is a JAX-based tensor-network library: DMRG/iDMRG on MPS, TRG/HOTRG, and i
 
 ## Git Workflow
 
-- Always open a PR instead of pushing directly to `main`; merge with `gh pr merge <number> --squash --delete-branch --auto` so CI must pass first.
+- Always open a PR instead of pushing directly to `main`; merge with `gh pr merge <number> --squash --auto` so CI must pass first. **Never pass `--delete-branch`** — `main` uses a merge queue, which deletes the head branch itself once the PR merges. Passing the flag deletes the branch the moment the PR *enters* the queue, which closes the PR and drops it from the queue (recover with `git push origin FETCH_HEAD:refs/heads/<branch>` from `refs/pull/<n>/head`, then reopen). The queue also picks the merge strategy, so `gh` reporting "The merge strategy for main is set by the merge queue" is normal, not a failure.
 - Branch protection on `main` requires `Tests (Python 3.11)`, `Tests (Python 3.12)`, and `Tests (macOS, Python 3.12)`, and the PR branch must be up-to-date with `main`. If behind, `git merge origin/main` — don't rebase.
 - Run `pre-commit install` once per clone — hooks (ruff, ruff-format) must pass before committing.
 - Tests are auto-marked by file name (`core`, `algorithm`, `slow`) via `conftest.py`. CI required checks run only `pytest -m core`; the full suite runs on push to `main` or with the `run-full-tests` PR label. Locally: `uv run pytest -m core` (fast), `uv run pytest -m "not slow"`, or `uv run pytest` (all). On macOS/headless runs, force the CPU backend: `JAX_PLATFORMS=cpu uv run pytest ...`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Tenax is a JAX-based tensor-network library: DMRG/iDMRG on MPS, TRG/HOTRG, and i
 
 ## Git Workflow
 
-- Always open a PR instead of pushing directly to `main`; merge with `gh pr merge <number> --squash --delete-branch --auto` so CI must pass first.
+- Always open a PR instead of pushing directly to `main`; merge with `gh pr merge <number> --squash --auto` so CI must pass first. **Never pass `--delete-branch`** — `main` uses a merge queue, which deletes the head branch itself once the PR merges. Passing the flag deletes the branch the moment the PR *enters* the queue, which closes the PR and drops it from the queue (recover with `git push origin FETCH_HEAD:refs/heads/<branch>` from `refs/pull/<n>/head`, then reopen). The queue also picks the merge strategy, so `gh` reporting "The merge strategy for main is set by the merge queue" is normal, not a failure.
 - Branch protection on `main` requires `Tests (Python 3.11)`, `Tests (Python 3.12)`, and `Tests (macOS, Python 3.12)`, and the PR branch must be up-to-date with `main`. If behind, `git merge origin/main` — don't rebase (rebase gets stuck on `--continue` here).
 - Run `pre-commit install` once per clone — hooks (ruff, ruff-format) must pass before committing.
 - Tests are auto-marked by file name (`core`, `algorithm`, `slow`) via `conftest.py`. CI required checks run only `pytest -m core`; the full suite runs on push to `main` or with the `run-full-tests` PR label. Locally: `uv run pytest -m core` (fast), `uv run pytest -m "not slow"`, or `uv run pytest` (all). On macOS/headless runs, force the CPU backend: `JAX_PLATFORMS=cpu uv run pytest ...`.


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

The merge command documented in `CLAUDE.md` / `AGENTS.md` is unsafe with the merge queue enabled on `main`.

## What went wrong

`gh pr merge <n> --squash --delete-branch --auto` on PR #669 produced this timeline:

```
16:57:45  added_to_merge_queue      (yingjerkao)
16:57:47  closed                    (yingjerkao)
16:57:47  removed_from_merge_queue  (github-merge-queue[bot])
16:57:48  head_ref_deleted          (yingjerkao)
```

`--delete-branch` fires when the PR **enters the queue**, not when it merges. Deleting the head branch closes the PR, which drops it from the queue — so the PR silently never merges. Recovered by restoring the branch from `refs/pull/669/head` and reopening.

## Fix

Both files now document `gh pr merge <number> --squash --auto` with an explicit **never pass `--delete-branch`** warning, the reason (the queue deletes the branch itself post-merge), and the recovery command. Also notes that gh printing "The merge strategy for main is set by the merge queue" is expected output, not an error — the queue owns the strategy, so `--squash` is informational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)