### PR TITLE
fix(#721): complex states in asymmetric root-implicit AD — dtype crash, lost bond gauge, and the RDM ordering

### DIFF
--- a/docs/plans/reference/718-codex-review-checks.py
+++ b/docs/plans/reference/718-codex-review-checks.py
@@ -1,5 +1,28 @@
 """Both Codex claims, with the dtype reality accounted for.
 
+SUPERSEDED — kept as the record of what #719/#720/#721 actually ran.  Two of the
+numbers below are wrong, and the corrected checks live in
+``tests/test_ctm_root_implicit_asym.py`` under the "Complex states (#721)"
+heading.  What was wrong:
+
+  * ``pair`` and ``inner`` use ``Re sum(conj(g) * delta)``.  For a real-valued
+    function of a complex input JAX's cotangent is already conjugated, so the
+    directional derivative is ``Re sum(g * delta)`` with no further conjugation.
+    That is why ``<null_dir, y_bar>`` reads 2.6e-2 when the true pairing is
+    -1.5e-16 and the adjoint system is consistent.  (It makes no difference to
+    the real-state Eq. 88 check, where ``conj`` is a no-op.)
+  * the ``alpha`` sweep at the end perturbs ``F_bar`` along a *right* null
+    direction of ``d_yF``.  The freedom in ``F_bar`` is the null space of the
+    operator actually inverted, ``B(v) = vjp_y(v)``, which is not
+    ``jacfwd(F)`` transposed under JAX's complex VJP convention.  Against
+    ``null(B)`` the leak is 6e-15, not 15%.
+
+The dtype crash (claim 3) was real and is fixed.  ``dE/dtheta = -7.9e-2`` was
+also real when this was written and is now 1e-14: it predates the
+``swap_env_convention`` fix in 30a2e4a, and the residual ordering bug it
+depended on — symmetrising the RDM before trace-normalising it — is fixed in
+``_normalise_rdm``.
+
 The existing test state is REAL (every leaf of y* is float64), so:
   * #719's phase null direction cannot exist there -- a real tensor times
     exp(i.theta) leaves the manifold -- but it should appear for a complex state,

--- a/src/tenax/algorithms/_ctm_root_implicit_asym.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_asym.py
@@ -42,6 +42,20 @@ is worse (20%): they are equivariant under independent left/right rotations,
 but their product is not ``S^-1``, so the closure breaks for a non-diagonal
 ``S``.  See ``docs/plans/2026-07-29-715-phase1-modified-variables.md``.
 
+Complex states (#721)
+---------------------
+Everything above holds for a complex site tensor, but three things about the
+real case are accidents of real data and were fixed only in #721.  ``S`` is real
+because ``svd`` returns a real spectrum, not because the equations want it real,
+and the reverse pass needs it widened to the environment's dtype.  A converged
+environment carries the bond gauge of the sweep chain that produced it, and
+re-pinning from cold — which a real state's sign gauge survives and a complex
+state's continuous phase does not — leaves ``y*`` describing a different
+environment; :func:`asym_root_parametrize` takes the chain now.  And ``∂_y F``
+is genuinely singular: an independent phase on each environment tensor is an
+exact null direction, so the root is a gauge orbit rather than a point.  That
+last one is not a defect — see :func:`asym_root_implicit_energy_and_grad`.
+
 Conventions (all dense ``jnp`` arrays, ``d2 = D²``)
 ---------------------------------------------------
 ``a[u, d, l, r]`` double layer; environment laid out exactly as
@@ -436,7 +450,16 @@ def all_projectors(env: AsymEnv, a: jax.Array, chi: int, prev=None):
         # inverse square root below produce NaNs.
         s_k = s[:chi]
         s_k = jnp.maximum(s_k, 1e-12 * s_k[0])
-        S_keep = jnp.diag(s_k / (jnp.linalg.norm(s_k) + 1e-300))
+        # Cast to the environment's dtype.  ``S`` is a *variable* of the
+        # characteristic equations, and the reverse pass needs it free to leave
+        # the reals for the same reason Eq. 79 needs it free to leave the
+        # diagonal: ``R_S = core/λ - S`` compares it against a complex
+        # contraction, and a cotangent inherits its primal's dtype, so a real
+        # ``S`` hands the adjoint solve a ``float64`` block where ``F``
+        # produced ``complex128`` and JAX refuses outright (#721).
+        # ``jnp.linalg.svd`` only ever returns a real spectrum, hence the cast
+        # rather than a genuinely complex construction.
+        S_keep = jnp.diag(s_k / (jnp.linalg.norm(s_k) + 1e-300)).astype(M.dtype)
         P_top, P_bot = _fishman_projectors(env_k, a_k, U, S_keep, Vh, chi)
         U, Vh, P_top, P_bot = _pin_bond_gauge(
             U, Vh, P_top, P_bot, chi, None if prev is None else prev[k][0]
@@ -519,8 +542,16 @@ def converge(
     max_iter: int = 200,
     conv_tol: float = 1e-12,
     min_iter: int = 4,
-) -> tuple[AsymEnv, jax.Array, dict[str, Any]]:
-    """Run sweeps until the corner spectra stop moving."""
+    return_projectors: bool = False,
+):
+    """Run sweeps until the corner spectra stop moving.
+
+    With ``return_projectors`` the final projector set comes back as a fourth
+    element.  That is not a diagnostic: the converged environment sits in the
+    bond gauge of the chain that built it, and
+    :func:`asym_root_parametrize` needs the same chain to extract a root in that
+    gauge rather than re-pinning a different one — see its docstring.
+    """
     env, a = _init_env(A, chi)
     prev = None
     prev_projs = None
@@ -541,7 +572,14 @@ def converge(
                 converged = True
                 break
         prev = cur
-    return env, a, {"iters": iters, "residual": residual, "converged": converged}
+    meta: dict[str, Any] = {
+        "iters": iters,
+        "residual": residual,
+        "converged": converged,
+    }
+    if return_projectors:
+        return env, a, meta, prev_projs
+    return env, a, meta
 
 
 # ---------------------------------------------------------------------------
@@ -843,6 +881,7 @@ def asym_root_parametrize(
     a: jax.Array,
     chi: int,
     *,
+    prev_projs=None,
     pinv_rtol: float = 1e-10,
     polish_steps: int = 40,
     polish_tol: float = 1e-10,
@@ -853,9 +892,21 @@ def asym_root_parametrize(
     ``λ`` defined as an inner product in Eqs. 76-77 really is the
     eigenvalue those equations need.  Rescaling is harmless: the energy is
     a ratio with equal numbers of corners and edges above and below.
+
+    Pass ``prev_projs`` — :func:`converge`'s fourth return value — whenever the
+    environment came from a sweep chain.  A converged environment carries that
+    chain's bond gauge, and :func:`_pin_bond_gauge`'s cold start pins a
+    *different* one, which leaves ``y*`` describing an environment it was not
+    extracted from.  The polish loop is meant to absorb that, and for a real
+    state it does in a single sweep, because there the bond gauge is a sign and
+    one sweep reproduces it exactly.  For a complex state the gauge is a
+    continuous phase, the warm alignment only ever recovers it to best fit, and
+    the corner residual — the one equation that couples two directions'
+    projectors, hence two bond phases — plateaus at 6e-5 instead of falling,
+    while the edges converge geometrically past 1e-8.  Warm-started off the
+    forward chain the same environment is a root to 6e-17 (#721).
     """
     best: tuple[AsymRoot, float] | None = None
-    prev_projs = None
     for _step in range(max(int(polish_steps), 1)):
         env = AsymEnv(*[t / (jnp.linalg.norm(t) + 1e-300) for t in env])
         projs = all_projectors(env, a, chi, prev_projs)
@@ -989,6 +1040,17 @@ def asym_root_implicit_energy_and_grad(
     be neither the equations nor Eq. 88's null-space restriction but the
     environment convention at the *energy* boundary — see
     :func:`swap_env_convention`.
+
+    A complex state reaches 2.5e-12 against the same reference at 40 sweeps
+    (#721).  Compare only against a reference that has actually converged: the
+    explicit map is truncated, and this state needs 53 forward iterations where
+    the real one needs 25, so at 12 sweeps the reference is itself 2.1e-5 away
+    and finite differences will agree with it to four digits.
+
+    ``diagnostics["gauge_consistency"]`` reports how far the energy's cotangent
+    is from orthogonal to the environment-phase gauge, which is what makes the
+    singular adjoint system solvable; it is ~1e-16 when the energy boundary is
+    right and is worth watching whenever that boundary changes.
     """
     from tenax.algorithms._ctm_c4v_root_implicit import _solve_root_adjoint
 
@@ -996,11 +1058,21 @@ def asym_root_implicit_energy_and_grad(
         raise TypeError("Asymmetric root implicit AD is dense-only (#715 Phase 3).")
 
     A_const = DenseTensor(jax.lax.stop_gradient(A.todense()), A.indices)
-    env, a_arr, meta = converge(
-        A_const, chi, max_iter=max_iter, conv_tol=conv_tol, min_iter=min_iter
+    env, a_arr, meta, forward_projs = converge(
+        A_const,
+        chi,
+        max_iter=max_iter,
+        conv_tol=conv_tol,
+        min_iter=min_iter,
+        return_projectors=True,
     )
     root, root_residual = asym_root_parametrize(
-        env, a_arr, chi, polish_steps=polish_steps, polish_tol=polish_tol
+        env,
+        a_arr,
+        chi,
+        prev_projs=forward_projs,
+        polish_steps=polish_steps,
+        polish_tol=polish_tol,
     )
     if root_residual > root_residual_warn:
         warnings.warn(
@@ -1043,6 +1115,45 @@ def asym_root_implicit_energy_and_grad(
         S_bar,
         tuple(jnp.zeros_like(x) for x in root_cov.v),
     )
+
+    # An independent phase on *each* environment tensor is an exact null
+    # direction of ``∂_y F``.  The normalisation is a ratio, and
+    # ``X'/⟨X, X'⟩`` is invariant under any phase on ``X'`` while picking up
+    # ``e^{iγ}`` from ``X``, so ``R = X'/⟨X, X'⟩ - X`` is phase-*covariant*
+    # tensor by tensor and vanishes along all eight orbits at once; ``R_u``,
+    # ``R_S`` and ``R_v`` are ratios throughout and are invariant outright.
+    # ``∂_y F`` is therefore singular — measured nullity 12 at ``D=2``,
+    # ``chi=4`` — and the implicit function theorem does not apply as literally
+    # written.
+    #
+    # Two things make that harmless, and only the first can fail here.  The
+    # adjoint system is consistent iff ``ў`` is orthogonal to every null
+    # direction, which holds because the energy is invariant along each orbit —
+    # but that invariance lives at the *energy* boundary, not in this module,
+    # and #718 is a standing reminder that the boundary is where conventions go
+    # wrong, so measure it rather than trust it.  The leftover freedom in
+    # ``F̆`` then cannot reach the gradient at all: differentiating
+    # ``F(y*(p), p) = 0`` puts ``∂_p F`` in the range of ``∂_y F``, and the
+    # freedom is orthogonal to that range (verified to 6e-15 in the tests).
+    y_bar_norm = float(
+        jnp.sqrt(sum(jnp.sum(jnp.abs(x) ** 2) for x in jax.tree.leaves(y_bar)))
+    )
+    gauge_consistency = 0.0
+    for bar, tensor in zip(tilde_bar, tilde):
+        pairing = float(jnp.real(jnp.sum(bar * (1j * tensor))))
+        scale = y_bar_norm * float(jnp.linalg.norm(tensor)) + 1e-300
+        gauge_consistency = max(gauge_consistency, abs(pairing) / scale)
+    if gauge_consistency > 1e-8:
+        warnings.warn(
+            f"Asymmetric root implicit AD: the energy cotangent has a "
+            f"{gauge_consistency:.3e} relative component along an environment "
+            "tensor's phase, which is a null direction of ∂F/∂y. The adjoint "
+            "system is inconsistent by that much and the gradient is "
+            "correspondingly unreliable; the energy is supposed to be "
+            "invariant under every such phase (#721).",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
     def F_of_y(y):
         return asym_characteristic_residual_covariant(y, a_arr, root_cov, chi)
@@ -1088,6 +1199,7 @@ def asym_root_implicit_energy_and_grad(
                 "root_residual": root_residual,
                 "covariant_residual": covariant_residual,
                 "adjoint_residual": float(solve_resid),
+                "gauge_consistency": gauge_consistency,
             },
         )
     return energy, grad

--- a/src/tenax/algorithms/_ctm_tensor_energy.py
+++ b/src/tenax/algorithms/_ctm_tensor_energy.py
@@ -28,6 +28,35 @@ from tenax.core import EPS
 from tenax.core.tensor import Tensor
 
 
+def _normalise_rdm(mat: jax.Array) -> jax.Array:
+    """Trace-normalise a raw RDM matrix, *then* symmetrise it.
+
+    The order is not cosmetic.  Every environment tensor carries an arbitrary
+    complex phase — a gauge of the CTM, fixed by nothing in the sweep — so the
+    raw RDM network is only ever defined up to an overall complex scalar.
+    Dividing by the trace cancels that scalar exactly, and symmetrising a
+    gauge-independent object is gauge-independent in turn.
+
+    Symmetrising first does not survive it.  Writing the raw RDM as ``H + K``
+    with ``H`` Hermitian and ``K`` anti-Hermitian,
+
+        Herm(e^{i.phi} (H + K)) = cos(phi) H + sin(phi) iK,
+
+    so the phase mixes the anti-Hermitian part into the result with weight
+    ``sin(phi)`` and rescales the physical part by ``cos(phi)``.  A converged
+    environment has ``|K|/|H| ~ 1e-14``, which hides this for generic ``phi``,
+    but at ``phi = pi/2`` the ``cos`` kills ``H`` outright and the energy is
+    computed entirely from the numerical noise in ``K``: on the #721 complex
+    test state a phase of ``pi/2`` on ``C1`` alone moved the energy by 5.4e-3
+    while a phase of 0.7 moved it by 1e-14.
+
+    For real data the two orders agree identically — ``tr Herm(R) = tr R`` — so
+    this changes nothing on any real-tensor path.
+    """
+    mat = mat / (jnp.trace(mat) + EPS)
+    return 0.5 * (mat + mat.conj().T)
+
+
 def _rdm_1site_tensor(A: Tensor, env: CTMTensorEnv) -> jax.Array:
     """Single-site RDM using label-based Tensor contractions.
 
@@ -78,8 +107,7 @@ def _rdm_1site_tensor(A: Tensor, env: CTMTensorEnv) -> jax.Array:
     )
 
     rdm = rdm_t.todense()
-    rdm = 0.5 * (rdm + rdm.conj().T)
-    rdm = rdm / (jnp.trace(rdm) + EPS)
+    rdm = _normalise_rdm(rdm)
     return rdm
 
 
@@ -186,8 +214,7 @@ def _rdm_diagonal_tensor(A: Tensor, env: CTMTensorEnv) -> jax.Array:
     rdm = rdm_t.todense()
     d = rdm.shape[0]
     rdm_mat = rdm.reshape(d * d, d * d)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-    rdm_mat = rdm_mat / (jnp.trace(rdm_mat) + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d, d, d, d)
 
 
@@ -308,8 +335,7 @@ def _rdm_diagonal_tensor_4site(
     rdm = rdm_t.todense()
     d = rdm.shape[0]
     rdm_mat = rdm.reshape(d * d, d * d)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-    rdm_mat = rdm_mat / (jnp.trace(rdm_mat) + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d, d, d, d)
 
 
@@ -398,8 +424,7 @@ def _rdm2x1_tensor(A: Tensor, env: CTMTensorEnv) -> jax.Array:
     rdm = rdm_t.todense()
     d = rdm.shape[0]
     rdm_mat = rdm.reshape(d * d, d * d)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-    rdm_mat = rdm_mat / (jnp.trace(rdm_mat) + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d, d, d, d)
 
 
@@ -487,8 +512,7 @@ def _rdm1x2_tensor(A: Tensor, env: CTMTensorEnv) -> jax.Array:
     rdm = rdm_t.todense()
     d = rdm.shape[0]
     rdm_mat = rdm.reshape(d * d, d * d)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-    rdm_mat = rdm_mat / (jnp.trace(rdm_mat) + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d, d, d, d)
 
 
@@ -593,8 +617,7 @@ def _rdm2x1_tensor_2site(
     rdm = rdm_t.todense()
     d = rdm.shape[0]
     rdm_mat = rdm.reshape(d * d, d * d)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-    rdm_mat = rdm_mat / (jnp.trace(rdm_mat) + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d, d, d, d)
 
 
@@ -678,8 +701,7 @@ def _rdm1x2_tensor_2site(
     rdm = rdm_t.todense()
     d = rdm.shape[0]
     rdm_mat = rdm.reshape(d * d, d * d)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-    rdm_mat = rdm_mat / (jnp.trace(rdm_mat) + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d, d, d, d)
 
 

--- a/tests/test_ctm_root_implicit_asym.py
+++ b/tests/test_ctm_root_implicit_asym.py
@@ -513,6 +513,9 @@ def test_gradient_entry_point_reports_clean_diagnostics():
     assert info["root_residual"] < 1e-10, info
     assert info["covariant_residual"] < 1e-10, info
     assert info["adjoint_residual"] < 1e-8, info
+    # Identically zero for a real state — the phase tangent is imaginary and the
+    # cotangent is real — but the key has to be there for anything to watch it.
+    assert info["gauge_consistency"] < 1e-10, info
 
 
 def test_the_energy_is_invariant_under_the_bond_gauge():
@@ -829,3 +832,364 @@ def test_covariant_characteristic_equations_vanish_at_the_root():
     )
     total = float(jnp.sqrt(sum(jnp.sum(jnp.abs(x) ** 2) for x in jax.tree.leaves(R))))
     assert total < 1e-10, total
+
+
+# ------------------------------------------------------------------ #
+# Complex states (#721)                                               #
+# ------------------------------------------------------------------ #
+#
+# Every test above runs on a *real* site tensor, and real data hides a whole
+# class of defect: a real tensor times ``exp(i theta)`` leaves the manifold, so
+# the environment's global phase gauge is invisible, and any variable that is
+# real only because it happens to be (singular values) never has to admit that
+# it is a complex unknown.  Complex tensors are the production regime for
+# iPEPS, so #721 covers them here.
+
+
+def _complex_site_tensor(D=2, d=2, seed=42, imag_seed=7, scale=0.25):
+    """The real test state plus an imaginary part, renormalised.
+
+    Same construction as ``docs/plans/reference/718-codex-review-checks.py`` so
+    the numbers in #721 stay comparable.
+    """
+    A = _site_tensor(D=D, d=d, seed=seed)
+    rng = np.random.RandomState(imag_seed)
+    base = np.asarray(A.todense())
+    data = base + scale * 1j * rng.standard_normal(base.shape)
+    data = jnp.asarray(data / np.linalg.norm(data))
+    return DenseTensor(data, A.indices)
+
+
+def _converged_complex_root(chi=4):
+    A = _complex_site_tensor()
+    env, a, info, projs = M.converge(
+        A, chi, max_iter=400, conv_tol=1e-13, return_projectors=True
+    )
+    assert info["converged"], info
+    root, residual = M.asym_root_parametrize(
+        env, a, chi, prev_projs=projs, polish_steps=30
+    )
+    return A, a, root, residual
+
+
+_ENV_NAMES = ("C1", "C2", "C3", "C4", "T1", "T2", "T3", "T4")
+
+
+def test_the_energy_is_invariant_under_every_environment_phase():
+    """A phase on any environment tensor cannot move the energy.
+
+    The RDM is one network, so a phase on any tensor in it is an overall complex
+    scalar on ``rho`` — and the energy is ``tr(rho H)/tr(rho)``, a ratio that
+    cancels any such scalar.  So all eight phases are separately free, not just
+    their sum.
+
+    #721 doubted this, and doubting it was reasonable: before
+    :func:`M.swap_env_convention` landed (#718) the energy moved by -7.9e-2 per
+    radian of the global phase.  A mis-glued network breaks the ket/bra
+    conjugation structure, so the raw RDM is genuinely non-Hermitian, and
+    ``_rdm2x1_tensor`` symmetrises *before* it divides by the trace — which
+    turns ``Herm(e^{i.phi} R)`` into ``cos(phi) H + sin(phi) iK`` and leaks the
+    anti-Hermitian part ``K`` into the energy as a physical-looking shift.  Glued
+    correctly, ``R`` is Hermitian up to one complex scalar and the ordering
+    stops mattering.
+
+    This is load bearing twice over.  Each of these phases is an exact null
+    direction of ``d_y F`` (see below), so the adjoint system is singular; it is
+    solvable only because ``E`` is invariant along every one of them.
+    """
+    A = _complex_site_tensor()
+    chi = 4
+    gate = _gate(1.0)
+    env, _a, info = M.converge(A, chi, max_iter=400, conv_tol=1e-13)
+    assert info["converged"], info
+    template = initialize_ctm_tensor_env(A, chi)
+
+    def energy_at(theta, which):
+        rot = M.AsymEnv(
+            *[
+                jnp.exp(1j * theta) * t if n in which else t
+                for n, t in zip(_ENV_NAMES, env)
+            ]
+        )
+        return float(jnp.real(M.asym_energy(A, rot, template, gate)))
+
+    base = energy_at(0.0, ())
+    assert abs(base) > 1e-3, base
+    for which in [(n,) for n in _ENV_NAMES] + [_ENV_NAMES]:
+        for theta in (0.2, 0.7, float(np.pi / 2)):
+            moved = energy_at(theta, which)
+            assert abs(moved - base) < 1e-11, (which, theta, moved - base)
+
+
+def test_characteristic_equations_hold_at_a_complex_root():
+    """All twenty residuals vanish for a complex state, not just a real one.
+
+    The environment and the root have to be in the *same* bond gauge, and
+    ``asym_root_parametrize`` used to throw the forward chain away and re-pin
+    from cold.  A real state survives that — its bond gauge is a sign, and one
+    sweep reproduces it exactly, which is why the polish loop drops from 1.3e-3
+    to 1.6e-17 in a single step.  A complex state does not: the gauge is a
+    continuous phase, and the corner residual plateaus at 5.8e-5 while the edges
+    fall geometrically past 1e-8.  Corners are where it shows because the corner
+    is the only equation built from two directions' projectors, so it is the
+    only one that sees a *relative* bond phase.
+    """
+    A, a, root, residual = _converged_complex_root()
+    chi = root.env.C1.shape[0]
+    assert jnp.iscomplexobj(root.env.C1)
+    assert residual < 1e-12, residual
+
+    R_env, R_u, R_S, R_v = M.asym_characteristic_residual(root.y, a, root, chi)
+    for name in ("C1", "C2", "C3", "C4", "T1", "T2", "T3", "T4"):
+        assert float(jnp.linalg.norm(getattr(R_env, name))) < 1e-12, name
+    for k in range(4):
+        assert float(jnp.linalg.norm(R_u[k])) < 1e-12, f"R_u[{k}]"
+        assert float(jnp.linalg.norm(R_S[k])) < 1e-12, f"R_S[{k}]"
+        assert float(jnp.linalg.norm(R_v[k])) < 1e-12, f"R_v[{k}]"
+
+
+def test_the_singular_values_are_a_complex_unknown():
+    """``S`` has to carry the environment's dtype, not the SVD's.
+
+    ``jnp.linalg.svd`` returns real singular values, so ``S`` came out
+    ``float64`` even for a ``complex128`` environment.  Two consequences, one
+    cosmetic and one fatal: ``R_S = core/lambda - S`` compares a complex matrix
+    against a real one, and — because the energy's cotangent inherits the
+    primal's dtype — the adjoint solve then hands ``vjp_y`` a ``float64`` block
+    where ``F`` produced ``complex128`` and JAX refuses outright.
+
+    This is the same argument that already promoted ``S`` from a diagonal to a
+    full ``chi x chi`` block, one axis further along: the reverse pass needs
+    ``S`` free to leave the reals, whatever the forward pass happens to put
+    there.
+    """
+    A = _complex_site_tensor()
+    chi = 4
+    env, a, _info = M.converge(A, chi, max_iter=400, conv_tol=1e-13)
+    for _pt, _pb, _U, S_keep, _Vh in M.all_projectors(env, a, chi):
+        assert jnp.iscomplexobj(S_keep), S_keep.dtype
+        # Still the SVD's real spectrum, only widened.
+        assert float(jnp.linalg.norm(jnp.imag(S_keep))) < 1e-300
+
+
+def test_gradient_parity_for_a_complex_state():
+    """End to end on a complex state: 2.5e-12 against explicit backprop.
+
+    The sweep count is the whole subtlety here.  The reference differentiates a
+    *truncated* sweep map, so it approaches the fixed-point gradient only as
+    fast as the CTM itself converges, and this state needs 53 forward iterations
+    where the real one needs 25.  At 12 sweeps — enough for the real state to
+    reach 4e-8 — the complex state sits at 2.1e-5, and finite differences agree
+    with the reference to four digits at two step sizes, so the gap reads
+    convincingly like a wrong gradient.  It is not: 20 sweeps gives 2.1e-7, 30
+    gives 6.9e-10, 40 gives 2.5e-12, each step matching the previous
+    reference-to-reference drift.  Do not "fix" a discrepancy here by hunting in
+    the adjoint before ruling the sweep count out.
+    """
+    A = _complex_site_tensor()
+    chi = 4
+    gate = _gate(1.0)
+    A_data = A.todense()
+
+    _energy, grad, info = M.asym_root_implicit_energy_and_grad(
+        A, gate, chi=chi, max_iter=400, conv_tol=1e-13, return_diagnostics=True
+    )
+    assert bool(jnp.all(jnp.isfinite(grad)))
+    assert jnp.iscomplexobj(grad)
+    assert info["converged"], info
+    assert info["root_residual"] < 1e-10, info
+    assert info["covariant_residual"] < 1e-10, info
+    assert info["adjoint_residual"] < 1e-8, info
+    assert info["gauge_consistency"] < 1e-10, info
+
+    env0, _a, _m = M.converge(A, chi, max_iter=400, conv_tol=1e-13)
+    template = initialize_ctm_tensor_env(A, chi)
+
+    def energy_explicit(pdata):
+        A_live = DenseTensor(pdata, A.indices)
+        a_live = _a_array(A_live)
+        env, projs = env0, None
+        for _ in range(40):
+            env, projs = M.sweep(env, a_live, chi, projs)
+        return jnp.real(M.asym_energy(A_live, env, template, gate))
+
+    g_ref = jax.grad(energy_explicit)(A_data)
+    assert bool(jnp.all(jnp.isfinite(g_ref))), "explicit backprop NaN'd; use FD instead"
+    rel = float(jnp.linalg.norm(grad - g_ref) / jnp.linalg.norm(g_ref))
+    assert rel < 1e-9, rel
+
+
+def test_the_environment_phases_are_licensed_gauges_of_the_root():
+    """The phase orbits are null directions of ``d_y F`` — and harmless ones.
+
+    ``F`` is phase-*covariant*, not phase-invariant, and the counting is exact.
+    An enlarged corner carries three environment tensors, so
+    ``EC -> e^{3i.theta}`` under a global phase, hence ``C_new -> e^{9i.theta}``
+    against ``lambda_C -> e^{8i.theta}``; the edge block goes ``e^{7i.theta}``
+    over ``e^{6i.theta}``.  But the mechanism is more general than the global
+    phase, because the normalisation is a *ratio*: ``X'/<X, X'>`` is invariant
+    under any phase on ``X'`` whatever, and picks up ``e^{i.gamma}`` from ``X``
+    alone, so ``R = X'/<X, X'> - X`` is covariant under a phase on **each**
+    environment tensor separately.  ``R_u``, ``R_S`` and ``R_v`` are ratios too
+    and are invariant outright.  So all eight phases are null directions, the
+    root is an eight-parameter family at least, and the implicit function
+    theorem does not apply as literally written.
+
+    Nothing is broken by that, and #721 filed it as a defect on the strength of
+    a mis-conjugated pairing.  Two conditions make the singular system fine, and
+    both are checked here:
+
+    * ``ў`` must be orthogonal to every null direction, or the adjoint system is
+      inconsistent and has no solution at all.  It is, because the energy is
+      invariant along each of them —
+      ``test_the_energy_is_invariant_under_every_environment_phase``, transported
+      to the cotangent.
+    * the leftover freedom in ``F̆`` must not reach the gradient.  It does not:
+      differentiating ``F(y*(p), p) = 0`` gives ``d_p F = -d_y F . d_p y*``, so
+      ``d_p F`` lands in the *range* of ``d_y F``, and the freedom is orthogonal
+      to that range.
+
+    The second one has to be tested on the operator that is actually inverted,
+    ``B(v) = vjp_y(v)``, and not on ``jacfwd(F)`` transposed: JAX's VJP for a
+    complex function is not the plain transpose of its JVP, so the null space of
+    ``jacfwd(F)^T`` is the wrong subspace and reports a 24% gradient change.
+    Against ``null(B)`` the same check gives 6e-15.
+
+    Both Jacobians come out with nullity 12 rather than 8, so there are four
+    more gauge directions than the eight phases named above.  They are not
+    chased here: whatever they are, the two conditions hold on all twelve, which
+    is what the gradient needs.
+    """
+    from tenax.algorithms._ctm_c4v_root_implicit import (
+        _from_real_vec,
+        _real_struct,
+        _solve_root_adjoint,
+        _to_real_vec,
+    )
+
+    A, a, root, _res = _converged_complex_root()
+    chi = root.env.C1.shape[0]
+    gate = _gate(1.0)
+    root = M.asym_root_to_covariant_convention(root)
+    S = _root_S(root)
+    tilde = M.remove_inverse_roots(root.env, S)
+    y_star = (tilde, root.u, S, root.v)
+    A_data = A.todense()
+    template = initialize_ctm_tensor_env(A, chi)
+
+    def F_of_y(y):
+        return M.asym_characteristic_residual_covariant(y, a, root, chi)
+
+    def nrm(t):
+        return float(
+            jnp.sqrt(sum(jnp.sum(jnp.abs(x) ** 2) for x in jax.tree.leaves(t)))
+        )
+
+    def rpair(x, y):
+        return float(
+            jnp.real(
+                sum(
+                    jnp.sum(p * q)
+                    for p, q in zip(jax.tree.leaves(x), jax.tree.leaves(y))
+                )
+            )
+        )
+
+    zeros = (
+        tuple(jnp.zeros_like(x) for x in root.u),
+        tuple(jnp.zeros_like(x) for x in S),
+        tuple(jnp.zeros_like(x) for x in root.v),
+    )
+
+    def phase_tangent(which):
+        """``i * tilde`` on the named tensors, zero everywhere else."""
+        return (
+            M.AsymEnv(
+                *[
+                    1j * x if n in which else jnp.zeros_like(x)
+                    for n, x in zip(_ENV_NAMES, tilde)
+                ]
+            ),
+            *zeros,
+        )
+
+    tangents = [phase_tangent({n}) for n in _ENV_NAMES] + [phase_tangent(_ENV_NAMES)]
+
+    # 1. every phase is a null direction, by a wide margin against a random one
+    _F0, jvp = jax.linearize(F_of_y, y_star)
+    rng = np.random.RandomState(5)
+    random_dir = jax.tree.map(
+        lambda x: jnp.asarray(
+            rng.standard_normal(x.shape) + 1j * rng.standard_normal(x.shape)
+        ).astype(x.dtype),
+        y_star,
+    )
+    scale = nrm(tangents[0]) / nrm(random_dir)
+    random_dir = jax.tree.map(lambda x: x * scale, random_dir)
+    assert nrm(jvp(random_dir)) / nrm(random_dir) > 1.0, nrm(jvp(random_dir))
+    for t, name in zip(tangents, (*_ENV_NAMES, "global")):
+        assert nrm(jvp(t)) / nrm(t) < 1e-10, (name, nrm(jvp(t)) / nrm(t))
+
+    # 2. the adjoint system is consistent against every one of them
+    def energy_of(a_data, env_tilde, S_all):
+        A_live = DenseTensor(a_data, A.indices)
+        return M.asym_energy(
+            A_live, M.absorb_inverse_roots(env_tilde, S_all), template, gate
+        )
+
+    energy, vjp_energy = jax.vjp(energy_of, A_data, tilde, S)
+    grad_direct, tilde_bar, S_bar = vjp_energy(jnp.ones((), dtype=energy.dtype))
+    y_bar = (tilde_bar, zeros[0], S_bar, zeros[2])
+    for t, name in zip(tangents, (*_ENV_NAMES, "global")):
+        cos = abs(rpair(y_bar, t)) / (nrm(y_bar) * nrm(t))
+        assert cos < 1e-12, (name, cos)
+
+    # 3. the Jacobian really is rank deficient, and the phases live in its kernel
+    _leaves, treedef = jax.tree.flatten(y_star)
+    struct = _real_struct(y_star)
+
+    def f_real(vec):
+        return _to_real_vec(F_of_y(_from_real_vec(vec, treedef, struct)))
+
+    J = jax.jacfwd(f_real)(_to_real_vec(y_star))
+    _Uj, s_j, Vh_j = jnp.linalg.svd(J)
+    nullity = int(jnp.sum(s_j / s_j[0] < 1e-10))
+    assert nullity == 12, (nullity, [float(x) for x in (s_j / s_j[0])[-14:]])
+    kernel = Vh_j[-nullity:].conj().T
+    phases = jnp.stack([_to_real_vec(phase_tangent({n})) for n in _ENV_NAMES], axis=1)
+    Q, _R = jnp.linalg.qr(phases)
+    cosines = jnp.linalg.svd(Q.T @ kernel, compute_uv=False)
+    assert float(jnp.min(cosines)) > 1 - 1e-8, [float(x) for x in cosines]
+
+    # 4. the freedom in F̆ does not reach the gradient
+    _F_at_root, vjp_y = jax.vjp(F_of_y, y_star)
+    F_bar, solve_resid = _solve_root_adjoint(
+        lambda v: vjp_y(v)[0], y_bar, tol=1e-10, maxiter=400, restart=30
+    )
+    assert float(solve_resid) < 1e-8, float(solve_resid)
+
+    def F_of_p(a_data):
+        A_live = DenseTensor(a_data, A.indices)
+        return M.asym_characteristic_residual_covariant(
+            y_star, _a_array(A_live), root, chi
+        )
+
+    _, vjp_p = jax.vjp(F_of_p, A_data)
+    grad = grad_direct - vjp_p(F_bar)[0]
+    grad_scale = float(jnp.linalg.norm(grad))
+
+    bar_leaves, bar_treedef = jax.tree.flatten(y_bar)
+    bar_struct = _real_struct(y_bar)
+    del bar_leaves
+
+    def B_real(vec):
+        return _to_real_vec(vjp_y(_from_real_vec(vec, bar_treedef, bar_struct))[0])
+
+    B = jax.jacfwd(B_real)(_to_real_vec(y_bar))
+    _Ub, s_b, Vh_b = jnp.linalg.svd(B)
+    nullity_b = int(jnp.sum(s_b / s_b[0] < 1e-10))
+    assert nullity_b == 12, (nullity_b, [float(x) for x in (s_b / s_b[0])[-14:]])
+    for j in range(nullity_b):
+        n_tree = _from_real_vec(Vh_b[-(j + 1)].conj(), bar_treedef, bar_struct)
+        leak = float(jnp.linalg.norm(vjp_p(n_tree)[0])) / grad_scale
+        assert leak < 1e-10, (j, leak)


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Closes #721. **Stacked on #722** (base `fix/718-env-convention`) — retarget to `main` once #722 merges.

#721 filed three defects. One was real as filed, one was real but not where it looked, and one does not exist. Fixing the first two turned up a fourth that nothing had reported.

## Verdict on the three filed claims

| # | Claim | Verdict |
|---|---|---|
| 3 | Adjoint solve crashes on a complex state | **Real.** `S` was `float64` because singular values are. Fixed. |
| 2 | Adjoint system is inconsistent; energy moves along the phase | **Does not exist** — `<null_dir, y_bar>` is -1.5e-16, not 2.59e-2. But the follow-up hunch about `asym_energy` was right, and found a real bug. |
| 1 | Global env phase is an exact null direction of `∂F/∂y` | **Real, and benign.** Also more general than filed: all 8 tensor phases, nullity 12. Documented + instrumented, not "fixed". |

## What changed

**1. `S` must carry the environment's dtype** (`all_projectors`). `jnp.linalg.svd` returns a real spectrum, so `S_keep` was `float64` even for a `complex128` environment, and a cotangent inherits its primal's dtype — the solve handed `vjp_y` a `float64` block where `F` produced `complex128` and JAX refused. `S` is a *variable* of the characteristic equations and the reverse pass needs it free to leave the reals; same argument that already promoted it from a diagonal to a full χ×χ block, one axis further along.

**2. (New defect) The root was not a root for complex states.** `asym_root_parametrize` discarded the forward sweep's projector chain and re-pinned the bond gauge from cold, so `y*` described an environment it was not extracted from. A real state survives that — its bond gauge is a sign, one sweep reproduces it exactly (1.3e-3 → 1.6e-17 in one polish step). A complex state's gauge is a continuous phase; the corner residual plateaus at **5.8e-5 forever** while the edges fall geometrically past 1e-8. Corners are where it shows because the corner is the only equation built from two directions' projectors, hence the only one that sees a *relative* bond phase. `converge(..., return_projectors=True)` hands the chain over → root to 2.8e-16. This was also firing a spurious `root_residual` warning on every complex state.

**3. The RDM was symmetrised *before* being trace-normalised** (`_normalise_rdm`). This is what claim 2 was really pointing at — the tensor count is balanced, the ordering was not. Writing the raw RDM as `H + K`:

```
Herm(e^{iφ}(H + K)) = cos(φ)·H + sin(φ)·iK
```

so the environment's phase gauge rescales the physical part by `cos φ` and mixes in the anti-Hermitian part with weight `sin φ`. At `|K|/|H| ~ 1e-14` that hides for generic `φ` — but at `φ = π/2` the cosine annihilates `H` and the energy is computed entirely from noise: **a π/2 phase on `C1` alone moved the energy by 5.4e-3**, where a phase of 0.7 moved it by 1e-14. Dividing by the trace first cancels the gauge exactly. Identical for real data (`tr Herm(R) = tr R`), so no real-tensor path moves.

**4. The phase gauge is documented and instrumented, not fixed.** The normalisation is a ratio, so `R = X'/⟨X,X'⟩ - X` is phase-covariant *tensor by tensor* — all eight environment phases are null directions (measured nullity 12). Two conditions make that harmless, both now tested: `y_bar` is orthogonal to every one of them (4e-17, because the energy is invariant along each), and the freedom left in `F̆` cannot reach the gradient — differentiating `F(y*(p), p) = 0` puts `∂_p F` in the range of `∂_y F` (leak **6e-15**). So the phase-fixing condition #721 suggested is **not needed**: GMRES converges to 4.3e-15 on the singular system. `diagnostics["gauge_consistency"]` now measures the orthogonality all of this rests on and warns above 1e-8 — it is a property of the *energy* boundary, and #718 is a standing reminder that the boundary is where conventions go wrong.

## Two measurement traps, both of which produced wrong conclusions in #721

- **JAX's cotangent for a real-valued function of a complex input is already conjugated.** The pairing is `Re Σ(g·dz)`, not `Re Σ(conj(g)·dz)`. The conjugated form is what produced `<null_dir, y_bar> = 2.59e-2`; calibrated against FD along three directions, it reports a nonzero derivative where FD gives 1e-11. Real tangents hide this completely (`conj` is a no-op).
- **The freedom in `F̆` is `null(B)` with `B(v) = vjp_y(v)`**, not `jacfwd(F)` transposed. That subspace is wrong under the same convention and reports a 24% gradient leak where the true leak is 6e-15.

The `dE/dθ = -7.9e-2` in the issue was real when filed, but predates `swap_env_convention` in 30a2e4a.

## Verification (D=2, χ=4, #721 complex state; real state unchanged)

| | before | after |
|---|---|---|
| root residual | 9.8e-05 | **2.8e-16** |
| gradient vs explicit backprop | crash | **2.5e-12** (40 sweeps) |
| adjoint solve residual | crash | **4.3e-15** |
| energy under a tensor phase | 5.4e-03 | **1e-14** (worst of 8, at π/2) |

⚠️ **Do not compare a complex gradient against a 12-sweep explicit reference.** The map is truncated and this state needs 53 forward iterations where the real one needs 25, so the reference is itself 2.1e-5 away — and finite differences agree with *it* to four digits at two step sizes, which reads convincingly like a wrong gradient. It converges 2.1e-5 → 2.1e-7 → 6.9e-10 → 2.5e-12 at 12/20/30/40 sweeps. This is recorded in the test docstring.

## Blast radius

`_ctm_tensor_energy.py` is shared by every CTM energy path, so beyond the 25 tests in `test_ctm_root_implicit_asym.py`:

- `pytest -m core` — **1086 passed**, 8 skipped
- 33 further iPEPS/CTM/split-CTM/PESS/fPEPS files — **562 passed**

Five pre-existing failures on this branch are **unchanged and unrelated** — `test_reduced_corner_qr.py` ×2 and `test_split_ctm_2site.py` ×3, verified identical to 10 digits with the patch stashed. One pre-existing failure is **fixed**: `test_implicit_qr_gradient_matches_fd`, which failed at 0.455 against a 0.35 tolerance.

## New tests

Five, under a "Complex states (#721)" heading — every existing test in the file runs on real data, which hides this whole class of defect:

- `test_the_energy_is_invariant_under_every_environment_phase` — all 8 phases, including π/2 (this is the one that catches the RDM ordering)
- `test_characteristic_equations_hold_at_a_complex_root` — all 20 residuals
- `test_the_singular_values_are_a_complex_unknown` — the dtype
- `test_gradient_parity_for_a_complex_state` — 2.5e-12 end to end
- `test_the_environment_phases_are_licensed_gauges_of_the_root` — nullity, consistency, and the `null(B)` leak

## Follow-up

The same symmetrise-before-normalise ordering is still present in `_split_ctm_tensor_energy.py` (6 sites) and `_pess_multisite_energy.py` (2 sites). Those paths are outside #721 and unverified here — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
