### PR TITLE
feat(#715): asymmetric CTMRG root implicit AD — forward + root (Phase 1, partial)

### DIFF
--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -43,6 +43,41 @@
 > `E_implicit` evaluates `parametrize`'s `y` (built with `consts(p)`) while the derivative
 > tracks `y*(p; consts(p₀))`. Reconciling those two is the remaining work.
 >
+> **RESOLVED — the frozen constants are the bug, and the fix is specific.**
+> Measured `dE/dc = -F̆ ∂_cF` for the frozen `U*`, `Vh*` (the energy has no explicit
+> dependence on them, so this should vanish if freezing is valid):
+>
+> ```
+> U*[0]:  |dE/dU*| = 1.455e-02   kept-rotation = 1.452e-02   tilt = 9.36e-04
+> U*[3]:  |dE/dU*| = 1.287e-02   kept-rotation = 1.287e-02   tilt = 1.11e-04
+> Vh*[3]: |dE/dVh*| = 1.736e-02  kept-rotation = 1.736e-02   tilt = 1.60e-04
+> ```
+>
+> Not zero, and the right scale to explain the missing 7.14e-3. Decisively dominated by
+> the **kept-subspace rotation** — 15x to 100x the subspace tilt.
+>
+> Working out what is actually invariant under that rotation, `U -> U W` with
+> `S -> W† S` (note: one-sided, not `W† S W`):
+>
+> ```
+> Π = bot Vh† S^-1 U† top      S^-1 U† -> (W† S)^-1 W† U† = S^-1 U†     invariant
+> ```
+>
+> and symmetrically `Vh† S^-1` is invariant under `Vh -> W_R† Vh`, `S -> S W_R`.
+> **Invariance requires `S^-1` adjacent to `U†` and `Vh†`, as one factor.**
+>
+> Every arrangement tried so far used a *symmetric* split `S^-1/2 … S^-1/2`. That
+> reproduces the correct energy *value* — the two halves meet on each bond and recombine
+> into `S^-1` — but it never places `S^-1` next to `U†` inside the **equations**, so `F`
+> stays non-covariant under precisely the rotation that dominates the error. It also
+> explains why the modified-variable test was an exact no-op: the map was written
+> `C = A C̃ A` with `A = S^-1/2`, which is still the symmetric split.
+>
+> **Next step:** rewrite `F` so `S^-1` never appears split — root-free projectors
+> `P̃_top = bot Vh†`, `P̃_bot = U† top`, with a single `S^-1` on each bond, and the
+> `y -> x` map assigning the *whole* inverse to one side per bond rather than a half to
+> each. Then re-measure `dE/dU*`; it should collapse toward zero, and the 2.5% with it.
+>
 > Things already checked and believed correct: the sign of Eq. 18; `ў = (env̆, 0, 0, 0)`
 > (the energy depends on `y` only through the environment, so `ŭ = v̆ = S̆ = 0`); the
 > transpose convention in the solve (`matvec(v) = vjp_y(v)[0]` applies `(∂_yF)^T`, and

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -124,7 +124,27 @@ smooth invertible change of variables, and a reparametrisation cannot change
 `dE/dp` — the measured error was identical to four digits. So the modified variables are
 *scaffolding*, not the fix. Useful only because the next step needs them.
 
-### Where the cut-leg roots go (derived, not yet measured)
+### The cut-leg roots: derived, measured, **falsified**
+
+Implemented and measured both conventions. Both are worse than doing nothing:
+
+| cut-leg placement | gradient error |
+|---|---|
+| none (baseline) | 2.508e-2 |
+| `s^L`/`s^R` as derived below | 6.245e-2 |
+| swapped L/R | 9.447e-1 |
+
+with the root residual still ~1e-16, so this is not a convergence artefact. **The
+remaining 2.5% is not explained by the cut-leg roots as placed here.** Either the leg
+assignment is wrong in some way not captured by the two-way L/R choice, or the missing
+ingredient is something else entirely.
+
+Do not retry this from the derivation below — it has been tested. The next attempt needs
+the actual figures for Eq. 65 and Eqs. 78–80 to pin the wiring, or a different
+hypothesis for the residual.
+
+The derivation, for the record:
+
 
 `M`'s two open legs are the right-facing legs of the two quadrants, and each carries a
 dangling `A = S^-1/2` inherited from the edge it came from: the left leg from move
@@ -148,12 +168,12 @@ directions. That made the measurement infeasible in practice. Compute the quarti
 **once per direction outside the per-equation loop**, or use a single fused iteration for
 `A^-1/4` directly, before attempting this.
 
-**Therefore the entire remaining discrepancy sits in step 4:** the half-infinite
-environment must be built from the *modified* edges with `s^L`, `s^R` on the dangling cut
-legs, i.e. `M̃ ≠ M`. That changes the equations rather than the coordinates, and it is the
-only ingredient of Eqs. 73–82 not yet accounted for. It is also the one part whose leg
-wiring is not derivable from the closure condition alone, so it needs the figures from
-Eq. 65 and Eqs. 78–80.
+**The remaining 2.5% is now unexplained.** Every ingredient of Eqs. 73–82 that could be
+derived from the closure condition has been implemented and measured: general-matrix `S`
+(the one that worked), the modified variables (a no-op, as a reparametrisation must be),
+the quartic roots in the projectors (worse), and the quartic roots on the cut legs
+(worse, both conventions). What is left is genuinely not derivable from the closure
+condition alone — it needs the figures.
 
 ## Order of work
 
@@ -162,9 +182,9 @@ Eq. 65 and Eqs. 78–80.
    `test_no_svd_in_the_differentiated_equations` caught exactly that.
 2. ~~Promote `S` to a general matrix; `R_S` becomes the full χ×χ block~~ **done**
    (84f05f1). This is what took the error from 1.2e0 to ~2.5e-2.
-3. Rebuild `half_infinite_environment` from the *modified* edges, with `s^L`, `s^R` on
-   the dangling cut legs. **This is the only step left**, and the one that needs the
-   figures rather than a derivation.
+3. ~~Rebuild `half_infinite_environment` with the cut-leg roots~~ **tried, falsified**
+   (6.2e-2 and 9.4e-1 for the two conventions, vs 2.5e-2 baseline). Needs the figures,
+   not another derivation.
 4. The tilde variables and the `y ↦ x` map come along with step 3; on their own they are
    a no-op (measured), so do not land them separately.
 5. Re-check in this order — each is a sharp oracle:

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -19,7 +19,31 @@
 > It does not. Everything below about Eqs. 73-82 is still accurate as *physics*, but it is
 > not where the remaining 2.5% lives. Start from the assembly.
 >
-> Things already checked there and believed correct: the sign of Eq. 18; `ў = (env̆, 0, 0, 0)`
+> **Narrowed further by a dense-Jacobian solve** (bypassing GMRES and the real
+> embedding entirely, `np.linalg.solve` on `J.T`, solve residual 2.2e-15):
+>
+> ```
+> dense-solve implicit = -0.810241844336
+> gmres      implicit  = -0.810241844341     <- identical to 11 digits
+> direct term only     = -0.352819362514
+> reference            = -0.817381274942
+> ```
+>
+> So GMRES, the real embedding, the transpose convention and the ў structure are all
+> exonerated. The direct term `∂_p e` is a plain VJP of the energy and is right by
+> construction. **The entire error is in the indirect term `-F̆ ∂_p F`**, which is off by
+> 0.0072 out of 0.4646 — 1.55% of that term alone.
+>
+> Since the solve is exact and `∂_yF`, `∂_pF` both come from `jacfwd` of the same `F`,
+> that leaves one candidate: **`∂_pF` is incomplete**. `F` is differentiated with respect
+> to `p` only through `a`, while the frozen constants `U*, U_perp, Vh*, Vh_perp,
+> s_star_inv` also depend on `p` and contribute `∂F/∂consts · dconsts/dp`, which is being
+> dropped. The method's justification for freezing them is that `u` absorbs the change —
+> but that argument is about the *solution* `y*(p)`, not about the partial derivative, and
+> `E_implicit` evaluates `parametrize`'s `y` (built with `consts(p)`) while the derivative
+> tracks `y*(p; consts(p₀))`. Reconciling those two is the remaining work.
+>
+> Things already checked and believed correct: the sign of Eq. 18; `ў = (env̆, 0, 0, 0)`
 > (the energy depends on `y` only through the environment, so `ŭ = v̆ = S̆ = 0`); the
 > transpose convention in the solve (`matvec(v) = vjp_y(v)[0]` applies `(∂_yF)^T`, and
 > `F̆ ∂_yF = ў` is the transposed system); GMRES convergence (residual 1e-11). The most

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -109,6 +109,32 @@
 > anything — and before GMRES has a chance. Only then is it worth re-testing whether the
 > rotations are genuinely flat and whether Hermitian `S` is the right gauge condition.
 >
+> **Equilibration result — corrects two claims above.** Ruiz-equilibrated `dF/dy` for the
+> tilde / unsplit-`Z` formulation and solved densely (row scaling of `F` and column
+> scaling of `y` both leave the gradient exactly invariant, so this is pure numerics):
+>
+> ```
+> energy through the y -> x map = 4.4e-13   (must be 0.18833050074260632)
+> raw    max 1.432e-11  cond 2.150e+19
+> equil  max 1.843e+01  cond 2.654e+05   modes below 1e-12 x max: 0 / 768
+> solve residual 2.59e-13
+> equilibrated implicit = +1.8e-11        reference -0.817381274942
+> ```
+>
+> 1. **There is no gauge degeneracy.** The "65 modes vs 4 chi^2 = 64" reading was a pure
+>    scaling artefact; after equilibration the null space is empty and cond = 2.7e5.
+> 2. **The unsplit map is unverified, not confirmed.** `‖F(y*)‖ = 3.3e-16` was taken as
+>    evidence the bond assignment was right. It is not — `F` is self-consistent on a
+>    nonphysical environment, whose energy is 4.4e-13 instead of 0.188.
+>
+> **Methodological point:** `‖F(y*)‖` alone is not a sufficient oracle. Any change to the
+> `y -> x` map must be checked against the reconstructed energy at the same time, or a
+> broken map hides behind a machine-precision root. Every earlier conclusion in this file
+> that rests on the root residual alone should be re-read with that in mind.
+>
+> The equilibration is a keeper: it turns an unsolvable system into a well-conditioned
+> one, and any future attempt at the tilde formulation should carry it.
+>
 > Things already checked and believed correct: the sign of Eq. 18; `ў = (env̆, 0, 0, 0)`
 > (the energy depends on `y` only through the environment, so `ŭ = v̆ = S̆ = 0`); the
 > transpose convention in the solve (`matvec(v) = vjp_y(v)[0]` applies `(∂_yF)^T`, and

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -160,6 +160,33 @@
 > again — but the map is now pinned by a twelve-digit check instead of assumed, and the
 > normalisation requirement is understood.
 >
+> **Numerics closed out.** Full pipeline on the verified symmetric map, Ruiz-equilibrated,
+> dense solve:
+>
+> ```
+> energy through the map = 0.18833050074260   (reference ...0632)   12 digits
+> raw    cond 4.556e+04
+> equil  cond 3.639e+02     modes below 1e-12 x max: 0 / 768
+> solve residual 2.33e-15
+> equilibrated implicit = -0.810241844336
+> baseline              = -0.810241844341     identical to 11 digits
+> reference             = -0.817381274942
+> ```
+>
+> Unchanged, as reparametrisation invariance requires — the prediction was stated before
+> the run. The symmetric map's raw cond is 4.6e4 against 2e19 for the unsplit one,
+> independently confirming which map is correct.
+>
+> **Every numerical component is now verified**: map, solve, conditioning, no null space,
+> and invariance under a change of variables. **No choice of variables, scaling or solver
+> can move the residual 2.5%.**
+>
+> One mechanism remains, matching the direct `dE/dU* ~ 1.5e-2` measurement: the
+> `∂_cF · dc/dp` term dropped by freezing `U*`, `Vh*`. Closing it needs either a genuinely
+> covariant formulation — every attempt here has failed — or `dU*/dp` itself, which is
+> dominated 15-100x by the rotation part, i.e. the divergent piece the method exists to
+> avoid. That tension is the open question.
+>
 > Things already checked and believed correct: the sign of Eq. 18; `ў = (env̆, 0, 0, 0)`
 > (the energy depends on `y` only through the environment, so `ŭ = v̆ = S̆ = 0`); the
 > transpose convention in the solve (`matvec(v) = vjp_y(v)[0]` applies `(∂_yF)^T`, and

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -167,6 +167,18 @@ fine as-is; JAX's VJP for it is a plain contraction.
 | **`S` promoted to a general matrix + matrix `S^-1/2`** | **1.1e-2 … 2.5e-2** |
 | `(S S†)^-1/4`, `(S† S)^-1/4` inside the projectors | 2.0e-1 (worse) |
 | `C̃`, `Ẽ` promoted to primitive variables with `C = A C̃ A` | 2.508e-2 (**no change**) |
+| quartic roots on the cut legs of `M` | 6.2e-2 / 9.4e-1 (both conventions worse) |
+| **combined package**: root-free projectors + `ρ_L`,`ρ_R` in the `y→x` map + `C̃`,`Ẽ` primitive + `S̆` routed through the map | 2.0e-1 … 2.9e-1 (worse) |
+
+The combined package was the one arrangement the frozen-constant analysis predicted
+should work — the two roots are individually equivariant under the *independent* left and
+right rotations that `dU*/dp` and `dVh*/dp` actually undergo. It is worse by an order of
+magnitude, with the root still at ~1e-15. So that prediction is falsified too.
+
+**Every covariance repair that could be formulated has now been tried and measured.**
+`S` as a general matrix remains the only change that helped. The 2.5% residual is real,
+reproducible, stable across states and χ, and localised to `∂_pF` — but not explained by
+any of the arrangements above.
 
 Two of these results narrow the remaining work sharply.
 

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -124,6 +124,30 @@ smooth invertible change of variables, and a reparametrisation cannot change
 `dE/dp` — the measured error was identical to four digits. So the modified variables are
 *scaffolding*, not the fix. Useful only because the next step needs them.
 
+### Where the cut-leg roots go (derived, not yet measured)
+
+`M`'s two open legs are the right-facing legs of the two quadrants, and each carries a
+dangling `A = S^-1/2` inherited from the edge it came from: the left leg from move
+`k+1` (via `T1`), the right leg from move `k+3` (via `T3`). The internal bonds are fine —
+two halves meet and combine into a covariant `S^-1`. So the correction is
+
+```
+M̃ = kron(X_L, 1_d2) @ M @ kron(X_R, 1_d2)
+X_L = (S_{k+1} S_{k+1}†)^-1/4 @ S_{k+1}^1/2
+X_R = S_{k+3}^1/2 @ (S_{k+3}† S_{k+3})^-1/4
+```
+
+i.e. divide out the dangling half-root and multiply the quartic root back in. At the root
+every factor is `S^-1/2`, so `X = 1` and `M̃ = M` — consistent with the root residual
+being unchanged, and confirming only the *variation* differs. Which quartic root belongs
+on which side is a two-way choice; the gradient error is the oracle.
+
+**Cost warning.** A naive `A^-1/4` as two nested Denman–Beavers loops is ~48 matrix
+inversions, and `F` is evaluated hundreds of times per GMRES solve across four
+directions. That made the measurement infeasible in practice. Compute the quartic roots
+**once per direction outside the per-equation loop**, or use a single fused iteration for
+`A^-1/4` directly, before attempting this.
+
 **Therefore the entire remaining discrepancy sits in step 4:** the half-infinite
 environment must be built from the *modified* edges with `s^L`, `s^R` on the dangling cut
 legs, i.e. `M̃ ≠ M`. That changes the equations rather than the coordinates, and it is the

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -1,5 +1,16 @@
 # #715 Phase 1 completion
 
+> **SUPERSEDED IN PART — 2026-07-30.** The exoneration/refutation table below
+> records each covariance arrangement tried *in isolation*, and concluded from each
+> failure that the arrangement was refuted. After reading §V.3 of arXiv:2607.15030v1
+> directly (rather than reconstructing it), that conclusion is wrong: §V.3 is a
+> package — `s` onto the edges + modified `C̃`/`Ẽ`/`P̃^L`/`P̃^R` (Eqs. 82, 74, 75),
+> `s^L`/`s^R` on the **cut legs** of the environment matrix in Eqs. 78–80, and `ў`
+> built by backpropagating `x̆` through Eq. 82 so that `S̆ ≠ 0`. Freezing `U*`, `V*`
+> is legitimate in the paper (Eq. 88); it is unlicensed *here* only because the
+> covariance package is absent. See tenax-lab/tenax#718 for the corrected diagnosis.
+> Read the table below as "tried in isolation, inconclusive", not "refuted".
+
 > **Read this first (supersedes most of what follows).** A discriminating
 > finite-difference test shows the residual error is **not** in the characteristic
 > equations:

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -78,6 +78,37 @@
 > `y -> x` map assigning the *whole* inverse to one side per bond rather than a half to
 > each. Then re-measure `dE/dU*`; it should collapse toward zero, and the 2.5% with it.
 >
+> **The unsplit-`S^-1` fix: implemented, partially works, blocked on scaling.**
+>
+> | attempt | root residual | adjoint solve | gradient |
+> |---|---|---|---|
+> | asymmetric split in the projectors (`P_bot = S^-1 P~_bot`) | 8.2e-4 | 0.64 | 6.8e-1 |
+> | tilde variables, one unsplit `Z_k = S_k^-1` per bond | **3.3e-16** | 0.84 | collapses |
+> | + `S` gauge-fixed Hermitian | 3.3e-16 | NaN | NaN |
+>
+> Row 1 fails because `P_bot = S^-1 P~_bot` inherits the full ~1e3 dynamic range of the
+> spectrum while `P_top` has none, so the *forward* environment becomes badly scaled and
+> stops converging. Keep the symmetric split in the forward; it is only the equations that
+> need the unsplit form.
+>
+> Row 2 is the real result: the bond assignment
+> (`Z_k` on the `P~_top` end of move `k`, covering each of the eight bonds exactly once)
+> is **self-consistent — the root is machine-precision**. So the `y -> x` map is right.
+> What breaks is the linear solve.
+>
+> Row 3 was an attempt to pin the resulting flat directions by requiring `S = S†`.
+> It made things worse, and in doing so exposed a flaw in the diagnosis: the row-2
+> Jacobian has **max singular value 1.4e-11**, i.e. the whole system is minuscule, so the
+> "65 modes below 1e-12 x max, against 4 chi^2 = 64" reading is confounded by scaling
+> rather than being clean evidence of one flat rotation per move. Adding an O(1) term
+> swamped every other equation (698/768 modes below threshold).
+>
+> **Next step: rescale before re-diagnosing.** The tilde equations carry factors of
+> `S^-1` that make them orders of magnitude smaller than the SVD equations, so `dF/dy`
+> must be row- and column-equilibrated before any conditioning or null-space claim means
+> anything — and before GMRES has a chance. Only then is it worth re-testing whether the
+> rotations are genuinely flat and whether Hermitian `S` is the right gauge condition.
+>
 > Things already checked and believed correct: the sign of Eq. 18; `ў = (env̆, 0, 0, 0)`
 > (the energy depends on `y` only through the environment, so `ŭ = v̆ = S̆ = 0`); the
 > transpose convention in the solve (`matvec(v) = vjp_y(v)[0]` applies `(∂_yF)^T`, and

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -135,6 +135,31 @@
 > The equilibration is a keeper: it turns an unsolvable system into a well-conditioned
 > one, and any future attempt at the tilde formulation should carry it.
 >
+> **The `y -> x` map, rederived against the energy.** Variants tested directly on the
+> reconstructed energy, no gradient in the loop:
+>
+> ```
+> tilde tensor norms ~2e-3
+> mode=sym      normalise=False   E = 3.1e-13            err 1.9e-01
+> mode=sym      normalise=True    E = 0.18833050074260   err 1.2e-04   <- reference to 12 digits
+> mode=unsplit  normalise=False   E = 4.4e-13            err 1.9e-01
+> mode=unsplit  normalise=True    E = 0.24729853079102   err 5.9e-02
+> ```
+>
+> **Normalisation was masking the comparison** — both variants underflow without it, so
+> the previous run could not distinguish a wrong map from a badly scaled one.
+>
+> **With scaling fixed, the unsplit map is genuinely wrong** (0.2473 vs 0.1883), and the
+> **symmetric** map `C = A_k C̃ A_(k+1)`, `T = A_k T̃ A_k` with `A = S^-1/2` is confirmed
+> correct to twelve digits. The unsplit-`S^-1` proposal is refuted at the level of the
+> map: the bond-counting behind it (`A_k` one end, `A_k^-1` the other, therefore a gauge)
+> does not hold.
+>
+> Consequence: the covariance reasoning that motivated this whole line is wrong somewhere,
+> even though it did correctly predict the general-matrix-`S` fix. The 2.5% is unexplained
+> again — but the map is now pinned by a twelve-digit check instead of assumed, and the
+> normalisation requirement is understood.
+>
 > Things already checked and believed correct: the sign of Eq. 18; `ў = (env̆, 0, 0, 0)`
 > (the energy depends on `y` only through the environment, so `ŭ = v̆ = S̆ = 0`); the
 > transpose convention in the solve (`matvec(v) = vjp_y(v)[0]` applies `(∂_yF)^T`, and

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -1,8 +1,11 @@
 # #715 Phase 1 completion: the modified-variable formulation
 
-Status: **derived, not implemented.** `test_gradient_parity_needs_the_modified_variables`
-in `tests/test_ctm_root_implicit_asym.py` is the gate; it is a strict xfail carrying the
-target number.
+Status: **partly implemented.** General-matrix `S` has landed (84f05f1) and takes the
+gradient error from 1.2e0 to 1.1e-2 … 2.5e-2. One ingredient remains — see
+"Measured: what actually moves the error" below.
+`test_gradient_parity_needs_the_modified_variables` in
+`tests/test_ctm_root_implicit_asym.py` is the gate; it is a strict xfail carrying the
+current number.
 
 ## Why the shortcut cannot be repaired in place
 
@@ -27,7 +30,7 @@ They are not: the `s^-1/2` inside the projectors does not transform covariantly
 Nor can `δω` simply be promoted to a variable. The equation that would determine it is
 the diagonality of `S` within the kept block — and linearising *that* is exactly the
 `1/(s_i² - s_j²)` divergence the whole method exists to avoid. There is no third option:
-the modified variables are required.
+`S` has to become a general matrix, which is the part now implemented.
 
 Phase 0 (C4v) gets away with the same restriction because the `eigh` formulation has no
 inverse roots and Eqs. 26–28 are genuinely covariant. That contrast is the cleanest
@@ -132,13 +135,14 @@ Eq. 65 and Eqs. 78–80.
 
 1. ~~Newton–Schulz helpers~~ **done** — `_denman_beavers` in the module, with
    `_inv_sqrt`. Note it must not call `svd` even for a scale factor;
-   `test_no_svd_in_the_differentiated_equations` caught exactly that. (`_inv_sqrt`, `_quartic_root`) + tests against `eigh` on
-   well-conditioned Hermitian PSD input, plus a gradient-finiteness test at degeneracy.
-2. Switch `_fishman_projectors` to the tilde form; add the explicit `s^-1` bond
-   insertions to the quadrants and to `half_infinite_environment`.
-3. Promote `S` to a general matrix; rewrite Eqs. 78–80 accordingly (`R_S` becomes the
-   full χ×χ block, not its diagonal).
-4. Add the `y ↦ x` map and route `ў` through it.
+   `test_no_svd_in_the_differentiated_equations` caught exactly that.
+2. ~~Promote `S` to a general matrix; `R_S` becomes the full χ×χ block~~ **done**
+   (84f05f1). This is what took the error from 1.2e0 to ~2.5e-2.
+3. Rebuild `half_infinite_environment` from the *modified* edges, with `s^L`, `s^R` on
+   the dangling cut legs. **This is the only step left**, and the one that needs the
+   figures rather than a derivation.
+4. The tilde variables and the `y ↦ x` map come along with step 3; on their own they are
+   a no-op (measured), so do not land them separately.
 5. Re-check in this order — each is a sharp oracle:
    - `‖F(y*)‖` back to ~1e-16 (it went 3.3e3 → 0.24 → 2.5e-16 as conventions were fixed
      the first time round; it localises errors to a single equation)

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -101,9 +101,38 @@ matrix multiplications only. It is polynomial in the input, so it differentiates
 and `test_no_svd_in_the_differentiated_equations` keeps passing. Matrix *inverse* is
 fine as-is; JAX's VJP for it is a plain contraction.
 
+## Measured: what actually moves the error
+
+| change | gradient error |
+|---|---|
+| baseline (diagonal `S`, standard projectors) | 1.2e0 |
+| **`S` promoted to a general matrix + matrix `S^-1/2`** | **1.1e-2 … 2.5e-2** |
+| `(S S†)^-1/4`, `(S† S)^-1/4` inside the projectors | 2.0e-1 (worse) |
+| `C̃`, `Ẽ` promoted to primitive variables with `C = A C̃ A` | 2.508e-2 (**no change**) |
+
+Two of these results narrow the remaining work sharply.
+
+**The quartic roots do not belong in the projectors.** They are equivariant under
+independent left/right rotations, but their product is not `S^-1`, so the projector
+closure breaks at first order in a non-diagonal `S`.
+
+**Step 2 above is a no-op on its own.** Switching to the modified corners and edges is a
+smooth invertible change of variables, and a reparametrisation cannot change
+`dE/dp` — the measured error was identical to four digits. So the modified variables are
+*scaffolding*, not the fix. Useful only because the next step needs them.
+
+**Therefore the entire remaining discrepancy sits in step 4:** the half-infinite
+environment must be built from the *modified* edges with `s^L`, `s^R` on the dangling cut
+legs, i.e. `M̃ ≠ M`. That changes the equations rather than the coordinates, and it is the
+only ingredient of Eqs. 73–82 not yet accounted for. It is also the one part whose leg
+wiring is not derivable from the closure condition alone, so it needs the figures from
+Eq. 65 and Eqs. 78–80.
+
 ## Order of work
 
-1. Newton–Schulz helpers (`_inv_sqrt`, `_quartic_root`) + tests against `eigh` on
+1. ~~Newton–Schulz helpers~~ **done** — `_denman_beavers` in the module, with
+   `_inv_sqrt`. Note it must not call `svd` even for a scale factor;
+   `test_no_svd_in_the_differentiated_equations` caught exactly that. (`_inv_sqrt`, `_quartic_root`) + tests against `eigh` on
    well-conditioned Hermitian PSD input, plus a gradient-finiteness test at degeneracy.
 2. Switch `_fishman_projectors` to the tilde form; add the explicit `s^-1` bond
    insertions to the quadrants and to `half_infinite_environment`.

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -1,0 +1,123 @@
+# #715 Phase 1 completion: the modified-variable formulation
+
+Status: **derived, not implemented.** `test_gradient_parity_needs_the_modified_variables`
+in `tests/test_ctm_root_implicit_asym.py` is the gate; it is a strict xfail carrying the
+target number.
+
+## Why the shortcut cannot be repaired in place
+
+`_ctm_root_implicit_asym.py` keeps `S` diagonal and uses standard Fishman projectors.
+Measured on a converged `D=2, chi=4` state:
+
+| | directional derivative |
+|---|---|
+| explicit backprop (matches symmetric FD to 10 digits) | −0.81738127494 |
+| root-implicit, diagonal `S` | −1.7898 |
+
+with `‖F(y*)‖ = 2.5e-16` and `cond(∂_yF) ≈ 8e3`. Not a solver problem.
+
+The parametrisation `U = U* + U_perp u` forces the kept-space component of the isometry
+to stay exactly `U*`. The true perturbed isometry is `U*(1 + δω) + U_perp δu`. Dropping
+`δω` is legitimate **only if the equations are covariant** under the environment gauge,
+so that `δω` is absorbed by `δC`, `δE`.
+
+They are not: the `s^-1/2` inside the projectors does not transform covariantly
+(paper Eq. 86). So `δω` is physical here and dropping it loses a real contribution.
+
+Nor can `δω` simply be promoted to a variable. The equation that would determine it is
+the diagonality of `S` within the kept block — and linearising *that* is exactly the
+`1/(s_i² - s_j²)` divergence the whole method exists to avoid. There is no third option:
+the modified variables are required.
+
+Phase 0 (C4v) gets away with the same restriction because the `eigh` formulation has no
+inverse roots and Eqs. 26–28 are genuinely covariant. That contrast is the cleanest
+statement of what §V.3 is for.
+
+## The construction, in this module's conventions
+
+Note the naming clash: the paper writes `S` for the singular values and `s = S^-1`.
+Below, `s` denotes the singular values themselves, matching `all_projectors`.
+
+### 1. Strip the roots out of the projectors
+
+```
+P_top = P̃_top s^-1/2      P̃_top = bot @ Vh†
+P_bot = s^-1/2 P̃_bot      P̃_bot = U† @ top
+```
+
+so `P̃_bot @ P̃_top = U† M Vh† = s`, and a bond insertion becomes `P̃_top s^-1 P̃_bot`.
+`s^-1` transforms covariantly (`s → Q^R s Q^L†` gives `s^-1 → Q^L s^-1 Q^R†`) where
+`s^-1/2` does not — that single change is what buys covariance.
+
+### 2. Modified corners and edges (paper Eq. 82)
+
+Substituting into `_renormalised_corner` / `_renormalised_edge`:
+
+```
+C = s_a^-1/2 C̃ s_b^-1/2      C̃ = P̃_bot^(k+1) Q P̃_top^(k)
+E = s_a^-1/2 Ẽ s_b^-1/2      Ẽ = P̃_bot^(k)   (T4·a) P̃_top^(k)
+```
+
+`a` and `b` are the two bonds the tensor touches. For a corner these are moves `k` and
+`k+1`; for an edge both are move `k`. This matches Appendix F Table 1, which puts
+`√S_{α-1}` and `√S_α` on the two legs — the shifted index is the neighbouring move.
+
+### 3. Variables and the `y ↦ x` map
+
+```
+y = ({C̃_α}, {Ẽ_α}, {u_α}, {S_α}, {v_α})    S_α a general complex χ×χ matrix
+x = ({C_α}, {E_α})                          via the relations above
+```
+
+The energy still consumes `x`, so `ў` comes from back-propagating `x̆` through the
+`y ↦ x` map — the paper's Algorithm 2 line 7, and the reason it insists the map be
+explicit. `ŭ = v̆ = 0` as before.
+
+`S` **must** be a general matrix, not a vector: with `U`, `V` restricted to null-space
+variations, the in-space rotation has nowhere else to go. This is the exact analogue of
+Phase 0's "treat `C` as a generic complex Hermitian matrix in the reverse pass".
+
+### 4. The cut legs (paper Eqs. 73, 87)
+
+`M` is formed by cutting a bond, which leaves a dangling `s^-1/2` that is again
+non-covariant. Replace the dangling roots by
+
+```
+s^L = (s† s)^(1/4)      s^R = (s s†)^(1/4)
+```
+
+which transform as `s^L → Q^L s^L Q^L†` and `s^R → Q^R s^R Q^R†`. For diagonal
+positive `s` both reduce to `sqrt(s)`, so they are invisible at the root and only their
+*variation* differs — which is the whole point.
+
+### 5. Keeping `F` decomposition-free
+
+`s^-1/2`, `s^L` and `s^R` are matrix functions of a varying matrix. Do **not** reach for
+`eigh`: although the composite is smooth at degeneracies (a Löwner divided difference
+tends to `f'(λ)`), JAX's `eigh` VJP still divides by `λ_i - λ_j` and will NaN.
+
+Use **Newton–Schulz / Denman–Beavers** iteration instead — a fixed number of steps,
+matrix multiplications only. It is polynomial in the input, so it differentiates cleanly
+and `test_no_svd_in_the_differentiated_equations` keeps passing. Matrix *inverse* is
+fine as-is; JAX's VJP for it is a plain contraction.
+
+## Order of work
+
+1. Newton–Schulz helpers (`_inv_sqrt`, `_quartic_root`) + tests against `eigh` on
+   well-conditioned Hermitian PSD input, plus a gradient-finiteness test at degeneracy.
+2. Switch `_fishman_projectors` to the tilde form; add the explicit `s^-1` bond
+   insertions to the quadrants and to `half_infinite_environment`.
+3. Promote `S` to a general matrix; rewrite Eqs. 78–80 accordingly (`R_S` becomes the
+   full χ×χ block, not its diagonal).
+4. Add the `y ↦ x` map and route `ў` through it.
+5. Re-check in this order — each is a sharp oracle:
+   - `‖F(y*)‖` back to ~1e-16 (it went 3.3e3 → 0.24 → 2.5e-16 as conventions were fixed
+     the first time round; it localises errors to a single equation)
+   - `cond(∂_yF)` still finite
+   - the xfail flips green
+
+## Then
+
+Phase 2 (unit cells, Appendix F shifted-cell indexing for `s_α`, `s^L`, `s^R`) and
+Phase 3 (`SymmetricTensor`/fermionic — block-diagonal roots, per-charge-sector null
+spaces) both build directly on this and are blocked until it lands.

--- a/docs/plans/2026-07-29-715-phase1-modified-variables.md
+++ b/docs/plans/2026-07-29-715-phase1-modified-variables.md
@@ -1,4 +1,35 @@
-# #715 Phase 1 completion: the modified-variable formulation
+# #715 Phase 1 completion
+
+> **Read this first (supersedes most of what follows).** A discriminating
+> finite-difference test shows the residual error is **not** in the characteristic
+> equations:
+>
+> ```
+> implicit AD                   = -0.810241844341
+> FD of the implicit energy     = -0.817381291970    (stable across h = 1e-4..1e-6)
+> reference (explicit backprop) = -0.817381274942
+> ```
+>
+> `FD(E_implicit)` agrees with the reference to eight digits. So `E_implicit(p)` — the
+> energy at the root of `F` — is the *correct function of p*. The equations, the root and
+> the environment are all right; the bug is downstream, in the ~40 lines of
+> `asym_root_implicit_energy_and_grad` that assemble `dE/dp = ∂_p e - F̆ ∂_p F`.
+>
+> This invalidates the earlier conclusion that the next step needs the paper's figures.
+> It does not. Everything below about Eqs. 73-82 is still accurate as *physics*, but it is
+> not where the remaining 2.5% lives. Start from the assembly.
+>
+> Things already checked there and believed correct: the sign of Eq. 18; `ў = (env̆, 0, 0, 0)`
+> (the energy depends on `y` only through the environment, so `ŭ = v̆ = S̆ = 0`); the
+> transpose convention in the solve (`matvec(v) = vjp_y(v)[0]` applies `(∂_yF)^T`, and
+> `F̆ ∂_yF = ў` is the transposed system); GMRES convergence (residual 1e-11). The most
+> likely remaining suspect is that `parametrize` recomputes the frozen constants
+> `U*, U_perp, Vh*, Vh_perp` at each `p`, so the `y*(p)` that `E_implicit` actually
+> evaluates is the root of `F(·, p; consts(p))` while the implicit derivative is taken of
+> `F(·, p; consts(p0))`. The method assumes those agree to first order because `u`
+> absorbs the difference — worth verifying directly rather than assuming.
+
+
 
 Status: **partly implemented.** General-matrix `S` has landed (84f05f1) and takes the
 gradient error from 1.2e0 to 1.1e-2 … 2.5e-2. One ingredient remains — see

--- a/src/tenax/algorithms/_ctm_c4v_root_implicit.py
+++ b/src/tenax/algorithms/_ctm_c4v_root_implicit.py
@@ -353,21 +353,33 @@ def _solve_root_adjoint(
     struct = _real_struct(rhs)
     b_vec = _to_real_vec(rhs)
 
+    @jax.jit
     def op(vec):
         tree = _from_real_vec(vec, treedef, struct)
         return _to_real_vec(matvec(tree))
 
-    sol, _ = jax.scipy.sparse.linalg.gmres(
-        op,
-        b_vec,
-        x0=b_vec,
-        tol=tol,
-        atol=0.0,
-        restart=restart,
-        maxiter=maxiter,
-        solve_method="batched",
-    )
-    resid = jnp.linalg.norm(op(sol) - b_vec) / (jnp.linalg.norm(b_vec) + 1e-30)
+    # The solve is the hot loop: GMRES evaluates ``op`` up to ``maxiter``
+    # times, and each evaluation is a VJP through the whole of ``F``.  Run
+    # eagerly, the per-operation Python dispatch dominates — enough that
+    # adding the Eq. 73 cut-leg roots to ``F`` made a single measurement
+    # fail to return.  Compiling the whole solve leaves one XLA program per
+    # call instead.
+    @jax.jit
+    def _solve(b):
+        sol, _info = jax.scipy.sparse.linalg.gmres(
+            op,
+            b,
+            x0=b,
+            tol=tol,
+            atol=0.0,
+            restart=restart,
+            maxiter=maxiter,
+            solve_method="batched",
+        )
+        resid = jnp.linalg.norm(op(sol) - b) / (jnp.linalg.norm(b) + 1e-30)
+        return sol, resid
+
+    sol, resid = _solve(b_vec)
     del leaves
     return _from_real_vec(sol, treedef, struct), resid
 

--- a/src/tenax/algorithms/_ctm_c4v_root_implicit.py
+++ b/src/tenax/algorithms/_ctm_c4v_root_implicit.py
@@ -1,0 +1,578 @@
+"""Root implicit differentiation for dense C4v CTMRG (#715, Phase 0).
+
+Implements Section III of Burgelman, Francuz, Brehmer, Devos, Haegeman,
+Verstraete and Vanhecke, *Implicit differentiation of tensor network
+algorithms*, arXiv:2607.15030.
+
+Where the production path in :mod:`tenax.algorithms._ctm_energy_ad`
+characterises the converged environment as a **fixed point** of one CTM
+sweep and solves ``(1 - J^T) λ = dE/denv`` — differentiating the sweep,
+truncated SVD backward and all — this module characterises it as the
+**root** of an algebraic equation ``F(y, p) = 0`` in the enlarged variable
+set ``y = (C, E, u)`` and solves ``F̆ ∂_y F = ў`` (paper Eqs. 14-18).
+
+The payoff is that ``F`` is a handful of plain contractions, so no ``eigh``
+or ``svd`` backward appears anywhere in the gradient path.  Degeneracies in
+the kept spectrum, which make the truncated-``eigh`` VJP diverge, are
+invisible here: the isometry only varies along its null space (Eq. 31),
+
+    U = U* + U_perp @ u,
+
+with ``U*`` and ``U_perp`` held constant.  The conditioning of the ``u``
+block is set by the *truncation gap* — the separation between kept and
+discarded eigenvalues — not by gaps inside the kept block.
+
+Characteristic equations (paper Eqs. 26-28), with ``M`` the Hermitian
+enlarged corner and ``N`` the enlarged edge:
+
+    R_C = U† M U - λ_C C                        (Eq. 26)
+    R_E = U† N U - λ_E E                        (Eq. 27)
+    R_u = (U_perp† M U) C*^-1 - λ_C u           (Eq. 28)
+
+``λ_C`` and ``λ_E`` are *differentiable* functions of ``y`` — the inner
+products of the first term of Eqs. 26 and 27 with ``C`` and ``E`` — which
+is what removes the zero mode associated with the overall normalisation
+(paper §III.3, Appendix B).  ``C*^-1`` is a constant right preconditioner.
+
+The forward contraction is unchanged: this module reuses
+:func:`tenax.algorithms._ctm_tensor_c4v._c4v_sweep`.
+
+Conventions match ``_c4v_sweep``:
+
+* ``C``  — corner, labels ``(c_a, c_b)``, shape ``(chi, chi)``
+* ``T``  — edge, labels ``(t_l, D2, t_r)``, shape ``(chi, d2, chi)``
+* ``a``  — double layer, labels ``(u2, d2, l2, r2)``, each of dim ``d2 = D²``
+* the fused environment leg is ordered ``(chi, d2)`` on both the corner
+  (``c_a``, ``D2``) and the edge (``t_l``, ``l2``), which is what lets the
+  same ``U`` act on the enlarged corner and the enlarged edge.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, NamedTuple
+
+import jax
+import jax.numpy as jnp
+
+from tenax.algorithms._ctm_tensor_c4v import _c4v_sweep, _c4v_to_full_env
+from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
+from tenax.algorithms._ctm_tensor_init import (
+    _build_double_layer_tensor,
+    initialize_ctm_tensor_env,
+)
+from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+
+__all__ = [
+    "C4vRoot",
+    "c4v_characteristic_residual",
+    "c4v_root_implicit_energy",
+    "c4v_root_implicit_energy_and_grad",
+    "c4v_root_parametrize",
+]
+
+
+class C4vRoot(NamedTuple):
+    """Root of the characteristic equations plus its constant tensors.
+
+    ``y = (C, E, u)`` are the differentiable variables; ``U_star``,
+    ``U_perp`` and ``C_star_inv`` are held constant when differentiating
+    ``F`` (paper Eq. 25 and the Eq. 28 preconditioner).
+    """
+
+    C: jax.Array
+    E: jax.Array
+    u: jax.Array
+    U_star: jax.Array
+    U_perp: jax.Array
+    C_star_inv: jax.Array
+
+    @property
+    def y(self) -> tuple[jax.Array, jax.Array, jax.Array]:
+        return (self.C, self.E, self.u)
+
+
+# ---------------------------------------------------------------------------
+# Enlarged corner / edge — the two contractions the sweep is built from.
+# ---------------------------------------------------------------------------
+
+
+def _enlarged_corner(C: jax.Array, E: jax.Array) -> jax.Array:
+    """Hermitian enlarged corner ``M = 2 Cg Cg†`` with ``Cg = (C·E)`` fused.
+
+    Mirrors steps 1 and 3 of :func:`_c4v_sweep`: the corner is grown by one
+    edge and the density matrix accumulated from the two (identical, by C4v)
+    corner slots.  Returns a ``(chi*d2, chi*d2)`` Hermitian PSD matrix whose
+    dominant eigenvectors are the CTM projector.
+    """
+    chi, d2 = C.shape[0], E.shape[1]
+    Cg = jnp.einsum("ab,bmc->amc", C, E).reshape(chi * d2, chi)
+    M = 2.0 * (Cg @ Cg.conj().T)
+    # eigh below assumes exact hermiticity; the product form is Hermitian up
+    # to rounding, so symmetrise rather than let the asymmetry leak into the
+    # eigenvectors.
+    return 0.5 * (M + M.conj().T)
+
+
+def _enlarged_edge(E: jax.Array, a: jax.Array) -> jax.Array:
+    """Enlarged edge ``N[fl, d2, fr]`` with ``fl = (t_l, l2)``, ``fr = (t_r, r2)``.
+
+    Mirrors step 2 of :func:`_c4v_sweep`.
+    """
+    chi, d2 = E.shape[0], E.shape[1]
+    N = jnp.einsum("xuy,uvlr->xlvyr", E, a)
+    return N.reshape(chi * d2, d2, chi * d2)
+
+
+def _project_corner(M: jax.Array, U: jax.Array) -> jax.Array:
+    return U.conj().T @ M @ U
+
+
+def _project_edge(N: jax.Array, U: jax.Array) -> jax.Array:
+    return jnp.einsum("fi,fmg,gj->imj", U.conj(), N, U)
+
+
+# ---------------------------------------------------------------------------
+# Characteristic equations (paper Eqs. 26-28)
+# ---------------------------------------------------------------------------
+
+
+def c4v_characteristic_residual(
+    y: tuple[jax.Array, jax.Array, jax.Array],
+    a: jax.Array,
+    U_star: jax.Array,
+    U_perp: jax.Array,
+    C_star_inv: jax.Array,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Evaluate ``F(y, p)`` — paper Eqs. 26, 27 and 28.
+
+    Args:
+        y:          ``(C, E, u)``; ``C`` is ``(chi, chi)``, ``E`` is
+                    ``(chi, d2, chi)``, ``u`` is ``(chi*d2 - chi, chi)``.
+        a:          Double-layer tensor, axes ordered ``(u2, d2, l2, r2)``.
+        U_star:     Fixed-point isometry ``(chi*d2, chi)``, constant.
+        U_perp:     Its null space ``(chi*d2, chi*d2 - chi)``, constant.
+        C_star_inv: Constant right preconditioner ``C*^-1`` for Eq. 28.
+
+    Returns:
+        ``(R_C, R_E, R_u)``, matching the shapes of ``(C, E, u)``.
+    """
+    C, E, u = y
+    U = U_star + U_perp @ u  # Eq. 25 — differentiable only through ``u``
+
+    M = _enlarged_corner(C, E)
+    N = _enlarged_edge(E, a)
+
+    proj_C = _project_corner(M, U)
+    proj_E = _project_edge(N, U)
+
+    # λ as a differentiable function of y, not an independent variable
+    # (paper §III.3 / Appendix B): this is what kills the normalisation
+    # zero mode in ∂_y F.
+    lam_C = jnp.vdot(C, proj_C).real
+    lam_E = jnp.vdot(E, proj_E).real
+
+    R_C = proj_C - lam_C * C
+    R_E = proj_E - lam_E * E
+    R_u = (U_perp.conj().T @ M @ U) @ C_star_inv - lam_C * u
+    return (R_C, R_E, R_u)
+
+
+def _align_isometry(U: jax.Array, U_prev: jax.Array | None) -> jax.Array:
+    """Rotate ``U`` inside the kept subspace to align it with ``U_prev``.
+
+    ``eigh`` fixes the kept subspace but not the basis inside it: column
+    signs flip and near-degenerate eigenvectors rotate freely between
+    calls on infinitesimally different matrices.  That is harmless for the
+    *subspace* but it makes the corner and edge jump between gauges, so
+    the polish loop below would oscillate instead of converging.
+
+    Maximal alignment is the unitary polar factor of the overlap
+    ``O = U_prev† U``: writing ``O = W S Vh``, the rotation ``Q = W Vh``
+    makes ``U Q†`` the element of the gauge orbit closest to ``U_prev``.
+
+    This is forward-pass bookkeeping only — the backward never sees it,
+    which is the point of the null-space parametrisation (paper §III.3).
+    """
+    if U_prev is None:
+        return U
+    overlap = U_prev.conj().T @ U
+    w_o, _s_o, vh_o = jnp.linalg.svd(overlap, full_matrices=False)
+    return U @ (w_o @ vh_o).conj().T
+
+
+def c4v_root_parametrize(
+    C: jax.Array,
+    E: jax.Array,
+    a: jax.Array,
+    chi: int,
+    *,
+    pinv_rtol: float = 1e-12,
+    polish_steps: int = 60,
+    polish_tol: float = 1e-10,
+) -> tuple[C4vRoot, float]:
+    """Map a converged environment to the root ``y* = (C*, E*, 0)``.
+
+    Performs the ``parametrize`` step of the paper's Algorithm 2: a full
+    ``eigh`` of the enlarged corner supplies both the kept isometry ``U*``
+    and its null space ``U_perp``, after which ``C*`` and ``E*`` are
+    redefined in that basis.
+
+    ``(C, E, U)`` must be *mutually* self-consistent for ``F(y*) = 0`` to
+    hold — it is not enough for the incoming ``(C, E)`` to be converged in
+    some other basis, because Eq. 28 is amplified by ``C*^-1`` and so
+    resolves a mismatch of order ``1e-12`` into a residual of order one.
+    The loop below therefore re-applies the (enlarged corner → ``eigh`` →
+    project) map, with the isometry gauge-aligned each step, until the
+    characteristic residual stops improving.
+
+    Returns:
+        ``(root, residual)`` where ``residual`` is ``‖F(y*, p)‖``.  This is
+        the CTM convergence error and is what limits gradient accuracy
+        (paper Fig. 1) — callers should surface or gate on it.
+    """
+    U_prev: jax.Array | None = None
+    best: tuple[C4vRoot, float] | None = None
+
+    for _step in range(max(int(polish_steps), 1)):
+        M = _enlarged_corner(C, E)
+        # eigh returns ascending eigenvalues; keep the chi dominant ones.
+        w, V = jnp.linalg.eigh(M)
+        order = jnp.argsort(-w)
+        V = V[:, order]
+        U_star = _align_isometry(V[:, :chi], U_prev)
+        U_perp = V[:, chi:]
+
+        proj_C = _project_corner(M, U_star)
+        C_star = proj_C / jnp.linalg.norm(proj_C)
+
+        proj_E = _project_edge(_enlarged_edge(E, a), U_star)
+        E_star = proj_E / jnp.linalg.norm(proj_E)
+
+        # C* is diagonal and positive when U* is aligned with the eigenbasis;
+        # after a gauge rotation it is Hermitian, so invert it as such with a
+        # relative floor on the spectrum.
+        C_star_inv = _hermitian_pinv(C_star, pinv_rtol)
+
+        u_zero = jnp.zeros((U_perp.shape[1], chi), dtype=C_star.dtype)
+        root = C4vRoot(C_star, E_star, u_zero, U_star, U_perp, C_star_inv)
+        residual = float(
+            jnp.sqrt(
+                sum(
+                    jnp.sum(jnp.abs(r) ** 2)
+                    for r in c4v_characteristic_residual(
+                        root.y, a, U_star, U_perp, C_star_inv
+                    )
+                )
+            )
+        )
+        if best is None or residual < best[1]:
+            best = (root, residual)
+        if residual <= polish_tol:
+            break
+        C, E, U_prev = C_star, E_star, U_star
+
+    assert best is not None
+    return best
+
+
+def _hermitian_pinv(H: jax.Array, rtol: float) -> jax.Array:
+    """Pseudo-inverse of a Hermitian matrix with a relative spectral floor.
+
+    Modes below the floor are dropped rather than inverted.  A kept mode
+    with vanishing weight carries no environment amplitude, so zeroing its
+    row of Eq. 28 leaves ``R_u = -λ_C u`` there — well conditioned, and it
+    correctly contributes nothing to the gradient.
+    """
+    w, V = jnp.linalg.eigh(0.5 * (H + H.conj().T))
+    cutoff = rtol * jnp.max(jnp.abs(w))
+    safe = jnp.where(jnp.abs(w) > cutoff, w, 1.0)
+    inv_w = jnp.where(jnp.abs(w) > cutoff, 1.0 / safe, 0.0)
+    return (V * inv_w[None, :]) @ V.conj().T
+
+
+# ---------------------------------------------------------------------------
+# Real-embedded linear algebra
+#
+# ``F`` is not holomorphic (it contains conjugations), so its VJP is only
+# real-linear.  Krylov solvers assume complex-linearity, so the solve runs on
+# the real embedding (real and imaginary parts stacked).  For real inputs this
+# reduces to the plain real solve at no extra cost.
+# ---------------------------------------------------------------------------
+
+
+def _real_struct(tree) -> list[tuple[Any, bool]]:
+    return [
+        (leaf.shape, bool(jnp.iscomplexobj(leaf))) for leaf in jax.tree.leaves(tree)
+    ]
+
+
+def _to_real_vec(tree) -> jax.Array:
+    parts = []
+    for leaf in jax.tree.leaves(tree):
+        if jnp.iscomplexobj(leaf):
+            parts.append(jnp.concatenate([leaf.real.ravel(), leaf.imag.ravel()]))
+        else:
+            parts.append(leaf.ravel())
+    return jnp.concatenate(parts)
+
+
+def _from_real_vec(vec: jax.Array, treedef, struct) -> Any:
+    leaves = []
+    off = 0
+    for shape, is_complex in struct:
+        n = 1
+        for s in shape:
+            n *= s
+        if is_complex:
+            re = vec[off : off + n].reshape(shape)
+            im = vec[off + n : off + 2 * n].reshape(shape)
+            leaves.append(re + 1j * im)
+            off += 2 * n
+        else:
+            leaves.append(vec[off : off + n].reshape(shape))
+            off += n
+    return jax.tree.unflatten(treedef, leaves)
+
+
+def _solve_root_adjoint(
+    matvec,
+    rhs,
+    *,
+    tol: float,
+    maxiter: int,
+    restart: int,
+):
+    """Solve ``matvec(F̆) = ў`` on the real embedding.
+
+    Returns ``(F̆, info)`` where ``info`` carries the achieved relative
+    residual so callers can surface a diagnostic rather than silently
+    returning a bad gradient.
+    """
+    leaves, treedef = jax.tree.flatten(rhs)
+    struct = _real_struct(rhs)
+    b_vec = _to_real_vec(rhs)
+
+    def op(vec):
+        tree = _from_real_vec(vec, treedef, struct)
+        return _to_real_vec(matvec(tree))
+
+    sol, _ = jax.scipy.sparse.linalg.gmres(
+        op,
+        b_vec,
+        x0=b_vec,
+        tol=tol,
+        atol=0.0,
+        restart=restart,
+        maxiter=maxiter,
+        solve_method="batched",
+    )
+    resid = jnp.linalg.norm(op(sol) - b_vec) / (jnp.linalg.norm(b_vec) + 1e-30)
+    del leaves
+    return _from_real_vec(sol, treedef, struct), resid
+
+
+# ---------------------------------------------------------------------------
+# Forward contraction
+# ---------------------------------------------------------------------------
+
+
+def _converge_c4v(
+    A: Tensor,
+    chi: int,
+    *,
+    max_iter: int,
+    conv_tol: float,
+    min_iter: int,
+    projector_method: str,
+) -> tuple[Tensor, Tensor, Tensor, dict[str, Any]]:
+    """Run the existing C4v sweep to convergence (no gradient tracked)."""
+    a = _build_double_layer_tensor(A)
+    env = initialize_ctm_tensor_env(A, chi)
+    C = env.C1.relabels({"c1_d": "c_a", "c1_r": "c_b"})
+    T = env.T1.relabels({"t1_l": "t_l", "u2": "D2", "t1_r": "t_r"})
+
+    prev = None
+    residual = float("inf")
+    converged = False
+    iters = 0
+    for it in range(int(max_iter)):
+        C, T = _c4v_sweep(C, T, a, chi, projector_method)
+        iters = it + 1
+        cur = jnp.linalg.svd(C.todense(), compute_uv=False)
+        if prev is not None and cur.shape == prev.shape:
+            residual = float(jnp.linalg.norm(cur / cur[0] - prev / prev[0]))
+            if iters >= min_iter and residual < conv_tol:
+                converged = True
+                break
+        prev = cur
+    meta = {"iters": iters, "residual": residual, "converged": converged}
+    return C, T, a, meta
+
+
+def _a_dense(a: Tensor) -> jax.Array:
+    """Double-layer array with axes ordered ``(u2, d2, l2, r2)``."""
+    labels = list(a.labels())
+    perm = tuple(labels.index(lbl) for lbl in ("u2", "d2", "l2", "r2"))
+    return jnp.asarray(a.transpose(perm).todense())
+
+
+def _energy_from_env_arrays(
+    A: Tensor,
+    C_arr: jax.Array,
+    E_arr: jax.Array,
+    C_tmpl: Tensor,
+    T_tmpl: Tensor,
+    gate,
+) -> jax.Array:
+    C_t = DenseTensor(C_arr, C_tmpl.indices)
+    T_t = DenseTensor(E_arr, T_tmpl.indices)
+    env = _c4v_to_full_env(C_t, T_t)
+    return compute_energy_ctm_tensor(A, env, gate)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def c4v_root_implicit_energy_and_grad(
+    A: Tensor,
+    gate,
+    *,
+    chi: int = 16,
+    max_iter: int = 100,
+    conv_tol: float = 1e-10,
+    min_iter: int = 4,
+    projector_method: str = "eigh",
+    polish_steps: int = 60,
+    polish_tol: float = 1e-10,
+    solve_tol: float = 1e-8,
+    solve_maxiter: int = 200,
+    solve_restart: int = 30,
+    root_residual_warn: float = 1e-6,
+    return_diagnostics: bool = False,
+):
+    """Energy and ``dE/dA`` for dense C4v iPEPS via root implicit AD.
+
+    The gradient is assembled as (paper Eqs. 17-18)::
+
+        dE/dp = ∂_p e  -  F̆ ∂_p F,      F̆ solves  F̆ ∂_y F = ў
+
+    with ``ў = (C̆, Ĕ, 0)``: the isometry never enters the energy, so its
+    adjoint vanishes.
+
+    Args:
+        A:                 iPEPS site tensor ``(u, d, l, r, phys)``, dense.
+        gate:              2-site Hamiltonian gate.
+        chi:               Environment bond dimension.
+        max_iter/conv_tol/min_iter: Forward CTM convergence controls.
+        projector_method:  Forward projector, ``"eigh"`` (default) or ``"qr"``.
+                           Only affects the forward — the backward never
+                           differentiates it.
+        solve_tol/solve_maxiter/solve_restart: GMRES controls for Eq. 17.
+        return_diagnostics: Also return a dict with the forward CTM meta,
+                           ``‖F(y*)‖`` and the adjoint solve residual.
+
+    Returns:
+        ``(energy, grad_A)`` where ``grad_A`` is a dense array shaped like
+        ``A``; plus a diagnostics dict when ``return_diagnostics`` is set.
+    """
+    if isinstance(A, SymmetricTensor):
+        raise TypeError(
+            "c4v_root_implicit_energy_and_grad supports dense tensors only "
+            "(#715 Phase 3 covers SymmetricTensor)."
+        )
+    if not isinstance(A, DenseTensor):
+        raise TypeError(f"Expected DenseTensor, got {type(A).__name__}.")
+
+    # --- Forward: converge, then parametrize the root (no grad tracked) ---
+    A_const = DenseTensor(jax.lax.stop_gradient(A.todense()), A.indices)
+    C_t, T_t, a_t, meta = _converge_c4v(
+        A_const,
+        chi,
+        max_iter=max_iter,
+        conv_tol=conv_tol,
+        min_iter=min_iter,
+        projector_method=projector_method,
+    )
+    a_arr = _a_dense(a_t)
+    root, root_residual = c4v_root_parametrize(
+        jnp.asarray(C_t.todense()),
+        jnp.asarray(T_t.todense()),
+        a_arr,
+        chi,
+        polish_steps=polish_steps,
+        polish_tol=polish_tol,
+    )
+
+    if root_residual > root_residual_warn:
+        warnings.warn(
+            f"C4v root implicit AD: ‖F(y*)‖ = {root_residual:.3e} exceeds "
+            f"{root_residual_warn:.1e}. The environment is not a root of the "
+            "characteristic equations, so the implicit-function gradient is "
+            "correspondingly inaccurate (paper Fig. 1). Usual cause: chi cuts "
+            "through a numerically degenerate part of the corner spectrum — "
+            "lower chi, or converge the forward CTM further.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    A_data = jnp.asarray(A.todense())
+
+    def energy_of(a_data, c_arr, e_arr):
+        A_live = DenseTensor(a_data, A.indices)
+        return _energy_from_env_arrays(A_live, c_arr, e_arr, C_t, T_t, gate)
+
+    # --- ∂_p e (direct) and ў = (C̆, Ĕ, 0) ---
+    energy, vjp_energy = jax.vjp(energy_of, A_data, root.C, root.E)
+    grad_direct, C_bar, E_bar = vjp_energy(jnp.ones((), dtype=energy.dtype))
+    y_bar = (C_bar, E_bar, jnp.zeros_like(root.u))
+
+    # --- ∂_y F at the root, with a and the constants frozen ---
+    def F_of_y(y):
+        return c4v_characteristic_residual(
+            y, a_arr, root.U_star, root.U_perp, root.C_star_inv
+        )
+
+    _, vjp_y = jax.vjp(F_of_y, root.y)
+
+    def matvec(v):
+        return vjp_y(v)[0]
+
+    F_bar, solve_resid = _solve_root_adjoint(
+        matvec,
+        y_bar,
+        tol=solve_tol,
+        maxiter=solve_maxiter,
+        restart=solve_restart,
+    )
+
+    # --- ∂_p F (indirect) ---
+    def F_of_p(a_data):
+        A_live = DenseTensor(a_data, A.indices)
+        a_live = _a_dense(_build_double_layer_tensor(A_live))
+        return c4v_characteristic_residual(
+            root.y, a_live, root.U_star, root.U_perp, root.C_star_inv
+        )
+
+    _, vjp_p = jax.vjp(F_of_p, A_data)
+    grad_indirect = vjp_p(F_bar)[0]
+
+    grad = grad_direct - grad_indirect
+
+    if return_diagnostics:
+        diag = {
+            **meta,
+            "root_residual": root_residual,
+            "adjoint_residual": float(solve_resid),
+        }
+        return energy, grad, diag
+    return energy, grad
+
+
+def c4v_root_implicit_energy(A: Tensor, gate, **kwargs) -> jax.Array:
+    """Energy only (forward contraction plus energy evaluation)."""
+    kwargs.pop("return_diagnostics", None)
+    energy, _ = c4v_root_implicit_energy_and_grad(A, gate, **kwargs)
+    return energy

--- a/src/tenax/algorithms/_ctm_c4v_root_implicit.py
+++ b/src/tenax/algorithms/_ctm_c4v_root_implicit.py
@@ -451,6 +451,7 @@ def c4v_root_implicit_energy_and_grad(
     solve_maxiter: int = 200,
     solve_restart: int = 30,
     root_residual_warn: float = 1e-6,
+    solve_residual_warn: float = 1e-6,
     return_diagnostics: bool = False,
 ):
     """Energy and ``dE/dA`` for dense C4v iPEPS via root implicit AD.
@@ -561,6 +562,23 @@ def c4v_root_implicit_energy_and_grad(
 
     grad = grad_direct - grad_indirect
 
+    # An unconverged adjoint solve does not give an approximate gradient — it
+    # gives an arbitrary one, because F̆ is then not the solution of Eq. 17 at
+    # all.  Surfacing the residual only under ``return_diagnostics`` hid that:
+    # ``solve_maxiter=1`` returns a finite, badly wrong gradient in silence.
+    # Checked unconditionally.
+    if float(solve_resid) > solve_residual_warn:
+        warnings.warn(
+            f"C4v root implicit AD: adjoint solve did not converge "
+            f"(relative residual {float(solve_resid):.3e} > "
+            f"{solve_residual_warn:.1e} after {solve_maxiter} restart(s) of "
+            f"a {solve_restart}-dimensional Krylov space). The returned "
+            "gradient does not solve F̆ ∂_y F = ў and should not be used; "
+            "raise solve_maxiter/solve_restart or loosen solve_tol.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
     if return_diagnostics:
         diag = {
             **meta,
@@ -571,8 +589,48 @@ def c4v_root_implicit_energy_and_grad(
     return energy, grad
 
 
-def c4v_root_implicit_energy(A: Tensor, gate, **kwargs) -> jax.Array:
-    """Energy only (forward contraction plus energy evaluation)."""
-    kwargs.pop("return_diagnostics", None)
-    energy, _ = c4v_root_implicit_energy_and_grad(A, gate, **kwargs)
-    return energy
+def c4v_root_implicit_energy(
+    A: Tensor,
+    gate,
+    *,
+    chi: int = 16,
+    max_iter: int = 100,
+    conv_tol: float = 1e-10,
+    min_iter: int = 4,
+    projector_method: str = "eigh",
+    polish_steps: int = 60,
+    polish_tol: float = 1e-10,
+    **_ignored,
+) -> jax.Array:
+    """Energy only — forward contraction, parametrisation and evaluation.
+
+    Deliberately does not build either VJP or run the adjoint solve.  Callers
+    that only want an energy (line searches, diagnostics, convergence probes)
+    would otherwise pay the whole backward cost, and could fail on an adjoint
+    solve they never asked for.
+    """
+    if isinstance(A, SymmetricTensor):
+        raise TypeError(
+            "c4v_root_implicit_energy supports dense tensors only "
+            "(#715 Phase 3 covers SymmetricTensor)."
+        )
+    if not isinstance(A, DenseTensor):
+        raise TypeError(f"Expected DenseTensor, got {type(A).__name__}.")
+
+    C_t, T_t, a_t, _meta = _converge_c4v(
+        A,
+        chi,
+        max_iter=max_iter,
+        conv_tol=conv_tol,
+        min_iter=min_iter,
+        projector_method=projector_method,
+    )
+    root, _residual = c4v_root_parametrize(
+        jnp.asarray(C_t.todense()),
+        jnp.asarray(T_t.todense()),
+        _a_dense(a_t),
+        chi,
+        polish_steps=polish_steps,
+        polish_tol=polish_tol,
+    )
+    return _energy_from_env_arrays(A, root.C, root.E, C_t, T_t, gate)

--- a/src/tenax/algorithms/_ctm_root_implicit_asym.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_asym.py
@@ -1,0 +1,649 @@
+"""Root implicit differentiation for asymmetric CTMRG (#715, Phase 1).
+
+Implements Section V of Burgelman, Francuz, Brehmer, Devos, Haegeman,
+Verstraete and Vanhecke, *Implicit differentiation of tensor network
+algorithms*, arXiv:2607.15030 — the general case with four distinct corner
+and four distinct edge tensors, no spatial symmetry.
+
+Relation to :mod:`tenax.algorithms._ctm_c4v_root_implicit` (Phase 0): same
+idea, bigger variable set.  Where C4v needs ``y = (C, E, u)`` and one
+``eigh``, the asymmetric case needs
+
+    y = ({C_a}, {E_a}, {u_a}, {S_a}, {v_a})           (paper Eq. 69)
+
+— 20 variables and 20 characteristic equations for a 1x1 unit cell, because
+the truncated *SVD* has two isometries to pin instead of one.
+
+Characteristic equations, per direction ``a``, with ``M_a`` the half-infinite
+environment of Eq. 65 and ``U_a = U*_a + U_perp,a u_a``,
+``Vh_a = Vh*_a + v_a Vh_perp,a`` (Eq. 88):
+
+    R_C = P_bot Q P_top - λ_C C                  (Eq. 76)
+    R_E = P_bot (E·a) P_top - λ_E E              (Eq. 77)
+    R_u = (U_perp† M Vh†) S*^-1 - λ_S u          (Eq. 78)
+    R_S = diag(U† M Vh†) - λ_S S                 (Eq. 79)
+    R_v = S*^-1 (U† M Vh_perp†) - λ_S v          (Eq. 80)
+
+Deliberate deviation from the paper
+-----------------------------------
+§V.3 additionally replaces ``(C, E)`` by *modified* corners and edges that
+carry the inverse singular values explicitly (Eq. 82), with quartic roots
+``s^L = (s†s)^(1/4)`` and ``s^R = (s s†)^(1/4)`` on the cut legs (Eq. 73),
+so that every object transforms covariantly under the eight environment
+gauge unitaries.  That machinery exists to let ``S`` be a *general complex
+matrix* in the reverse pass.
+
+Here ``S`` is kept diagonal — a length-χ vector — which is what it is at the
+root.  The consequence is that ``S^-1/2`` in the projectors stays an
+elementwise reciprocal instead of a matrix function, so no decomposition
+enters ``F`` and the whole point of the method is preserved.  What is given
+up is exact gauge covariance under *degenerate singular values*: the
+null-space restriction of Eq. 88 still removes the divergent in-subspace
+rotations, but the residual gauge inside a degenerate block is fixed by the
+deterministic phase convention of :func:`_pin_bond_gauge` rather than
+cancelled algebraically.  See the module tests for where that shows up.
+
+Conventions (all dense ``jnp`` arrays, ``d2 = D²``)
+---------------------------------------------------
+``a[u, d, l, r]`` double layer; environment laid out exactly as
+:class:`~tenax.algorithms._ctm_tensor_init.CTMTensorEnv`::
+
+    C1[d, r]      C2[l, d]      C3[u, l]      C4[r, u]
+    T1[l, u2, r]  T2[u, r2, d]  T3[r, d2, l]  T4[d, l2, u]
+
+The middle index of each edge contracts the correspondingly-named leg of
+``a``.  A 90° counter-clockwise rotation is a pure cyclic relabel of the
+eight environment tensors with **no axis permutation** — only ``a`` is
+transposed — which is what lets one ``left`` move serve all four directions.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, NamedTuple
+
+import jax
+import jax.numpy as jnp
+
+from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
+from tenax.algorithms._ctm_tensor_init import (
+    _build_double_layer_tensor,
+    initialize_ctm_tensor_env,
+)
+from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
+
+__all__ = [
+    "AsymEnv",
+    "asym_characteristic_residual",
+    "asym_root_implicit_energy_and_grad",
+    "asym_root_parametrize",
+]
+
+
+class AsymEnv(NamedTuple):
+    """Eight-tensor CTM environment as dense arrays."""
+
+    C1: jax.Array
+    C2: jax.Array
+    C3: jax.Array
+    C4: jax.Array
+    T1: jax.Array
+    T2: jax.Array
+    T3: jax.Array
+    T4: jax.Array
+
+
+def rotate_env(env: AsymEnv) -> AsymEnv:
+    """Rotate the environment 90° counter-clockwise.
+
+    Old top-right becomes new top-left, and so on.  Every tensor's axis
+    order is already the rotated one (``C2[l, d]`` read as ``C1[d, r]``
+    is the same array), so this is a pure relabel.
+    """
+    return AsymEnv(
+        C1=env.C2,
+        C2=env.C3,
+        C3=env.C4,
+        C4=env.C1,
+        T1=env.T2,
+        T2=env.T3,
+        T3=env.T4,
+        T4=env.T1,
+    )
+
+
+def rotate_a(a: jax.Array) -> jax.Array:
+    """Rotate the double-layer tensor 90° counter-clockwise.
+
+    new-up = old-right, new-down = old-left, new-left = old-up,
+    new-right = old-down.
+    """
+    return jnp.transpose(a, (3, 2, 0, 1))
+
+
+def _unrotate_index(slot: int, k: int) -> int:
+    """Which original tensor sits in ``slot`` after ``k`` rotations.
+
+    Slots and tensors are both numbered 1..4 in the ``C1..C4`` order, and
+    one rotation advances the label by one, so this is modular arithmetic.
+    """
+    return (slot - 1 + k) % 4 + 1
+
+
+# ---------------------------------------------------------------------------
+# Enlarged corners and the half-infinite environment (paper Eq. 65)
+# ---------------------------------------------------------------------------
+
+
+def _upper_left_quadrant(env: AsymEnv, a: jax.Array) -> jax.Array:
+    """``C1·T1·T4·a`` with axes ``(chi_r, a_r, chi_d, a_d)``.
+
+    The ``(chi_d, a_d)`` pair is the vertical bond to be truncated; the
+    ``(chi_r, a_r)`` pair is what remains open to the right.
+    """
+    # C1[c,e] T1[e,f,g] T4[h,i,c] a[f,j,i,k]
+    #   c = C1.d = T4.u   e = C1.r = T1.l   f = T1's a-leg = a.u
+    #   g = T1.r          h = T4.d          i = T4's a-leg = a.l
+    #   j = a.d           k = a.r
+    return jnp.einsum("ce,efg,hic,fjik->gkhj", env.C1, env.T1, env.T4, a)
+
+
+def _lower_left_quadrant(env: AsymEnv, a: jax.Array) -> jax.Array:
+    """``C4·T3·T4·a`` with axes ``(chi_u, a_u, chi_r, a_r)``.
+
+    The ``(chi_u, a_u)`` pair is the vertical bond to be truncated.
+    """
+    # C4[m,n] T3[p,q,m] T4[n,i,t] a[u,q,i,k]
+    #   m = C4.r = T3.l   n = C4.u = T4.d   p = T3.r
+    #   q = T3's a-leg = a.d               i = T4's a-leg = a.l
+    #   t = T4.u          u = a.u          k = a.r
+    return jnp.einsum("mn,pqm,nit,uqik->tupk", env.C4, env.T3, env.T4, a)
+
+
+def _pin_bond_gauge(U, Vh, P_top, P_bot, chi, prev_P_top=None):
+    """Pin the residual phase freedom on each renormalised bond.
+
+    An SVD fixes the singular subspaces but leaves one phase per retained
+    index free (one *sign*, for real input).  That phase is a gauge of the
+    CTM bond, so the corner spectra converge without it being fixed — and
+    indeed the environment converges element-wise in ``|·|`` to 1e-14 while
+    individual signs keep flipping from sweep to sweep.  A characteristic
+    equation cannot have a root under those conditions: ``F`` compares
+    tensors, not their magnitudes.
+
+    Fixing the phase on ``U`` alone is not enough, because the projectors
+    also inherit the *previous* bond gauge through the quadrants.  Pinning
+    the largest-magnitude entry of each ``P_top`` column to be real-positive
+    fixes the new bond directly, and pushing the conjugate phase onto
+    ``P_bot`` keeps ``P_bot @ P_top = 1``.
+
+    The same phase is folded into ``(U, Vh)`` so that projectors rebuilt
+    from them inside the characteristic equations land in the same gauge.
+    """
+    if prev_P_top is None:
+        # Cold start: pin the largest-magnitude entry of each column.
+        idx = jnp.argmax(jnp.abs(P_top), axis=0)
+        ref = P_top[idx, jnp.arange(P_top.shape[1])]
+    else:
+        # Warm: align to the previous sweep.  ``argmax`` is discontinuous —
+        # when two retained singular values are close its row index hops
+        # between sweeps and the pinned phase oscillates with period two,
+        # which is exactly what a near-degenerate pair produced here.
+        ref = jnp.sum(jnp.conj(prev_P_top) * P_top, axis=0)
+    psi = jnp.where(jnp.abs(ref) > 0, jnp.conj(ref) / jnp.abs(ref), 1.0)
+    P_top = P_top * psi[None, :]
+    P_bot = jnp.conj(psi)[:, None] * P_bot
+    U = U.at[:, :chi].multiply(psi[None, :])
+    Vh = Vh.at[:chi, :].multiply(jnp.conj(psi)[:, None])
+    return U, Vh, P_top, P_bot
+
+
+def half_infinite_environment(env: AsymEnv, a: jax.Array) -> jax.Array:
+    """Paper Eq. 65: upper-left quadrant glued to lower-left along the cut.
+
+    Returns a ``(chi*d2, chi*d2)`` matrix indexed by the two quadrants'
+    outward-facing leg pairs.
+    """
+    chi, d2 = env.C1.shape[0], a.shape[0]
+    top = _upper_left_quadrant(env, a).reshape(chi * d2, chi * d2)
+    bot = _lower_left_quadrant(env, a).reshape(chi * d2, chi * d2)
+    return top @ bot
+
+
+def _fishman_projectors(
+    env: AsymEnv,
+    a: jax.Array,
+    U: jax.Array,
+    s: jax.Array,
+    Vh: jax.Array,
+    chi: int,
+):
+    """Paper Eqs. 66-67 from a *given* decomposition of the cut.
+
+    ``P_bot`` acts on the upper piece's downward leg, ``P_top`` on the lower
+    piece's upward leg, and ``P_bot @ P_top`` reconstructs the identity on
+    the retained subspace by construction.
+
+    Taking ``(U, s, Vh)`` as arguments rather than recomputing them is what
+    makes this usable inside the characteristic equations: there the
+    isometries are the *variables*, not the output of a decomposition.
+    """
+    n = env.C1.shape[0] * a.shape[0]
+    top = _upper_left_quadrant(env, a).reshape(n, n)
+    bot = _lower_left_quadrant(env, a).reshape(n, n)
+    inv_sqrt = jnp.where(s > 0, 1.0 / jnp.sqrt(jnp.where(s > 0, s, 1.0)), 0.0)
+
+    # top[(chi_r,a_r), (chi_d,a_d)] and bot[(chi_u,a_u), (chi_r,a_r)] so that
+    # M = top @ bot.  P_bot @ P_top = s^-1/2 U† (top bot) Vh† s^-1/2 = 1.
+    P_top = (bot @ Vh[:chi].conj().T) * inv_sqrt[None, :]
+    P_bot = inv_sqrt[:, None] * (U[:, :chi].conj().T @ top)
+    return P_top, P_bot
+
+
+# ---------------------------------------------------------------------------
+# Forward: one left move, four rotations to a sweep
+# ---------------------------------------------------------------------------
+
+
+def _left_move_pieces(env: AsymEnv, a: jax.Array):
+    """The three tensors a left move renormalises, before projection."""
+    chi, d2 = env.C1.shape[0], a.shape[0]
+    # C1·T1 -> (C1.d, a.u) x T1.r: the fused pair is the bond above the row.
+    c1g = jnp.einsum("ce,efg->cfg", env.C1, env.T1).reshape(chi * d2, -1)
+    # C4·T3 -> (C4.u, a.d) x T3.r: the bond below the row.
+    c4g = jnp.einsum("mn,pqm->nqp", env.C4, env.T3).reshape(chi * d2, -1)
+    # T4·a -> (T4.u, a.u) x a.r x (T4.d, a.d)
+    t4g = jnp.einsum("hit,ujik->tukhj", env.T4, a).reshape(chi * d2, d2, chi * d2)
+    return c1g, c4g, t4g
+
+
+def _apply_left_projectors(c1g, c4g, t4g, P_top, P_bot, chi):
+    """Insert ``P_top P_bot ≈ 1`` on both vertical bonds of the column."""
+    # Which projector goes where follows from the insertion
+    # ``Q_upper · (P_top P_bot) · Q_lower ≈ Q_upper · Q_lower``: the piece
+    # *above* a bond carries P_top, the piece *below* carries P_bot.  (P_top
+    # is indexed by the lower quadrant's legs and P_bot by the upper
+    # quadrant's, which reads backwards until you write out the insertion.)
+    #
+    # C1' sits above its bond.
+    C1_new = jnp.einsum("ia,ir->ar", P_top, c1g)
+    # C4' sits below its bond; result is C4[chi_r, chi_new].
+    C4_new = jnp.einsum("ir,ai->ra", c4g, P_bot)
+    # T4' is below its upper bond and above its lower one.  Result is
+    # T4[chi_down, a_r, chi_up].
+    T4_new = jnp.einsum("ui,ixj,jd->dxu", P_bot, t4g, P_top)
+    del chi
+    return C1_new, C4_new, T4_new
+
+
+def _normalize(x: jax.Array) -> jax.Array:
+    return x / (jnp.max(jnp.abs(x)) + 1e-300)
+
+
+def all_projectors(env: AsymEnv, a: jax.Array, chi: int, prev=None):
+    """Decompose the cut in all four directions, from the *same* environment.
+
+    Paper Eq. 65 and "their corresponding rotated versions": every projector
+    in a sweep is built from one environment, and every corner and edge is
+    then renormalised simultaneously.  This matters — a sequential
+    (Gauss-Seidel) sweep, where move ``k+1`` sees the output of move ``k``,
+    has a fixed point that does *not* satisfy Eqs. 76-77, because those
+    equations evaluate all four moves at the same ``y``.
+    """
+    out = []
+    env_k, a_k = env, a
+    for k in range(4):
+        M = half_infinite_environment(env_k, a_k)
+        U, s, Vh = jnp.linalg.svd(M, full_matrices=True)
+        s_keep = s[:chi] / (jnp.linalg.norm(s[:chi]) + 1e-300)
+        P_top, P_bot = _fishman_projectors(env_k, a_k, U, s_keep, Vh, chi)
+        U, Vh, P_top, P_bot = _pin_bond_gauge(
+            U, Vh, P_top, P_bot, chi, None if prev is None else prev[k][0]
+        )
+        out.append((P_top, P_bot, U, s_keep, Vh))
+        env_k, a_k = rotate_env(env_k), rotate_a(a_k)
+    return out
+
+
+def _renormalised_corner(env_k, a_k, P_top_k, P_bot_next, chi):
+    """Paper Eq. 68: the quadrant projected on *both* open legs.
+
+    The corner sits in the ``C1`` slot of move ``k`` (above its vertical
+    bond, so ``P_top`` of move ``k``) and in the ``C4`` slot of move
+    ``k+1`` (below its bond in the rotated frame, so ``P_bot`` of move
+    ``k+1``).  Both projectors act on the same upper-left quadrant.
+    """
+    n = env_k.C1.shape[0] * a_k.shape[0]
+    Q = _upper_left_quadrant(env_k, a_k).reshape(n, n)
+    del chi
+    return jnp.einsum("br,rd,da->ab", P_bot_next, Q, P_top_k)
+
+
+def _renormalised_edge(env_k, a_k, P_top_k, P_bot_k, chi):
+    """Paper Eq. 69: the edge absorbs one ``a`` and is projected on both bonds."""
+    _c1g, _c4g, t4g = _left_move_pieces(env_k, a_k)
+    del chi
+    return jnp.einsum("ui,ixj,jd->dxu", P_bot_k, t4g, P_top_k)
+
+
+def sweep(env: AsymEnv, a: jax.Array, chi: int, prev=None):
+    """One simultaneous CTMRG sweep: all four directions from one environment.
+
+    Returns ``(env, projectors)``; the projectors feed the next sweep's
+    gauge alignment.
+    """
+    projs = all_projectors(env, a, chi, prev)
+    corners: list = [None] * 4
+    edges: list = [None] * 4
+    env_k, a_k = env, a
+    for k in range(4):
+        P_top_k, P_bot_k = projs[k][0], projs[k][1]
+        P_bot_next = projs[(k + 1) % 4][1]
+        corners[_unrotate_index(1, k) - 1] = _normalize(
+            _renormalised_corner(env_k, a_k, P_top_k, P_bot_next, chi)
+        )
+        edges[_unrotate_index(4, k) - 1] = _normalize(
+            _renormalised_edge(env_k, a_k, P_top_k, P_bot_k, chi)
+        )
+        env_k, a_k = rotate_env(env_k), rotate_a(a_k)
+    return AsymEnv(*corners, *edges), projs
+
+
+def _init_env(A: Tensor, chi: int) -> tuple[AsymEnv, jax.Array]:
+    env_t = initialize_ctm_tensor_env(A, chi)
+    a_t = _build_double_layer_tensor(A)
+    labels = list(a_t.labels())
+    perm = tuple(labels.index(lbl) for lbl in ("u2", "d2", "l2", "r2"))
+    a = jnp.asarray(a_t.transpose(perm).todense())
+    env = AsymEnv(
+        C1=jnp.asarray(env_t.C1.todense()),
+        C2=jnp.asarray(env_t.C2.todense()),
+        C3=jnp.asarray(env_t.C3.todense()),
+        C4=jnp.asarray(env_t.C4.todense()),
+        T1=jnp.asarray(env_t.T1.todense()),
+        T2=jnp.asarray(env_t.T2.todense()),
+        T3=jnp.asarray(env_t.T3.todense()),
+        T4=jnp.asarray(env_t.T4.todense()),
+    )
+    return env, a
+
+
+def converge(
+    A: Tensor,
+    chi: int,
+    *,
+    max_iter: int = 200,
+    conv_tol: float = 1e-12,
+    min_iter: int = 4,
+) -> tuple[AsymEnv, jax.Array, dict[str, Any]]:
+    """Run sweeps until the corner spectra stop moving."""
+    env, a = _init_env(A, chi)
+    prev = None
+    prev_projs = None
+    residual = float("inf")
+    converged = False
+    iters = 0
+    for it in range(int(max_iter)):
+        env, prev_projs = sweep(env, a, chi, prev_projs)
+        iters = it + 1
+        # Element-wise, not spectral.  Corner *singular values* are invariant
+        # under independent rotations of each bond, so a spectral criterion
+        # calls convergence while the tensors are still moving — and the
+        # characteristic equations compare tensors.
+        cur = tuple(t / (jnp.linalg.norm(t) + 1e-300) for t in env)
+        if prev is not None and all(c.shape == q.shape for c, q in zip(cur, prev)):
+            residual = float(max(jnp.max(jnp.abs(c - q)) for c, q in zip(cur, prev)))
+            if iters >= min_iter and residual < conv_tol:
+                converged = True
+                break
+        prev = cur
+    return env, a, {"iters": iters, "residual": residual, "converged": converged}
+
+
+# ---------------------------------------------------------------------------
+# Characteristic equations (paper Eqs. 76-80)
+# ---------------------------------------------------------------------------
+
+
+class AsymRoot(NamedTuple):
+    """Root variables plus the constants held fixed while differentiating."""
+
+    env: AsymEnv
+    u: tuple  # 4 x ((n - chi) x chi)
+    s: tuple  # 4 x (chi,)
+    v: tuple  # 4 x (chi x (n - chi))
+    U_star: tuple
+    U_perp: tuple
+    Vh_star: tuple
+    Vh_perp: tuple
+    s_star_inv: tuple
+
+    @property
+    def y(self):
+        return (self.env, self.u, self.s, self.v)
+
+
+def asym_characteristic_residual(y, a: jax.Array, consts: AsymRoot, chi: int):
+    """Evaluate ``F(y, p)`` for all four directions (paper Eqs. 76-80).
+
+    Returns a pytree matching ``y``, so the system is square: 4 corners,
+    4 edges, and per direction one ``u``, one ``S`` and one ``v``.
+    """
+    env, u_all, s_all, v_all = y
+
+    # Pass 1: every projector from the same y, mirroring ``all_projectors``.
+    P_top, P_bot, M_all = [], [], []
+    env_k, a_k = env, a
+    for k in range(4):
+        U = consts.U_star[k] + consts.U_perp[k] @ u_all[k]  # Eq. 71
+        Vh = consts.Vh_star[k] + v_all[k] @ consts.Vh_perp[k]  # Eq. 72
+        M_all.append((half_infinite_environment(env_k, a_k), U, Vh))
+        pt, pb = _fishman_projectors(env_k, a_k, U, s_all[k], Vh, chi)
+        P_top.append(pt)
+        P_bot.append(pb)
+        env_k, a_k = rotate_env(env_k), rotate_a(a_k)
+
+    # Pass 2: residuals.
+    corners: list = [None] * 4
+    edges: list = [None] * 4
+    R_u, R_S, R_v = [None] * 4, [None] * 4, [None] * 4
+    env_k, a_k = env, a
+    for k in range(4):
+        M, U, Vh = M_all[k]
+        s_inv = consts.s_star_inv[k]
+        core = U.conj().T @ M @ Vh.conj().T
+        lam_S = jnp.vdot(s_all[k], jnp.diag(core)).real
+
+        R_S[k] = jnp.diag(core) - lam_S * s_all[k]
+        R_u[k] = (consts.U_perp[k].conj().T @ M @ Vh.conj().T) * s_inv[
+            None, :
+        ] - lam_S * u_all[k]
+        R_v[k] = (
+            s_inv[:, None] * (U.conj().T @ M @ consts.Vh_perp[k].conj().T)
+            - lam_S * v_all[k]
+        )
+
+        C_new = _renormalised_corner(env_k, a_k, P_top[k], P_bot[(k + 1) % 4], chi)
+        C_cur = env_k.C1
+        lam_C = jnp.vdot(C_cur, C_new).real
+        corners[_unrotate_index(1, k) - 1] = C_new - lam_C * C_cur
+
+        E_new = _renormalised_edge(env_k, a_k, P_top[k], P_bot[k], chi)
+        E_cur = env_k.T4
+        lam_E = jnp.vdot(E_cur, E_new).real
+        edges[_unrotate_index(4, k) - 1] = E_new - lam_E * E_cur
+
+        env_k, a_k = rotate_env(env_k), rotate_a(a_k)
+
+    return (AsymEnv(*corners, *edges), tuple(R_u), tuple(R_S), tuple(R_v))
+
+
+def asym_root_parametrize(
+    env: AsymEnv,
+    a: jax.Array,
+    chi: int,
+    *,
+    pinv_rtol: float = 1e-10,
+    polish_steps: int = 40,
+    polish_tol: float = 1e-10,
+) -> tuple[AsymRoot, float]:
+    """Extract ``y* = ({C}, {E}, 0, {S*}, 0)`` and the frozen isometries.
+
+    Each environment tensor is rescaled to unit Frobenius norm so that the
+    ``λ`` defined as an inner product in Eqs. 76-77 really is the
+    eigenvalue those equations need.  Rescaling is harmless: the energy is
+    a ratio with equal numbers of corners and edges above and below.
+    """
+    best: tuple[AsymRoot, float] | None = None
+    prev_projs = None
+    for _step in range(max(int(polish_steps), 1)):
+        env = AsymEnv(*[t / (jnp.linalg.norm(t) + 1e-300) for t in env])
+        projs = all_projectors(env, a, chi, prev_projs)
+        prev_projs = projs
+        U_star, U_perp, Vh_star, Vh_perp, s_list, s_inv = [], [], [], [], [], []
+        for k in range(4):
+            _pt, _pb, U, s_keep, Vh = projs[k]
+            U_star.append(U[:, :chi])
+            U_perp.append(U[:, chi:])
+            Vh_star.append(Vh[:chi])
+            Vh_perp.append(Vh[chi:])
+            s_list.append(s_keep)
+            cutoff = pinv_rtol * jnp.max(s_keep)
+            s_inv.append(
+                jnp.where(
+                    s_keep > cutoff, 1.0 / jnp.where(s_keep > cutoff, s_keep, 1.0), 0.0
+                )
+            )
+
+        n = env.C1.shape[0] * a.shape[0]
+        root = AsymRoot(
+            env=env,
+            u=tuple(jnp.zeros((n - chi, chi), dtype=env.C1.dtype) for _ in range(4)),
+            s=tuple(s_list),
+            v=tuple(jnp.zeros((chi, n - chi), dtype=env.C1.dtype) for _ in range(4)),
+            U_star=tuple(U_star),
+            U_perp=tuple(U_perp),
+            Vh_star=tuple(Vh_star),
+            Vh_perp=tuple(Vh_perp),
+            s_star_inv=tuple(s_inv),
+        )
+        R = asym_characteristic_residual(root.y, a, root, chi)
+        residual = float(
+            jnp.sqrt(sum(jnp.sum(jnp.abs(leaf) ** 2) for leaf in jax.tree.leaves(R)))
+        )
+        if best is None or residual < best[1]:
+            best = (root, residual)
+        if residual <= polish_tol:
+            break
+        env, prev_projs = sweep(env, a, chi, projs)
+
+    assert best is not None
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Energy and gradient
+# ---------------------------------------------------------------------------
+
+
+def _to_ctm_env(env: AsymEnv, template):
+    return type(template)(
+        **{
+            name: DenseTensor(getattr(env, name), getattr(template, name).indices)
+            for name in ("C1", "C2", "C3", "C4", "T1", "T2", "T3", "T4")
+        }
+    )
+
+
+def asym_energy(A: Tensor, env: AsymEnv, template, gate) -> jax.Array:
+    return compute_energy_ctm_tensor(A, _to_ctm_env(env, template), gate)
+
+
+def asym_root_implicit_energy_and_grad(
+    A: Tensor,
+    gate,
+    *,
+    chi: int = 8,
+    max_iter: int = 200,
+    conv_tol: float = 1e-12,
+    min_iter: int = 4,
+    polish_steps: int = 40,
+    polish_tol: float = 1e-10,
+    solve_tol: float = 1e-8,
+    solve_maxiter: int = 400,
+    solve_restart: int = 30,
+    root_residual_warn: float = 1e-6,
+    return_diagnostics: bool = False,
+):
+    """Energy and ``dE/dA`` for a 1x1 unit cell via asymmetric root implicit AD."""
+    from tenax.algorithms._ctm_c4v_root_implicit import _solve_root_adjoint
+
+    if isinstance(A, SymmetricTensor):
+        raise TypeError("Asymmetric root implicit AD is dense-only (#715 Phase 3).")
+
+    A_const = DenseTensor(jax.lax.stop_gradient(A.todense()), A.indices)
+    env, a_arr, meta = converge(
+        A_const, chi, max_iter=max_iter, conv_tol=conv_tol, min_iter=min_iter
+    )
+    root, root_residual = asym_root_parametrize(
+        env, a_arr, chi, polish_steps=polish_steps, polish_tol=polish_tol
+    )
+    if root_residual > root_residual_warn:
+        warnings.warn(
+            f"Asymmetric root implicit AD: ‖F(y*)‖ = {root_residual:.3e} exceeds "
+            f"{root_residual_warn:.1e}; the implicit-function gradient is "
+            "correspondingly inaccurate (paper Fig. 1).",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    template = initialize_ctm_tensor_env(A_const, chi)
+    A_data = jnp.asarray(A.todense())
+
+    def energy_of(a_data, env_arrays):
+        A_live = DenseTensor(a_data, A.indices)
+        return asym_energy(A_live, env_arrays, template, gate)
+
+    energy, vjp_energy = jax.vjp(energy_of, A_data, root.env)
+    grad_direct, env_bar = vjp_energy(jnp.ones((), dtype=energy.dtype))
+    y_bar = (
+        env_bar,
+        tuple(jnp.zeros_like(x) for x in root.u),
+        tuple(jnp.zeros_like(x) for x in root.s),
+        tuple(jnp.zeros_like(x) for x in root.v),
+    )
+
+    def F_of_y(y):
+        return asym_characteristic_residual(y, a_arr, root, chi)
+
+    _, vjp_y = jax.vjp(F_of_y, root.y)
+    F_bar, solve_resid = _solve_root_adjoint(
+        lambda v: vjp_y(v)[0],
+        y_bar,
+        tol=solve_tol,
+        maxiter=solve_maxiter,
+        restart=solve_restart,
+    )
+
+    def F_of_p(a_data):
+        A_live = DenseTensor(a_data, A.indices)
+        a_t = _build_double_layer_tensor(A_live)
+        labels = list(a_t.labels())
+        perm = tuple(labels.index(lbl) for lbl in ("u2", "d2", "l2", "r2"))
+        a_live = a_t.transpose(perm).todense()
+        return asym_characteristic_residual(root.y, a_live, root, chi)
+
+    _, vjp_p = jax.vjp(F_of_p, A_data)
+    grad = grad_direct - vjp_p(F_bar)[0]
+
+    if return_diagnostics:
+        return (
+            energy,
+            grad,
+            {
+                **meta,
+                "root_residual": root_residual,
+                "adjoint_residual": float(solve_resid),
+            },
+        )
+    return energy, grad

--- a/src/tenax/algorithms/_ctm_root_implicit_asym.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_asym.py
@@ -24,24 +24,23 @@ environment of Eq. 65 and ``U_a = U*_a + U_perp,a u_a``,
     R_S = diag(U† M Vh†) - λ_S S                 (Eq. 79)
     R_v = S*^-1 (U† M Vh_perp†) - λ_S v          (Eq. 80)
 
-Deliberate deviation from the paper
------------------------------------
-§V.3 additionally replaces ``(C, E)`` by *modified* corners and edges that
-carry the inverse singular values explicitly (Eq. 82), with quartic roots
-``s^L = (s†s)^(1/4)`` and ``s^R = (s s†)^(1/4)`` on the cut legs (Eq. 73),
-so that every object transforms covariantly under the eight environment
-gauge unitaries.  That machinery exists to let ``S`` be a *general complex
-matrix* in the reverse pass.
+Where this stands (#715 Phase 1, incomplete)
+-------------------------------------------
+``S`` is a general complex chi x chi matrix, and the projectors use a genuine
+matrix inverse square root (Denman-Beavers, so no decomposition enters ``F``).
+That much is required, not optional: with a *diagonal* ``S`` the in-space
+rotation of the isometries has nowhere to go, the projector closure breaks at
+first order, and Eq. 88's null-space restriction then discards a physical
+contribution instead of a gauge one — the gradient came out 120% wrong.
+Promoting ``S`` brings it to 1-2.5%.
 
-Here ``S`` is kept diagonal — a length-χ vector — which is what it is at the
-root.  The consequence is that ``S^-1/2`` in the projectors stays an
-elementwise reciprocal instead of a matrix function, so no decomposition
-enters ``F`` and the whole point of the method is preserved.  What is given
-up is exact gauge covariance under *degenerate singular values*: the
-null-space restriction of Eq. 88 still removes the divergent in-subspace
-rotations, but the residual gauge inside a degenerate block is fixed by the
-deterministic phase convention of :func:`_pin_bond_gauge` rather than
-cancelled algebraically.  See the module tests for where that shows up.
+Still missing is the rest of Eqs. 73-82: the modified corners and edges that
+carry ``s`` explicitly on the bonds, and the quartic roots
+``s^L = (S S†)^-1/4``, ``s^R = (S† S)^-1/4`` on the *cut legs* of that
+environment.  Putting those roots inside the projectors instead was tried and
+is worse (20%): they are equivariant under independent left/right rotations,
+but their product is not ``S^-1``, so the closure breaks for a non-diagonal
+``S``.  See ``docs/plans/2026-07-29-715-phase1-modified-variables.md``.
 
 Conventions (all dense ``jnp`` arrays, ``d2 = D²``)
 ---------------------------------------------------
@@ -160,6 +159,43 @@ def _lower_left_quadrant(env: AsymEnv, a: jax.Array) -> jax.Array:
     return jnp.einsum("mn,pqm,nit,uqik->tupk", env.C4, env.T3, env.T4, a)
 
 
+def _denman_beavers(A: jax.Array, n_iter: int = 24):
+    """Principal square root and inverse square root, together.
+
+    Deliberately *not* ``eigh``.  ``S`` is a general matrix here, and while a
+    matrix root is smooth even where the spectrum is degenerate (its Frechet
+    derivative is a Loewner divided difference, which tends to ``f'(x)``),
+    JAX's ``eigh`` VJP still divides by eigenvalue differences and would NaN
+    exactly where this method is supposed to be safe.
+
+    Denman-Beavers is matrix multiplications and inverses only, so ``F``
+    stays free of decompositions and differentiates cleanly.  Convergence is
+    quadratic; the spectral range seen here (1 to ~1e-3) is comfortable.
+    """
+    eye = jnp.eye(A.shape[0], dtype=A.dtype)
+    # Frobenius scaling only — deliberately no decomposition here, not even
+    # for the scale factor, or an ``svd`` reappears in the jaxpr of ``F`` and
+    # the whole point of the method is lost.  Rank deficiency is handled
+    # where it arises, by flooring the retained spectrum in
+    # :func:`all_projectors`.
+    scale = jnp.sqrt(jnp.linalg.norm(A) + 1e-300)
+    Y, Z = A / (scale**2), eye
+    for _ in range(n_iter):
+        Yn = 0.5 * (Y + jnp.linalg.inv(Z))
+        Zn = 0.5 * (Z + jnp.linalg.inv(Y))
+        Y, Z = Yn, Zn
+    return Y * scale, Z / scale
+
+
+def _inv_sqrt(A: jax.Array, n_iter: int = 24) -> jax.Array:
+    return _denman_beavers(A, n_iter)[1]
+
+
+def _inv_quartic_root(A: jax.Array, n_iter: int = 24) -> jax.Array:
+    """``A^-1/4`` for Hermitian positive ``A``, as ``(A^1/2)^-1/2``."""
+    return _denman_beavers(_denman_beavers(A, n_iter)[0], n_iter)[1]
+
+
 def _pin_bond_gauge(U, Vh, P_top, P_bot, chi, prev_P_top=None):
     """Pin the residual phase freedom on each renormalised bond.
 
@@ -231,12 +267,31 @@ def _fishman_projectors(
     n = env.C1.shape[0] * a.shape[0]
     top = _upper_left_quadrant(env, a).reshape(n, n)
     bot = _lower_left_quadrant(env, a).reshape(n, n)
-    inv_sqrt = jnp.where(s > 0, 1.0 / jnp.sqrt(jnp.where(s > 0, s, 1.0)), 0.0)
+    # ``s`` is a general chi x chi matrix, not a vector of singular values.
+    # That is what makes the pair gauge-covariant: under the bond rotation
+    # U -> U W, Vh -> W† Vh, S -> W† S W the matrix root is equivariant,
+    # (W† S W)^-1/2 = W† S^-1/2 W, so P_bot -> W† P_bot and P_top -> P_top W
+    # and the closure survives.  With a *diagonal* S the in-space rotation is
+    # not representable, the closure breaks at first order, and the
+    # null-space restriction of Eq. 88 then discards a real contribution
+    # instead of a gauge one.
+    # A genuine *matrix* inverse square root, symmetric on both ends.  This
+    # is what makes the pair gauge-covariant: under the bond rotation
+    # U -> U W, Vh -> W† Vh, S -> W† S W the matrix root is equivariant,
+    # (W† S W)^-1/2 = W† S^-1/2 W, so P_bot -> W† P_bot, P_top -> P_top W and
+    # P_bot @ P_top = S^-1/2 (U† M Vh†) S^-1/2 = S^-1/2 S S^-1/2 = 1 survives
+    # for *any* S, diagonal or not.
+    #
+    # The two-sided roots of paper Eq. 73, (S S†)^-1/4 and (S† S)^-1/4, were
+    # tried here and are worse (2e-1 vs 2.5e-2 gradient error): they are
+    # equivariant under independent left/right rotations, but their product
+    # is not S^-1, so the closure breaks at first order in a non-diagonal S.
+    # In the paper they sit on the *cut legs* of the modified environment,
+    # where no closure condition applies — not inside the projectors.
+    inv_sqrt = _inv_sqrt(s)
 
-    # top[(chi_r,a_r), (chi_d,a_d)] and bot[(chi_u,a_u), (chi_r,a_r)] so that
-    # M = top @ bot.  P_bot @ P_top = s^-1/2 U† (top bot) Vh† s^-1/2 = 1.
-    P_top = (bot @ Vh[:chi].conj().T) * inv_sqrt[None, :]
-    P_bot = inv_sqrt[:, None] * (U[:, :chi].conj().T @ top)
+    P_top = bot @ Vh[:chi].conj().T @ inv_sqrt
+    P_bot = inv_sqrt @ (U[:, :chi].conj().T @ top)
     return P_top, P_bot
 
 
@@ -295,12 +350,18 @@ def all_projectors(env: AsymEnv, a: jax.Array, chi: int, prev=None):
     for k in range(4):
         M = half_infinite_environment(env_k, a_k)
         U, s, Vh = jnp.linalg.svd(M, full_matrices=True)
-        s_keep = s[:chi] / (jnp.linalg.norm(s[:chi]) + 1e-300)
-        P_top, P_bot = _fishman_projectors(env_k, a_k, U, s_keep, Vh, chi)
+        # Floor the retained spectrum before it becomes a matrix: early
+        # sweeps start from a near-identity environment whose half-infinite
+        # matrix is rank deficient, and a singular S makes the matrix
+        # inverse square root below produce NaNs.
+        s_k = s[:chi]
+        s_k = jnp.maximum(s_k, 1e-12 * s_k[0])
+        S_keep = jnp.diag(s_k / (jnp.linalg.norm(s_k) + 1e-300))
+        P_top, P_bot = _fishman_projectors(env_k, a_k, U, S_keep, Vh, chi)
         U, Vh, P_top, P_bot = _pin_bond_gauge(
             U, Vh, P_top, P_bot, chi, None if prev is None else prev[k][0]
         )
-        out.append((P_top, P_bot, U, s_keep, Vh))
+        out.append((P_top, P_bot, U, S_keep, Vh))
         env_k, a_k = rotate_env(env_k), rotate_a(a_k)
     return out
 
@@ -452,15 +513,19 @@ def asym_characteristic_residual(y, a: jax.Array, consts: AsymRoot, chi: int):
         M, U, Vh = M_all[k]
         s_inv = consts.s_star_inv[k]
         core = U.conj().T @ M @ Vh.conj().T
-        lam_S = jnp.vdot(s_all[k], jnp.diag(core)).real
+        lam_S = jnp.vdot(s_all[k], core).real
 
-        R_S[k] = jnp.diag(core) - lam_S * s_all[k]
-        R_u[k] = (consts.U_perp[k].conj().T @ M @ Vh.conj().T) * s_inv[
-            None, :
-        ] - lam_S * u_all[k]
+        # Eq. 79 as the full chi x chi block, not just its diagonal.  With U
+        # and Vh pinned to their null-space variations (Eq. 88) the in-space
+        # rotation has nowhere to go except into S, so S has to be free to
+        # leave the diagonal in the reverse pass.  Phase 0's analogue is
+        # "treat C as a generic complex Hermitian matrix".
+        R_S[k] = core - lam_S * s_all[k]
+        R_u[k] = (consts.U_perp[k].conj().T @ M @ Vh.conj().T) @ s_inv - lam_S * u_all[
+            k
+        ]
         R_v[k] = (
-            s_inv[:, None] * (U.conj().T @ M @ consts.Vh_perp[k].conj().T)
-            - lam_S * v_all[k]
+            s_inv @ (U.conj().T @ M @ consts.Vh_perp[k].conj().T) - lam_S * v_all[k]
         )
 
         C_new = _renormalised_corner(env_k, a_k, P_top[k], P_bot[(k + 1) % 4], chi)
@@ -502,18 +567,20 @@ def asym_root_parametrize(
         prev_projs = projs
         U_star, U_perp, Vh_star, Vh_perp, s_list, s_inv = [], [], [], [], [], []
         for k in range(4):
-            _pt, _pb, U, s_keep, Vh = projs[k]
+            _pt, _pb, U, S_keep, Vh = projs[k]
             U_star.append(U[:, :chi])
             U_perp.append(U[:, chi:])
             Vh_star.append(Vh[:chi])
             Vh_perp.append(Vh[chi:])
-            s_list.append(s_keep)
-            cutoff = pinv_rtol * jnp.max(s_keep)
-            s_inv.append(
-                jnp.where(
-                    s_keep > cutoff, 1.0 / jnp.where(s_keep > cutoff, s_keep, 1.0), 0.0
-                )
+            s_list.append(S_keep)
+            diag = jnp.diag(S_keep).real
+            cutoff = pinv_rtol * jnp.max(diag)
+            inv_diag = jnp.where(
+                diag > cutoff, 1.0 / jnp.where(diag > cutoff, diag, 1.0), 0.0
             )
+            # Constant right/left preconditioner for Eqs. 78 and 80; diagonal
+            # because the root S* is.
+            s_inv.append(jnp.diag(inv_diag).astype(S_keep.dtype))
 
         n = env.C1.shape[0] * a.shape[0]
         root = AsymRoot(

--- a/src/tenax/algorithms/_ctm_root_implicit_asym.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_asym.py
@@ -640,9 +640,36 @@ def asym_root_implicit_energy_and_grad(
     solve_maxiter: int = 400,
     solve_restart: int = 30,
     root_residual_warn: float = 1e-6,
+    allow_known_invalid_gradient: bool = False,
     return_diagnostics: bool = False,
 ):
-    """Energy and ``dE/dA`` for a 1x1 unit cell via asymmetric root implicit AD."""
+    """Energy and ``dE/dA`` for a 1x1 unit cell via asymmetric root implicit AD.
+
+    .. warning::
+
+       **The gradient this returns is known to be wrong by ~2.5%** and is
+       gated behind ``allow_known_invalid_gradient`` so it cannot reach an
+       optimiser by accident.  See #718: ``F`` freezes ``U*`` and ``Vh*``,
+       which drops a real ``∂_c F · dc/dp`` term — measured directly as
+       ``dE/dU* ≈ 1.5e-2`` against a missing ``7.1e-3``.
+
+       Everything else in this path is verified: the root sits at 2.5e-16,
+       the ``y -> x`` map reproduces the energy to twelve digits, the solve
+       agrees with a dense reference to eleven digits, and the system is well
+       conditioned.  None of that makes the gradient usable.
+
+       The *energy* is correct and may be used; call :func:`asym_energy` on a
+       converged environment if that is all you need.
+    """
+    if not allow_known_invalid_gradient:
+        raise NotImplementedError(
+            "Asymmetric root-implicit gradients are incorrect by ~2.5% "
+            "(tenax-lab/tenax#718: freezing U*, Vh* in F drops a real term). "
+            "The forward energy is correct and the root is exact, but this "
+            "gradient must not be used for optimisation. Pass "
+            "allow_known_invalid_gradient=True to obtain it anyway, for "
+            "debugging or for reproducing the #718 measurements."
+        )
     from tenax.algorithms._ctm_c4v_root_implicit import _solve_root_adjoint
 
     if isinstance(A, SymmetricTensor):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,7 @@ _FILE_MARKERS = {
     # Root implicit AD for C4v CTMRG (#715 Phase 0): each parity test runs a
     # full CTM convergence plus finite-difference reruns.
     "test_ctm_c4v_root_implicit.py": "algorithm",
+    "test_ctm_root_implicit_asym.py": "algorithm",
     "test_ctm_truncation_error.py": "core",
     "test_ctm_paired.py": "algorithm",
     "test_ctm_python_loop.py": "algorithm",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,9 @@ _FILE_MARKERS = {
     "test_krylov.py": "core",
     "test_tdvp.py": "algorithm",
     "test_ctm_tensor_c4v.py": "algorithm",
+    # Root implicit AD for C4v CTMRG (#715 Phase 0): each parity test runs a
+    # full CTM convergence plus finite-difference reruns.
+    "test_ctm_c4v_root_implicit.py": "algorithm",
     "test_ctm_truncation_error.py": "core",
     "test_ctm_paired.py": "algorithm",
     "test_ctm_python_loop.py": "algorithm",

--- a/tests/test_ctm_c4v_root_implicit.py
+++ b/tests/test_ctm_c4v_root_implicit.py
@@ -1,0 +1,205 @@
+"""Root implicit differentiation for C4v CTMRG (#715 Phase 0, arXiv:2607.15030).
+
+The point of these tests is the paper's central claim: the gradient is
+obtained from an algebraic characteristic equation, so no ``eigh``/``svd``
+backward appears in the gradient path, and degenerate spectra — which make
+the truncated-decomposition VJP diverge — are harmless.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_c4v_root_implicit import (
+    c4v_characteristic_residual,
+    c4v_root_implicit_energy_and_grad,
+)
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import U1Symmetry
+from tenax.core.tensor import DenseTensor
+
+
+def _site_tensor(D: int = 2, d: int = 2, seed: int = 42, eps: float = 0.5):
+    """Entangled-but-C4v-friendly iPEPS tensor with trivial U(1) charges.
+
+    ``eps`` controls the deviation from a product state.  It must be large
+    enough that the kept corner spectrum sits above numerical noise: at
+    ``eps = 0.1`` and ``chi = 8`` the truncation cuts through eigenvalues of
+    order 1e-12 and the environment is no longer a root of the
+    characteristic equations (see ``test_warns_on_degenerate_truncation``).
+    """
+    rng = np.random.RandomState(seed)
+    data = eps * jnp.array(rng.standard_normal((D, D, D, D, d)))
+    data = data.at[0, 0, 0, 0, 0].set(1.0)
+    data = data / (jnp.linalg.norm(data) + 1e-10)
+    sym = U1Symmetry()
+    charges = np.zeros(D, dtype=np.int32)
+    phys_charges = np.zeros(d, dtype=np.int32)
+    indices = (
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(
+            sym, phys_charges.copy(), FlowDirection.IN, label="phys"
+        ),
+    )
+    return DenseTensor(data, indices)
+
+
+def _xxz_gate(delta: float = 1.0):
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+    H = delta * jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+    return H.reshape(2, 2, 2, 2)
+
+
+_CTM_KW = dict(max_iter=300, conv_tol=1e-12, projector_method="eigh")
+
+
+def _directional_fd(A, gate, direction, h, **kw):
+    base = A.todense()
+
+    def at(t):
+        e, _ = c4v_root_implicit_energy_and_grad(
+            DenseTensor(base + t * direction, A.indices), gate, **kw
+        )
+        return float(e)
+
+    return (at(h) - at(-h)) / (2.0 * h)
+
+
+# ------------------------------------------------------------------ #
+# The root                                                            #
+# ------------------------------------------------------------------ #
+
+
+def test_characteristic_residual_vanishes_at_root():
+    """``F(y*, p) = 0`` — the environment really is a root, not just a fixed point.
+
+    This is the precondition for the implicit function theorem, and per the
+    paper's Fig. 1 it is what bounds the gradient accuracy.
+    """
+    A = _site_tensor(eps=1.0)
+    _e, _g, diag = c4v_root_implicit_energy_and_grad(
+        A, _xxz_gate(1.0), chi=6, return_diagnostics=True, **_CTM_KW
+    )
+    assert diag["root_residual"] < 1e-9, diag
+    assert diag["adjoint_residual"] < 1e-8, diag
+
+
+def test_no_eigh_or_svd_in_the_differentiated_equations():
+    """The characteristic equations are pure contractions.
+
+    This is the structural claim that makes the method stable: whatever the
+    forward contraction does, the backward differentiates only ``F``, and
+    ``F`` contains no decomposition to differentiate.
+    """
+    rng = np.random.RandomState(0)
+    chi, d2 = 4, 4
+    n = chi * d2
+    C = jnp.array(rng.standard_normal((chi, chi)))
+    E = jnp.array(rng.standard_normal((chi, d2, chi)))
+    a = jnp.array(rng.standard_normal((d2, d2, d2, d2)))
+    Q, _ = jnp.linalg.qr(jnp.array(rng.standard_normal((n, n))))
+    U_star, U_perp = Q[:, :chi], Q[:, chi:]
+    C_inv = jnp.eye(chi)
+    u = jnp.zeros((n - chi, chi))
+
+    def F(y):
+        return c4v_characteristic_residual(y, a, U_star, U_perp, C_inv)
+
+    forward = str(jax.make_jaxpr(F)((C, E, u)))
+    _, vjp = jax.vjp(F, (C, E, u))
+    backward = str(jax.make_jaxpr(vjp)(F((C, E, u))))
+
+    for banned in ("eigh", "svd", "eig "):
+        assert banned not in forward, f"{banned!r} in forward jaxpr of F"
+        assert banned not in backward, f"{banned!r} in backward jaxpr of F"
+
+
+# ------------------------------------------------------------------ #
+# Gradient parity                                                     #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize("delta,chi", [(0.3, 6), (1.0, 6), (1.0, 4)])
+def test_gradient_matches_finite_difference(delta, chi):
+    """AD gradient reproduces a symmetric finite difference.
+
+    ``delta = 1.0`` is the isotropic Heisenberg point, where the corner
+    spectrum is SU(2)-degenerate — the case that floors the truncated-SVD
+    backward on the production path at ~5e-4.
+    """
+    A = _site_tensor(eps=1.0)
+    gate = _xxz_gate(delta)
+    kw = dict(chi=chi, **_CTM_KW)
+
+    _e, grad, diag = c4v_root_implicit_energy_and_grad(
+        A, gate, return_diagnostics=True, **kw
+    )
+    assert diag["root_residual"] < 1e-9, diag
+
+    rng = np.random.RandomState(7)
+    v = jnp.array(rng.standard_normal(A.todense().shape))
+    v = v / jnp.linalg.norm(v)
+
+    ad = float(jnp.sum(grad * v))
+    fd = _directional_fd(A, gate, v, 1e-5, **kw)
+    assert abs(fd - ad) / max(abs(fd), 1e-30) < 1e-5, (fd, ad)
+
+
+def test_gradient_is_finite_on_a_degenerate_spectrum():
+    """A deliberately degenerate corner spectrum yields a finite gradient.
+
+    A near-product state at ``chi = 8`` retains eigenvalues that are equal
+    to within numerical noise — the configuration that produces NaNs from a
+    ``_gauge_fixed_svd`` backward on the production path.  Nothing here
+    divides by an eigenvalue difference, so the gradient stays finite.
+    """
+    A = _site_tensor(eps=0.02)
+    with warnings.catch_warnings():
+        # A large residual is a legitimate outcome here and is covered by
+        # ``test_warns_on_degenerate_truncation``; this test is about the
+        # gradient being finite either way.
+        warnings.simplefilter("ignore", RuntimeWarning)
+        _e, grad = c4v_root_implicit_energy_and_grad(
+            A, _xxz_gate(1.0), chi=8, **_CTM_KW
+        )
+    assert jnp.all(jnp.isfinite(grad))
+
+
+def test_warns_on_degenerate_truncation():
+    """Truncating through numerical noise is reported, not silently absorbed."""
+    A = _site_tensor(eps=0.1)
+    with pytest.warns(RuntimeWarning, match=r"‖F\(y\*\)‖"):
+        c4v_root_implicit_energy_and_grad(A, _xxz_gate(1.0), chi=8, **_CTM_KW)
+
+
+# ------------------------------------------------------------------ #
+# Guards                                                              #
+# ------------------------------------------------------------------ #
+
+
+def test_rejects_symmetric_tensor():
+    """SymmetricTensor support is #715 Phase 3, not silently wrong here."""
+    from tenax.core.tensor import SymmetricTensor
+
+    sym = U1Symmetry()
+    idx = tuple(
+        TensorIndex.from_charges(
+            sym, np.zeros(2, dtype=np.int32), FlowDirection.OUT, label=lbl
+        )
+        for lbl in ("u", "d", "l", "r", "phys")
+    )
+    A = SymmetricTensor.from_dense(jnp.ones((2, 2, 2, 2, 2)), idx, tol=float("inf"))
+    with pytest.raises(TypeError, match="Phase 3"):
+        c4v_root_implicit_energy_and_grad(A, _xxz_gate(1.0), chi=4)

--- a/tests/test_ctm_c4v_root_implicit.py
+++ b/tests/test_ctm_c4v_root_implicit.py
@@ -19,6 +19,7 @@ jax.config.update("jax_enable_x64", True)
 
 from tenax.algorithms._ctm_c4v_root_implicit import (
     c4v_characteristic_residual,
+    c4v_root_implicit_energy,
     c4v_root_implicit_energy_and_grad,
 )
 from tenax.core.index import FlowDirection, TensorIndex
@@ -182,6 +183,54 @@ def test_warns_on_degenerate_truncation():
     A = _site_tensor(eps=0.1)
     with pytest.warns(RuntimeWarning, match=r"‖F\(y\*\)‖"):
         c4v_root_implicit_energy_and_grad(A, _xxz_gate(1.0), chi=8, **_CTM_KW)
+
+
+def test_warns_when_the_adjoint_solve_does_not_converge():
+    """An unconverged solve is an invalid gradient, not an approximate one.
+
+    ``F̆`` is defined as *the* solution of Eq. 17; stop the Krylov iteration
+    early and what comes back is finite, plausible-looking and wrong.  The
+    residual used to be visible only under ``return_diagnostics``.
+    """
+    A = _site_tensor(eps=1.0)
+    # ``solve_maxiter`` counts GMRES *restarts*, so the Krylov dimension has
+    # to be squeezed too -- one restart of a 30-dimensional space converges.
+    with pytest.warns(RuntimeWarning, match="adjoint solve did not converge"):
+        c4v_root_implicit_energy_and_grad(
+            A,
+            _xxz_gate(1.0),
+            chi=6,
+            solve_maxiter=1,
+            solve_restart=1,
+            solve_tol=1e-14,
+            **_CTM_KW,
+        )
+
+
+def test_energy_only_helper_skips_the_adjoint_solve():
+    """``c4v_root_implicit_energy`` must not pay for -- or fail in -- a solve.
+
+    Sabotaging the adjoint solve leaves the energy untouched, which is the
+    property that makes the helper usable in a line search.
+    """
+    import tenax.algorithms._ctm_c4v_root_implicit as mod
+
+    A = _site_tensor(eps=1.0)
+    gate = _xxz_gate(1.0)
+    kw = dict(chi=6, **_CTM_KW)
+
+    reference, _grad = c4v_root_implicit_energy_and_grad(A, gate, **kw)
+
+    original = mod._solve_root_adjoint
+    mod._solve_root_adjoint = lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("energy-only path ran the adjoint solve")
+    )
+    try:
+        energy = c4v_root_implicit_energy(A, gate, **kw)
+    finally:
+        mod._solve_root_adjoint = original
+
+    assert abs(float(energy) - float(reference)) < 1e-12
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_ctm_root_implicit_asym.py
+++ b/tests/test_ctm_root_implicit_asym.py
@@ -212,7 +212,12 @@ def test_gradient_parity_needs_the_modified_variables():
     chi = 4
     gate = _gate(1.0)
     _e, grad = M.asym_root_implicit_energy_and_grad(
-        A, gate, chi=chi, max_iter=300, conv_tol=1e-13
+        A,
+        gate,
+        chi=chi,
+        max_iter=300,
+        conv_tol=1e-13,
+        allow_known_invalid_gradient=True,
     )
 
     env0, _a, _m = M.converge(A, chi, max_iter=300, conv_tol=1e-13)
@@ -229,3 +234,100 @@ def test_gradient_parity_needs_the_modified_variables():
     g_ref = jax.grad(energy_explicit)(A.todense())
     rel = float(jnp.linalg.norm(grad - g_ref) / jnp.linalg.norm(g_ref))
     assert rel < 1e-5, rel
+
+
+def test_gradient_entry_point_is_gated():
+    """The known-bad gradient cannot reach an optimiser by accident (#718)."""
+    A = _site_tensor()
+    with pytest.raises(NotImplementedError, match="718"):
+        M.asym_root_implicit_energy_and_grad(A, _gate(1.0), chi=4)
+
+
+def _contract_by_label(pieces, bonds, open_legs):
+    """``einsum`` driven purely by leg names, not by hand-written subscripts."""
+    letters: dict[tuple[str, str], str] = {}
+    canonical = {b: a for a, b in bonds}
+
+    def key(piece, leg):
+        return canonical.get((piece, leg), (piece, leg))
+
+    def letter(tag):
+        if tag not in letters:
+            letters[tag] = "abcdefghijklmnopqrstuvwxyz"[len(letters)]
+        return letters[tag]
+
+    subscripts = [
+        "".join(letter(key(name, leg)) for leg in legs) for name, _arr, legs in pieces
+    ]
+    out = "".join(letter(key(p, leg)) for p, leg in open_legs)
+    return jnp.einsum(
+        f"{','.join(subscripts)}->{out}", *[arr for _n, arr, _l in pieces]
+    )
+
+
+def test_quadrant_wiring_matches_the_library_leg_labels():
+    """The quadrant einsums join the legs the CTM env labels say are adjacent.
+
+    Every endpoint in a quadrant has dimension ``chi`` or ``D**2``, so a
+    transposed contraction is shape-legal and silently wrong.  This rebuilds
+    both quadrants from the adjacency the labels encode -- ``*_d`` meets
+    ``*_u``, ``*_r`` meets ``*_l``, and an edge's double-layer leg meets the
+    matching leg of ``a`` -- and pins the hand-written einsums against it.
+
+    The environment must be *converged*: the initial one is up/down
+    symmetric, which makes several distinct wirings agree numerically.
+    """
+    A = _site_tensor(seed=5)
+    chi = 6
+    env, a, info = M.converge(A, chi, max_iter=200, conv_tol=1e-12)
+    assert info["converged"]
+
+    template = initialize_ctm_tensor_env(A, chi)
+    legs = {
+        name: list(getattr(template, name).labels())
+        for name in ("C1", "C4", "T1", "T3", "T4")
+    }
+    a_legs = ["u2", "d2", "l2", "r2"]
+
+    def piece(name):
+        return (name, getattr(env, name), legs[name])
+
+    # C1 is left of T1 and above T4; a sits under T1 and right of T4.
+    upper_left = _contract_by_label(
+        pieces=[piece("C1"), piece("T1"), piece("T4"), ("a", a, a_legs)],
+        bonds=[
+            (("C1", "c1_r"), ("T1", "t1_l")),
+            (("C1", "c1_d"), ("T4", "t4_u")),
+            (("T1", "u2"), ("a", "u2")),
+            (("T4", "l2"), ("a", "l2")),
+        ],
+        open_legs=[("T1", "t1_r"), ("a", "r2"), ("T4", "t4_d"), ("a", "d2")],
+    )
+    assert jnp.allclose(upper_left, M._upper_left_quadrant(env, a), atol=1e-13)
+
+    # C4 is left of T3 and below T4; a sits above T3 and right of T4.
+    lower_left = _contract_by_label(
+        pieces=[piece("C4"), piece("T3"), piece("T4"), ("a", a, a_legs)],
+        bonds=[
+            (("C4", "c4_r"), ("T3", "t3_l")),
+            (("C4", "c4_u"), ("T4", "t4_d")),
+            (("T3", "d2"), ("a", "d2")),
+            (("T4", "l2"), ("a", "l2")),
+        ],
+        open_legs=[("T4", "t4_u"), ("a", "u2"), ("T3", "t3_r"), ("a", "r2")],
+    )
+    assert jnp.allclose(lower_left, M._lower_left_quadrant(env, a), atol=1e-13)
+
+    # The test has to be able to fail: joining C1's down leg to T4's *down*
+    # leg is shape-legal, and must give a different tensor.
+    miswired = _contract_by_label(
+        pieces=[piece("C1"), piece("T1"), piece("T4"), ("a", a, a_legs)],
+        bonds=[
+            (("C1", "c1_r"), ("T1", "t1_l")),
+            (("C1", "c1_d"), ("T4", "t4_d")),
+            (("T1", "u2"), ("a", "u2")),
+            (("T4", "l2"), ("a", "l2")),
+        ],
+        open_legs=[("T1", "t1_r"), ("a", "r2"), ("T4", "t4_u"), ("a", "d2")],
+    )
+    assert not jnp.allclose(miswired, upper_left, atol=1e-8)

--- a/tests/test_ctm_root_implicit_asym.py
+++ b/tests/test_ctm_root_implicit_asym.py
@@ -1,0 +1,229 @@
+"""Asymmetric CTMRG root implicit AD (#715 Phase 1, arXiv:2607.15030 §V).
+
+Status: the forward, the characteristic equations and the root are all
+verified here.  The *gradient* is not — see
+``test_gradient_parity_needs_the_modified_variables`` for the reason and
+what it costs to fix.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+import tenax.algorithms._ctm_root_implicit_asym as M
+from tenax.algorithms._ctm_tensor_init import (
+    _build_double_layer_tensor,
+    initialize_ctm_tensor_env,
+)
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import U1Symmetry
+from tenax.core.tensor import DenseTensor
+
+
+def _site_tensor(D=2, d=2, seed=42, eps=1.0):
+    rng = np.random.RandomState(seed)
+    data = eps * jnp.array(rng.standard_normal((D, D, D, D, d)))
+    data = data.at[0, 0, 0, 0, 0].set(1.0)
+    data = data / (jnp.linalg.norm(data) + 1e-10)
+    sym = U1Symmetry()
+    ch = np.zeros(D, dtype=np.int32)
+    pch = np.zeros(d, dtype=np.int32)
+    idx = (
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(sym, pch.copy(), FlowDirection.IN, label="phys"),
+    )
+    return DenseTensor(data, idx)
+
+
+def _gate(delta=1.0):
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+    H = delta * jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+    return H.reshape(2, 2, 2, 2)
+
+
+def _a_array(A):
+    at = _build_double_layer_tensor(A)
+    lab = list(at.labels())
+    perm = tuple(lab.index(x) for x in ("u2", "d2", "l2", "r2"))
+    return jnp.asarray(at.transpose(perm).todense())
+
+
+# ------------------------------------------------------------------ #
+# Geometry                                                            #
+# ------------------------------------------------------------------ #
+
+
+def test_rotation_is_order_four():
+    A = _site_tensor()
+    a = _a_array(A)
+    assert jnp.allclose(M.rotate_a(M.rotate_a(M.rotate_a(M.rotate_a(a)))), a)
+
+
+def test_projectors_close_on_the_retained_subspace():
+    """``P_bot @ P_top = 1`` is what makes the Fishman insertion exact."""
+    A = _site_tensor()
+    chi = 6
+    env, a, _meta = M.converge(A, chi, max_iter=300, conv_tol=1e-12)
+    P_top, P_bot, _U, _s, _Vh = M.all_projectors(env, a, chi)[0]
+    # Proportional to the identity, not equal to it: the retained singular
+    # values are normalised, so the closure carries their overall scale.
+    closure = P_bot @ P_top
+    scale = jnp.trace(closure) / chi
+    assert jnp.linalg.norm(closure / scale - jnp.eye(chi)) < 1e-9
+
+
+# ------------------------------------------------------------------ #
+# Forward                                                             #
+# ------------------------------------------------------------------ #
+
+
+def test_energy_is_stationary_at_the_root():
+    """Further sweeps from the polished root leave the energy alone.
+
+    ``converge`` alone is not enough: its element-wise criterion is not met
+    within 300 sweeps at chi=6, and its output energy is still 2e-4 away.
+    The gauge-aligned polish inside :func:`asym_root_parametrize` is what
+    actually lands on the fixed point, which is why the root is extracted
+    there rather than taken straight from ``converge``.
+    """
+    A = _site_tensor()
+    chi = 4
+    gate = _gate(1.0)
+    env, a, _m = M.converge(A, chi, max_iter=300, conv_tol=1e-13)
+    root, residual = M.asym_root_parametrize(env, a, chi, polish_steps=40)
+    assert residual < 1e-12, residual
+
+    template = initialize_ctm_tensor_env(A, chi)
+    e0 = float(M.asym_energy(A, root.env, template, gate))
+    env2, projs = root.env, None
+    for _ in range(12):
+        env2, projs = M.sweep(env2, a, chi, projs)
+    e1 = float(M.asym_energy(A, env2, template, gate))
+    assert abs(e0 - e1) < 1e-9, (e0, e1)
+
+
+# ------------------------------------------------------------------ #
+# The root                                                            #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize("chi", [4, 6])
+def test_all_twenty_characteristic_equations_hold_at_the_root(chi):
+    """‖F(y*, p)‖ at machine precision — the root really is a root.
+
+    Twenty equations for twenty variables: four corners, four edges, and
+    per direction one ``u``, one ``S`` and one ``v`` (paper Eqs. 76-80).
+    """
+    A = _site_tensor()
+    env, a, _m = M.converge(A, chi, max_iter=300, conv_tol=1e-13)
+    root, residual = M.asym_root_parametrize(env, a, chi, polish_steps=30)
+    assert residual < 1e-12, residual
+
+    R_env, R_u, R_S, R_v = M.asym_characteristic_residual(root.y, a, root, chi)
+    for name, leaf in zip(R_env._fields, R_env):
+        assert float(jnp.linalg.norm(leaf)) < 1e-12, name
+    for k in range(4):
+        assert float(jnp.linalg.norm(R_u[k])) < 1e-12, f"R_u[{k}]"
+        assert float(jnp.linalg.norm(R_S[k])) < 1e-12, f"R_S[{k}]"
+        assert float(jnp.linalg.norm(R_v[k])) < 1e-12, f"R_v[{k}]"
+
+
+def test_jacobian_of_F_is_nonsingular():
+    """``∂_y F`` is invertible, so the implicit function theorem applies.
+
+    Worth pinning: it rules out a zero mode as the explanation for the
+    gradient failure below, which is what a missing normalisation
+    condition would have looked like.
+    """
+    from tenax.algorithms._ctm_c4v_root_implicit import (
+        _from_real_vec,
+        _real_struct,
+        _to_real_vec,
+    )
+
+    A = _site_tensor()
+    chi = 4
+    env, a, _m = M.converge(A, chi, max_iter=300, conv_tol=1e-13)
+    root, _res = M.asym_root_parametrize(env, a, chi, polish_steps=30)
+    _leaves, treedef = jax.tree.flatten(root.y)
+    struct = _real_struct(root.y)
+
+    def f(vec):
+        return _to_real_vec(
+            M.asym_characteristic_residual(
+                _from_real_vec(vec, treedef, struct), a, root, chi
+            )
+        )
+
+    J = jax.jacfwd(f)(_to_real_vec(root.y))
+    sv = jnp.linalg.svd(J, compute_uv=False)
+    assert float(sv[-1] / sv[0]) > 1e-8, float(sv[-1] / sv[0])
+
+
+def test_no_svd_in_the_differentiated_equations():
+    """``F`` is contractions only — no decomposition to back-propagate."""
+    A = _site_tensor()
+    chi = 4
+    env, a, _m = M.converge(A, chi, max_iter=300, conv_tol=1e-13)
+    root, _res = M.asym_root_parametrize(env, a, chi, polish_steps=5)
+
+    def F(y):
+        return M.asym_characteristic_residual(y, a, root, chi)
+
+    text = str(jax.make_jaxpr(F)(root.y))
+    for banned in ("svd", "eigh"):
+        assert banned not in text, banned
+
+
+# ------------------------------------------------------------------ #
+# The gradient — known-bad, documented                                #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.xfail(
+    reason=(
+        "#715 Phase 1 is incomplete: this module keeps S diagonal and uses the "
+        "standard Fishman projectors, skipping the modified corners/edges of "
+        "paper Eqs. 73-75/82. Those exist to make the equations covariant under "
+        "the eight environment gauge unitaries; the s^-1/2 inside the projectors "
+        "breaks that covariance (paper Eq. 86). Without it, restricting the "
+        "isometry variation to its null space (Eq. 88) discards a real "
+        "contribution rather than a gauge one, so the gradient is wrong even "
+        "though F(y*)=0 to 1e-16 and dF/dy is well conditioned. Measured: "
+        "implicit -1.7898 vs explicit-backprop -0.81738127494, which itself "
+        "matches a symmetric finite difference to ten digits."
+    ),
+    strict=True,
+)
+def test_gradient_parity_needs_the_modified_variables():
+    A = _site_tensor()
+    chi = 4
+    gate = _gate(1.0)
+    _e, grad = M.asym_root_implicit_energy_and_grad(
+        A, gate, chi=chi, max_iter=300, conv_tol=1e-13
+    )
+
+    env0, _a, _m = M.converge(A, chi, max_iter=300, conv_tol=1e-13)
+    template = initialize_ctm_tensor_env(A, chi)
+
+    def energy_explicit(pdata):
+        A_live = DenseTensor(pdata, A.indices)
+        a_live = _a_array(A_live)
+        env, projs = env0, None
+        for _ in range(12):
+            env, projs = M.sweep(env, a_live, chi, projs)
+        return M.asym_energy(A_live, env, template, gate)
+
+    g_ref = jax.grad(energy_explicit)(A.todense())
+    rel = float(jnp.linalg.norm(grad - g_ref) / jnp.linalg.norm(g_ref))
+    assert rel < 1e-5, rel

--- a/tests/test_ctm_root_implicit_asym.py
+++ b/tests/test_ctm_root_implicit_asym.py
@@ -192,16 +192,18 @@ def test_no_svd_in_the_differentiated_equations():
 
 @pytest.mark.xfail(
     reason=(
-        "#715 Phase 1 is incomplete: this module keeps S diagonal and uses the "
-        "standard Fishman projectors, skipping the modified corners/edges of "
-        "paper Eqs. 73-75/82. Those exist to make the equations covariant under "
-        "the eight environment gauge unitaries; the s^-1/2 inside the projectors "
-        "breaks that covariance (paper Eq. 86). Without it, restricting the "
-        "isometry variation to its null space (Eq. 88) discards a real "
-        "contribution rather than a gauge one, so the gradient is wrong even "
-        "though F(y*)=0 to 1e-16 and dF/dy is well conditioned. Measured: "
-        "implicit -1.7898 vs explicit-backprop -0.81738127494, which itself "
-        "matches a symmetric finite difference to ten digits."
+        "#715 Phase 1 is not finished. Promoting S from a diagonal vector to a "
+        "general matrix, with a genuine matrix inverse square root, took the "
+        "gradient error from 1.2e0 to 1.1e-2..2.5e-2 — the in-space rotation of "
+        "the isometries now has somewhere to go, which is what Eq. 88's "
+        "null-space restriction needs in order to discard a gauge rather than "
+        "a physical contribution. What remains is the rest of paper Eqs. 73-82: "
+        "the modified corners/edges carrying s explicitly on the bonds, and the "
+        "s^L/s^R quartic roots on the *cut legs* of that environment. Putting "
+        "those roots inside the projectors instead was tried and is worse "
+        "(2.0e-1) — their product is not S^-1, so the closure breaks at first "
+        "order in a non-diagonal S. Reference: explicit backprop -0.817381274942, "
+        "itself matching a symmetric finite difference to ten digits."
     ),
     strict=True,
 )


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Phase 1 of #715, **partial**. Stacked on #716 (Phase 0). §V of [arXiv:2607.15030](https://arxiv.org/abs/2607.15030): asymmetric CTMRG, 1×1 unit cell, four distinct corners and edges.

## Verified

| claim | measurement |
|---|---|
| Fishman half-infinite projectors close | `P_bot @ P_top ∝ 1` to 1e-15 |
| Forward energy is right | matches plain sweep iteration to 1e-13; that energy's explicit-backprop gradient matches symmetric FD to **10 digits** |
| All 20 characteristic equations (Eqs. 76–80) hold at the root | ‖F(y*)‖ = 2.5e-16 |
| `∂_yF` is invertible — implicit function theorem applies | cond ≈ 8e3, no zero mode |
| `F` is contractions only | no `svd`/`eigh` in the jaxpr |

## Three things the paper leaves implicit

Each cost a debugging cycle; all three are documented in the module:

1. **The sweep must be simultaneous, not Gauss–Seidel.** Eqs. 76–77 evaluate all four moves at the same `y`, so a sequential sweep's fixed point is not a root.
2. **Eq. 68 projects each corner on *both* open legs**, using projectors from two different moves.
3. **The per-bond phase must be pinned or nothing converges element-wise.** Corner spectra are invariant under bond rotations, so they converge to 1e-14 while signs keep flipping — and `F` compares tensors, not magnitudes. Pinning the phase on `U` alone is insufficient (the projectors inherit the previous bond gauge through the quadrants); it has to be pinned on `P_top`, and near-degenerate singular values make an `argmax` rule oscillate with period two, so it aligns to the previous sweep instead.

## Not verified — the gradient

This module keeps `S` diagonal and uses the standard Fishman projectors, **skipping the modified corners/edges of Eqs. 73–75/82**. I had documented that as a stability-only shortcut. It is not:

> implicit **−1.7898** vs explicit-backprop reference **−0.81738127494**

with `‖F(y*)‖ = 1e-16` and a well-conditioned Jacobian. The `s^-1/2` inside the projectors breaks covariance under the eight environment gauge unitaries (Eq. 86), so restricting the isometry variation to its null space (Eq. 88) discards a *real* contribution rather than a gauge one.

**So §V.3's modified variables are load-bearing for correctness, not just for stability under degenerate singular values.** That is the main finding of this PR and it changes the Phase 1 estimate in #715.

`test_gradient_parity_needs_the_modified_variables` is a **strict xfail** carrying that measurement; completing Eqs. 73–75/82 flips it green.

## Merge guidance

Reviewable and safe to land as infrastructure (nothing existing is touched, no public API), or hold until the gradient is finished — your call. Phases 2 and 3 are blocked on this, since both build on the §V equations.

7 passing tests + 1 documented xfail, `algorithm` bucket, 27 s.