### PR TITLE
test: move brute-force PESS RDM oracles from core to slow

### DIFF
--- a/tests/test_pess_3site_multisite_rdm_invariants.py
+++ b/tests/test_pess_3site_multisite_rdm_invariants.py
@@ -76,7 +76,13 @@ def _contract_multisite_3x3_torus(sites: dict[str, jnp.ndarray]) -> jnp.ndarray:
     return jnp.einsum(spec, *args, optimize="optimal")
 
 
-@pytest.mark.core
+# ``slow``, not ``core``: this builds the full 3×3 torus wavefunction by brute
+# force, which costs ~184s at D=1 alone.  The three brute-force gates in this
+# file were 585s of the ~2500s ``-m core`` run (23%) — the single largest item
+# in the merge gate.  They are oracle checks against exact contraction, so
+# their value is catching a wrong answer, not catching it *fast*; the full
+# suite (push to main, ``run-full-tests`` label, nightly) is the right cadence.
+@pytest.mark.slow
 @pytest.mark.parametrize("D", [1, 2, 3])
 def test_multisite_3x3_torus_translation_invariant_diagonal(D):
     """ψ on the 3×3 PBC torus must be invariant under the (1,-1) diagonal
@@ -154,7 +160,7 @@ def _brute_force_rdm_from_torus_psi(
     return jnp.transpose(rho, perm)
 
 
-@pytest.mark.core
+@pytest.mark.slow  # brute-force oracle; see the note above
 @pytest.mark.parametrize("D", [1, 2, 3])
 def test_brute_force_rdm_is_physical(D):
     """Brute-force RDMs from the 3×3 torus ψ must be Hermitian, trace 1, PSD."""
@@ -298,7 +304,7 @@ def _brute_force_rdms(state: IPESSState) -> dict[str, jnp.ndarray]:
     return out
 
 
-@pytest.mark.core
+@pytest.mark.slow  # brute-force oracle; see the note above
 def test_d1_brute_force_equals_ctm_rdms():
     """Gate #6: at D=1 the encoded state is a product state, so finite-torus
     brute-force = infinite-lattice CTM exactly. All 6 RDMs must agree to 1e-10


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Trims the merge gate by moving the three brute-force PESS RDM oracle tests from `core` to `slow`.

## Why these three

Profiling `-m core` (`--durations`, local, 2526s total) found the top 40 tests consume **71% of the run**, and this one file is **585s of it — 23% of the entire merge gate**:

| test | time |
|---|---|
| `test_multisite_3x3_torus_translation_invariant_diagonal[1]` | 184s |
| `test_d1_brute_force_equals_ctm_rdms` | 174s |
| `test_brute_force_rdm_is_physical[1]` | 169s |
| (+ D=2/D=3 params) | 58s |

For scale: the other **1,080 core tests together** account for roughly 44% of the run. This is not a test-count problem.

## Why slow is the right home

These build the full 3×3 PBC torus wavefunction by brute force and check multisite-CTM RDMs against exact contraction. That is oracle-grade verification — its value is catching a *wrong answer*, not catching it inside the merge gate. They still run on every push to `main`, on any PR labeled `run-full-tests`, and in the `slow` CI bucket.

The three `algorithm`-marked tests in the same file are untouched (they already did not gate merges).

## Context

The merge queue's `checkResponseTimeout` is 60 minutes. PR #710 was dequeued **with every check green** because one slow runner stretched a normally-49-minute run to 65. Trimming the gate widens that margin for every future PR, independent of the timeout bump.

## Verification

- `-m core` selection: **1101 → 1094** tests
- this file under `-m core`: **0 collected** (10 deselected)
- this file under `-m slow`: **7 collected**
- full `-m core` re-run in progress to confirm the ~23% wall-clock drop and no collateral failures

## Not done here

The other large gate item is `test_ctm_implicit_warm_start_adjoint.py` (540s, 21% — seven tests at ~75s each). I deliberately left it in `core`: it covers the implicit-AD warm-start path, which is exactly the blast radius of the #667/#670/#700/#702 CTM cluster, so demoting it would move #702-class regression detection to after merge. Worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)