### PR TITLE
feat(#715): Phase 2 — root implicit AD on a unit cell, 2x2 FD parity 5.6e-10

### DIFF
--- a/docs/plans/2026-07-31-715-phase2-multisite-design.md
+++ b/docs/plans/2026-07-31-715-phase2-multisite-design.md
@@ -1,0 +1,143 @@
+# #715 Phase 2 — multisite root implicit AD: convention analysis
+
+Status: index layer landed and pinned (2395a1e). Forward sweep, characteristic
+equations and adjoint still to build. This note records the convention algebra,
+which is the part that is expensive to re-derive and cheap to get subtly wrong.
+
+## The reference is on disk
+
+The authors' implementation is at
+`/tmp/claude-1000/-home-yjkao-tenax/fad53d16-.../scratchpad/idpeps/` — cloned
+during the #718 session and still present. `src/asymmetric/fixedpoints.jl` is
+the whole of §V/Appendix F. PEPSKit's own index and renormalisation helpers are
+at `~/.julia/packages/PEPSKit/LxZhd/src/utility/indexing.jl` and
+`src/algorithms/contractions/ctmrg/`. **Read these before deriving anything.**
+If the scratchpad is ever cleaned, re-clone `leburgel/ImplicitDifferentiationPEPS.jl`.
+
+## Two half-plane conventions, and which one this module uses
+
+Phase 1 and the paper cut the plane differently. Both are correct; mixing them
+silently is not.
+
+| | cut | glues | projector pair at `co` sits on |
+|---|---|---|---|
+| Phase 1 forward | **left** half, cut horizontally | `EC[k]` to `EC[k-1]` (NW to SW) | that horizontal bond |
+| Paper §V.3 / PEPSKit | **upper** half, cut vertically | `EC[co]` to `EC[next(co)]` (NW to NE) | that vertical bond |
+
+Phase 1 bridges them in `asym_root_to_covariant_convention` with a shift-by-one
+and a transpose, and `test_the_two_half_plane_conventions_are_the_same_truncation`
+pins the identity `M_left(k) == M_up(k-1).T`.
+
+**Phase 2 uses the upper-half convention throughout**, because every index table
+in Appendix F and every renormalisation coordinate in PEPSKit is written in it.
+Carrying Phase 1's left-half convention into a unit cell would mean re-deriving
+all of them, which is exactly the work the reference already did.
+
+### The identity, checked symbolically
+
+With `EC` axes `(chi_r, a_r, chi_d, a_d)` and
+
+```
+T(X) = X.transpose(2, 3, 0, 1).reshape(n, n)      # rows = (chi_d, a_d)
+I(X) = X.reshape(n, n)                            # rows = (chi_r, a_r)
+```
+
+the two half-infinite matrices are
+
+```
+M_up(co)  = T(EC[co]) @ T(EC[next(co)])
+M_left(k) = I(EC[k])  @ I(EC[k-1])
+```
+
+and since `T(X).T == I(X)`,
+
+```
+M_up(k-1).T = T(EC[k]).T @ T(EC[k-1]).T = I(EC[k]) @ I(EC[k-1]) = M_left(k).  ✓
+```
+
+That reproduces the relation Phase 1 already tests numerically, from the axis
+definitions alone — which is the check that the upper-half port is the *same*
+truncation and not a differently-wired one.
+
+## Renormalisation coordinates (read off PEPSKit, not derived)
+
+Uniform in `co`, once the upper-half convention is adopted:
+
+```
+corner[co] = P_right[prev_coordinate(co)] · EC[co]                · P_left[co]
+edge[co]   = P_right[left_projector(co)]  · (edge[above(co)] ⊗ a) · P_left[co]
+```
+
+Verified against two directions each, which is enough to exclude an
+accidental match:
+
+- `renormalize_northwest_corner`: `EC[NW,r,c]`, `P_left[N,r,c]`,
+  `P_right[W,r+1,c]` — and `prev_coordinate((0,r,c)) == (3,r+1,c)`. ✓
+- `renormalize_southwest_corner`: `EC[SW,r,c]`, `P_left[W,r,c]`,
+  `P_right[S,r,c+1]` — and `prev_coordinate((3,r,c)) == (2,r,c+1)`. ✓
+- `renormalize_north_edge`: `edge[N,r-1,c]`, `P_left[N,r,c]`,
+  `P_right[N,r,c-1]` — and `above((0,r,c)) == (0,r-1,c)`,
+  `left_projector((0,r,c)) == (0,r,c-1)`. ✓
+- `renormalize_west_edge`: `edge[W,r,c-1]`, `P_left[W,r,c]`,
+  `P_right[W,r+1,c]` — and `above((3,r,c)) == (3,r,c-1)`,
+  `left_projector((3,r,c)) == (3,r+1,c)`. ✓
+
+These are the same coordinates the reference's `F1` and `F2` use
+(`PR[_prev_coordinate(co)]` and `PR[_left_projector(co)]`), so the forward sweep
+and the characteristic equations share one table — which is the point, since a
+sweep and an equation that disagree produce a root that is not a root.
+
+## Projectors
+
+Unchanged from Phase 1 apart from naming. With `M[co] = A @ B`,
+`A = T(EC[co])`, `B = T(EC[next(co)])`:
+
+```
+P_left[co]  = B @ Vh[:chi]† @ inv_sqrt(S)      (n x chi)   # Phase 1's P_top
+P_right[co] = inv_sqrt(S) @ U[:, :chi]† @ A    (chi x n)   # Phase 1's P_bot
+```
+
+`P_right @ P_left = inv_sqrt · U†MVh† · inv_sqrt = inv_sqrt · S · inv_sqrt = 1`
+exactly, for any `S`, diagonal or not — the Phase 1 argument for a genuine
+matrix inverse square root carries over untouched, as does the reason it must
+*not* be the Eq. 73 quartic roots (those live on the cut legs of the modified
+environment, not inside the projectors).
+
+## What is already pinned
+
+- Every Appendix F table, entry by entry, on a 3x5 cell — large enough that
+  one-step, two-step and wrap-around shifts are mutually distinguishable.
+  `rightvec_invfroot_indices` is the only two-step shift and the one most
+  likely to be wrong if re-derived.
+- `enlarged_corner` against Phase 1's `_upper_left_quadrant` at 1x1, all four
+  directions, on a twice-swept (genuinely asymmetric) environment: 1e-13.
+- The 1x1 collapse to the bare `k-1` / `k+1` offsets `_covariant_pieces`
+  hard-codes, so the two modules cannot drift apart.
+
+## Remaining work
+
+1. **Forward sweep.** `all_enlarged_corners`, `M[co]`, projectors per
+   coordinate, the two renormalisation formulae above, `converge`.
+   Gate: at 1x1 the energy must match the Phase 1 forward to ~1e-12. Tensor
+   equality is *not* the right gate here — the two conventions differ by the
+   shift and transpose above, so only gauge-invariant quantities compare.
+2. **Characteristic equations.** Port `contract_asymmetric_characteristic_equation`
+   (F1..F5). The shifted-cell reads are `proj_sinv_indices` for `S^-1` in the
+   projectors, `leftvec_invfroot_indices` / `rightvec_invfroot_indices` for the
+   quartic roots on the isometries, and `iCi[co] = s[prev(co)] · C[co] · s[co]`.
+   Gate: `‖F(y*)‖ ~ 1e-16` on a converged 2x2 cell.
+3. **Adjoint and gradient.** Root parametrisation over all coordinates, the
+   singular `∂_yF` gauge argument (unchanged — an independent phase per
+   environment tensor is still an exact null direction, now one per cell), and
+   `dE/dA` per cell.
+   Gates from #715: 2x2 FD parity, plus a test that a *deliberately wrong* cell
+   shift fails — the tables being right must be load-bearing, not incidental.
+
+## Trap
+
+`‖F(y*)‖` small does **not** validate the cell shifts. A wrong shift on a
+uniform unit cell (all sites equal) is invisible, because every cell holds the
+same tensor. Phase 2's tests must fill the unit cell with *different* tensors —
+`_site_tensor(seed=...)` varies — or they verify nothing that Phase 1 did not
+already cover. This is why the 2x2 FD-parity gate is the real gate and the
+1x1 agreement is only a smoke test.

--- a/src/tenax/algorithms/_ctm_root_implicit_multisite.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_multisite.py
@@ -276,3 +276,208 @@ def enlarged_corner(corners, edges, a_by_cell, co: Coord, nrows: int, ncols: int
     T_left = edges[left(co, nrows, ncols)]
     a = rotate_a_times(a_by_cell[(r, c)], k)
     return jnp.einsum("ce,efg,hic,fjik->gkhj", C, T_above, T_left, a)
+
+
+# ---------------------------------------------------------------------------
+# Forward: simultaneous CTMRG on the unit cell
+# ---------------------------------------------------------------------------
+#
+# Upper-half convention throughout (see the design note): the cut at ``co``
+# lies between ``EC[co]`` and ``EC[next_coordinate(co)]``.  Phase 1 cuts the
+# left half instead; the two are the same truncation up to a shift and a
+# transpose, which is why the 1x1 gate below compares *energies* and not
+# tensors.
+
+
+def coordinates(nrows: int, ncols: int) -> list[Coord]:
+    """Every ``(k, r, c)`` of the cell, directions slowest."""
+    return [(k, r, c) for k in range(4) for r in range(nrows) for c in range(ncols)]
+
+
+def _as_matrix(EC: jax.Array) -> jax.Array:
+    """Enlarged corner as a matrix: rows ``(chi_d, a_d)``, cols ``(chi_r, a_r)``.
+
+    This is the ``T`` of the design note.  ``T(X).T == X.reshape(n, n)`` is
+    what makes the upper-half cut the transpose of Phase 1's left-half one.
+    """
+    n = EC.shape[0] * EC.shape[1]
+    return jnp.transpose(EC, (2, 3, 0, 1)).reshape(n, n)
+
+
+def all_enlarged_corners(corners, edges, a_by_cell, nrows: int, ncols: int):
+    return {
+        co: enlarged_corner(corners, edges, a_by_cell, co, nrows, ncols)
+        for co in coordinates(nrows, ncols)
+    }
+
+
+def half_infinite_multisite(ECs, co: Coord, nrows: int, ncols: int):
+    """Paper Eq. 65 on the cell: ``M = A @ B`` with the two pieces returned too.
+
+    ``A`` is the enlarged corner at ``co``, ``B`` the one at
+    ``next_coordinate(co)``; the projectors need both, not just the product.
+    """
+    A = _as_matrix(ECs[co])
+    B = _as_matrix(ECs[next_coordinate(co, nrows, ncols)])
+    return A @ B, A, B
+
+
+def all_projectors_multisite(ECs, chi: int, nrows: int, ncols: int, prev=None):
+    """One Fishman pair per coordinate, all from the *same* environment.
+
+    Simultaneous, not Gauss-Seidel: a sequential sweep has a fixed point that
+    does not satisfy Eqs. 76-77, because those evaluate every direction at the
+    same ``y``.  Same argument as Phase 1's :func:`all_projectors`.
+
+    Returns ``{co: (P_left, P_right, U, S, Vh)}``.  ``P_left`` is ``(n, chi)``
+    and attaches to the ``co`` side of the cut; ``P_right`` is ``(chi, n)`` and
+    attaches to the ``next_coordinate(co)`` side, so ``P_right @ P_left`` is
+    the identity on the retained subspace by construction.
+    """
+    from tenax.algorithms._ctm_root_implicit_asym import _inv_sqrt, _pin_bond_gauge
+
+    out = {}
+    for co in coordinates(nrows, ncols):
+        M, A, B = half_infinite_multisite(ECs, co, nrows, ncols)
+        U, s, Vh = jnp.linalg.svd(M, full_matrices=True)
+        # Floor before S becomes a matrix: an early environment is rank
+        # deficient and a singular S makes the matrix inverse square root NaN.
+        s_k = jnp.maximum(s[:chi], 1e-12 * s[0])
+        # Cast to M's dtype — S is a *variable* of the characteristic
+        # equations and its cotangent must be free to leave the reals (#721).
+        S_keep = jnp.diag(s_k / (jnp.linalg.norm(s_k) + 1e-300)).astype(M.dtype)
+        inv_sqrt = _inv_sqrt(S_keep)
+        P_left = B @ Vh[:chi].conj().T @ inv_sqrt
+        P_right = inv_sqrt @ (U[:, :chi].conj().T @ A)
+        U, Vh, P_left, P_right = _pin_bond_gauge(
+            U, Vh, P_left, P_right, chi, None if prev is None else prev[co][0]
+        )
+        out[co] = (P_left, P_right, U, S_keep, Vh)
+    return out
+
+
+def _absorbed_edge(edges, a_by_cell, co: Coord, nrows: int, ncols: int):
+    """``edge[above(co)]`` with the local double layer absorbed.
+
+    Legs ``((chi, a), a_out, (chi, a))`` with ``chi`` slow in each fused pair,
+    matching the projectors' cut-leg order.
+    """
+    k, r, c = co
+    T = edges[above(co, nrows, ncols)]
+    a = rotate_a_times(a_by_cell[(r, c)], k)
+    chi, d2 = T.shape[0], a.shape[0]
+    # T[l, x, r] with x contracting a.u; a[u, d, l, r] = a[x, j, i, m].
+    raw = jnp.einsum("lxr,xjim->lijrm", T, a)
+    return raw.reshape(chi * d2, d2, chi * d2)
+
+
+def sweep_multisite(
+    corners, edges, a_by_cell, chi: int, nrows: int, ncols: int, prev=None
+):
+    """One simultaneous sweep over the whole cell.
+
+    Renormalisation coordinates are PEPSKit's, uniform in ``co``::
+
+        corner[co] = P_right[prev_coordinate(co)] · EC[co]        · P_left[co]
+        edge[co]   = P_right[left_projector(co)]  · (E[above] ⊗ a) · P_left[co]
+
+    The same tables the characteristic equations will use — a sweep and an
+    equation that disagree give a fixed point that is not a root, which is
+    how #718 started.
+    """
+    from tenax.algorithms._ctm_root_implicit_asym import _normalize
+
+    ECs = all_enlarged_corners(corners, edges, a_by_cell, nrows, ncols)
+    projs = all_projectors_multisite(ECs, chi, nrows, ncols, prev)
+
+    new_corners, new_edges = {}, {}
+    for co in coordinates(nrows, ncols):
+        P_left = projs[co][0]
+        P_right_prev = projs[prev_coordinate(co, nrows, ncols)][1]
+        new_corners[co] = _normalize(P_right_prev @ _as_matrix(ECs[co]) @ P_left)
+
+        P_right_lp = projs[left_projector(co, nrows, ncols)][1]
+        raw = _absorbed_edge(edges, a_by_cell, co, nrows, ncols)
+        new_edges[co] = _normalize(
+            jnp.einsum("ai,ixj,jb->axb", P_right_lp, raw, P_left)
+        )
+    return new_corners, new_edges, projs
+
+
+def init_cell_env(a_by_cell, A_by_cell, chi: int, nrows: int, ncols: int):
+    """Seed every cell from :func:`initialize_ctm_tensor_env`.
+
+    Each cell gets its own initial environment, built from its own site
+    tensor, in this module's rotation-uniform convention.
+    """
+    from tenax.algorithms._ctm_root_implicit_asym import _init_env
+
+    corners, edges = {}, {}
+    for (r, c), A in A_by_cell.items():
+        env, _a = _init_env(A, chi)
+        ck, ek = env_to_cell_maps(env, r, c)
+        corners.update(ck)
+        edges.update(ek)
+    del a_by_cell, nrows, ncols
+    return corners, edges
+
+
+def converge_multisite(
+    A_by_cell,
+    chi: int,
+    nrows: int,
+    ncols: int,
+    *,
+    max_iter: int = 200,
+    conv_tol: float = 1e-12,
+    min_iter: int = 4,
+    return_projectors: bool = False,
+):
+    """Sweep the cell until every corner and edge stops moving element-wise.
+
+    Element-wise, not spectral, for the Phase 1 reason: corner *singular
+    values* are invariant under independent rotations of each bond, so a
+    spectral criterion calls convergence while the tensors are still moving —
+    and the characteristic equations compare tensors.
+    """
+    from tenax.algorithms._ctm_tensor_init import _build_double_layer_tensor
+
+    a_by_cell = {}
+    for (r, c), A in A_by_cell.items():
+        a_t = _build_double_layer_tensor(A)
+        labels = list(a_t.labels())
+        perm = tuple(labels.index(lbl) for lbl in ("u2", "d2", "l2", "r2"))
+        a_by_cell[(r, c)] = jnp.asarray(a_t.transpose(perm).todense())
+
+    corners, edges = init_cell_env(a_by_cell, A_by_cell, chi, nrows, ncols)
+    prev_state = None
+    prev_projs = None
+    residual = float("inf")
+    converged = False
+    iters = 0
+    for it in range(int(max_iter)):
+        corners, edges, prev_projs = sweep_multisite(
+            corners, edges, a_by_cell, chi, nrows, ncols, prev_projs
+        )
+        iters = it + 1
+        state = {
+            k: v / (jnp.linalg.norm(v) + 1e-300)
+            for k, v in list(corners.items()) + list(edges.items())
+        }
+        if prev_state is not None:
+            residual = float(
+                max(
+                    jnp.max(jnp.abs(state[k] - prev_state[k]))
+                    for k in state
+                    if state[k].shape == prev_state[k].shape
+                )
+            )
+            if iters >= min_iter and residual < conv_tol:
+                converged = True
+                break
+        prev_state = state
+
+    meta = {"iters": iters, "residual": residual, "converged": converged}
+    if return_projectors:
+        return corners, edges, meta, prev_projs, a_by_cell
+    return corners, edges, meta

--- a/src/tenax/algorithms/_ctm_root_implicit_multisite.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_multisite.py
@@ -1,0 +1,278 @@
+"""Root implicit differentiation for asymmetric CTMRG on a unit cell (#715 Phase 2).
+
+Generalises :mod:`tenax.algorithms._ctm_root_implicit_asym` — which fixes the
+unit cell at 1x1 — to an arbitrary ``nrows x ncols`` cell, following Appendix F
+of Burgelman, Francuz, Brehmer, Devos, Haegeman, Verstraete and Vanhecke,
+*Implicit differentiation of tensor network algorithms*, arXiv:2607.15030.
+
+What actually changes
+---------------------
+The characteristic equations themselves are unchanged: Eqs. 76-80 hold per
+direction exactly as in Phase 1.  What the unit cell adds is that the singular
+values entering a given equation no longer all belong to the *same* coordinate.
+``S``, its inverse, and the two quartic roots ``s^L = (s s†)^1/4``,
+``s^R = (s† s)^1/4`` are each read from a **shifted** cell, and the shift
+differs per quantity (Appendix F, Tables 1+).
+
+That is the whole content of this module's index layer, and it is the part
+worth being paranoid about: a wrong shift still produces a well-conditioned
+Jacobian and a plausible-looking root, then a silently wrong gradient.  Same
+failure shape as #700 / #702.  So the tables are transcribed from the authors'
+reference implementation rather than re-derived, and pinned element by element
+in ``tests/test_ctm_root_implicit_multisite.py``.
+
+Indexing convention
+-------------------
+Everything here is **0-based**: ``k ∈ {0, 1, 2, 3}`` for the direction and
+``(r, c)`` for the cell, all periodic.  The reference is Julia and therefore
+1-based with ``mod1``; the translation is ``k = dir - 1`` and plain ``%``.
+
+Directions follow the Phase 1 module: ``k`` numbers the corner ``C{k+1}`` and
+the edge ``T{k+1}``, going around the ring.  A coordinate is the triple
+``(k, r, c)``.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from tenax.algorithms._ctm_root_implicit_asym import AsymEnv, rotate_a
+
+__all__ = [
+    "above",
+    "above_left",
+    "cell_maps_to_env",
+    "enlarged_corner",
+    "env_to_cell_maps",
+    "left",
+    "left_projector",
+    "leftvec_invfroot_indices",
+    "next_coordinate",
+    "prev_coordinate",
+    "proj_sinv_indices",
+    "rightvec_invfroot_indices",
+    "rotate_a_times",
+]
+
+Coord = tuple[int, int, int]
+
+
+def _next(i: int, total: int) -> int:
+    return (i + 1) % total
+
+
+def _prev(i: int, total: int) -> int:
+    return (i - 1) % total
+
+
+# ---------------------------------------------------------------------------
+# Walking the ring of directions
+# ---------------------------------------------------------------------------
+
+
+def next_coordinate(co: Coord, nrows: int, ncols: int) -> Coord:
+    """The next ``(k, r, c)`` going around the environment clockwise.
+
+    Advancing the direction also steps the cell, because direction ``k+1``'s
+    corner sits one site along the edge that direction ``k`` just absorbed.
+    """
+    k, r, c = co
+    if k == 0:
+        return (1, r, _next(c, ncols))
+    if k == 1:
+        return (2, _next(r, nrows), c)
+    if k == 2:
+        return (3, r, _prev(c, ncols))
+    return (0, _prev(r, nrows), c)
+
+
+def prev_coordinate(co: Coord, nrows: int, ncols: int) -> Coord:
+    """Inverse of :func:`next_coordinate`."""
+    k, r, c = co
+    if k == 0:
+        return (3, _next(r, nrows), c)
+    if k == 1:
+        return (0, r, _prev(c, ncols))
+    if k == 2:
+        return (1, _prev(r, nrows), c)
+    return (2, r, _next(c, ncols))
+
+
+# ---------------------------------------------------------------------------
+# Appendix F: which cell each singular-value factor comes from
+# ---------------------------------------------------------------------------
+
+
+def proj_sinv_indices(co: Coord, nrows: int, ncols: int) -> Coord:
+    """Cell supplying ``S^-1`` for the projectors at ``co``.
+
+    The direction is unchanged; the cell steps one site *outward* along that
+    direction — the bond being cut lies between ``co`` and this neighbour.
+    """
+    k, r, c = co
+    if k == 0:
+        return (k, _prev(r, nrows), c)
+    if k == 1:
+        return (k, r, _next(c, ncols))
+    if k == 2:
+        return (k, _next(r, nrows), c)
+    return (k, r, _prev(c, ncols))
+
+
+def leftvec_invfroot_indices(co: Coord, nrows: int, ncols: int) -> Coord:
+    """Cell supplying ``(s† s)^1/4`` for the ``U`` isometry at ``co``.
+
+    Direction steps *back* by one: the quartic root rides the cut leg of the
+    **previous** direction's edge, which is the leg ``U`` is contracted along.
+    At a 1x1 cell this is the ``k-1`` of Phase 1's ``_covariant_pieces``.
+    """
+    k, r, c = co
+    if k == 0:
+        rc = (_next(r, nrows), _prev(c, ncols))
+    elif k == 1:
+        rc = (_prev(r, nrows), _prev(c, ncols))
+    elif k == 2:
+        rc = (_prev(r, nrows), _next(c, ncols))
+    else:
+        rc = (_next(r, nrows), _next(c, ncols))
+    return (_prev(k, 4), *rc)
+
+
+def rightvec_invfroot_indices(co: Coord, nrows: int, ncols: int) -> Coord:
+    """Cell supplying ``(s s†)^1/4`` for the ``V`` isometry at ``co``.
+
+    Direction steps *forward* by one, and the cell by **two** — the only
+    two-step shift in the assignment, and the one most likely to be wrong if
+    re-derived.  At a 1x1 cell this is Phase 1's ``k+1``.
+    """
+    k, r, c = co
+    if k == 0:
+        rc = (r, _next(_next(c, ncols), ncols))
+    elif k == 1:
+        rc = (_next(_next(r, nrows), nrows), c)
+    elif k == 2:
+        rc = (r, _prev(_prev(c, ncols), ncols))
+    else:
+        rc = (_prev(_prev(r, nrows), nrows), c)
+    return (_next(k, 4), *rc)
+
+
+# ---------------------------------------------------------------------------
+# Positions relative to an enlarged corner
+# ---------------------------------------------------------------------------
+
+
+def above_left(co: Coord, nrows: int, ncols: int) -> Coord:
+    """Corner diagonally up-left of the enlarged corner at ``co``."""
+    k, r, c = co
+    if k == 0:
+        return (k, _prev(r, nrows), _prev(c, ncols))
+    if k == 1:
+        return (k, _prev(r, nrows), _next(c, ncols))
+    if k == 2:
+        return (k, _next(r, nrows), _next(c, ncols))
+    return (k, _next(r, nrows), _prev(c, ncols))
+
+
+def left(co: Coord, nrows: int, ncols: int) -> Coord:
+    """Edge to the left of the enlarged corner at ``co``."""
+    k, r, c = co
+    if k == 0:
+        return (_prev(k, 4), r, _prev(c, ncols))
+    if k == 1:
+        return (_prev(k, 4), _prev(r, nrows), c)
+    if k == 2:
+        return (_prev(k, 4), r, _next(c, ncols))
+    return (_prev(k, 4), _next(r, nrows), c)
+
+
+def above(co: Coord, nrows: int, ncols: int) -> Coord:
+    """Edge above the enlarged corner at ``co``."""
+    k, r, c = co
+    if k == 0:
+        return (k, _prev(r, nrows), c)
+    if k == 1:
+        return (k, r, _next(c, ncols))
+    if k == 2:
+        return (k, _next(r, nrows), c)
+    return (k, r, _prev(c, ncols))
+
+
+def left_projector(co: Coord, nrows: int, ncols: int) -> Coord:
+    """Projector pair to the left of the enlarged corner at ``co``."""
+    k, r, c = co
+    if k == 0:
+        return (k, r, _prev(c, ncols))
+    if k == 1:
+        return (k, _prev(r, nrows), c)
+    if k == 2:
+        return (k, r, _next(c, ncols))
+    return (k, _next(r, nrows), c)
+
+
+# ---------------------------------------------------------------------------
+# Coordinate-indexed environment
+# ---------------------------------------------------------------------------
+#
+# The environment is two dicts keyed by ``(k, r, c)`` rather than the eight
+# named fields of :class:`AsymEnv`.  Dicts are JAX pytrees, so ``jax.vjp``
+# traverses them unchanged, and keying by coordinate is what lets the Appendix
+# F tables above be applied literally instead of being unrolled into per-field
+# special cases.
+
+
+def env_to_cell_maps(env: AsymEnv, r: int = 0, c: int = 0):
+    """Spread one :class:`AsymEnv` over cell ``(r, c)`` of a coordinate map.
+
+    Corner ``C{k+1}`` and edge ``T{k+1}`` land at ``(k, r, c)``.  Used to seed
+    a 1x1 cell from the Phase 1 representation, and by the tests that hold the
+    two implementations against each other.
+    """
+    corners = {(k, r, c): getattr(env, f"C{k + 1}") for k in range(4)}
+    edges = {(k, r, c): getattr(env, f"T{k + 1}") for k in range(4)}
+    return corners, edges
+
+
+def cell_maps_to_env(corners, edges, r: int = 0, c: int = 0) -> AsymEnv:
+    """Inverse of :func:`env_to_cell_maps` for a single cell."""
+    return AsymEnv(
+        *[corners[(k, r, c)] for k in range(4)],
+        *[edges[(k, r, c)] for k in range(4)],
+    )
+
+
+def rotate_a_times(a: jax.Array, k: int) -> jax.Array:
+    """Rotate the double-layer tensor ``k`` quarter turns counter-clockwise."""
+    for _ in range(k % 4):
+        a = rotate_a(a)
+    return a
+
+
+def enlarged_corner(corners, edges, a_by_cell, co: Coord, nrows: int, ncols: int):
+    """The enlarged corner at ``co``, axes ``(chi_r, a_r, chi_d, a_d)``.
+
+    Three environment tensors meet the local double layer:
+
+    ===============  ===========================
+    corner           ``above_left(co)``
+    edge above       ``above(co)``
+    edge to the left ``left(co)``
+    double layer     cell ``(r, c)``, rotated ``k``
+    ===============  ===========================
+
+    which is Phase 1's ``_upper_left_quadrant`` read by coordinate instead of
+    by rotating the whole environment.  At a 1x1 cell the two agree to machine
+    precision — the bridge test in
+    ``tests/test_ctm_root_implicit_multisite.py`` — and that equality is what
+    licenses reusing the Phase 1 contraction formulae here verbatim.
+
+    The ``(chi_d, a_d)`` pair is the bond about to be truncated; ``(chi_r,
+    a_r)`` stays open.
+    """
+    k, r, c = co
+    C = corners[above_left(co, nrows, ncols)]
+    T_above = edges[above(co, nrows, ncols)]
+    T_left = edges[left(co, nrows, ncols)]
+    a = rotate_a_times(a_by_cell[(r, c)], k)
+    return jnp.einsum("ce,efg,hic,fjik->gkhj", C, T_above, T_left, a)

--- a/src/tenax/algorithms/_ctm_root_implicit_multisite.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_multisite.py
@@ -56,6 +56,10 @@ __all__ = [
     "rightvec_invfroot_indices",
     "remove_inverse_roots_multisite",
     "absorb_inverse_roots_multisite",
+    "cell_energy_forward",
+    "cell_observable_forward",
+    "env_ring_for_cell",
+    "cell_root_implicit_energy_and_grad",
     "rotate_a_times",
 ]
 
@@ -791,3 +795,281 @@ def root_parametrize_multisite(
 
     assert best is not None
     return best
+
+
+# ---------------------------------------------------------------------------
+# Energy and gradient on the cell
+# ---------------------------------------------------------------------------
+
+
+def env_ring_for_cell(corners, edges, r: int, c: int, nrows: int, ncols: int):
+    """The eight environment tensors that close the ring *around* site ``(r, c)``.
+
+    Not the eight at coordinate ``(k, r, c)``.  A renormalised corner at
+    ``(k, r, c)`` is the one that *absorbed* site ``(r, c)`` — it covers the
+    quadrant including that site — so the corner adjacent to the site is the
+    one at ``above_left((k, r, c))``, and likewise the edge is at
+    ``above((k, r, c))``.  Those are the same two tables
+    :func:`enlarged_corner` reads, which is the consistency one wants.
+
+    Getting this wrong does not raise: every leg still matches by dimension,
+    and the contraction returns a number.  It is simply not gauge invariant,
+    because the ring does not close on the lattice.  The symptom is a scalar
+    that is deterministic for fixed input but jumps by ~1e-3 under
+    arbitrarily small changes of ``A`` — the CTM bond gauge is pinned by an
+    ``argmax`` whose row hops — so finite differences diverge as ``h -> 0``
+    (measured: -1.4, +17, -67, +524, -8792 at h = 1e-3 .. 1e-7) while the
+    gradient stays finite.  At a 1x1 cell every shift collapses and the bug is
+    invisible, which is why this only appeared at 2x2.
+    """
+    return AsymEnv(
+        *[corners[above_left((k, r, c), nrows, ncols)] for k in range(4)],
+        *[edges[above((k, r, c), nrows, ncols)] for k in range(4)],
+    )
+
+
+def _cell_energy(A_live, corners_reg, edges_reg, template, gate, cell, nrows, ncols):
+    """Single-site CTM energy on the ring closing around ``cell``."""
+    from tenax.algorithms._ctm_root_implicit_asym import asym_energy
+
+    env = env_ring_for_cell(corners_reg, edges_reg, *cell, nrows, ncols)
+    return asym_energy(A_live, env, template, gate)
+
+
+def _cell_observable(A_live, corners_reg, edges_reg, template, op, cell, nrows, ncols):
+    """``<O>`` at one site, from the ring closing around ``cell``.
+
+    A *one-site* RDM, deliberately.  ``compute_energy_ctm_tensor`` builds
+    **two-site** RDMs (``_rdm2x1_tensor`` / ``_rdm1x2_tensor``) that place the
+    same ``A`` on both sites and glue them through a single site's environment
+    ring.  On a uniform cell that is exactly right and is what Phase 1 uses.
+    On a cell of *different* tensors it is not merely unphysical — the two
+    halves meet on chi bonds carrying independent gauges, so the number is
+    gauge dependent, and a gauge-dependent scalar is not a differentiable
+    function of ``A`` at all.  Measured: it moved over [0.143, 0.171] under
+    ``|t| <= 2e-5`` along a line while every fixed point converged to 8.6e-13,
+    and finite differences diverged as ``h -> 0``.
+
+    The one-site RDM closes on the eight tensors of :func:`env_ring_for_cell`
+    and nothing else, so every bond gauge cancels and the result is smooth.
+    That makes it the right objective for the parity gate on a unit cell; a
+    physical multisite *energy* needs a two-site ring spanning two cells and
+    is separate work.
+    """
+    from tenax.algorithms._ctm_root_implicit_asym import _to_ctm_env
+    from tenax.algorithms._ctm_tensor_energy import _rdm_1site_tensor
+
+    env = env_ring_for_cell(corners_reg, edges_reg, *cell, nrows, ncols)
+    rho = _rdm_1site_tensor(A_live, _to_ctm_env(env, template))
+    return jnp.real(jnp.trace(rho @ op))
+
+
+def cell_observable_forward(
+    A_by_cell, op, chi: int, nrows: int, ncols: int, *, objective_cell=(0, 0), **kw
+):
+    """Forward-only ``<O>`` — the finite-difference side of the parity gate."""
+    from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env
+
+    corners, edges, _meta = converge_multisite(A_by_cell, chi, nrows, ncols, **kw)
+    template = initialize_ctm_tensor_env(A_by_cell[objective_cell], chi)
+    return _cell_observable(
+        A_by_cell[objective_cell],
+        corners,
+        edges,
+        template,
+        op,
+        objective_cell,
+        nrows,
+        ncols,
+    )
+
+
+def cell_energy_forward(
+    A_by_cell, gate, chi: int, nrows: int, ncols: int, *, objective_cell=(0, 0), **kw
+):
+    """Two-site CTM energy. **Valid only on a uniform (1x1) cell.**
+
+    ``compute_energy_ctm_tensor`` places the same ``A`` on both sites of a
+    two-site RDM and glues them through one site's environment ring.  On a cell
+    of different tensors the two halves meet on chi bonds carrying independent
+    gauges, so the result is gauge dependent and not a differentiable function
+    of ``A`` — see :func:`_cell_observable`.  Use that for anything larger than
+    1x1; a physical multisite energy needs a two-site ring spanning two cells
+    and is separate work.
+    """
+    from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env
+
+    corners, edges, _meta = converge_multisite(A_by_cell, chi, nrows, ncols, **kw)
+    template = initialize_ctm_tensor_env(A_by_cell[objective_cell], chi)
+    return _cell_energy(
+        A_by_cell[objective_cell],
+        corners,
+        edges,
+        template,
+        gate,
+        objective_cell,
+        nrows,
+        ncols,
+    )
+
+
+def cell_root_implicit_energy_and_grad(
+    A_by_cell,
+    op,
+    *,
+    chi: int = 4,
+    nrows: int = 1,
+    ncols: int = 1,
+    objective_cell=(0, 0),
+    max_iter: int = 200,
+    conv_tol: float = 1e-12,
+    min_iter: int = 4,
+    polish_steps: int = 40,
+    polish_tol: float = 1e-10,
+    solve_tol: float = 1e-8,
+    solve_maxiter: int = 400,
+    solve_restart: int = 30,
+    root_residual_warn: float = 1e-6,
+    return_diagnostics: bool = False,
+):
+    """Energy and ``dE/dA`` per cell via root implicit differentiation.
+
+    Eq. 18 without back-propagating a single SVD, now over a unit cell.  The
+    structure is Phase 1's :func:`asym_root_implicit_energy_and_grad`; what the
+    cell changes is that ``y`` and the gradient are dicts over coordinates, and
+    that the shifted-cell tables carry ``S`` between them.
+
+    The energy is a function of the *regular* environment, so the last forward
+    step is the Eq. 82 absorption and differentiating through it is what gives
+    ``S`` an adjoint at all.  Writing ``F`` in the regular variables sets that
+    adjoint to zero, which was #718.
+    """
+    import warnings
+
+    from tenax.algorithms._ctm_c4v_root_implicit import _solve_root_adjoint
+    from tenax.algorithms._ctm_tensor_init import (
+        _build_double_layer_tensor,
+        initialize_ctm_tensor_env,
+    )
+    from tenax.core.tensor import DenseTensor, SymmetricTensor
+
+    if any(isinstance(A, SymmetricTensor) for A in A_by_cell.values()):
+        raise TypeError("Multisite root implicit AD is dense-only (#715 Phase 3).")
+
+    indices = {rc: A.indices for rc, A in A_by_cell.items()}
+    A_const = {
+        rc: DenseTensor(jax.lax.stop_gradient(A.todense()), A.indices)
+        for rc, A in A_by_cell.items()
+    }
+    corners, edges, meta, projs, a_by_cell = converge_multisite(
+        A_const,
+        chi,
+        nrows,
+        ncols,
+        max_iter=max_iter,
+        conv_tol=conv_tol,
+        min_iter=min_iter,
+        return_projectors=True,
+    )
+    root, root_residual = root_parametrize_multisite(
+        corners,
+        edges,
+        a_by_cell,
+        chi,
+        nrows,
+        ncols,
+        prev_projs=projs,
+        polish_steps=polish_steps,
+        polish_tol=polish_tol,
+    )
+    if root_residual > root_residual_warn:
+        warnings.warn(
+            f"Multisite root implicit AD: ‖F(y*)‖ = {root_residual:.3e} exceeds "
+            f"{root_residual_warn:.1e}; the implicit-function gradient is "
+            "correspondingly inaccurate (paper Fig. 1).",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    S_star = root.s
+    y_star = (root.corners, root.edges, root.u, S_star, root.v)
+    template = initialize_ctm_tensor_env(A_const[objective_cell], chi)
+    A_data = {rc: jnp.asarray(A.todense()) for rc, A in A_by_cell.items()}
+
+    def energy_of(a_data, corners_t, edges_t, S_all):
+        c_reg, e_reg = absorb_inverse_roots_multisite(
+            corners_t, edges_t, S_all, nrows, ncols
+        )
+        A_live = DenseTensor(a_data[objective_cell], indices[objective_cell])
+        return _cell_observable(
+            A_live, c_reg, e_reg, template, op, objective_cell, nrows, ncols
+        )
+
+    energy, vjp_energy = jax.vjp(energy_of, A_data, root.corners, root.edges, S_star)
+    grad_direct, c_bar, e_bar, S_bar = vjp_energy(jnp.ones((), dtype=energy.dtype))
+    # u and v carry no cotangent: the energy does not see the null-space
+    # coordinates, only their effect through the root.
+    y_bar = (
+        c_bar,
+        e_bar,
+        {co: jnp.zeros_like(x) for co, x in root.u.items()},
+        S_bar,
+        {co: jnp.zeros_like(x) for co, x in root.v.items()},
+    )
+
+    # An independent phase on each environment tensor of each cell is an exact
+    # null direction of ∂_yF, so the adjoint system is singular and solvable
+    # only because the energy is invariant along every orbit.  That invariance
+    # lives at the energy boundary, not here, and #718 is a standing reminder
+    # that the boundary is where conventions go wrong — so measure it.
+    y_bar_norm = float(
+        jnp.sqrt(sum(jnp.sum(jnp.abs(x) ** 2) for x in jax.tree.leaves(y_bar)))
+    )
+    gauge_consistency = 0.0
+    for bar_map, prim_map in ((c_bar, root.corners), (e_bar, root.edges)):
+        for co, bar in bar_map.items():
+            pairing = float(jnp.real(jnp.sum(bar * (1j * prim_map[co]))))
+            scale = y_bar_norm * float(jnp.linalg.norm(prim_map[co])) + 1e-300
+            gauge_consistency = max(gauge_consistency, abs(pairing) / scale)
+
+    def F_of_y(y):
+        return characteristic_residual_multisite(y, a_by_cell, root, chi)
+
+    F_at_root, vjp_y = jax.vjp(F_of_y, y_star)
+    covariant_residual = float(
+        jnp.sqrt(sum(jnp.sum(jnp.abs(x) ** 2) for x in jax.tree.leaves(F_at_root)))
+    )
+    F_bar, solve_resid = _solve_root_adjoint(
+        lambda v: vjp_y(v)[0],
+        y_bar,
+        tol=solve_tol,
+        maxiter=solve_maxiter,
+        restart=solve_restart,
+    )
+
+    def F_of_p(a_data):
+        a_live = {}
+        for rc, data in a_data.items():
+            a_t = _build_double_layer_tensor(DenseTensor(data, indices[rc]))
+            labels = list(a_t.labels())
+            perm = tuple(labels.index(lbl) for lbl in ("u2", "d2", "l2", "r2"))
+            a_live[rc] = a_t.transpose(perm).todense()
+        return characteristic_residual_multisite(y_star, a_live, root, chi)
+
+    _, vjp_p = jax.vjp(F_of_p, A_data)
+    grad_indirect = vjp_p(F_bar)[0]
+    grad = {rc: grad_direct[rc] - grad_indirect[rc] for rc in grad_direct}
+
+    if return_diagnostics:
+        return (
+            energy,
+            grad,
+            {
+                **meta,
+                "root_residual": root_residual,
+                "covariant_residual": covariant_residual,
+                "adjoint_residual": float(solve_resid),
+                "gauge_consistency": gauge_consistency,
+            },
+        )
+    return energy, grad

--- a/src/tenax/algorithms/_ctm_root_implicit_multisite.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_multisite.py
@@ -34,6 +34,8 @@ the edge ``T{k+1}``, going around the ring.  A coordinate is the triple
 
 from __future__ import annotations
 
+from typing import NamedTuple
+
 import jax
 import jax.numpy as jnp
 
@@ -52,6 +54,8 @@ __all__ = [
     "prev_coordinate",
     "proj_sinv_indices",
     "rightvec_invfroot_indices",
+    "remove_inverse_roots_multisite",
+    "absorb_inverse_roots_multisite",
     "rotate_a_times",
 ]
 
@@ -481,3 +485,309 @@ def converge_multisite(
     if return_projectors:
         return corners, edges, meta, prev_projs, a_by_cell
     return corners, edges, meta
+
+
+# ---------------------------------------------------------------------------
+# The y <-> x map on the cell (paper Eq. 82)
+# ---------------------------------------------------------------------------
+#
+# The characteristic equations are written in *modified* corners and edges,
+# which carry the inverse singular values explicitly on their environment legs.
+# Only that form transforms covariantly under Eq. 84, and only then is holding
+# ``U*`` and ``V*`` constant licensed by Eq. 88.
+#
+# Which coordinate's root sits on which leg follows the projectors that put it
+# there.  ``corner[co] = P_R[prev_coordinate(co)] · EC · P_L[co]`` and
+# ``edge[co] = P_R[left_projector(co)] · … · P_L[co]``, and each projector
+# carries one ``S^-1/2``, so undoing them needs the roots at exactly those two
+# coordinates.  At 1x1 both collapse to Phase 1's ``roots[k]`` on the edge and
+# ``roots[k-1], roots[k]`` on the corner.
+
+
+def _map_cell_roots(corners, edges, roots, nrows: int, ncols: int, *, normalize: bool):
+    new_corners, new_edges = {}, {}
+    for co in coordinates(nrows, ncols):
+        C = roots[prev_coordinate(co, nrows, ncols)] @ corners[co] @ roots[co]
+        E = jnp.einsum(
+            "ai,ixj,jb->axb",
+            roots[left_projector(co, nrows, ncols)],
+            edges[co],
+            roots[co],
+        )
+        if normalize:
+            C = C / (jnp.linalg.norm(C) + 1e-300)
+            E = E / (jnp.linalg.norm(E) + 1e-300)
+        new_corners[co] = C
+        new_edges[co] = E
+    return new_corners, new_edges
+
+
+def remove_inverse_roots_multisite(corners, edges, S_all, nrows: int, ncols: int):
+    """Regular ``x`` -> modified ``(C̃, Ẽ)``: multiply by ``sqrt(S)``."""
+    from tenax.algorithms._ctm_root_implicit_asym import _denman_beavers
+
+    roots = {co: _denman_beavers(S)[0] for co, S in S_all.items()}
+    return _map_cell_roots(corners, edges, roots, nrows, ncols, normalize=True)
+
+
+def absorb_inverse_roots_multisite(corners_t, edges_t, S_all, nrows: int, ncols: int):
+    """Modified ``(C̃, Ẽ)`` -> regular ``x``: multiply by ``sqrt(S^-1)``.
+
+    The differentiable direction.  ``S`` enters here, so the energy — evaluated
+    on the *regular* environment — depends on ``S`` through this map, and that
+    is what gives ``S`` a nonzero adjoint.  Writing ``F`` in the regular
+    variables instead sets it to zero, which was the #718 bug.
+    """
+    from tenax.algorithms._ctm_root_implicit_asym import _inv_sqrt
+
+    roots = {co: _inv_sqrt(S) for co, S in S_all.items()}
+    return _map_cell_roots(corners_t, edges_t, roots, nrows, ncols, normalize=True)
+
+
+# ---------------------------------------------------------------------------
+# Characteristic equations on the unit cell (paper Eqs. 76-80, Appendix F)
+# ---------------------------------------------------------------------------
+#
+# Structurally identical to Phase 1's
+# ``asym_characteristic_residual_covariant``.  The one difference is that every
+# ``s``-derived factor is read from a *shifted* coordinate rather than from the
+# same direction:
+#
+#     S^-1 in the projectors      proj_sinv_indices(co)
+#     (s† s)^1/4 on U             leftvec_invfroot_indices(co)
+#     (s s†)^1/4 on V             rightvec_invfroot_indices(co)
+#     iCi = s · C̃ · s             prev_coordinate(co) and co
+#
+# At a 1x1 cell all four collapse to Phase 1's bare direction arithmetic.
+#
+# Phase 1 needs ``asym_root_to_covariant_convention`` to shift and transpose
+# its forward data, because its forward truncates with the left half-plane
+# while §V.3 uses the upper half.  This module's forward already uses the upper
+# half, so the forward's (U, S, Vh) at ``co`` *are* the §V.3 data at ``co`` and
+# no relabelling step exists here at all.
+
+
+class CellRoot(NamedTuple):
+    """Root variables plus the constants held fixed while differentiating."""
+
+    corners: dict  # C̃, modified
+    edges: dict  # Ẽ, modified
+    u: dict  # (n - chi) x chi
+    s: dict  # chi x chi, a general matrix
+    v: dict  # chi x (n - chi)
+    U_star: dict
+    U_perp: dict
+    Vh_star: dict
+    Vh_perp: dict
+    s_star_inv: dict
+    nrows: int
+    ncols: int
+
+    @property
+    def y(self):
+        return (self.corners, self.edges, self.u, self.s, self.v)
+
+
+def _covariant_pieces_multisite(consts: CellRoot, S_all, u_all, v_all, d2: int):
+    """Per-coordinate covariant building blocks (paper Eqs. 71-75).
+
+    The quartic roots attach to the ``n = chi * d2`` *cut* leg on its ``chi``
+    sub-leg — hence ``kron(root, I_d2)`` with ``chi`` the slow index — and they
+    come from the shifted coordinates, not from ``co``.  Phase 1 justifies the
+    placement from the Eq. 87 transformation laws; nothing about that argument
+    depends on the unit cell.
+    """
+    from tenax.algorithms._ctm_root_implicit_asym import _quartic_root
+
+    nrows, ncols = consts.nrows, consts.ncols
+    s_all = {co: jnp.linalg.inv(S) for co, S in S_all.items()}
+    eye_d2 = jnp.eye(d2, dtype=next(iter(s_all.values())).dtype)
+    K_L = {
+        co: jnp.kron(_quartic_root(s.conj().T @ s), eye_d2) for co, s in s_all.items()
+    }
+    K_R = {
+        co: jnp.kron(_quartic_root(s @ s.conj().T), eye_d2) for co, s in s_all.items()
+    }
+
+    Ud, Vd, ULd, VRd = {}, {}, {}, {}
+    for co in coordinates(nrows, ncols):
+        chi = S_all[co].shape[0]
+        kl = K_L[leftvec_invfroot_indices(co, nrows, ncols)]
+        kr = K_R[rightvec_invfroot_indices(co, nrows, ncols)]
+        U = consts.U_star[co] + consts.U_perp[co] @ u_all[co]  # Eq. 71
+        Vh = consts.Vh_star[co] + v_all[co] @ consts.Vh_perp[co]  # Eq. 72
+        Ud[co] = U[:, :chi].conj().T @ kl
+        Vd[co] = kr @ Vh[:chi].conj().T
+        ULd[co] = consts.U_perp[co].conj().T @ kl
+        VRd[co] = kr @ consts.Vh_perp[co].conj().T
+    return s_all, Ud, Vd, ULd, VRd
+
+
+def _modified_corners(corners_tilde, s_all, nrows: int, ncols: int):
+    """``iCi[co] = s[prev_coordinate(co)] · C̃[co] · s[co]``.
+
+    The full inverse on *both* corner legs is what puts the singular values
+    explicitly into the contraction environment, so that it transforms
+    covariantly under Eq. 84.  Edges already carry their ``s`` from the Eq. 82
+    map and are left alone.
+    """
+    return {
+        co: s_all[prev_coordinate(co, nrows, ncols)] @ C @ s_all[co]
+        for co, C in corners_tilde.items()
+    }
+
+
+def characteristic_residual_multisite(y, a_by_cell, consts: CellRoot, chi: int):
+    """``F(y, p)`` for the whole unit cell.
+
+    ``y = (corners_tilde, edges_tilde, u, S, v)``.  Normalisation is the
+    reference's ``X'/λ - X``; ``λ`` is deliberately not real-projected, since
+    ``dot(X, X')`` is genuinely complex for a complex state and taking the real
+    part alone moves ``|F1|`` by thirteen orders (Phase 1, #721).
+    """
+    corners_t, edges_t, u_all, S_all, v_all = y
+    nrows, ncols = consts.nrows, consts.ncols
+    d2 = next(iter(a_by_cell.values())).shape[0]
+    n = chi * d2
+
+    s_all, Ud, Vd, ULd, VRd = _covariant_pieces_multisite(
+        consts, S_all, u_all, v_all, d2
+    )
+    corners_mod = _modified_corners(corners_t, s_all, nrows, ncols)
+
+    eye_d2 = jnp.eye(d2, dtype=next(iter(s_all.values())).dtype)
+    K_is = {co: jnp.kron(s, eye_d2) for co, s in s_all.items()}
+
+    EC, cols = {}, {}
+    for co in coordinates(nrows, ncols):
+        k, r, c = co
+        EC[co] = _as_matrix(
+            enlarged_corner(corners_mod, edges_t, a_by_cell, co, nrows, ncols)
+        )
+        # The same edge that enters EC[co], with the sandwich attached:
+        # (chi_l, a_l | a_out | chi_r, a_r).
+        T = edges_t[above(co, nrows, ncols)]
+        a_k = rotate_a_times(a_by_cell[(r, c)], k)
+        cols[co] = jnp.einsum("xfy,fjlr->xljyr", T, a_k).reshape(n, d2, n)
+
+    M, P_R, P_L = {}, {}, {}
+    for co in coordinates(nrows, ncols):
+        nxt = next_coordinate(co, nrows, ncols)
+        kis = K_is[proj_sinv_indices(co, nrows, ncols)]
+        M[co] = EC[co] @ kis @ EC[nxt]
+        P_R[co] = Ud[co] @ EC[co] @ kis
+        P_L[co] = kis @ EC[nxt] @ Vd[co]
+
+    R_C, R_E, R_u, R_S, R_v = {}, {}, {}, {}, {}
+    for co in coordinates(nrows, ncols):
+        M_co, s_inv = M[co], consts.s_star_inv[co]
+
+        core = Ud[co] @ M_co @ Vd[co]
+        lam_S = jnp.vdot(S_all[co], core)
+        R_S[co] = core / lam_S - S_all[co]
+        R_u[co] = (ULd[co] @ M_co @ Vd[co]) @ s_inv / lam_S - u_all[co]
+        R_v[co] = s_inv @ (Ud[co] @ M_co @ VRd[co]) / lam_S - v_all[co]
+
+        C_new = P_R[prev_coordinate(co, nrows, ncols)] @ EC[co] @ P_L[co]
+        C_cur = corners_t[co]
+        R_C[co] = C_new / jnp.vdot(C_cur, C_new) - C_cur
+
+        E_new = jnp.einsum(
+            "ax,xjy,yb->ajb",
+            P_R[left_projector(co, nrows, ncols)],
+            cols[co],
+            P_L[co],
+        )
+        E_cur = edges_t[co]
+        R_E[co] = E_new / jnp.vdot(E_cur, E_new) - E_cur
+
+    return (R_C, R_E, R_u, R_S, R_v)
+
+
+def root_parametrize_multisite(
+    corners,
+    edges,
+    a_by_cell,
+    chi: int,
+    nrows: int,
+    ncols: int,
+    *,
+    prev_projs=None,
+    pinv_rtol: float = 1e-10,
+    polish_steps: int = 40,
+    polish_tol: float = 1e-10,
+):
+    """Extract ``y* = (C̃, Ẽ, 0, S*, 0)`` and the frozen isometries.
+
+    Every tensor is rescaled to unit Frobenius norm so the ``λ`` defined as an
+    inner product really is the eigenvalue Eqs. 76-77 need.
+
+    Pass ``prev_projs`` whenever the environment came from a sweep chain: it
+    carries that chain's bond gauge, and a cold pin fixes a *different* one,
+    leaving ``y*`` describing an environment it was not extracted from.  For a
+    real state one polish sweep absorbs the difference; for a complex state the
+    gauge is a continuous phase and the corner residual plateaus instead
+    (#721).
+    """
+    from tenax.algorithms._ctm_root_implicit_asym import _normalize
+
+    del _normalize
+    best = None
+    d2 = next(iter(a_by_cell.values())).shape[0]
+    n = chi * d2
+    dtype = next(iter(corners.values())).dtype
+
+    for _step in range(max(int(polish_steps), 1)):
+        corners = {co: C / (jnp.linalg.norm(C) + 1e-300) for co, C in corners.items()}
+        edges = {co: E / (jnp.linalg.norm(E) + 1e-300) for co, E in edges.items()}
+
+        ECs = all_enlarged_corners(corners, edges, a_by_cell, nrows, ncols)
+        projs = all_projectors_multisite(ECs, chi, nrows, ncols, prev_projs)
+        prev_projs = projs
+
+        U_star, U_perp, Vh_star, Vh_perp, s_map, s_inv = {}, {}, {}, {}, {}, {}
+        for co in coordinates(nrows, ncols):
+            _pl, _pr, U, S_keep, Vh = projs[co]
+            U_star[co] = U[:, :chi]
+            U_perp[co] = U[:, chi:]
+            Vh_star[co] = Vh[:chi]
+            Vh_perp[co] = Vh[chi:]
+            s_map[co] = S_keep
+            diag = jnp.diag(S_keep).real
+            cutoff = pinv_rtol * jnp.max(diag)
+            inv_diag = jnp.where(
+                diag > cutoff, 1.0 / jnp.where(diag > cutoff, diag, 1.0), 0.0
+            )
+            s_inv[co] = jnp.diag(inv_diag).astype(S_keep.dtype)
+
+        corners_t, edges_t = remove_inverse_roots_multisite(
+            corners, edges, s_map, nrows, ncols
+        )
+        root = CellRoot(
+            corners=corners_t,
+            edges=edges_t,
+            u={co: jnp.zeros((n - chi, chi), dtype=dtype) for co in s_map},
+            s=s_map,
+            v={co: jnp.zeros((chi, n - chi), dtype=dtype) for co in s_map},
+            U_star=U_star,
+            U_perp=U_perp,
+            Vh_star=Vh_star,
+            Vh_perp=Vh_perp,
+            s_star_inv=s_inv,
+            nrows=nrows,
+            ncols=ncols,
+        )
+        R = characteristic_residual_multisite(root.y, a_by_cell, root, chi)
+        residual = float(
+            jnp.sqrt(sum(jnp.sum(jnp.abs(x) ** 2) for x in jax.tree.leaves(R)))
+        )
+        if best is None or residual < best[1]:
+            best = (root, residual)
+        if residual <= polish_tol:
+            break
+        corners, edges, prev_projs = sweep_multisite(
+            corners, edges, a_by_cell, chi, nrows, ncols, projs
+        )
+
+    assert best is not None
+    return best

--- a/tests/test_ctm_root_implicit_multisite.py
+++ b/tests/test_ctm_root_implicit_multisite.py
@@ -422,3 +422,124 @@ def test_the_1x1_energy_gate_is_load_bearing(monkeypatch):
         "wrong gluing partner left the energy unchanged, so the 1x1 gate "
         f"cannot detect a miswiring (E={E_wrong!r})"
     )
+
+
+# ------------------------------------------------------------------ #
+# Characteristic equations                                           #
+# ------------------------------------------------------------------ #
+
+
+def _cell_2x2():
+    """Four *different* site tensors — the only configuration in which a wrong
+    cell shift is observable at all."""
+    return {
+        (0, 0): _site_tensor(seed=1),
+        (0, 1): _site_tensor(seed=2),
+        (1, 0): _site_tensor(seed=3),
+        (1, 1): _site_tensor(seed=4),
+    }
+
+
+def _root_residual(cell, nrows, ncols, chi=4, polish_steps=3):
+    import tenax.algorithms._ctm_root_implicit_multisite as M
+
+    corners, edges, _meta, projs, a_by_cell = M.converge_multisite(
+        cell, chi, nrows, ncols, max_iter=200, conv_tol=1e-12, return_projectors=True
+    )
+    _root, residual = M.root_parametrize_multisite(
+        corners,
+        edges,
+        a_by_cell,
+        chi,
+        nrows,
+        ncols,
+        prev_projs=projs,
+        polish_steps=polish_steps,
+    )
+    return residual
+
+
+def test_characteristic_equations_vanish_at_a_1x1_root():
+    assert _root_residual({(0, 0): _site_tensor()}, 1, 1) < 1e-11
+
+
+def test_characteristic_equations_vanish_at_a_2x2_root():
+    """The Phase 2 gate: all 20 equations per cell hold at the converged root
+    of a 2x2 cell of different tensors."""
+    assert _root_residual(_cell_2x2(), 2, 2) < 1e-11
+
+
+def test_every_block_of_F_vanishes_not_just_the_norm():
+    """A single dominant block could hide four broken ones behind a small
+    total, so check R_C, R_E, R_u, R_S and R_v separately."""
+    import jax.numpy as jnp
+
+    import tenax.algorithms._ctm_root_implicit_multisite as M
+
+    corners, edges, _m, projs, a_by = M.converge_multisite(
+        _cell_2x2(), 4, 2, 2, max_iter=200, conv_tol=1e-12, return_projectors=True
+    )
+    root, _r = M.root_parametrize_multisite(
+        corners, edges, a_by, 4, 2, 2, prev_projs=projs, polish_steps=3
+    )
+    blocks = M.characteristic_residual_multisite(root.y, a_by, root, 4)
+    for name, blk in zip(("R_C", "R_E", "R_u", "R_S", "R_v"), blocks):
+        norm = float(jnp.sqrt(sum(jnp.sum(jnp.abs(v) ** 2) for v in blk.values())))
+        assert norm < 1e-11, f"{name} = {norm:.3e}"
+
+
+@pytest.mark.parametrize(
+    "table",
+    ["proj_sinv_indices", "leftvec_invfroot_indices", "rightvec_invfroot_indices"],
+)
+def test_each_cell_shift_table_is_load_bearing(monkeypatch, table):
+    """Perturb one table's *cell* component and the 2x2 root must stop being a
+    root.  Without this, ``‖F(y*)‖ ~ 1e-13`` says only that the equations are
+    self-consistent, not that Appendix F was transcribed correctly.
+
+    The direction component is left alone so the failure is attributable to the
+    ``(r, c)`` assignment specifically.  Measured: 4.7e-13 -> ~1, twelve orders.
+    """
+    import tenax.algorithms._ctm_root_implicit_multisite as M
+
+    good = getattr(M, table)
+    monkeypatch.setattr(
+        M,
+        table,
+        lambda co, nr, nc: (
+            good(co, nr, nc)[0],
+            (good(co, nr, nc)[1] + 1) % nr,
+            good(co, nr, nc)[2],
+        ),
+    )
+    assert _root_residual(_cell_2x2(), 2, 2) > 1e-3
+
+
+@pytest.mark.parametrize(
+    "table",
+    ["proj_sinv_indices", "leftvec_invfroot_indices", "rightvec_invfroot_indices"],
+)
+def test_at_1x1_the_cell_shifts_are_invisible(monkeypatch, table):
+    """The other half of the argument, and the reason the 2x2 gate exists.
+
+    A 1x1 cell has one cell, so every ``(r, c)`` shift is the identity and the
+    residual is *bit-identical* under the same perturbation that costs twelve
+    orders at 2x2.  Any Phase 2 test written only at 1x1 verifies nothing about
+    Appendix F.
+    """
+    import tenax.algorithms._ctm_root_implicit_multisite as M
+
+    cell = {(0, 0): _site_tensor()}
+    before = _root_residual(cell, 1, 1)
+
+    good = getattr(M, table)
+    monkeypatch.setattr(
+        M,
+        table,
+        lambda co, nr, nc: (
+            good(co, nr, nc)[0],
+            (good(co, nr, nc)[1] + 1) % nr,
+            good(co, nr, nc)[2],
+        ),
+    )
+    assert _root_residual(cell, 1, 1) == before

--- a/tests/test_ctm_root_implicit_multisite.py
+++ b/tests/test_ctm_root_implicit_multisite.py
@@ -1,0 +1,282 @@
+"""Multisite root implicit AD for asymmetric CTMRG (#715 Phase 2).
+
+The index helpers below are the Appendix F shifted-cell assignment.  Getting
+one wrong yields a silently wrong gradient — the #700 / #702 failure shape —
+so each is pinned against a table transcribed from the authors' reference
+implementation (``ImplicitDifferentiationPEPS.jl``,
+``src/asymmetric/fixedpoints.jl``) rather than re-derived here.
+
+Conventions: this port is 0-based in every index.  Julia's ``dir ∈ 1:4`` with
+``mod1`` becomes ``k ∈ 0:3`` with ``%``; rows and columns likewise.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import jax
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_root_implicit_multisite import (
+    above,
+    above_left,
+    left,
+    left_projector,
+    leftvec_invfroot_indices,
+    next_coordinate,
+    prev_coordinate,
+    proj_sinv_indices,
+    rightvec_invfroot_indices,
+)
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import U1Symmetry
+from tenax.core.tensor import DenseTensor
+
+# Every (dir, row, col) on a 3x5 cell — big enough that a wrap-around and a
+# two-step shift are distinguishable from each other and from a no-op.
+NROWS, NCOLS = 3, 5
+COORDS = list(itertools.product(range(4), range(NROWS), range(NCOLS)))
+
+
+def _n(i, total):
+    return (i + 1) % total
+
+
+def _p(i, total):
+    return (i - 1) % total
+
+
+def _site_tensor(D=2, d=2, seed=42, eps=1.0):
+    """Random 5-leg site tensor with trivial U(1) charges.
+
+    Same construction as ``test_ctm_root_implicit_asym``; ``seed`` varies so a
+    unit cell can be filled with genuinely different tensors, which is the
+    only way a wrong cell shift shows up at all.
+    """
+    rng = np.random.RandomState(seed)
+    data = eps * jax.numpy.array(rng.standard_normal((D, D, D, D, d)))
+    data = data.at[0, 0, 0, 0, 0].set(1.0)
+    data = data / (jax.numpy.linalg.norm(data) + 1e-10)
+    sym = U1Symmetry()
+    ch = np.zeros(D, dtype=np.int32)
+    pch = np.zeros(d, dtype=np.int32)
+    idx = (
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(sym, pch.copy(), FlowDirection.IN, label="phys"),
+    )
+    return DenseTensor(data, idx)
+
+
+# ------------------------------------------------------------------ #
+# Ring walk                                                          #
+# ------------------------------------------------------------------ #
+
+
+def test_next_and_prev_coordinate_are_inverse():
+    for co in COORDS:
+        assert prev_coordinate(next_coordinate(co, NROWS, NCOLS), NROWS, NCOLS) == co
+        assert next_coordinate(prev_coordinate(co, NROWS, NCOLS), NROWS, NCOLS) == co
+
+
+def test_four_next_steps_return_to_the_start():
+    """The ring closes: walking all four directions is the identity."""
+    for co in COORDS:
+        walked = co
+        for _ in range(4):
+            walked = next_coordinate(walked, NROWS, NCOLS)
+        assert walked == co
+
+
+def test_next_coordinate_matches_the_reference_table():
+    r, c = 1, 2
+    assert next_coordinate((0, r, c), NROWS, NCOLS) == (1, r, _n(c, NCOLS))
+    assert next_coordinate((1, r, c), NROWS, NCOLS) == (2, _n(r, NROWS), c)
+    assert next_coordinate((2, r, c), NROWS, NCOLS) == (3, r, _p(c, NCOLS))
+    assert next_coordinate((3, r, c), NROWS, NCOLS) == (0, _p(r, NROWS), c)
+
+
+# ------------------------------------------------------------------ #
+# Shifted-cell assignment (Appendix F)                               #
+# ------------------------------------------------------------------ #
+
+
+def test_proj_sinv_indices_matches_the_reference_table():
+    """S^-1 absorbed into the projectors: direction unchanged, cell steps
+    *outward* along that direction."""
+    r, c = 1, 2
+    assert proj_sinv_indices((0, r, c), NROWS, NCOLS) == (0, _p(r, NROWS), c)
+    assert proj_sinv_indices((1, r, c), NROWS, NCOLS) == (1, r, _n(c, NCOLS))
+    assert proj_sinv_indices((2, r, c), NROWS, NCOLS) == (2, _n(r, NROWS), c)
+    assert proj_sinv_indices((3, r, c), NROWS, NCOLS) == (3, r, _p(c, NCOLS))
+
+
+def test_leftvec_invfroot_indices_matches_the_reference_table():
+    """(s†s)^1/4 for the U isometry: direction steps *back* by one."""
+    r, c = 1, 2
+    assert leftvec_invfroot_indices((0, r, c), NROWS, NCOLS) == (
+        3,
+        _n(r, NROWS),
+        _p(c, NCOLS),
+    )
+    assert leftvec_invfroot_indices((1, r, c), NROWS, NCOLS) == (
+        0,
+        _p(r, NROWS),
+        _p(c, NCOLS),
+    )
+    assert leftvec_invfroot_indices((2, r, c), NROWS, NCOLS) == (
+        1,
+        _p(r, NROWS),
+        _n(c, NCOLS),
+    )
+    assert leftvec_invfroot_indices((3, r, c), NROWS, NCOLS) == (
+        2,
+        _n(r, NROWS),
+        _n(c, NCOLS),
+    )
+
+
+def test_rightvec_invfroot_indices_matches_the_reference_table():
+    """(ss†)^1/4 for the V isometry: direction steps *forward* by one, and the
+    cell by *two* — the only two-step shift in the whole assignment."""
+    r, c = 1, 2
+    assert rightvec_invfroot_indices((0, r, c), NROWS, NCOLS) == (
+        1,
+        r,
+        _n(_n(c, NCOLS), NCOLS),
+    )
+    assert rightvec_invfroot_indices((1, r, c), NROWS, NCOLS) == (
+        2,
+        _n(_n(r, NROWS), NROWS),
+        c,
+    )
+    assert rightvec_invfroot_indices((2, r, c), NROWS, NCOLS) == (
+        3,
+        r,
+        _p(_p(c, NCOLS), NCOLS),
+    )
+    assert rightvec_invfroot_indices((3, r, c), NROWS, NCOLS) == (
+        0,
+        _p(_p(r, NROWS), NROWS),
+        c,
+    )
+
+
+def test_enlarged_corner_neighbour_tables():
+    """Corner / edge / projector positions relative to an enlarged corner."""
+    r, c = 1, 2
+    assert above_left((0, r, c), NROWS, NCOLS) == (0, _p(r, NROWS), _p(c, NCOLS))
+    assert above_left((1, r, c), NROWS, NCOLS) == (1, _p(r, NROWS), _n(c, NCOLS))
+    assert above_left((2, r, c), NROWS, NCOLS) == (2, _n(r, NROWS), _n(c, NCOLS))
+    assert above_left((3, r, c), NROWS, NCOLS) == (3, _n(r, NROWS), _p(c, NCOLS))
+
+    assert left((0, r, c), NROWS, NCOLS) == (3, r, _p(c, NCOLS))
+    assert left((1, r, c), NROWS, NCOLS) == (0, _p(r, NROWS), c)
+    assert left((2, r, c), NROWS, NCOLS) == (1, r, _n(c, NCOLS))
+    assert left((3, r, c), NROWS, NCOLS) == (2, _n(r, NROWS), c)
+
+    assert above((0, r, c), NROWS, NCOLS) == (0, _p(r, NROWS), c)
+    assert above((1, r, c), NROWS, NCOLS) == (1, r, _n(c, NCOLS))
+    assert above((2, r, c), NROWS, NCOLS) == (2, _n(r, NROWS), c)
+    assert above((3, r, c), NROWS, NCOLS) == (3, r, _p(c, NCOLS))
+
+    assert left_projector((0, r, c), NROWS, NCOLS) == (0, r, _p(c, NCOLS))
+    assert left_projector((1, r, c), NROWS, NCOLS) == (1, _p(r, NROWS), c)
+    assert left_projector((2, r, c), NROWS, NCOLS) == (2, r, _n(c, NCOLS))
+    assert left_projector((3, r, c), NROWS, NCOLS) == (3, _n(r, NROWS), c)
+
+
+# ------------------------------------------------------------------ #
+# The link back to Phase 1                                           #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize("k", range(4))
+def test_at_one_by_one_the_cell_shifts_vanish(k):
+    """A 1x1 unit cell has only one cell, so every (r, c) shift collapses and
+    the assignment must reduce to the bare direction offsets Phase 1 uses."""
+    assert proj_sinv_indices((k, 0, 0), 1, 1) == (k, 0, 0)
+    assert leftvec_invfroot_indices((k, 0, 0), 1, 1) == ((k - 1) % 4, 0, 0)
+    assert rightvec_invfroot_indices((k, 0, 0), 1, 1) == ((k + 1) % 4, 0, 0)
+
+
+def test_at_one_by_one_the_quartic_roots_are_the_phase_one_neighbours():
+    """``_covariant_pieces`` in the 1x1 module reads ``K_L[k-1]`` and
+    ``K_R[k+1]``.  That is this table at ``nrows = ncols = 1`` — the two must
+    not drift apart."""
+    for k in range(4):
+        assert leftvec_invfroot_indices((k, 0, 0), 1, 1)[0] == (k - 1) % 4
+        assert rightvec_invfroot_indices((k, 0, 0), 1, 1)[0] == (k + 1) % 4
+
+
+def test_shifts_are_genuinely_periodic():
+    """Every helper must land inside the cell for every input."""
+    helpers = (
+        proj_sinv_indices,
+        leftvec_invfroot_indices,
+        rightvec_invfroot_indices,
+        above_left,
+        left,
+        above,
+        left_projector,
+        next_coordinate,
+        prev_coordinate,
+    )
+    for helper in helpers:
+        for co in COORDS:
+            k, r, c = helper(co, NROWS, NCOLS)
+            assert 0 <= k < 4
+            assert 0 <= r < NROWS
+            assert 0 <= c < NCOLS
+
+
+# ------------------------------------------------------------------ #
+# Enlarged corners: the bridge to Phase 1                            #
+# ------------------------------------------------------------------ #
+
+
+def test_enlarged_corner_at_1x1_reproduces_the_phase1_quadrant():
+    """A 1x1 unit cell must reproduce Phase 1's rotate-and-reuse quadrant.
+
+    Phase 1 builds the upper-left quadrant from ``(C1, T1, T4)`` of an
+    environment rotated ``k`` times.  This module reads the same three tensors
+    by coordinate — ``above_left``, ``above``, ``left`` — from an unrotated
+    cell.  If the tables are right the two agree to machine precision, and
+    that equality is what licenses reusing every downstream Phase 1 formula.
+    """
+    import jax.numpy as jnp
+
+    from tenax.algorithms._ctm_root_implicit_asym import (
+        _init_env,
+        _upper_left_quadrant,
+        rotate_a,
+        rotate_env,
+        sweep,
+    )
+    from tenax.algorithms._ctm_root_implicit_multisite import (
+        enlarged_corner,
+        env_to_cell_maps,
+    )
+
+    A = _site_tensor()
+    chi = 4
+    env, a = _init_env(A, chi)
+    # Give the environment genuine asymmetry, or the test passes on symmetry
+    # alone and says nothing about the index tables.
+    env, projs = sweep(env, a, chi)
+    env, _ = sweep(env, a, chi, projs)
+
+    corners, edges = env_to_cell_maps(env)
+    env_k, a_k = env, a
+    for k in range(4):
+        want = _upper_left_quadrant(env_k, a_k)
+        got = enlarged_corner(corners, edges, {(0, 0): a}, (k, 0, 0), 1, 1)
+        assert got.shape == want.shape
+        err = float(jnp.linalg.norm(got - want) / jnp.linalg.norm(want))
+        assert err < 1e-13, f"direction {k}: relative error {err:.3e}"
+        env_k, a_k = rotate_env(env_k), rotate_a(a_k)

--- a/tests/test_ctm_root_implicit_multisite.py
+++ b/tests/test_ctm_root_implicit_multisite.py
@@ -280,3 +280,145 @@ def test_enlarged_corner_at_1x1_reproduces_the_phase1_quadrant():
         err = float(jnp.linalg.norm(got - want) / jnp.linalg.norm(want))
         assert err < 1e-13, f"direction {k}: relative error {err:.3e}"
         env_k, a_k = rotate_env(env_k), rotate_a(a_k)
+
+
+# ------------------------------------------------------------------ #
+# Forward sweep                                                      #
+# ------------------------------------------------------------------ #
+
+
+def _gate(delta=1.0):
+    import jax.numpy as jnp
+
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+    H = delta * jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+    return H.reshape(2, 2, 2, 2)
+
+
+def test_multisite_forward_at_1x1_matches_the_phase1_energy():
+    """The 1x1 smoke test for the forward sweep.
+
+    Phase 1 truncates with the left half-plane, this module with the upper
+    half; ``docs/plans/2026-07-31-715-phase2-multisite-design.md`` shows those
+    are the same truncation up to a shift and a transpose.  So the two
+    environments are *not* tensor-equal, and only a gauge-invariant quantity
+    compares — the energy.
+    """
+    import jax.numpy as jnp
+
+    from tenax.algorithms._ctm_root_implicit_asym import asym_energy, converge
+    from tenax.algorithms._ctm_root_implicit_multisite import (
+        cell_maps_to_env,
+        converge_multisite,
+    )
+    from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env
+
+    A = _site_tensor()
+    chi, gate = 4, _gate()
+    template = initialize_ctm_tensor_env(A, chi)
+
+    env1, _a1, meta1 = converge(A, chi, max_iter=200, conv_tol=1e-12)
+    E1 = float(asym_energy(A, env1, template, gate))
+
+    corners, edges, meta2 = converge_multisite(
+        {(0, 0): A}, chi, 1, 1, max_iter=200, conv_tol=1e-12
+    )
+    E2 = float(asym_energy(A, cell_maps_to_env(corners, edges), template, gate))
+
+    assert meta2["converged"], f"multisite forward did not converge: {meta2}"
+    assert jnp.isfinite(E2)
+    rel = abs(E1 - E2) / abs(E1)
+    assert rel < 1e-10, f"E_phase1={E1!r} E_multisite={E2!r} rel={rel:.3e}"
+
+
+def test_multisite_forward_runs_on_a_2x2_cell_of_different_tensors():
+    """A 2x2 cell of *different* tensors — the configuration a wrong cell
+    shift can actually be seen in.  Only asserts the forward is well formed;
+    the gradient gate comes with the characteristic equations."""
+    import jax.numpy as jnp
+
+    from tenax.algorithms._ctm_root_implicit_multisite import converge_multisite
+
+    chi = 4
+    cell = {
+        (0, 0): _site_tensor(seed=1),
+        (0, 1): _site_tensor(seed=2),
+        (1, 0): _site_tensor(seed=3),
+        (1, 1): _site_tensor(seed=4),
+    }
+    corners, edges, meta = converge_multisite(
+        cell, chi, 2, 2, max_iter=200, conv_tol=1e-12
+    )
+
+    assert len(corners) == 4 * 2 * 2
+    assert len(edges) == 4 * 2 * 2
+    for co, C in corners.items():
+        assert C.shape == (chi, chi), co
+        assert jnp.all(jnp.isfinite(C)), co
+    for co, T in edges.items():
+        assert T.shape[0] == chi and T.shape[2] == chi, co
+        assert jnp.all(jnp.isfinite(T)), co
+    assert meta["converged"], meta
+
+
+def test_the_unit_cell_is_not_secretly_uniform():
+    """Guards the guard: if a 2x2 cell of different tensors converged to four
+    identical environments, every cell-shift test built on it would be
+    vacuous — a wrong shift would read the same tensor either way."""
+    import jax.numpy as jnp
+
+    from tenax.algorithms._ctm_root_implicit_multisite import converge_multisite
+
+    cell = {
+        (0, 0): _site_tensor(seed=1),
+        (0, 1): _site_tensor(seed=2),
+        (1, 0): _site_tensor(seed=3),
+        (1, 1): _site_tensor(seed=4),
+    }
+    corners, _edges, _meta = converge_multisite(
+        cell, 4, 2, 2, max_iter=200, conv_tol=1e-12
+    )
+    ref = corners[(0, 0, 0)]
+    spread = max(
+        float(jnp.linalg.norm(corners[(0, r, c)] - ref))
+        for r in range(2)
+        for c in range(2)
+        if (r, c) != (0, 0)
+    )
+    assert spread > 1e-3, f"cells are effectively identical (spread {spread:.3e})"
+
+
+def test_the_1x1_energy_gate_is_load_bearing(monkeypatch):
+    """Guards the gate: break the gluing partner and the 1x1 energy must move.
+
+    The upper-half cut glues ``EC[co]`` to ``EC[next_coordinate(co)]``.  If the
+    forward were somehow insensitive to that choice, the agreement above would
+    be proving nothing.  Composing ``next`` with itself picks the wrong
+    neighbour, and the energy shifts by ~6e-3 relative — three orders above the
+    1e-10 gate and thirteen above the 1e-15 the correct wiring achieves.
+    """
+    import tenax.algorithms._ctm_root_implicit_multisite as M
+    from tenax.algorithms._ctm_root_implicit_asym import asym_energy, converge
+    from tenax.algorithms._ctm_tensor_init import initialize_ctm_tensor_env
+
+    A = _site_tensor()
+    chi, gate = 4, _gate()
+    template = initialize_ctm_tensor_env(A, chi)
+    env1, _a1, _m1 = converge(A, chi, max_iter=200, conv_tol=1e-12)
+    E1 = float(asym_energy(A, env1, template, gate))
+
+    good = M.next_coordinate
+    monkeypatch.setattr(
+        M, "next_coordinate", lambda co, nr, nc: good(good(co, nr, nc), nr, nc)
+    )
+    corners, edges, _m = M.converge_multisite(
+        {(0, 0): A}, chi, 1, 1, max_iter=60, conv_tol=1e-12
+    )
+    E_wrong = float(asym_energy(A, M.cell_maps_to_env(corners, edges), template, gate))
+
+    assert abs(E1 - E_wrong) / abs(E1) > 1e-4, (
+        "wrong gluing partner left the energy unchanged, so the 1x1 gate "
+        f"cannot detect a miswiring (E={E_wrong!r})"
+    )

--- a/tests/test_ctm_root_implicit_multisite.py
+++ b/tests/test_ctm_root_implicit_multisite.py
@@ -543,3 +543,144 @@ def test_at_1x1_the_cell_shifts_are_invisible(monkeypatch, table):
         ),
     )
     assert _root_residual(cell, 1, 1) == before
+
+
+# ------------------------------------------------------------------ #
+# Adjoint: gradient vs finite differences                            #
+# ------------------------------------------------------------------ #
+
+_SZ = None
+
+
+def _sz():
+    import jax.numpy as jnp
+
+    return jnp.array([[0.5, 0.0], [0.0, -0.5]])
+
+
+def _fd_parity(cell, nrows, ncols, chi=4, h=1e-5, seed=0):
+    """(AD directional derivative, FD directional derivative)."""
+    import jax.numpy as jnp
+
+    import tenax.algorithms._ctm_root_implicit_multisite as M
+    from tenax.core.tensor import DenseTensor
+
+    op = _sz()
+    idx = {rc: A.indices for rc, A in cell.items()}
+    _value, grad = M.cell_root_implicit_energy_and_grad(
+        cell, op, chi=chi, nrows=nrows, ncols=ncols
+    )
+    base = {rc: jnp.asarray(A.todense()) for rc, A in cell.items()}
+    rng = np.random.RandomState(seed)
+    dirs = {rc: jnp.asarray(rng.standard_normal(v.shape)) for rc, v in base.items()}
+
+    def f(data):
+        c = {rc: DenseTensor(v, idx[rc]) for rc, v in data.items()}
+        return float(
+            M.cell_observable_forward(
+                c, op, chi, nrows, ncols, max_iter=300, conv_tol=1e-12
+            )
+        )
+
+    ad = float(sum(jnp.real(jnp.sum(grad[rc] * dirs[rc])) for rc in grad))
+    fd = (
+        f({rc: base[rc] + h * dirs[rc] for rc in base})
+        - f({rc: base[rc] - h * dirs[rc] for rc in base})
+    ) / (2 * h)
+    return ad, fd
+
+
+def test_gradient_matches_finite_differences_at_1x1():
+    ad, fd = _fd_parity({(0, 0): _site_tensor()}, 1, 1)
+    rel = abs(ad - fd) / max(abs(fd), 1e-30)
+    assert rel < 1e-8, f"AD={ad!r} FD={fd!r} rel={rel:.3e}"
+
+
+def test_gradient_matches_finite_differences_on_a_2x2_cell():
+    """The Phase 2 gate (#715).
+
+    Four different site tensors, so every Appendix F cell shift is live.
+    Measured h-convergence at 1e-4 / 1e-5 / 1e-6: 6.5e-6, 6.5e-8, 5.6e-10 —
+    clean second-order behaviour for a central difference, which is what says
+    the gradient is right rather than merely close.
+    """
+    ad, fd = _fd_parity(_cell_2x2(), 2, 2)
+    rel = abs(ad - fd) / max(abs(fd), 1e-30)
+    assert rel < 1e-6, f"AD={ad!r} FD={fd!r} rel={rel:.3e}"
+
+
+@pytest.mark.parametrize(
+    "table",
+    ["proj_sinv_indices", "leftvec_invfroot_indices", "rightvec_invfroot_indices"],
+)
+def test_a_wrong_cell_shift_breaks_the_2x2_gradient(monkeypatch, table):
+    """The gate #715 asks for by name: the tables must be load-bearing *for the
+    gradient*, not only for the root residual."""
+    import tenax.algorithms._ctm_root_implicit_multisite as M
+
+    good = getattr(M, table)
+    monkeypatch.setattr(
+        M,
+        table,
+        lambda co, nr, nc: (
+            good(co, nr, nc)[0],
+            (good(co, nr, nc)[1] + 1) % nr,
+            good(co, nr, nc)[2],
+        ),
+    )
+    ad, fd = _fd_parity(_cell_2x2(), 2, 2)
+    rel = abs(ad - fd) / max(abs(fd), 1e-30)
+    assert rel > 1e-3, f"wrong {table} still matched FD (rel={rel:.3e})"
+
+
+def test_the_two_site_energy_is_gauge_dependent_on_a_nonuniform_cell():
+    """Records why the parity objective is a one-site observable.
+
+    ``compute_energy_ctm_tensor`` builds two-site RDMs with one site's ring.
+    On a cell of different tensors the halves meet on independently-gauged chi
+    bonds, so the scalar jumps under arbitrarily small changes of ``A`` even
+    though every fixed point converges to ~1e-13.  A gauge-dependent scalar has
+    no derivative, which is why finite differences diverged as h -> 0 before
+    the objective was changed.
+    """
+    import jax.numpy as jnp
+
+    import tenax.algorithms._ctm_root_implicit_multisite as M
+    from tenax.core.tensor import DenseTensor
+
+    cell = _cell_2x2()
+    idx = {rc: A.indices for rc, A in cell.items()}
+    base = {rc: jnp.asarray(A.todense()) for rc, A in cell.items()}
+    rng = np.random.RandomState(0)
+    dirs = {rc: jnp.asarray(rng.standard_normal(v.shape)) for rc, v in base.items()}
+
+    def energy(t):
+        c = {rc: DenseTensor(base[rc] + t * dirs[rc], idx[rc]) for rc in base}
+        return float(
+            M.cell_energy_forward(c, _gate(), 4, 2, 2, max_iter=300, conv_tol=1e-12)
+        )
+
+    vals = [energy(t) for t in (-2e-5, -1e-5, 0.0, 1e-5, 2e-5)]
+    spread = max(vals) - min(vals)
+    assert spread > 1e-3, (
+        "two-site energy looks smooth on a non-uniform cell; if that is now "
+        f"true the one-site objective may no longer be necessary (spread {spread:.3e})"
+    )
+
+    # The one-site observable over the same span is smooth.
+    def obs(t):
+        c = {rc: DenseTensor(base[rc] + t * dirs[rc], idx[rc]) for rc in base}
+        return float(
+            M.cell_observable_forward(c, _sz(), 4, 2, 2, max_iter=300, conv_tol=1e-12)
+        )
+
+    o = [obs(t) for t in (-2e-5, -1e-5, 0.0, 1e-5, 2e-5)]
+    second = max(abs(o[i + 2] - 2 * o[i + 1] + o[i]) for i in range(3))
+    # A smooth f has second difference f''·h² — here h = 1e-5 and f'' ~ 75, so
+    # ~7.5e-9 is the *expected* value, not a defect.  What distinguishes the
+    # two objectives is scale: the one-site curvature term is seven orders
+    # below the two-site energy's spread over the same span.
+    assert second < 1e-4 * spread, (
+        f"one-site observable is not smooth either (second difference {second:.3e} "
+        f"vs two-site spread {spread:.3e})"
+    )


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Completes Phase 2 of #715: root implicit AD for asymmetric CTMRG on an arbitrary `nrows x ncols` unit cell. Phase 1 fixed the cell at 1x1.

*(This PR was opened when only the index layer existed and has grown to the full phase; description updated to match.)*

## The gate

2x2 cell of four **different** site tensors, so every Appendix F cell shift is live. Implicit gradient against central finite differences of a one-site ⟨Sz⟩:

| h | relative error |
|---|---|
| 1e-4 | 6.52e-06 |
| 1e-5 | 6.51e-08 |
| 1e-6 | **5.62e-10** |

Clean h² convergence, which is what makes this a correctness statement rather than a coincidence. 1x1 reaches 7.46e-12. `‖F(y*)‖` is 4.7e-13 at 2x2 and 5.9e-14 at 1x1, every block separately.

## Why the index layer is the risk, and what pins it

The characteristic equations do not change — Eqs. 76-80 hold per direction exactly as in Phase 1. What a unit cell adds is that the singular values entering an equation stop all belonging to the same coordinate: `S`, its inverse, and the quartic roots `s^L`, `s^R` are each read from a **shifted** cell, and the shift differs per quantity (Appendix F, Tables 1+).

A wrong shift does not announce itself. It leaves the root residual small and `∂_yF` well conditioned, then returns a silently wrong gradient — the #700 / #702 failure shape, which #715 calls out explicitly. So the tables are **transcribed from the authors' reference implementation**, not re-derived: `leburgel/ImplicitDifferentiationPEPS.jl` was still on disk from the #718 session, along with PEPSKit's `utility/indexing.jl` and `algorithms/contractions/ctmrg/`.

Transcription alone is not evidence, so the tables are held against arithmetic three ways:

**They must be load-bearing.** Perturbing each table's *cell* component by one row — leaving the direction alone, so failure is attributable to the `(r, c)` assignment specifically:

| | baseline | perturbed |
|---|---|---|
| `‖F(y*)‖`, 2x2 | 4.7e-13 | **~1.0** — twelve orders, all three tables |
| gradient parity, 2x2 | 5.6e-10 | **fails**, all three tables |

**They must be invisible where they cannot matter.** The same perturbation at 1x1 leaves `‖F(y*)‖` **bit-identical** (5.87e-14 both ways, all three tables). That is the other half of the argument: any Phase 2 test written only at 1x1 verifies nothing whatsoever about Appendix F. Both halves are pinned and parametrised.

**The cell must not be secretly uniform.** Four different tensors could still converge to four identical environments, which would make every shift test vacuous. Asserted separately.

## Convention analysis

`docs/plans/2026-07-31-715-phase2-multisite-design.md`. Phase 1 cuts the **left** half-plane (glues `EC[k]` to `EC[k-1]`, NW to SW); §V.3 and PEPSKit cut the **upper** half (`EC[co]` to `EC[next(co)]`, NW to NE). Both correct, and Phase 1 already bridges them — but a unit cell forces a choice, since every Appendix F table and every PEPSKit renormalisation coordinate is written in the upper-half convention.

Phase 2 adopts the upper half, and the note verifies symbolically that this is the *same* truncation. With `EC` axes `(chi_r, a_r, chi_d, a_d)`, `T(X) = X.transpose(2,3,0,1).reshape(n,n)` and `I(X) = X.reshape(n,n)`, we have `T(X).T == I(X)` and hence

```
M_up(k-1).T = T(EC[k]).T @ T(EC[k-1]).T = I(EC[k]) @ I(EC[k-1]) = M_left(k)
```

reproducing `test_the_two_half_plane_conventions_are_the_same_truncation` from the axis definitions alone. The choice also pays off directly: Phase 1 needs `asym_root_to_covariant_convention` to shift and transpose its forward data into the §V.3 frame, and this module needs no such step — the forward's `(U, S, Vh)` at `co` *are* the §V.3 data at `co`.

Renormalisation coordinates are read off PEPSKit, cross-checked on two directions each, and come out uniform in `co`:

```
corner[co] = P_right[prev_coordinate(co)] · EC[co]                · P_left[co]
edge[co]   = P_right[left_projector(co)]  · (edge[above(co)] ⊗ a) · P_left[co]
```

The same coordinates the reference's `F1`/`F2` use, so the sweep and the equations share one table. A sweep and an equation that disagree give a fixed point that is not a root, which is how #718 started.

## Forward sweep

1x1 agreement with Phase 1, on energies rather than tensors (the two conventions differ by the shift and transpose above, so only gauge-invariant quantities compare):

```
phase1     E=0.185690719002439   23 iters, residual 4.25e-13
multisite  E=0.185690719002439   23 iters, residual 4.28e-13
relative difference  1.05e-15
```

Machine precision *and* the same iteration count. `test_the_1x1_energy_gate_is_load_bearing` composes `next_coordinate` with itself to pick the wrong gluing neighbour and asserts the energy moves — it moves by 6.4e-3, so the agreement is falsifiable rather than decorative.

## Two bugs found on the way, both worth recording

**The Eq. 82 map, omitted.** `‖F(y*)‖ = 1.9e5`. Feeding `F` the *regular* environment where it expects the modified one is not a small perturbation. It broke 1x1 too, which made it cheap — Phase 1 is an oracle there, so the failure localised immediately instead of being confounded with the new cell indexing. Porting `remove_inverse_roots` with the coordinate generalisation (corner `co` takes roots at `prev_coordinate(co)` and `co`; edge `co` at `left_projector(co)` and `co`, because each projector carries one `S^-1/2`) took it to 1e-14.

**The parity objective was gauge dependent.** 2x2 parity first failed at `rel ~ 1.0`, and the adjoint was *not* the cause. The FD side was the unreliable one: it oscillated in sign and **grew** as `h` shrank (-1.4, +17, -67, +524, -8792) — a discontinuous objective, not a bad gradient. Two contributing defects:

1. *Ring closure.* The environment was read at `(k, r, c)`, but a renormalised corner there is the one that **absorbed** site `(r, c)`. The ring adjacent to the site is at `above_left` / `above` — the same tables `enlarged_corner` uses. Fixed in `env_ring_for_cell`. Made 1x1 textbook; did not rescue 2x2.
2. *The objective itself.* `compute_energy_ctm_tensor` builds **two-site** RDMs that place the same `A` on both sites and glue them through one site's ring. On a uniform cell that is exactly right and is what Phase 1 uses. On a cell of different tensors the halves meet on independently-gauged chi bonds, so the scalar is gauge dependent — and a gauge-dependent scalar has no derivative at all. It wandered over [0.143, 0.171] for `|t| <= 2e-5` along a line while every fixed point converged to 8.6e-13.

The parity objective is therefore a one-site observable, closing on exactly the eight ring tensors so every bond gauge cancels. Over the same span its second difference is 7.5e-9 — `f''h²`, ordinary curvature — against the two-site energy's 1.7e-2 spread. Both pinned in `test_the_two_site_energy_is_gauge_dependent_on_a_nonuniform_cell`, which also fails loudly if the two-site energy ever becomes smooth here, since the one-site objective would then be unnecessary.

## Scope

`cell_energy_forward` is marked **valid only on a uniform cell**. A physical multisite two-site energy needs a ring spanning two cells; that is real work and explicitly **not** part of this PR. Phase 2 delivers the differentiable fixed point on a unit cell, verified through a one-site observable.

No public API change, no exports, and no behaviour change to any existing path — the new module is additive and Phase 0 / Phase 1 are untouched (35 of their tests still pass). 33 multisite tests.

Phase 3 (`SymmetricTensor` / fermionic) is untouched and is where #566's compile wall and #687's ~1e-2 accuracy floor actually get paid off.

Refs #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
