### PR TITLE
feat(#734): charge-arithmetic boundary on BaseSymmetry (1/4)

### DIFF
--- a/docs/superpowers/plans/2026-08-01-charge-arithmetic-boundary.md
+++ b/docs/superpowers/plans/2026-08-01-charge-arithmetic-boundary.md
@@ -1,0 +1,1418 @@
+# Charge Arithmetic Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `BaseSymmetry` the only place in Tenax that inverts or combines a charge, fixing Z_n bond mislabelling (#733), Z_n `contract` silently returning zeros, and `ProductSymmetry` being unusable.
+
+**Architecture:** Add `flow_charge` and `canonicalize` to `BaseSymmetry`, plus a `net_charge(indices, key)` helper in `core/index.py` seeded with `identity()`. `flow_charge` is an involution on canonical representatives; `TensorIndex.__post_init__` guarantees canonical representatives by canonicalising and merging duplicate sectors. Then replace all eight hand-rolled `int(flow) * q` sites with these.
+
+**Tech Stack:** Python 3.11+, NumPy (charge algebra is host-side, never traced), JAX (block data only), pytest with `core`/`algorithm`/`slow` markers auto-applied by `tests/conftest.py`.
+
+**Spec:** `docs/superpowers/specs/2026-08-01-charge-arithmetic-boundary-design.md`
+**Issue:** #734 (umbrella); #733 closed by Task 2.
+
+---
+
+## Background an implementer needs
+
+A `SymmetricTensor` stores blocks keyed by one charge per leg. A block is valid when the
+flow-weighted charges of all legs fuse to the symmetry's identity. Existing code writes
+that as:
+
+```python
+total = sum(int(idx.flow) * int(q) for idx, q in zip(tensor.indices, key))
+if total != sym.identity(): ...
+```
+
+This encodes two assumptions that are true **only for U(1)**:
+
+1. the group inverse is integer negation (`int(flow) * q` where `flow` is `+1`/`-1`)
+2. the group operation is integer addition (the bare `sum`)
+
+For `Z_n` they are accidentally true whenever at least two legs fuse afterwards, because
+`ZnSymmetry.fuse` applies `% n`. They fail exactly when nothing fuses — which is the
+single-leg case in #733. For `ProductSymmetry`, charges are bit-packed
+(`encode = (q2 << 16) | (q1 & 0xFFFF)`), so negating the packed integer is meaningless and
+the assumptions never hold.
+
+`FlowDirection` is an `IntEnum` with `IN = 1` and `OUT = -1`.
+
+**Charge labels are not observable.** Every physical observable is a scalar obtained by
+collapsing all legs. A stored charge label is a basis/sector convention, so rewriting the
+Z₂ partner of `1` from `-1` to `1` changes nothing physical. What must hold is that
+operations **compose** — and today mismatched labels make `contract` silently zero the
+non-matching sectors rather than raising.
+
+### Verification commands
+
+```bash
+# fast gate (what required CI runs)
+JAX_PLATFORMS=cpu uv run pytest -m core -q
+
+# a single file
+JAX_PLATFORMS=cpu uv run pytest tests/test_symmetry.py -q
+```
+
+All five test files touched by this plan (`test_symmetry.py`, `test_index.py`,
+`test_tensor.py`, `test_linalg.py`, `test_contraction.py`) are already registered as
+`core` in `tests/conftest.py:_FILE_MARKERS`, so new tests land in the required CI gate
+without a conftest change. **Do not create new test files** — add to these.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `src/tenax/core/symmetry.py` | Owns all charge algebra. Gains `flow_charge`, `canonicalize`; `is_conserved` rewritten on top of them. | 1 |
+| `src/tenax/core/index.py` | Gains `net_charge(indices, key)` — the one way to evaluate a block's conservation law. `TensorIndex.__post_init__` canonicalises and merges. | 1, 2 |
+| `src/tenax/core/tensor.py` | `_validate` and `_compute_valid_blocks` consume `net_charge` / `flow_charge`. | 2 |
+| `src/tenax/linalg.py` | Four sites (80, 121, 605, 2109) consume `net_charge`. | 2 |
+| `src/tenax/contraction/contractor.py` | Target inference consumes `net_charge` and fuses targets instead of adding them. | 3 |
+| `src/tenax/algorithms/dmrg.py` | Target inference consumes `net_charge`. | 3 |
+| `src/tenax/algorithms/_tensor_utils.py` | `_compute_fused_sectors` drops its hand-rolled `% n`. | 4 |
+
+`core/index.py` imports only `core/symmetry.py`; `core/tensor.py` imports `core/index.py`.
+So `net_charge` in `index.py` is importable by `tensor.py`, `linalg.py`, `contractor.py`
+and `dmrg.py` with no import cycle. **Do not put `net_charge` in `core/_tensor_utils.py`**
+— that module imports `core/tensor.py`, which would make `_validate` circular.
+
+---
+
+## Task 1: The boundary API (PR 1 — behaviourally inert)
+
+**Files:**
+- Modify: `src/tenax/core/symmetry.py` (add two methods to `BaseSymmetry`; override in `U1Symmetry` and `FermionicU1`; rewrite `is_conserved` at lines 156-179)
+- Modify: `src/tenax/core/index.py` (add module-level `net_charge`)
+- Test: `tests/test_symmetry.py`, `tests/test_index.py`
+
+- [ ] **Step 1: Write the failing tests for the symmetry boundary**
+
+Append to `tests/test_symmetry.py`. Note `ProductSymmetry` is included in every case list —
+it is the symmetry the current code gets wrong, so excluding it defeats the purpose.
+
+```python
+import numpy as np
+import pytest
+
+from tenax.core.symmetry import (
+    FermionicU1,
+    FermionParity,
+    ProductSymmetry,
+    U1Symmetry,
+    ZnSymmetry,
+)
+
+_BOUNDARY_CASES = [
+    ("U1", U1Symmetry(), [-2, -1, 0, 1, 2]),
+    ("Z2", ZnSymmetry(2), [0, 1]),
+    ("Z3", ZnSymmetry(3), [0, 1, 2]),
+    ("Z4", ZnSymmetry(4), [0, 1, 2, 3]),
+    ("FermionParity", FermionParity(), [0, 1]),
+    ("FermionicU1", FermionicU1(), [-2, -1, 0, 1, 2]),
+    (
+        "Prod(Z2,U1)",
+        ProductSymmetry(ZnSymmetry(2), U1Symmetry()),
+        [ProductSymmetry.encode(a, b) for a in (0, 1) for b in (-2, -1, 0, 1, 2)],
+    ),
+    (
+        "Prod(Z2,Z3)",
+        ProductSymmetry(ZnSymmetry(2), ZnSymmetry(3)),
+        [ProductSymmetry.encode(a, b) for a in (0, 1) for b in (0, 1, 2)],
+    ),
+]
+_BOUNDARY_IDS = [c[0] for c in _BOUNDARY_CASES]
+
+
+@pytest.mark.parametrize("name,sym,sectors", _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
+def test_canonicalize_fixes_canonical_sectors_and_is_idempotent(name, sym, sectors):
+    secs = np.array(sectors, dtype=np.int32)
+    once = sym.canonicalize(secs)
+    assert np.array_equal(once, secs), f"{name}: canonical input was rewritten"
+    assert np.array_equal(sym.canonicalize(once), once), f"{name}: not idempotent"
+
+
+@pytest.mark.parametrize("name,sym,sectors", _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
+def test_flow_charge_is_an_involution_on_canonical_sectors(name, sym, sectors):
+    secs = np.array(sectors, dtype=np.int32)
+    twice = sym.flow_charge(-1, sym.flow_charge(-1, secs))
+    assert np.array_equal(twice, secs), f"{name}: OUT twice is not the identity map"
+    assert np.array_equal(sym.flow_charge(1, secs), secs), f"{name}: IN altered charges"
+
+
+@pytest.mark.parametrize("name,sym,sectors", _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
+def test_fuse_with_dual_gives_identity(name, sym, sectors):
+    secs = np.array(sectors, dtype=np.int32)
+    assert np.all(sym.fuse(secs, sym.dual(secs)) == sym.identity()), name
+
+
+@pytest.mark.parametrize("name,sym,sectors", _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
+def test_closed_form_solves_the_last_leg_charge(name, sym, sectors):
+    """``q = flow_charge(flow, fuse(target, dual(partial)))`` inverts conservation.
+
+    This is the property that lets ``_compute_valid_blocks`` drop its
+    ``n_values() is None`` split: it holds for every abelian group, not just U(1).
+    """
+    secs = np.array(sectors, dtype=np.int32)
+    for flow in (1, -1):
+        for partial in secs:
+            for target in secs:
+                p = np.array([partial], dtype=np.int32)
+                t = np.array([target], dtype=np.int32)
+                q_last = sym.flow_charge(flow, sym.fuse(t, sym.dual(p)))
+                got = int(sym.fuse(p, sym.flow_charge(flow, q_last))[0])
+                assert got == int(t[0]), f"{name}: flow={flow} partial={partial}"
+
+
+def test_canonicalize_maps_negative_zn_representatives():
+    sym = ZnSymmetry(3)
+    got = sym.canonicalize(np.array([-1, -2, 0], dtype=np.int32))
+    assert np.array_equal(got, np.array([2, 1, 0], dtype=np.int32))
+
+
+def test_is_conserved_accepts_a_conserving_product_symmetry_block():
+    """The IN/OUT pair that ``int(flow) * q`` rejects for bit-packed charges."""
+    ps = ProductSymmetry(ZnSymmetry(2), U1Symmetry())
+    q = ProductSymmetry.encode(1, 1)
+    assert ps.is_conserved([q, q], [1, -1])
+    assert not ps.is_conserved([q, ProductSymmetry.encode(0, 1)], [1, -1])
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_symmetry.py -k "canonicalize or flow_charge or closed_form or is_conserved" -q`
+
+Expected: FAIL — `AttributeError: 'U1Symmetry' object has no attribute 'canonicalize'` for the
+new-method tests, and `test_is_conserved_accepts_a_conserving_product_symmetry_block` failing
+on the first assert.
+
+- [ ] **Step 3: Add `flow_charge` and `canonicalize` to `BaseSymmetry`**
+
+In `src/tenax/core/symmetry.py`, insert both methods into `BaseSymmetry` immediately after
+`fuse_many` (which ends at line 87, before the `braiding_style` property):
+
+```python
+    def flow_charge(self, flow: int, charges: np.ndarray) -> np.ndarray:
+        """Return the flow-weighted effective charge of a leg.
+
+        An IN leg (flow ``+1``) contributes its charge unchanged; an OUT leg
+        (flow ``-1``) contributes the group inverse.
+
+        This is the only sanctioned way to weight a charge by a flow.
+        ``int(flow) * charge`` hard-codes "the group inverse is integer
+        negation": true for U(1), true for ``Z_n`` only because ``fuse``
+        reduces mod ``n`` afterwards, and meaningless for the bit-packed
+        charges of :class:`ProductSymmetry` (#734).
+
+        On canonical representatives this is an involution, which is what makes
+        ``q = flow_charge(flow, fuse(target, dual(partial)))`` a valid closed
+        form for the last leg of a conservation law in any abelian group.
+
+        Args:
+            flow:    ``+1`` (IN) or ``-1`` (OUT); a ``FlowDirection`` works too.
+            charges: Integer charge array.
+
+        Returns:
+            Effective charge array of the same shape.
+        """
+        charges = np.asarray(charges, dtype=np.int32)
+        return charges if int(flow) > 0 else self.dual(charges)
+
+    def canonicalize(self, charges: np.ndarray) -> np.ndarray:
+        """Return the canonical representative of each charge.
+
+        Fusing against the identity applies whatever reduction the group
+        defines — ``% n`` for ``Z_n``, component-wise reduction for
+        :class:`ProductSymmetry`, nothing for U(1).  Charge representatives are
+        a basis convention and not observable, so rewriting them is free; what
+        is *not* free is letting two representatives of one sector coexist,
+        because label equality is how blocks are paired during contraction.
+
+        Args:
+            charges: Integer charge array.
+
+        Returns:
+            Canonical charge array of the same shape.
+        """
+        charges = np.asarray(charges, dtype=np.int32)
+        return self.fuse(np.full_like(charges, self.identity()), charges)
+```
+
+- [ ] **Step 4: Override `canonicalize` in the two symmetries where it is a no-op**
+
+`TensorIndex.__post_init__` will call `canonicalize` on every index construction (Task 2),
+and the codebase builds millions of them. For U(1)-style groups every integer already *is*
+its own canonical representative, so skip the allocation.
+
+Add to `U1Symmetry` (after `identity`, before `n_values`):
+
+```python
+    def canonicalize(self, charges: np.ndarray) -> np.ndarray:
+        # Every integer is its own canonical U(1) representative.
+        return np.asarray(charges, dtype=np.int32)
+```
+
+Add the identical method to `FermionicU1` (after its `identity`, before `n_values`).
+
+- [ ] **Step 5: Rewrite `is_conserved` on top of the new primitives**
+
+Replace the body of `BaseSymmetry.is_conserved` (currently `src/tenax/core/symmetry.py:156-180`,
+the version ending `return net == target`) with:
+
+```python
+    def is_conserved(
+        self,
+        charges_per_leg: list[np.ndarray],
+        flows: list[int],
+        target: int | None = None,
+    ) -> bool:
+        """Check if a single charge combination satisfies conservation.
+
+        Args:
+            charges_per_leg: List of scalar charge values per leg.
+            flows: List of +1 (IN) or -1 (OUT) per leg.
+            target: Required net charge; defaults to identity().
+
+        Returns:
+            True if the net charge equals target.
+        """
+        if target is None:
+            target = self.identity()
+        effective = [np.array([self.identity()], dtype=np.int32)]
+        effective.extend(
+            self.flow_charge(f, np.array([int(q)], dtype=np.int32))
+            for f, q in zip(flows, charges_per_leg)
+        )
+        net = int(self.fuse_many(effective)[0])
+        want = int(self.canonicalize(np.array([int(target)], dtype=np.int32))[0])
+        return net == want
+```
+
+The old `net % n_values()` reduction is gone: `fuse` already reduces, and `% n` was wrong
+for `ProductSymmetry`, whose `n_values()` is a cardinality (`2 * 3 == 6`) rather than a
+modulus for the packed integer.
+
+- [ ] **Step 6: Run the symmetry tests to verify they pass**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_symmetry.py -q`
+
+Expected: PASS, all cases including both `ProductSymmetry` variants.
+
+- [ ] **Step 7: Write the failing test for `net_charge`**
+
+Append to `tests/test_index.py`:
+
+```python
+import numpy as np
+
+from tenax.core.index import FlowDirection, TensorIndex, net_charge
+from tenax.core.symmetry import ProductSymmetry, U1Symmetry, ZnSymmetry
+
+
+def test_net_charge_reduces_a_single_out_leg():
+    """The #733 case: one OUT leg, nothing to fuse against, so no reduction ran."""
+    sym = ZnSymmetry(2)
+    idx = TensorIndex.from_charges(
+        sym, np.array([0, 1], dtype=np.int32), FlowDirection.OUT, label="a"
+    )
+    assert net_charge((idx,), (1,)) == 1  # not -1
+
+
+def test_net_charge_agrees_between_one_leg_and_two_legs():
+    sym = ZnSymmetry(3)
+    out = TensorIndex.from_charges(
+        sym, np.array([0, 1, 2], dtype=np.int32), FlowDirection.OUT, label="a"
+    )
+    trivial = TensorIndex.from_charges(
+        sym, np.array([0], dtype=np.int32), FlowDirection.IN, label="b"
+    )
+    for q in (0, 1, 2):
+        assert net_charge((out,), (q,)) == net_charge((out, trivial), (q, 0))
+
+
+def test_net_charge_is_identity_for_a_conserving_product_symmetry_block():
+    ps = ProductSymmetry(ZnSymmetry(2), U1Symmetry())
+    q = ProductSymmetry.encode(1, 1)
+    secs = np.array([ProductSymmetry.encode(0, 0), q], dtype=np.int32)
+    a = TensorIndex.from_charges(ps, secs, FlowDirection.IN, label="a")
+    b = TensorIndex.from_charges(ps, secs, FlowDirection.OUT, label="b")
+    assert net_charge((a, b), (q, q)) == ps.identity()
+
+
+def test_net_charge_matches_plain_summation_for_u1():
+    """U(1) is the case the old hand-rolled arithmetic got right; keep it right."""
+    sym = U1Symmetry()
+    a = TensorIndex.from_charges(
+        sym, np.array([-1, 0, 1], dtype=np.int32), FlowDirection.IN, label="a"
+    )
+    b = TensorIndex.from_charges(
+        sym, np.array([-1, 0, 1], dtype=np.int32), FlowDirection.OUT, label="b"
+    )
+    for qa in (-1, 0, 1):
+        for qb in (-1, 0, 1):
+            assert net_charge((a, b), (qa, qb)) == qa - qb
+```
+
+- [ ] **Step 8: Run it to verify it fails**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_index.py -k net_charge -q`
+
+Expected: FAIL with `ImportError: cannot import name 'net_charge' from 'tenax.core.index'`.
+
+- [ ] **Step 9: Add `net_charge` to `core/index.py`**
+
+Append at module level in `src/tenax/core/index.py` (after the `TensorIndex` class):
+
+```python
+def net_charge(
+    indices: Sequence[TensorIndex],
+    key: Sequence[int],
+) -> int:
+    """Return the net fused charge of a block key, as a Python int.
+
+    This is the only sanctioned way to evaluate a block's conservation law: a
+    block is valid exactly when ``net_charge(indices, key) == symmetry.identity()``.
+
+    ``sum(int(idx.flow) * int(q) for ...)`` is **not** equivalent. It assumes the
+    group inverse is integer negation and the group operation is integer
+    addition — true for U(1), accidentally true for ``Z_n`` whenever two or more
+    legs fuse afterwards, and false for the bit-packed charges of
+    :class:`~tenax.core.symmetry.ProductSymmetry` (#734).
+
+    The fusion is seeded with ``identity()`` so that a rank-1 tensor is reduced
+    exactly like a rank-N one. Without the seed, ``fuse_many`` of a single array
+    returns it unreduced and a lone OUT leg yields a non-canonical
+    representative (#733).
+
+    Args:
+        indices: Tensor indices, one per leg.
+        key:     One charge per leg, in the same order.
+
+    Returns:
+        The fused net charge.
+
+    Raises:
+        ValueError: If ``indices`` is empty.
+    """
+    if len(indices) == 0:
+        raise ValueError("net_charge requires at least one index")
+    sym = indices[0].symmetry
+    effective = [np.array([sym.identity()], dtype=np.int32)]
+    effective.extend(
+        sym.flow_charge(idx.flow, np.array([int(q)], dtype=np.int32))
+        for idx, q in zip(indices, key)
+    )
+    return int(sym.fuse_many(effective)[0])
+```
+
+Add `Sequence` to the imports at the top of `src/tenax/core/index.py`:
+
+```python
+from collections.abc import Sequence
+```
+
+- [ ] **Step 10: Run the index tests to verify they pass**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_index.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 11: Confirm Task 1 changed no existing behaviour**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest -m core -q`
+
+Expected: PASS with no new failures. Task 1 only *adds* callable surface — `is_conserved`
+had zero call sites before this change, so rewriting it cannot move any existing behaviour.
+If anything fails here, it is a genuine regression; stop and diagnose before continuing.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/tenax/core/symmetry.py src/tenax/core/index.py tests/test_symmetry.py tests/test_index.py
+git commit -m "feat(#734): charge-arithmetic boundary on BaseSymmetry
+
+Add flow_charge and canonicalize to BaseSymmetry plus a net_charge helper
+in core/index.py, seeded with identity so a rank-1 tensor reduces exactly
+like a rank-N one. Rewrite the never-called is_conserved on top of them,
+dropping its % n_values() reduction (wrong for the bit-packed
+ProductSymmetry, whose n_values is a cardinality, not a modulus).
+
+flow_charge is an involution on canonical representatives; verified across
+U1, Z2, Z3, Z4, FermionParity, FermionicU1 and both ProductSymmetry
+variants, along with the closed form that Task 2 relies on.
+
+Behaviourally inert: pure addition plus a dead method.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Canonical indices, `_validate`, `_compute_valid_blocks`, `linalg.py` (PR 2 — closes #733)
+
+**Prerequisite:** PR #729 must be merged and `origin/main` merged into this branch, so that
+`tests/test_ctm_root_implicit_sym_sectors.py::test_zn_same_flow_bonds_carry_the_library_s_own_representative`
+exists to be updated in Step 11.
+
+**Files:**
+- Modify: `src/tenax/core/index.py` (`TensorIndex.__post_init__`)
+- Modify: `src/tenax/core/tensor.py` (`_compute_valid_blocks` lines 162-274; `_validate` lines 727-744)
+- Modify: `src/tenax/linalg.py` (lines 80-92, 95-130, 601-607, 2105-2111)
+- Modify: `tests/test_ctm_root_implicit_sym_sectors.py:417-470`
+- Test: `tests/test_index.py`, `tests/test_linalg.py`
+
+- [ ] **Step 1: Write the failing tests for index canonicalisation**
+
+Append to `tests/test_index.py`:
+
+```python
+def test_index_canonicalises_and_merges_duplicate_representatives():
+    """Z2 ``-1`` and ``1`` are one sector written two ways; they must merge."""
+    sym = ZnSymmetry(2)
+    idx = TensorIndex.from_charges(
+        sym, np.array([-1, 0, 1], dtype=np.int32), FlowDirection.IN, label="x"
+    )
+    assert np.array_equal(idx.sectors, np.array([0, 1], dtype=np.int32))
+    assert np.array_equal(idx.multiplicities, np.array([1, 2], dtype=np.int32))
+    assert idx.dim == 3
+    assert idx.n_sectors == 2
+    assert idx.multiplicity(1) == 2
+    assert not idx.has_sector(-1)
+
+
+def test_index_charges_stay_consistent_with_sectors_after_canonicalisation():
+    """``charges`` must not desynchronise from ``sectors``/``multiplicities``."""
+    sym = ZnSymmetry(2)
+    idx = TensorIndex.from_charges(
+        sym, np.array([-1, 0, 1], dtype=np.int32), FlowDirection.IN, label="x"
+    )
+    charges = idx.charges
+    assert len(charges) == idx.dim
+    for q in idx.sectors:
+        assert int(np.sum(charges == q)) == idx.multiplicity(int(q))
+
+
+def test_index_dual_is_an_involution():
+    """``dual()`` used to sort without merging, emitting sectors=[0, 1, 1]."""
+    sym = ZnSymmetry(3)
+    idx = TensorIndex.from_charges(
+        sym, np.array([0, 1, 2], dtype=np.int32), FlowDirection.IN, label="x"
+    )
+    back = idx.dual().dual()
+    assert np.array_equal(back.sectors, idx.sectors)
+    assert np.array_equal(back.multiplicities, idx.multiplicities)
+    assert back.flow == idx.flow
+
+
+def test_index_sectors_are_always_sorted_and_unique():
+    sym = ZnSymmetry(2)
+    idx = TensorIndex(
+        symmetry=sym,
+        sectors=np.array([1, -1, 0], dtype=np.int32),
+        multiplicities=np.array([2, 3, 4], dtype=np.int32),
+        flow=FlowDirection.IN,
+        label="x",
+    )
+    assert np.array_equal(idx.sectors, np.array([0, 1], dtype=np.int32))
+    assert np.array_equal(idx.multiplicities, np.array([4, 5], dtype=np.int32))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_index.py -k "canonicalises or consistent or involution or sorted_and_unique" -q`
+
+Expected: FAIL — `sectors` is still `[-1, 0, 1]`, `multiplicities` still `[1, 1, 1]`.
+
+- [ ] **Step 3: Canonicalise and merge in `TensorIndex.__post_init__`**
+
+In `src/tenax/core/index.py`, append to the end of `__post_init__` (after the existing
+`multiplicities` dtype coercion):
+
+```python
+        # Canonicalise sectors through the symmetry and merge duplicates.
+        #
+        # Charge representatives are a basis convention, not physics, so
+        # rewriting them is free.  But ``flow_charge`` is an involution only on
+        # canonical representatives, and label *equality* is how blocks get
+        # paired during contraction -- so two representatives of one sector
+        # (Z2 ``-1`` and ``1``) must never coexist on a leg (#734).
+        #
+        # Every construction path funnels through __post_init__, so this also
+        # repairs ``dual()``, which sorted without merging and could emit
+        # sectors=[0, 1, 1] in violation of the sorted-unique invariant.
+        canon = self.symmetry.canonicalize(self.sectors)
+        uniq, inverse = np.unique(canon, return_inverse=True)
+        if len(uniq) != len(canon) or not np.array_equal(canon, self.sectors):
+            merged = np.zeros(len(uniq), dtype=np.int32)
+            np.add.at(merged, inverse, self.multiplicities)
+            object.__setattr__(self, "sectors", uniq.astype(np.int32))
+            object.__setattr__(self, "multiplicities", merged)
+```
+
+`np.unique` returns sorted unique values plus an `inverse` mapping each original position
+to its slot, so `np.add.at` sums the multiplicities of merged sectors. This handles
+canonicalisation, duplicate merging and re-sorting in one path.
+
+- [ ] **Step 4: Canonicalise the cached dense charges too**
+
+`from_charges` stores the original dense charges in `_charges_cache` to preserve basis
+ordering. If it is not canonicalised, `charges` desynchronises from `sectors` and
+`np.where(idx.charges == q)` finds nothing.
+
+In `src/tenax/core/index.py`, in `from_charges`, replace:
+
+```python
+        charges = np.asarray(charges, dtype=np.int32)
+        if charges.ndim != 1:
+            raise ValueError(f"charges must be 1-D, got shape {charges.shape}")
+        sectors, multiplicities = np.unique(charges, return_counts=True)
+```
+
+with:
+
+```python
+        charges = np.asarray(charges, dtype=np.int32)
+        if charges.ndim != 1:
+            raise ValueError(f"charges must be 1-D, got shape {charges.shape}")
+        # Canonicalise before deriving sectors so the cached dense array and the
+        # sector table agree on representatives (#734).  Element-wise, so basis
+        # ordering within the leg is preserved.
+        charges = symmetry.canonicalize(charges)
+        sectors, multiplicities = np.unique(charges, return_counts=True)
+```
+
+And in `dual`, replace `object.__setattr__(obj, "_charges_cache", self.symmetry.dual(self._charges_cache))` with:
+
+```python
+            object.__setattr__(
+                obj,
+                "_charges_cache",
+                self.symmetry.canonicalize(self.symmetry.dual(self._charges_cache)),
+            )
+```
+
+- [ ] **Step 5: Run the index tests to verify they pass**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_index.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 6: Check the hot-path cost of canonicalisation**
+
+`TensorIndex` is constructed millions of times, so confirm the added work is not material.
+
+Run:
+
+```bash
+JAX_PLATFORMS=cpu uv run python -c "
+import numpy as np, timeit
+from tenax.core.index import TensorIndex, FlowDirection
+from tenax.core.symmetry import U1Symmetry, ZnSymmetry
+for name, sym in [('U1', U1Symmetry()), ('Z2', ZnSymmetry(2))]:
+    secs = np.array([0,1,2,3], dtype=np.int32); mult = np.array([4,4,4,4], dtype=np.int32)
+    t = timeit.timeit(lambda: TensorIndex(symmetry=sym, sectors=secs,
+                                          multiplicities=mult, flow=FlowDirection.IN,
+                                          label='a'), number=20000)
+    print(f'{name}: {t/20000*1e6:.2f} us per construction')
+"
+```
+
+Expected: single-digit microseconds. U(1) should be the cheaper of the two because
+`U1Symmetry.canonicalize` is overridden to return its argument. If Z2 exceeds ~10 µs,
+record the number in the PR description rather than optimising speculatively.
+
+- [ ] **Step 7: Write the failing test for `svd` bond-label symmetry**
+
+This is the regression test #733 asks for. Append to `tests/test_linalg.py`:
+
+```python
+import numpy as np
+import pytest
+
+import tenax.linalg as tl
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import FermionParity, U1Symmetry, ZnSymmetry
+from tenax.core.tensor import SymmetricTensor
+
+_BOND_LABEL_CASES = [
+    ("U1", U1Symmetry(), [0, 1]),
+    ("Z2", ZnSymmetry(2), [0, 1]),
+    ("Z3", ZnSymmetry(3), [0, 1, 2]),
+    ("FermionParity", FermionParity(), [0, 1]),
+]
+
+
+@pytest.mark.parametrize(
+    "name,sym,sectors", _BOND_LABEL_CASES, ids=[c[0] for c in _BOND_LABEL_CASES]
+)
+def test_svd_bond_sectors_do_not_depend_on_left_leg_flow(name, sym, sectors):
+    """Same decomposition, mirrored flows -> same bond sectors.
+
+    Before #734 a single OUT left leg skipped the modular reduction, so Z2 gave
+    ``[-1, 0]`` where the IN orientation gave ``[0, 1]`` -- self-consistent
+    labels that silently fail to pair with canonically-built tensors.
+    """
+
+    def leg(flow, lbl):
+        return TensorIndex(
+            symmetry=sym,
+            sectors=np.array(sectors, dtype=np.int32),
+            multiplicities=np.array([2] * len(sectors), dtype=np.int32),
+            flow=flow,
+            label=lbl,
+        )
+
+    seen = {}
+    for left_flow, right_flow in (
+        (FlowDirection.IN, FlowDirection.OUT),
+        (FlowDirection.OUT, FlowDirection.IN),
+    ):
+        t = SymmetricTensor.random_normal_np(
+            (leg(left_flow, "a"), leg(right_flow, "b")), np.random.RandomState(0)
+        )
+        U = tl.svd(t, left_labels=["a"], right_labels=["b"])[0]
+        bond = [i for i in U.indices if i.label != "a"][0]
+        seen[left_flow.name] = sorted(int(q) for q in bond.sectors)
+
+    assert seen["IN"] == seen["OUT"], f"{name}: bond labels depend on flow: {seen}"
+    canonical = sorted(
+        int(sym.canonicalize(np.array([q], dtype=np.int32))[0]) for q in seen["IN"]
+    )
+    assert seen["IN"] == canonical, f"{name}: bond labels are not canonical: {seen}"
+```
+
+- [ ] **Step 8: Run it to verify it fails**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_linalg.py -k svd_bond_sectors -q`
+
+Expected: FAIL for `Z2`, `Z3` and `FermionParity` with e.g. `Z2: bond labels depend on flow:
+{'IN': [0, 1], 'OUT': [-1, 0]}`. `U1` passes — `-1` is a genuine U(1) charge.
+
+- [ ] **Step 9: Route the four `linalg.py` sites through `net_charge`**
+
+Add the import near the top of `src/tenax/linalg.py`, alongside the existing
+`tenax.core.index` import:
+
+```python
+from tenax.core.index import net_charge
+```
+
+**9a.** Replace the body of `_has_nonstandard_blocks` (lines 80-92):
+
+```python
+def _has_nonstandard_blocks(tensor: SymmetricTensor) -> bool:
+    """Return True if any block violates standard conservation."""
+    if not tensor.blocks:
+        return False
+    identity = tensor.indices[0].symmetry.identity()
+    for key in tensor.blocks:
+        if net_charge(tensor.indices, key) != identity:
+            return True
+    return False
+```
+
+The old raw `sum` reported `True` for standard `Z3` tensors that `_validate` accepts — a
+3-leg all-IN block `(1, 1, 1)` sums to `3` but fuses to `0`. It gates the `_bypass`
+branch at line 1516.
+
+**9b.** Replace the charge computation inside `_group_blocks_by_bond_charge` (lines 116-124):
+
+```python
+    grouped: dict[int, list[tuple[BlockKey, BlockKey, jax.Array]]] = {}
+    left_indices_for_charge = tuple(tensor.indices[i] for i in left_leg_positions)
+
+    for key, block in tensor.blocks.items():
+        left_subkey = tuple(key[i] for i in left_leg_positions)
+        right_subkey = tuple(key[i] for i in right_leg_positions)
+        q = net_charge(left_indices_for_charge, left_subkey)
+        grouped.setdefault(q, []).append((left_subkey, right_subkey, block))
+
+    return grouped
+```
+
+Delete the now-unused `sym = tensor.indices[0].symmetry` line at the top of the function if
+nothing else in it uses `sym`.
+
+**9c.** Replace the `input_target` computation at lines 601-607 **and** the identical one at
+lines 2105-2111 with:
+
+```python
+    input_target = 0
+    if tensor.blocks:
+        key0 = next(iter(tensor.blocks))
+        input_target = net_charge(tensor.indices, key0)
+
+    if input_target != tensor.indices[0].symmetry.identity():
+```
+
+(the following line is the existing `if input_target != 0:` — replace that whole line as
+shown, keeping its indented body unchanged).
+
+- [ ] **Step 10: Route `core/tensor.py` through the boundary**
+
+**10a.** Replace `_validate` (lines 727-744) in `src/tenax/core/tensor.py`:
+
+```python
+    def _validate(self) -> None:
+        """Verify all block keys satisfy the symmetry conservation law."""
+        if not self._indices:
+            return
+        identity = self._indices[0].symmetry.identity()
+
+        for key in self._block_keys:
+            fused_val = net_charge(self._indices, key)
+            if fused_val != identity:
+                raise ValueError(
+                    f"Block {key} violates charge conservation: "
+                    f"fused={fused_val}, expected identity={identity}"
+                )
+```
+
+Add `net_charge` to the existing `from tenax.core.index import ...` line at
+`src/tenax/core/tensor.py:28`.
+
+**10b.** Replace `_compute_valid_blocks` (lines 162-274). The `is_infinite` split
+disappears: with `flow_charge` an involution, the closed form works for every abelian
+group.
+
+```python
+def _compute_valid_blocks(
+    indices: tuple[TensorIndex, ...],
+    target: int | None = None,
+) -> list[BlockKey]:
+    """Find all charge-sector tuples satisfying the symmetry conservation law.
+
+    Uses incremental fused-sector propagation: builds up partial fused charges
+    one leg at a time, then solves the last leg in closed form via
+    ``q = flow_charge(flow, fuse(target, dual(partial)))``.  That inversion is
+    valid for any abelian group because ``flow_charge`` is an involution on
+    canonical representatives, so there is no longer a separate U(1) branch
+    (#734 -- the old ``n_values() is None`` split ran U(1)-only integer algebra
+    on ``ProductSymmetry``'s bit-packed charges).
+
+    Args:
+        indices: Tuple of TensorIndex objects, one per tensor leg.
+        target:  Target charge for the conservation law. If None, uses the
+                 symmetry identity (standard conservation).  Setting target=Q
+                 selects blocks whose net charge is Q instead of the identity;
+                 used at MPS boundaries to enforce a specific quantum number.
+
+    Returns:
+        List of BlockKey tuples (one charge per leg) for valid sectors.
+    """
+    if not indices:
+        return [()]
+
+    sym = indices[0].symmetry
+    identity_arr = np.array([sym.identity()], dtype=np.int32)
+    raw_target = target if target is not None else sym.identity()
+    effective_target = int(
+        sym.canonicalize(np.array([int(raw_target)], dtype=np.int32))[0]
+    )
+
+    # Sectors are canonical, sorted and unique (guaranteed by TensorIndex).
+    unique_charges_per_leg = [idx.sectors.tolist() for idx in indices]
+    n_legs = len(indices)
+
+    def _effective(leg_i: int, q: int) -> np.ndarray:
+        return sym.flow_charge(indices[leg_i].flow, np.array([q], dtype=np.int32))
+
+    if n_legs == 1:
+        # Seed with identity so the lone leg is still reduced (#733).
+        return [
+            (q,)
+            for q in unique_charges_per_leg[0]
+            if int(sym.fuse(identity_arr, _effective(0, q))[0]) == effective_target
+        ]
+
+    partial: dict[int, list[tuple[int, ...]]] = {}
+    for q in unique_charges_per_leg[0]:
+        fused = int(sym.fuse(identity_arr, _effective(0, q))[0])
+        partial.setdefault(fused, []).append((q,))
+
+    last_leg_idx = n_legs - 1
+    for leg_i in range(1, last_leg_idx):
+        next_partial: dict[int, list[tuple[int, ...]]] = {}
+        for q in unique_charges_per_leg[leg_i]:
+            eff_q = _effective(leg_i, q)
+            for prev_fused, prev_combos in partial.items():
+                new_fused = int(
+                    sym.fuse(np.array([prev_fused], dtype=np.int32), eff_q)[0]
+                )
+                extended = [combo + (q,) for combo in prev_combos]
+                if new_fused in next_partial:
+                    next_partial[new_fused].extend(extended)
+                else:
+                    next_partial[new_fused] = extended
+        partial = next_partial
+
+    # Closed form for the last leg. In an abelian group the solution is unique,
+    # so this replaces enumeration for finite groups too.
+    last_charge_set = set(unique_charges_per_leg[last_leg_idx])
+    flow_last = indices[last_leg_idx].flow
+    target_arr = np.array([effective_target], dtype=np.int32)
+    valid_keys: list[BlockKey] = []
+
+    for prev_fused, prev_combos in partial.items():
+        needed = sym.fuse(target_arr, sym.dual(np.array([prev_fused], dtype=np.int32)))
+        q_last = int(sym.flow_charge(flow_last, needed)[0])
+        if q_last in last_charge_set:
+            for combo in prev_combos:
+                valid_keys.append(combo + (q_last,))
+
+    return valid_keys
+```
+
+- [ ] **Step 11: Update the test that pinned the old convention**
+
+`tests/test_ctm_root_implicit_sym_sectors.py:417` is
+`test_zn_same_flow_bonds_carry_the_library_s_own_representative`, whose docstring says it is
+the test that should fail and be updated when #733 is fixed. Rename it and invert its
+assertion. Replace the assertion at line 454:
+
+```python
+    assert sorted(int(q) for q in lib_bond.sectors) == [-1, 0]
+```
+
+with:
+
+```python
+    assert sorted(int(q) for q in lib_bond.sectors) == [0, 1]
+```
+
+Rename the function to `test_zn_same_flow_bonds_carry_the_canonical_representative` and
+replace its docstring with:
+
+```python
+    """Same-flow legs label ``Z_n`` partners canonically, matching ``tenax.linalg``.
+
+    This is the orientation the CTM cut actually uses (both projectors are built
+    with row and col flowing the same way).  Before #734 the partner of charge 1
+    was written ``-1`` here and by ``tenax.linalg.svd``, because
+    ``_group_blocks_by_bond_charge`` fused a single flow-weighted charge and
+    ``fuse_many`` of one array skipped the ``% n``.  Both now go through
+    ``net_charge``, which seeds the fusion with the identity, so the single-leg
+    and multi-leg paths agree by construction.
+    """
+```
+
+Then read the rest of the function body (lines 455-470) and update any further assertion
+that assumes a negative representative, so the module's convention and the library's stay
+pinned together.
+
+- [ ] **Step 12: Run the targeted tests**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_linalg.py tests/test_index.py tests/test_tensor.py -q
+JAX_PLATFORMS=cpu uv run pytest tests/test_ctm_root_implicit_sym_sectors.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 13: Run the full core gate**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest -m core -q`
+
+Expected: PASS. This is the step most likely to surface fallout — 15 test files touch block
+keys or sectors. Any failure asserting a negative Z_n representative is an expected update;
+any failure about *values* is a real regression, so diagnose rather than re-baseline.
+
+- [ ] **Step 14: Run the broader suite**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest -m "not slow" -q`
+
+Expected: PASS.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add src/tenax/core/index.py src/tenax/core/tensor.py src/tenax/linalg.py \
+        tests/test_index.py tests/test_linalg.py tests/test_ctm_root_implicit_sym_sectors.py
+git commit -m "fix(#733): canonical charge representatives through the boundary
+
+TensorIndex now canonicalises sectors and merges duplicate representatives,
+so Z2 [-1, 0, 1] becomes sectors [0, 1] with multiplicities [1, 2]. That
+guarantees the precondition flow_charge needs, and repairs dual(), which
+sorted without merging and could emit sectors=[0, 1, 1] against its own
+sorted-unique invariant.
+
+_validate and the four linalg.py sites consume net_charge.
+_compute_valid_blocks loses its n_values() is None split entirely: with
+flow_charge an involution, the closed form for the last leg is valid for
+any abelian group, so the U(1)-only integer algebra that ran on
+ProductSymmetry's packed charges is gone rather than patched.
+
+svd bond sectors no longer depend on the left leg's flow: Z2/Z3/
+FermionParity gave [-1, 0] / [-2, -1, 0] with the left leg OUT and
+[0, 1] / [0, 1, 2] with it IN. Updates the #729 test that pinned the old
+convention, as its docstring anticipated.
+
+Closes #733. Refs #734.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Contraction and DMRG target inference (PR 3 — fixes the silent zeros)
+
+**Files:**
+- Modify: `src/tenax/contraction/contractor.py:420-435`
+- Modify: `src/tenax/algorithms/dmrg.py:3112-3131`
+- Test: `tests/test_contraction.py`
+
+- [ ] **Step 1: Write the failing regression test**
+
+This is the measured repro: the contraction should have norm ≈ 5.824 and returns 0.0.
+Append to `tests/test_contraction.py`:
+
+```python
+import jax.numpy as jnp
+import numpy as np
+
+from tenax.contraction.contractor import contract
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import ZnSymmetry
+from tenax.core.tensor import SymmetricTensor
+
+
+def test_zn_contract_does_not_drop_blocks_on_uniform_raw_sum():
+    """Every block of A has raw sum(flow*q) == 3 while its fused charge is 0.
+
+    The old target inference added flow-weighted charges as plain integers, so
+    it read a target of 3, and _compute_valid_blocks then admitted no output
+    block at all -- an all-zero result with no error raised (#734).
+    """
+    sym = ZnSymmetry(3)
+
+    def leg(sectors, flow, lbl):
+        return TensorIndex(
+            symmetry=sym,
+            sectors=np.array(sectors, dtype=np.int32),
+            multiplicities=np.array([2] * len(sectors), dtype=np.int32),
+            flow=flow,
+            label=lbl,
+        )
+
+    A = SymmetricTensor.random_normal_np(
+        (
+            leg([1], FlowDirection.IN, "a"),
+            leg([1], FlowDirection.IN, "b"),
+            leg([1], FlowDirection.IN, "c"),
+        ),
+        np.random.RandomState(0),
+    )
+    B = SymmetricTensor.random_normal_np(
+        (leg([1], FlowDirection.OUT, "c"), leg([0, 1, 2], FlowDirection.IN, "d")),
+        np.random.RandomState(1),
+    )
+
+    out = contract(A, B)
+    ref = jnp.einsum("abc,cd->abd", A.todense(), B.todense())
+
+    # Compare against a dense reference in norm: asserting only that the
+    # contraction "succeeds" would pass on the all-zero result.
+    assert float(jnp.linalg.norm(ref)) > 1.0, "reference is degenerate, test is vacuous"
+    assert float(jnp.max(jnp.abs(out.todense() - ref))) < 1e-10
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_contraction.py -k uniform_raw_sum -q`
+
+Expected: FAIL — the max-abs-difference assertion fails at roughly `3.55`, because
+`out.todense()` is all zeros while `ref` has norm ≈ 5.824.
+
+- [ ] **Step 3: Fix target inference in `contractor.py`**
+
+Add the import near the other `tenax.core` imports in
+`src/tenax/contraction/contractor.py`:
+
+```python
+from tenax.core.index import net_charge
+```
+
+Replace lines 421-433 (the `output_target: int | None = None` block through
+`output_target = total_target`) with:
+
+```python
+    output_target: int | None = None
+    sym = None
+    for tensor in tensors:
+        if getattr(tensor, "indices", None):
+            sym = tensor.indices[0].symmetry
+            break
+
+    if sym is not None:
+        # Accumulate with fuse, not +=: adding targets as plain integers is the
+        # same category error as weighting a charge by int(flow) (#734).
+        total = np.array([sym.identity()], dtype=np.int32)
+        for tensor in tensors:
+            if getattr(tensor, "_block_keys", None):
+                targets = {net_charge(tensor.indices, key) for key in tensor._block_keys}
+                if len(targets) == 1:
+                    total = sym.fuse(
+                        total, np.array([targets.pop()], dtype=np.int32)
+                    )
+        total_target = int(total[0])
+        if total_target != sym.identity():
+            output_target = total_target
+```
+
+Keep the surrounding comment block above it (lines 413-420) and the
+`valid_output_set = set(_compute_valid_blocks(...))` line below it unchanged.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_contraction.py -k uniform_raw_sum -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify `BlockArray` exposes `.indices` before touching dmrg.py**
+
+`dmrg.py:3115` accepts both `SymmetricTensor` and `BlockArray`, and `net_charge` needs
+`.indices`.
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run python -c "
+from tenax.core._block_array import BlockArray
+print('indices' in dir(BlockArray))
+"
+```
+
+Expected: `True`. If it prints `False`, do not proceed with Step 6 — instead keep the
+`BlockArray` branch on its existing code path and note the gap in the PR description.
+
+- [ ] **Step 6: Fix target inference in `dmrg.py`**
+
+Add `from tenax.core.index import net_charge` to the imports at the top of
+`src/tenax/algorithms/dmrg.py`. Replace lines 3120-3131:
+
+```python
+        sectors: set[int] = set()
+        for key in site.blocks:
+            total = 0
+            for idx, q in zip(site.indices, key):
+                total += int(idx.flow) * q
+            sectors.add(total)
+
+        if len(sectors) != 1:
+            return None
+        charge = sectors.pop()
+        if charge != 0:
+            return charge
+```
+
+with:
+
+```python
+        sectors = {net_charge(site.indices, key) for key in site.blocks}
+
+        if len(sectors) != 1:
+            return None
+        charge = sectors.pop()
+        if charge != site.indices[0].symmetry.identity():
+            return charge
+```
+
+- [ ] **Step 7: Run contraction and DMRG tests**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run pytest tests/test_contraction.py -q
+JAX_PLATFORMS=cpu uv run pytest tests/test_dmrg.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run the full core gate and the broader suite**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run pytest -m core -q
+JAX_PLATFORMS=cpu uv run pytest -m "not slow" -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/tenax/contraction/contractor.py src/tenax/algorithms/dmrg.py \
+        tests/test_contraction.py
+git commit -m "fix(#734): fuse contraction targets instead of adding them
+
+contractor.py inferred each tensor's target from a raw integer sum, so a
+Z_n tensor whose blocks share a nonzero raw sum got a spurious
+output_target and _compute_valid_blocks then admitted nothing -- an
+all-zero contraction with no error raised. Measured on Z3: reference norm
+5.824, contract result 0.0.
+
+Targets are now read with net_charge and accumulated with fuse rather
+than +=; adding them as plain integers was the same category error as
+weighting a charge by int(flow). dmrg.py's target inference gets the same
+treatment.
+
+The regression test compares against a dense einsum reference in norm:
+asserting only that the contraction succeeds would have passed on the
+all-zero result.
+
+Refs #734.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: ProductSymmetry enablement (PR 4)
+
+**Files:**
+- Modify: `src/tenax/algorithms/_tensor_utils.py:180-206`
+- Modify: `src/tenax/algorithms/_ctm_root_implicit_sym_sectors.py` (lift the refusal near line 290)
+- Test: `tests/test_symmetry.py`, `tests/test_tensor.py`
+
+- [ ] **Step 1: Write the failing end-to-end ProductSymmetry test**
+
+Append to `tests/test_tensor.py`:
+
+```python
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import tenax.linalg as tl
+from tenax.contraction.contractor import contract
+from tenax.core.index import FlowDirection, TensorIndex
+from tenax.core.symmetry import ProductSymmetry, U1Symmetry, ZnSymmetry
+from tenax.core.tensor import SymmetricTensor
+
+_PRODUCT_CASES = [
+    (
+        "Prod(Z2,U1)",
+        ProductSymmetry(ZnSymmetry(2), U1Symmetry()),
+        [ProductSymmetry.encode(0, 0), ProductSymmetry.encode(1, 1)],
+    ),
+    (
+        "Prod(Z2,Z3)",
+        ProductSymmetry(ZnSymmetry(2), ZnSymmetry(3)),
+        [ProductSymmetry.encode(0, 0), ProductSymmetry.encode(1, 1)],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name,sym,sectors", _PRODUCT_CASES, ids=[c[0] for c in _PRODUCT_CASES]
+)
+def test_product_symmetry_mixed_flow_tensor_constructs(name, sym, sectors):
+    """Before #734 this raised: fused=-65536 for the conserving block (q, q)."""
+
+    def leg(flow, lbl):
+        return TensorIndex(
+            symmetry=sym,
+            sectors=np.array(sectors, dtype=np.int32),
+            multiplicities=np.array([2, 2], dtype=np.int32),
+            flow=flow,
+            label=lbl,
+        )
+
+    t = SymmetricTensor.random_normal_np(
+        (leg(FlowDirection.IN, "a"), leg(FlowDirection.OUT, "b")),
+        np.random.RandomState(0),
+    )
+    assert t.blocks, f"{name}: no valid blocks found"
+    t._validate()
+
+
+@pytest.mark.parametrize(
+    "name,sym,sectors", _PRODUCT_CASES, ids=[c[0] for c in _PRODUCT_CASES]
+)
+def test_product_symmetry_svd_reconstructs(name, sym, sectors):
+    def leg(flow, lbl):
+        return TensorIndex(
+            symmetry=sym,
+            sectors=np.array(sectors, dtype=np.int32),
+            multiplicities=np.array([2, 2], dtype=np.int32),
+            flow=flow,
+            label=lbl,
+        )
+
+    t = SymmetricTensor.random_normal_np(
+        (leg(FlowDirection.IN, "a"), leg(FlowDirection.OUT, "b")),
+        np.random.RandomState(0),
+    )
+    U, s, Vh, _ = tl.svd(t, left_labels=["a"], right_labels=["b"])
+    rebuilt = contract(U, Vh)
+    ref = t.todense()
+    assert float(jnp.linalg.norm(ref)) > 1.0, "reference is degenerate"
+    # U and Vh carry the singular values folded in per sector; compare the
+    # reconstruction against the dense original in norm.
+    assert float(jnp.max(jnp.abs(rebuilt.todense() - ref))) < 1e-8
+```
+
+Note: if `tl.svd` returns `U`, `s`, `Vh` with `s` held out rather than folded in, the
+reconstruction needs `s` reapplied. Run Step 2 first and read the failure before adjusting;
+mirror whatever the existing `Z2` round-trip test in `tests/test_linalg.py` does.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_tensor.py -k product_symmetry -q`
+
+Expected: after Tasks 1-3 the construction test may already PASS (`_validate` and
+`_compute_valid_blocks` are fixed). The `svd` test is the one expected to fail, in
+`_compute_fused_sectors`. Record which of the two fails — that determines whether Step 3
+is needed at all.
+
+- [ ] **Step 3: Remove the hand-rolled `% n` from `_compute_fused_sectors`**
+
+In `src/tenax/algorithms/_tensor_utils.py`, replace the loop body at lines 193-204:
+
+```python
+    for i in range(da):
+        for j in range(db):
+            # Raw charge contribution: flow_a * q_a + flow_b * q_b
+            raw = flow_a_sign * int(idx_a.charges[i]) + flow_b_sign * int(
+                idx_b.charges[j]
+            )
+            # Map to fused charge: q_f such that fused_flow * q_f = raw
+            q_f = raw * fused_sign  # since fused_sign^2 = 1
+            # For Zn: reduce mod n
+            n = sym.n_values() if hasattr(sym, "n_values") else None
+            if n is not None:
+                q_f = q_f % n
+            fused[i * db + j] = q_f
+```
+
+with:
+
+```python
+    for i in range(da):
+        for j in range(db):
+            # Effective charge contributed by each parent leg, then fused.
+            # int(flow) * q plus a hand-rolled "% n_values()" was wrong for
+            # ProductSymmetry twice over: negating a bit-packed charge is not
+            # the component-wise inverse, and n_values() is a cardinality
+            # (2 * 3 == 6) rather than a modulus for the packed integer (#734).
+            raw = sym.fuse(
+                sym.flow_charge(flow_a_sign, np.array([idx_a.charges[i]], np.int32)),
+                sym.flow_charge(flow_b_sign, np.array([idx_b.charges[j]], np.int32)),
+            )
+            # q_f such that flow_charge(fused_flow, q_f) == raw; flow_charge is
+            # an involution on canonical representatives.
+            fused[i * db + j] = int(sym.flow_charge(fused_sign, raw)[0])
+```
+
+Delete the now-unused `fused_sign = int(fused_flow)` only if nothing else references it —
+it is still used above, so keep it.
+
+- [ ] **Step 4: Run the ProductSymmetry tests to verify they pass**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_tensor.py -k product_symmetry -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Lift the ProductSymmetry refusal in the root-implicit module**
+
+Read `src/tenax/algorithms/_ctm_root_implicit_sym_sectors.py` around lines 280-315. It
+raises for `ProductSymmetry` with a message about `-q` not being the group inverse, and
+builds keys with `key[col_axis] = -int(q) * col_flow`.
+
+Replace the key construction at lines 310-311:
+
+```python
+        key[row_axis] = int(q) * row_flow
+        key[col_axis] = -int(q) * col_flow
+```
+
+with:
+
+```python
+        q_arr = np.array([int(q)], dtype=np.int32)
+        key[row_axis] = int(sym.flow_charge(row_flow, q_arr)[0])
+        key[col_axis] = int(sym.flow_charge(col_flow, sym.dual(q_arr))[0])
+```
+
+binding `sym = row_index.symmetry` above the loop if it is not already in scope. Then delete
+the `ProductSymmetry` refusal block and update the surrounding docstring (lines 245-295),
+which describes the old `-q` convention at length, to state that keys now go through
+`flow_charge` and that `ProductSymmetry` is supported.
+
+- [ ] **Step 6: Run the root-implicit sector tests**
+
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_ctm_root_implicit_sym_sectors.py -q`
+
+Expected: PASS. If the refusal had a dedicated test asserting `ProductSymmetry` raises,
+convert it into a test asserting the round-trip now succeeds.
+
+- [ ] **Step 7: Run the full core gate and the broader suite**
+
+Run:
+```bash
+JAX_PLATFORMS=cpu uv run pytest -m core -q
+JAX_PLATFORMS=cpu uv run pytest -m "not slow" -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/tenax/algorithms/_tensor_utils.py \
+        src/tenax/algorithms/_ctm_root_implicit_sym_sectors.py tests/test_tensor.py
+git commit -m "feat(#734): mixed-flow ProductSymmetry tensors
+
+_compute_fused_sectors no longer negates a bit-packed charge and no
+longer applies % n_values() to it -- n_values() is a cardinality (2*3==6),
+not a modulus for the packed integer. Both go through flow_charge/fuse.
+
+With the boundary in place, mixed-flow ProductSymmetry tensors construct,
+decompose and contract for the first time, so the root-implicit sector
+module's refusal is lifted and its keys built with flow_charge.
+
+Refs #734.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification (before opening each PR)
+
+- [ ] `JAX_PLATFORMS=cpu uv run pytest -m core -q` passes
+- [ ] `pre-commit run --all-files` passes (ruff, ruff-format)
+- [ ] No `int(idx.flow) *` or `int(...flow) *` remains outside `core/symmetry.py`:
+
+```bash
+grep -rn "flow) \* \|flow\.value \* " src/tenax --include=*.py
+```
+
+Expected after Task 4: no hits in executable code. Prose in docstrings that *describes* the
+old convention is fine only where it explains why the convention changed.
+
+- [ ] Open the PR with `gh pr create`, then `gh pr merge <n> --squash --auto`.
+      **Never pass `--delete-branch`** — the merge queue deletes the head branch itself, and
+      the flag deletes it the moment the PR *enters* the queue, closing the PR and dropping
+      it from the queue.
+
+---
+
+## Self-review notes
+
+**Spec coverage.** §1 boundary API → Task 1 Steps 3-5, 9. §2 invariant and the
+`_compute_valid_blocks` unification → Task 1 Step 1 (`test_closed_form_solves_the_last_leg_charge`)
+and Task 2 Step 10b. §3 canonicalisation at construction, including the four sub-steps and
+`_charges_cache` → Task 2 Steps 3-4. §4 staging → Tasks 1-4 in order. Testing section →
+Task 1 Steps 1, 7; Task 2 Steps 1, 7; Task 3 Step 1; Task 4 Step 1. Risks: regression
+surface → Task 2 Steps 13-14; silent-zero weak evidence → Task 3 Step 1 asserts against a
+dense reference in norm and guards the reference is non-degenerate; `_charges_cache` →
+Task 2 Step 4 plus its dedicated test; fermionic paths → `FermionParity` appears in every
+parametrised case list.
+
+**Naming consistency.** `flow_charge(flow, charges)`, `canonicalize(charges)`,
+`net_charge(indices, key)` — used identically in every task.
+
+**Known judgement calls left to the implementer**, each with a verification step rather than
+a guess: whether `BlockArray` exposes `.indices` (Task 3 Step 5), whether `tl.svd` folds the
+singular values into `U`/`Vh` (Task 4 Step 1 note, resolved by Task 4 Step 2), and whether
+the `ProductSymmetry` refusal has a dedicated test (Task 4 Step 6).

--- a/docs/superpowers/plans/2026-08-01-charge-arithmetic-boundary.md
+++ b/docs/superpowers/plans/2026-08-01-charge-arithmetic-boundary.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make `BaseSymmetry` the only place in Tenax that inverts or combines a charge, fixing Z_n bond mislabelling (#733), Z_n `contract` silently returning zeros, and `ProductSymmetry` being unusable.
 
-**Architecture:** Add `flow_charge` and `canonicalize` to `BaseSymmetry`, plus a `net_charge(indices, key)` helper in `core/index.py` seeded with `identity()`. `flow_charge` is an involution on canonical representatives; `TensorIndex.__post_init__` guarantees canonical representatives by canonicalising and merging duplicate sectors. Then replace all eight hand-rolled `int(flow) * q` sites with these.
+**Architecture:** Add `flow_charge` and `canonicalize_charges` to `BaseSymmetry`, plus a `_net_charge(indices, key)` helper in `core/index.py` seeded with `identity()`. `flow_charge` is an involution on canonical representatives; `TensorIndex.__post_init__` guarantees canonical representatives by canonicalising and merging duplicate sectors. Then replace all eight hand-rolled `int(flow) * q` sites with these.
 
 **Tech Stack:** Python 3.11+, NumPy (charge algebra is host-side, never traced), JAX (block data only), pytest with `core`/`algorithm`/`slow` markers auto-applied by `tests/conftest.py`.
 
@@ -64,17 +64,17 @@ without a conftest change. **Do not create new test files** — add to these.
 
 | File | Responsibility | Task |
 |---|---|---|
-| `src/tenax/core/symmetry.py` | Owns all charge algebra. Gains `flow_charge`, `canonicalize`; `is_conserved` rewritten on top of them. | 1 |
-| `src/tenax/core/index.py` | Gains `net_charge(indices, key)` — the one way to evaluate a block's conservation law. `TensorIndex.__post_init__` canonicalises and merges. | 1, 2 |
-| `src/tenax/core/tensor.py` | `_validate` and `_compute_valid_blocks` consume `net_charge` / `flow_charge`. | 2 |
-| `src/tenax/linalg.py` | Four sites (80, 121, 605, 2109) consume `net_charge`. | 2 |
-| `src/tenax/contraction/contractor.py` | Target inference consumes `net_charge` and fuses targets instead of adding them. | 3 |
-| `src/tenax/algorithms/dmrg.py` | Target inference consumes `net_charge`. | 3 |
+| `src/tenax/core/symmetry.py` | Owns all charge algebra. Gains `flow_charge`, `canonicalize_charges`; `is_conserved` rewritten on top of them. | 1 |
+| `src/tenax/core/index.py` | Gains `_net_charge(indices, key)` — the one way to evaluate a block's conservation law. `TensorIndex.__post_init__` canonicalises and merges. | 1, 2 |
+| `src/tenax/core/tensor.py` | `_validate` and `_compute_valid_blocks` consume `_net_charge` / `flow_charge`. | 2 |
+| `src/tenax/linalg.py` | Four sites (80, 121, 605, 2109) consume `_net_charge`. | 2 |
+| `src/tenax/contraction/contractor.py` | Target inference consumes `_net_charge` and fuses targets instead of adding them. | 3 |
+| `src/tenax/algorithms/dmrg.py` | Target inference consumes `_net_charge`. | 3 |
 | `src/tenax/algorithms/_tensor_utils.py` | `_compute_fused_sectors` drops its hand-rolled `% n`. | 4 |
 
 `core/index.py` imports only `core/symmetry.py`; `core/tensor.py` imports `core/index.py`.
-So `net_charge` in `index.py` is importable by `tensor.py`, `linalg.py`, `contractor.py`
-and `dmrg.py` with no import cycle. **Do not put `net_charge` in `core/_tensor_utils.py`**
+So `_net_charge` in `index.py` is importable by `tensor.py`, `linalg.py`, `contractor.py`
+and `dmrg.py` with no import cycle. **Do not put `_net_charge` in `core/_tensor_utils.py`**
 — that module imports `core/tensor.py`, which would make `_validate` circular.
 
 ---
@@ -83,7 +83,7 @@ and `dmrg.py` with no import cycle. **Do not put `net_charge` in `core/_tensor_u
 
 **Files:**
 - Modify: `src/tenax/core/symmetry.py` (add two methods to `BaseSymmetry`; override in `U1Symmetry` and `FermionicU1`; rewrite `is_conserved` at lines 156-179)
-- Modify: `src/tenax/core/index.py` (add module-level `net_charge`)
+- Modify: `src/tenax/core/index.py` (add module-level `_net_charge`)
 - Test: `tests/test_symmetry.py`, `tests/test_index.py`
 
 - [ ] **Step 1: Write the failing tests for the symmetry boundary**
@@ -125,11 +125,11 @@ _BOUNDARY_IDS = [c[0] for c in _BOUNDARY_CASES]
 
 
 @pytest.mark.parametrize("name,sym,sectors", _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
-def test_canonicalize_fixes_canonical_sectors_and_is_idempotent(name, sym, sectors):
+def test_canonicalize_charges_fixes_canonical_sectors_and_is_idempotent(name, sym, sectors):
     secs = np.array(sectors, dtype=np.int32)
-    once = sym.canonicalize(secs)
+    once = sym.canonicalize_charges(secs)
     assert np.array_equal(once, secs), f"{name}: canonical input was rewritten"
-    assert np.array_equal(sym.canonicalize(once), once), f"{name}: not idempotent"
+    assert np.array_equal(sym.canonicalize_charges(once), once), f"{name}: not idempotent"
 
 
 @pytest.mark.parametrize("name,sym,sectors", _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
@@ -164,9 +164,9 @@ def test_closed_form_solves_the_last_leg_charge(name, sym, sectors):
                 assert got == int(t[0]), f"{name}: flow={flow} partial={partial}"
 
 
-def test_canonicalize_maps_negative_zn_representatives():
+def test_canonicalize_charges_maps_negative_zn_representatives():
     sym = ZnSymmetry(3)
-    got = sym.canonicalize(np.array([-1, -2, 0], dtype=np.int32))
+    got = sym.canonicalize_charges(np.array([-1, -2, 0], dtype=np.int32))
     assert np.array_equal(got, np.array([2, 1, 0], dtype=np.int32))
 
 
@@ -180,13 +180,13 @@ def test_is_conserved_accepts_a_conserving_product_symmetry_block():
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_symmetry.py -k "canonicalize or flow_charge or closed_form or is_conserved" -q`
+Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_symmetry.py -k "canonicalize_charges or flow_charge or closed_form or is_conserved" -q`
 
-Expected: FAIL — `AttributeError: 'U1Symmetry' object has no attribute 'canonicalize'` for the
+Expected: FAIL — `AttributeError: 'U1Symmetry' object has no attribute 'canonicalize_charges'` for the
 new-method tests, and `test_is_conserved_accepts_a_conserving_product_symmetry_block` failing
 on the first assert.
 
-- [ ] **Step 3: Add `flow_charge` and `canonicalize` to `BaseSymmetry`**
+- [ ] **Step 3: Add `flow_charge` and `canonicalize_charges` to `BaseSymmetry`**
 
 In `src/tenax/core/symmetry.py`, insert both methods into `BaseSymmetry` immediately after
 `fuse_many` (which ends at line 87, before the `braiding_style` property):
@@ -218,7 +218,7 @@ In `src/tenax/core/symmetry.py`, insert both methods into `BaseSymmetry` immedia
         charges = np.asarray(charges, dtype=np.int32)
         return charges if int(flow) > 0 else self.dual(charges)
 
-    def canonicalize(self, charges: np.ndarray) -> np.ndarray:
+    def canonicalize_charges(self, charges: np.ndarray) -> np.ndarray:
         """Return the canonical representative of each charge.
 
         Fusing against the identity applies whatever reduction the group
@@ -238,16 +238,16 @@ In `src/tenax/core/symmetry.py`, insert both methods into `BaseSymmetry` immedia
         return self.fuse(np.full_like(charges, self.identity()), charges)
 ```
 
-- [ ] **Step 4: Override `canonicalize` in the two symmetries where it is a no-op**
+- [ ] **Step 4: Override `canonicalize_charges` in the two symmetries where it is a no-op**
 
-`TensorIndex.__post_init__` will call `canonicalize` on every index construction (Task 2),
+`TensorIndex.__post_init__` will call `canonicalize_charges` on every index construction (Task 2),
 and the codebase builds millions of them. For U(1)-style groups every integer already *is*
 its own canonical representative, so skip the allocation.
 
 Add to `U1Symmetry` (after `identity`, before `n_values`):
 
 ```python
-    def canonicalize(self, charges: np.ndarray) -> np.ndarray:
+    def canonicalize_charges(self, charges: np.ndarray) -> np.ndarray:
         # Every integer is its own canonical U(1) representative.
         return np.asarray(charges, dtype=np.int32)
 ```
@@ -284,7 +284,7 @@ the version ending `return net == target`) with:
             for f, q in zip(flows, charges_per_leg)
         )
         net = int(self.fuse_many(effective)[0])
-        want = int(self.canonicalize(np.array([int(target)], dtype=np.int32))[0])
+        want = int(self.canonicalize_charges(np.array([int(target)], dtype=np.int32))[0])
         return net == want
 ```
 
@@ -298,14 +298,14 @@ Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_symmetry.py -q`
 
 Expected: PASS, all cases including both `ProductSymmetry` variants.
 
-- [ ] **Step 7: Write the failing test for `net_charge`**
+- [ ] **Step 7: Write the failing test for `_net_charge`**
 
 Append to `tests/test_index.py`:
 
 ```python
 import numpy as np
 
-from tenax.core.index import FlowDirection, TensorIndex, net_charge
+from tenax.core.index import FlowDirection, TensorIndex, _net_charge
 from tenax.core.symmetry import ProductSymmetry, U1Symmetry, ZnSymmetry
 
 
@@ -315,7 +315,7 @@ def test_net_charge_reduces_a_single_out_leg():
     idx = TensorIndex.from_charges(
         sym, np.array([0, 1], dtype=np.int32), FlowDirection.OUT, label="a"
     )
-    assert net_charge((idx,), (1,)) == 1  # not -1
+    assert _net_charge((idx,), (1,)) == 1  # not -1
 
 
 def test_net_charge_agrees_between_one_leg_and_two_legs():
@@ -327,7 +327,7 @@ def test_net_charge_agrees_between_one_leg_and_two_legs():
         sym, np.array([0], dtype=np.int32), FlowDirection.IN, label="b"
     )
     for q in (0, 1, 2):
-        assert net_charge((out,), (q,)) == net_charge((out, trivial), (q, 0))
+        assert _net_charge((out,), (q,)) == _net_charge((out, trivial), (q, 0))
 
 
 def test_net_charge_is_identity_for_a_conserving_product_symmetry_block():
@@ -336,7 +336,7 @@ def test_net_charge_is_identity_for_a_conserving_product_symmetry_block():
     secs = np.array([ProductSymmetry.encode(0, 0), q], dtype=np.int32)
     a = TensorIndex.from_charges(ps, secs, FlowDirection.IN, label="a")
     b = TensorIndex.from_charges(ps, secs, FlowDirection.OUT, label="b")
-    assert net_charge((a, b), (q, q)) == ps.identity()
+    assert _net_charge((a, b), (q, q)) == ps.identity()
 
 
 def test_net_charge_matches_plain_summation_for_u1():
@@ -350,28 +350,28 @@ def test_net_charge_matches_plain_summation_for_u1():
     )
     for qa in (-1, 0, 1):
         for qb in (-1, 0, 1):
-            assert net_charge((a, b), (qa, qb)) == qa - qb
+            assert _net_charge((a, b), (qa, qb)) == qa - qb
 ```
 
 - [ ] **Step 8: Run it to verify it fails**
 
 Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_index.py -k net_charge -q`
 
-Expected: FAIL with `ImportError: cannot import name 'net_charge' from 'tenax.core.index'`.
+Expected: FAIL with `ImportError: cannot import name '_net_charge' from 'tenax.core.index'`.
 
-- [ ] **Step 9: Add `net_charge` to `core/index.py`**
+- [ ] **Step 9: Add `_net_charge` to `core/index.py`**
 
 Append at module level in `src/tenax/core/index.py` (after the `TensorIndex` class):
 
 ```python
-def net_charge(
+def _net_charge(
     indices: Sequence[TensorIndex],
     key: Sequence[int],
 ) -> int:
     """Return the net fused charge of a block key, as a Python int.
 
     This is the only sanctioned way to evaluate a block's conservation law: a
-    block is valid exactly when ``net_charge(indices, key) == symmetry.identity()``.
+    block is valid exactly when ``_net_charge(indices, key) == symmetry.identity()``.
 
     ``sum(int(idx.flow) * int(q) for ...)`` is **not** equivalent. It assumes the
     group inverse is integer negation and the group operation is integer
@@ -395,7 +395,7 @@ def net_charge(
         ValueError: If ``indices`` is empty.
     """
     if len(indices) == 0:
-        raise ValueError("net_charge requires at least one index")
+        raise ValueError("_net_charge requires at least one index")
     sym = indices[0].symmetry
     effective = [np.array([sym.identity()], dtype=np.int32)]
     effective.extend(
@@ -431,7 +431,7 @@ If anything fails here, it is a genuine regression; stop and diagnose before con
 git add src/tenax/core/symmetry.py src/tenax/core/index.py tests/test_symmetry.py tests/test_index.py
 git commit -m "feat(#734): charge-arithmetic boundary on BaseSymmetry
 
-Add flow_charge and canonicalize to BaseSymmetry plus a net_charge helper
+Add flow_charge and canonicalize_charges to BaseSymmetry plus a _net_charge helper
 in core/index.py, seeded with identity so a rank-1 tensor reduces exactly
 like a rank-N one. Rewrite the never-called is_conserved on top of them,
 dropping its % n_values() reduction (wrong for the bit-packed
@@ -540,7 +540,7 @@ In `src/tenax/core/index.py`, append to the end of `__post_init__` (after the ex
         # Every construction path funnels through __post_init__, so this also
         # repairs ``dual()``, which sorted without merging and could emit
         # sectors=[0, 1, 1] in violation of the sorted-unique invariant.
-        canon = self.symmetry.canonicalize(self.sectors)
+        canon = self.symmetry.canonicalize_charges(self.sectors)
         uniq, inverse = np.unique(canon, return_inverse=True)
         if len(uniq) != len(canon) or not np.array_equal(canon, self.sectors):
             merged = np.zeros(len(uniq), dtype=np.int32)
@@ -577,7 +577,7 @@ with:
         # Canonicalise before deriving sectors so the cached dense array and the
         # sector table agree on representatives (#734).  Element-wise, so basis
         # ordering within the leg is preserved.
-        charges = symmetry.canonicalize(charges)
+        charges = symmetry.canonicalize_charges(charges)
         sectors, multiplicities = np.unique(charges, return_counts=True)
 ```
 
@@ -587,7 +587,7 @@ And in `dual`, replace `object.__setattr__(obj, "_charges_cache", self.symmetry.
             object.__setattr__(
                 obj,
                 "_charges_cache",
-                self.symmetry.canonicalize(self.symmetry.dual(self._charges_cache)),
+                self.symmetry.canonicalize_charges(self.symmetry.dual(self._charges_cache)),
             )
 ```
 
@@ -618,7 +618,7 @@ for name, sym in [('U1', U1Symmetry()), ('Z2', ZnSymmetry(2))]:
 ```
 
 Expected: single-digit microseconds. U(1) should be the cheaper of the two because
-`U1Symmetry.canonicalize` is overridden to return its argument. If Z2 exceeds ~10 µs,
+`U1Symmetry.canonicalize_charges` is overridden to return its argument. If Z2 exceeds ~10 µs,
 record the number in the PR description rather than optimising speculatively.
 
 - [ ] **Step 7: Write the failing test for `svd` bond-label symmetry**
@@ -676,7 +676,7 @@ def test_svd_bond_sectors_do_not_depend_on_left_leg_flow(name, sym, sectors):
 
     assert seen["IN"] == seen["OUT"], f"{name}: bond labels depend on flow: {seen}"
     canonical = sorted(
-        int(sym.canonicalize(np.array([q], dtype=np.int32))[0]) for q in seen["IN"]
+        int(sym.canonicalize_charges(np.array([q], dtype=np.int32))[0]) for q in seen["IN"]
     )
     assert seen["IN"] == canonical, f"{name}: bond labels are not canonical: {seen}"
 ```
@@ -688,13 +688,13 @@ Run: `JAX_PLATFORMS=cpu uv run pytest tests/test_linalg.py -k svd_bond_sectors -
 Expected: FAIL for `Z2`, `Z3` and `FermionParity` with e.g. `Z2: bond labels depend on flow:
 {'IN': [0, 1], 'OUT': [-1, 0]}`. `U1` passes — `-1` is a genuine U(1) charge.
 
-- [ ] **Step 9: Route the four `linalg.py` sites through `net_charge`**
+- [ ] **Step 9: Route the four `linalg.py` sites through `_net_charge`**
 
 Add the import near the top of `src/tenax/linalg.py`, alongside the existing
 `tenax.core.index` import:
 
 ```python
-from tenax.core.index import net_charge
+from tenax.core.index import _net_charge
 ```
 
 **9a.** Replace the body of `_has_nonstandard_blocks` (lines 80-92):
@@ -706,7 +706,7 @@ def _has_nonstandard_blocks(tensor: SymmetricTensor) -> bool:
         return False
     identity = tensor.indices[0].symmetry.identity()
     for key in tensor.blocks:
-        if net_charge(tensor.indices, key) != identity:
+        if _net_charge(tensor.indices, key) != identity:
             return True
     return False
 ```
@@ -724,7 +724,7 @@ branch at line 1516.
     for key, block in tensor.blocks.items():
         left_subkey = tuple(key[i] for i in left_leg_positions)
         right_subkey = tuple(key[i] for i in right_leg_positions)
-        q = net_charge(left_indices_for_charge, left_subkey)
+        q = _net_charge(left_indices_for_charge, left_subkey)
         grouped.setdefault(q, []).append((left_subkey, right_subkey, block))
 
     return grouped
@@ -740,7 +740,7 @@ lines 2105-2111 with:
     input_target = 0
     if tensor.blocks:
         key0 = next(iter(tensor.blocks))
-        input_target = net_charge(tensor.indices, key0)
+        input_target = _net_charge(tensor.indices, key0)
 
     if input_target != tensor.indices[0].symmetry.identity():
 ```
@@ -760,7 +760,7 @@ shown, keeping its indented body unchanged).
         identity = self._indices[0].symmetry.identity()
 
         for key in self._block_keys:
-            fused_val = net_charge(self._indices, key)
+            fused_val = _net_charge(self._indices, key)
             if fused_val != identity:
                 raise ValueError(
                     f"Block {key} violates charge conservation: "
@@ -768,7 +768,7 @@ shown, keeping its indented body unchanged).
                 )
 ```
 
-Add `net_charge` to the existing `from tenax.core.index import ...` line at
+Add `_net_charge` to the existing `from tenax.core.index import ...` line at
 `src/tenax/core/tensor.py:28`.
 
 **10b.** Replace `_compute_valid_blocks` (lines 162-274). The `is_infinite` split
@@ -807,7 +807,7 @@ def _compute_valid_blocks(
     identity_arr = np.array([sym.identity()], dtype=np.int32)
     raw_target = target if target is not None else sym.identity()
     effective_target = int(
-        sym.canonicalize(np.array([int(raw_target)], dtype=np.int32))[0]
+        sym.canonicalize_charges(np.array([int(raw_target)], dtype=np.int32))[0]
     )
 
     # Sectors are canonical, sorted and unique (guaranteed by TensorIndex).
@@ -891,7 +891,7 @@ replace its docstring with:
     was written ``-1`` here and by ``tenax.linalg.svd``, because
     ``_group_blocks_by_bond_charge`` fused a single flow-weighted charge and
     ``fuse_many`` of one array skipped the ``% n``.  Both now go through
-    ``net_charge``, which seeds the fusion with the identity, so the single-leg
+    ``_net_charge``, which seeds the fusion with the identity, so the single-leg
     and multi-leg paths agree by construction.
     """
 ```
@@ -937,7 +937,7 @@ guarantees the precondition flow_charge needs, and repairs dual(), which
 sorted without merging and could emit sectors=[0, 1, 1] against its own
 sorted-unique invariant.
 
-_validate and the four linalg.py sites consume net_charge.
+_validate and the four linalg.py sites consume _net_charge.
 _compute_valid_blocks loses its n_values() is None split entirely: with
 flow_charge an involution, the closed form for the last leg is valid for
 any abelian group, so the U(1)-only integer algebra that ran on
@@ -1030,7 +1030,7 @@ Add the import near the other `tenax.core` imports in
 `src/tenax/contraction/contractor.py`:
 
 ```python
-from tenax.core.index import net_charge
+from tenax.core.index import _net_charge
 ```
 
 Replace lines 421-433 (the `output_target: int | None = None` block through
@@ -1050,7 +1050,7 @@ Replace lines 421-433 (the `output_target: int | None = None` block through
         total = np.array([sym.identity()], dtype=np.int32)
         for tensor in tensors:
             if getattr(tensor, "_block_keys", None):
-                targets = {net_charge(tensor.indices, key) for key in tensor._block_keys}
+                targets = {_net_charge(tensor.indices, key) for key in tensor._block_keys}
                 if len(targets) == 1:
                     total = sym.fuse(
                         total, np.array([targets.pop()], dtype=np.int32)
@@ -1071,7 +1071,7 @@ Expected: PASS.
 
 - [ ] **Step 5: Verify `BlockArray` exposes `.indices` before touching dmrg.py**
 
-`dmrg.py:3115` accepts both `SymmetricTensor` and `BlockArray`, and `net_charge` needs
+`dmrg.py:3115` accepts both `SymmetricTensor` and `BlockArray`, and `_net_charge` needs
 `.indices`.
 
 Run:
@@ -1087,7 +1087,7 @@ Expected: `True`. If it prints `False`, do not proceed with Step 6 — instead k
 
 - [ ] **Step 6: Fix target inference in `dmrg.py`**
 
-Add `from tenax.core.index import net_charge` to the imports at the top of
+Add `from tenax.core.index import _net_charge` to the imports at the top of
 `src/tenax/algorithms/dmrg.py`. Replace lines 3120-3131:
 
 ```python
@@ -1108,7 +1108,7 @@ Add `from tenax.core.index import net_charge` to the imports at the top of
 with:
 
 ```python
-        sectors = {net_charge(site.indices, key) for key in site.blocks}
+        sectors = {_net_charge(site.indices, key) for key in site.blocks}
 
         if len(sectors) != 1:
             return None
@@ -1150,7 +1150,7 @@ output_target and _compute_valid_blocks then admitted nothing -- an
 all-zero contraction with no error raised. Measured on Z3: reference norm
 5.824, contract result 0.0.
 
-Targets are now read with net_charge and accumulated with fuse rather
+Targets are now read with _net_charge and accumulated with fuse rather
 than +=; adding them as plain integers was the same category error as
 weighting a charge by int(flow). dmrg.py's target inference gets the same
 treatment.
@@ -1409,8 +1409,8 @@ dense reference in norm and guards the reference is non-degenerate; `_charges_ca
 Task 2 Step 4 plus its dedicated test; fermionic paths → `FermionParity` appears in every
 parametrised case list.
 
-**Naming consistency.** `flow_charge(flow, charges)`, `canonicalize(charges)`,
-`net_charge(indices, key)` — used identically in every task.
+**Naming consistency.** `flow_charge(flow, charges)`, `canonicalize_charges(charges)`,
+`_net_charge(indices, key)` — used identically in every task.
 
 **Known judgement calls left to the implementer**, each with a verification step rather than
 a guess: whether `BlockArray` exposes `.indices` (Task 3 Step 5), whether `tl.svd` folds the

--- a/docs/superpowers/specs/2026-08-01-charge-arithmetic-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-01-charge-arithmetic-boundary-design.md
@@ -87,13 +87,13 @@ Nothing outside `BaseSymmetry` may invert or combine a charge. Two additions to
 
 ```python
 def flow_charge(self, flow, charges):   # charges if IN else self.dual(charges)
-def canonicalize(self, charges):        # self.fuse(identity, charges)
+def canonicalize_charges(self, charges):        # self.fuse(identity, charges)
 ```
 
 One helper in `core/`, used by every conservation site:
 
 ```python
-def net_charge(indices, key) -> int:    # fuse_many of flow_charge per leg, seeded with identity
+def _net_charge(indices, key) -> int:    # fuse_many of flow_charge per leg, seeded with identity
 ```
 
 Seeding with `identity()` is what fixes #733: there is no longer a path where zero fusions
@@ -132,7 +132,7 @@ construction rather than by discipline. Every construction path — `from_charge
 Merging is not optional: canonicalising Z2 `[-1, 0, 1]` yields `[1, 0, 1]`, which must
 become sectors `[0, 1]` with multiplicities `[1, 2]`. The steps are:
 
-1. `sectors ← symmetry.canonicalize(sectors)`
+1. `sectors ← symmetry.canonicalize_charges(sectors)`
 2. group equal sectors, summing their multiplicities
 3. re-sort ascending
 4. canonicalise `_charges_cache` the same way when present, so `charges`,
@@ -147,7 +147,7 @@ Four PRs, each independently landable, each with its own regression gate.
 
 | PR | Scope | Behaviour change | Gate |
 |---|---|---|---|
-| 1 | `flow_charge`, `canonicalize`, `net_charge`; rewrite the dead `is_conserved` to use them | none (pure addition) | unit tests per symmetry, including `ProductSymmetry`: `flow_charge` involution, `fuse(q, dual(q)) == identity`, `canonicalize` idempotent |
+| 1 | `flow_charge`, `canonicalize_charges`, `BaseSymmetry.net_charge` + the `core/index.py` `_net_charge` adapter; rewrite the dead `is_conserved` to use them | none (pure addition) | unit tests per symmetry, including `ProductSymmetry`: `flow_charge` involution, `fuse(q, dual(q)) == identity`, `canonicalize_charges` idempotent |
 | 2 | `core/tensor.py` (`_validate`, `_compute_valid_blocks`, `TensorIndex.__post_init__`) and `linalg.py` (lines 80, 121, 605, 2109) | **Z_n bond labels canonicalise**; updates `test_zn_same_flow_bonds_carry_the_library_s_own_representative` | full symmetric-tensor suite; new test asserting `svd` gives identical bond sectors with the left leg IN and OUT, for U(1), Z2, Z3 |
 | 3 | `contraction/contractor.py:427`, `dmrg.py:3124` | **fixes Z_n `contract` returning all zeros** | the verified 5.824 → 0.0 repro becomes a regression test |
 | 4 | `ProductSymmetry` enablement; `_tensor_utils.py:204` | mixed-flow `ProductSymmetry` tensors work for the first time | construction, `svd`, `contract` round-trips on `ProductSymmetry(Z2, U1)` and `(Z2, Z3)`; lift the refusal in `_ctm_root_implicit_sym_sectors.py` |
@@ -164,7 +164,7 @@ Per-symmetry parametrised tests over `U1Symmetry`, `ZnSymmetry(2)`, `ZnSymmetry(
 
 - `flow_charge(OUT, flow_charge(OUT, q)) == q` for canonical `q`
 - `fuse(q, dual(q)) == identity()` for every sector
-- `canonicalize` is idempotent, and `canonicalize(sectors)` equals `sectors` for any index
+- `canonicalize_charges` is idempotent, and `canonicalize_charges(sectors)` equals `sectors` for any index
   built through `TensorIndex`
 - `svd` produces the same bond sectors with the left leg IN and with it OUT (the
   regression test named in #733)

--- a/docs/superpowers/specs/2026-08-01-charge-arithmetic-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-01-charge-arithmetic-boundary-design.md
@@ -1,0 +1,199 @@
+# Charge arithmetic must go through the symmetry
+
+**Date:** 2026-08-01
+**Issue:** #734 (umbrella); #733 is one symptom, closed by PR 2 below
+**Branch:** `fix/733-charge-arithmetic-boundary`
+
+## Guiding principle
+
+The stored elements and charge labels of a symmetric tensor are not physically
+observable. Every observable is a scalar with respect to the symmetry group, obtained by
+collapsing all legs. A single stored coordinate is a *coefficient in a chosen
+basis/sector*, not a scalar; that a fused-all-legs scalar coincides with a stored element
+is a special case, true only for abelian symmetries with trivial fusion coefficients.
+
+Two consequences drive this design:
+
+1. Charge **representatives** are convention. Rewriting the Z₂ partner of `1` from `-1` to
+   `1` breaks nothing observable, so it is free to canonicalise.
+2. What *must* hold is that operations **compose**. Labels that disagree make `contract`
+   silently keep the charge-matching components and zero the rest, rather than raising.
+
+## Problem
+
+Eight sites in `src/tenax` hand-roll group arithmetic on charges, encoding one of two
+assumptions that are true only for U(1):
+
+- **"the group inverse is integer negation"** — `int(flow) * q`
+- **"the group operation is integer addition"** — a raw `sum(...)` compared to `identity()`
+
+For Z_n these are accidentally true whenever at least two legs fuse afterwards (`fuse`
+reduces mod n), and fail exactly when nothing fuses. For `ProductSymmetry`, whose charges
+are bit-packed (`encode = (q2 << 16) | (q1 & 0xFFFF)`), they are never true.
+
+### Verified findings
+
+Severity 1 — silent wrong numbers, no error raised:
+
+| Site | Defect | Evidence |
+|---|---|---|
+| `contraction/contractor.py:427` | Target inferred from a raw integer sum; a Z_n tensor whose blocks share a nonzero raw sum gets a spurious `output_target` and `_compute_valid_blocks` then admits nothing | Z3 contraction: `norm(ref)=5.824`, `norm(contract)=0.0`, every block dropped |
+| `linalg.py:121` `_group_blocks_by_bond_charge` | Single left leg ⇒ `fuse_many` of one array skips reduction ⇒ non-canonical bond label (#733) | Z2/Z3/FermionParity left-OUT bonds label `[-1,0]` / `[-2,-1,0]` where left-IN gives `[0,1]` / `[0,1,2]` |
+
+Severity 2 — wrong control-flow decisions:
+
+| Site | Defect | Evidence |
+|---|---|---|
+| `linalg.py:80` `_has_nonstandard_blocks` | Raw sum with no modular reduction; gates the `_bypass` branch at `linalg.py:1516` | Returns `True` for a standard Z3 tensor `_validate` accepts; 8 of 9 blocks misjudged |
+| `dmrg.py:3124`, `linalg.py:605`, `linalg.py:2109` | Same raw-sum pattern, used to infer target charge and select the validation-bypass path | same class |
+
+Severity 3 — `ProductSymmetry` is systemically non-functional, failing well before #733's site:
+
+| Site | Defect | Evidence |
+|---|---|---|
+| `core/tensor.py:736` `_validate` | Raw negation of a packed charge rejects conserving blocks at construction | `Block (65537, 65537) violates charge conservation: fused=-65536, expected identity=0` |
+| `core/tensor.py:255` | `ProductSymmetry(Z2, U1).n_values()` is `None`, so the U(1)-only closed form `q_last = needed * flow_last` runs on packed charges | branch verified |
+| `core/tensor.py:205` | Single-leg enumeration, raw and unreduced | same class as #733 |
+| `algorithms/_tensor_utils.py:204`, `core/symmetry.py:178` | `ProductSymmetry(Z2, Z3).n_values()` is `6`, so both apply `% 6` to a bit-packed charge | branch verified |
+
+Severity 4 — the API invites the violation:
+
+- `n_values()` reads as *"the modulus"*. Every caller that does `% n` is correct only when
+  the charge is literally an integer in Z_n.
+- `BaseSymmetry.is_conserved` — the one method that reduces properly — has **zero call
+  sites**. A sanctioned abstraction exists, is dead, and eight sites reimplement a worse
+  version of it. (It also negates raw, so it is still wrong for `ProductSymmetry`.)
+
+Severity 5 — index invariant already violated:
+
+- `TensorIndex` documents `sectors` as *sorted unique*, but `dual()` sorts without merging.
+  A Z2 index `[-1, 0, 1]` duals to `sectors=[0, 1, 1]`, after which `multiplicity(1)`
+  undercounts because `searchsorted` returns only the first match. `dual` is therefore not
+  an involution: `[-1,0,1] → [0,1,1] → [0,1,1]`.
+
+Element-as-scalar, the principle's most direct subject, is respected: **zero hits** for raw
+element access on symmetric tensors across `src/tenax`, and README never teaches users to
+reach for `.blocks`. The one exception is `algorithms/tdvp.py:251` and `:270`,
+`float(left_env.todense().real.ravel()[0])` — a genuine scalar only because every leg is
+dim-1 after contracting the full chain; `.ravel()[0]` would silently return a basis
+coefficient rather than raising if that stopped holding.
+
+## Design
+
+### 1. The boundary
+
+Nothing outside `BaseSymmetry` may invert or combine a charge. Two additions to
+`BaseSymmetry`, both with working defaults so no subclass needs to override:
+
+```python
+def flow_charge(self, flow, charges):   # charges if IN else self.dual(charges)
+def canonicalize(self, charges):        # self.fuse(identity, charges)
+```
+
+One helper in `core/`, used by every conservation site:
+
+```python
+def net_charge(indices, key) -> int:    # fuse_many of flow_charge per leg, seeded with identity
+```
+
+Seeding with `identity()` is what fixes #733: there is no longer a path where zero fusions
+happen, so the single-leg and multi-leg cases agree by construction.
+
+`is_conserved` is rewritten in terms of these and thereby becomes correct for
+`ProductSymmetry`. Its `% n_values()` reduction is removed.
+
+### 2. The invariant
+
+**`flow_charge` is an involution on canonical representatives.** This is the load-bearing
+property. It makes the following valid for *any* abelian group, not just U(1):
+
+```python
+q_last = flow_charge(flow_last, fuse(target, dual(partial)))
+```
+
+Consequently `core/tensor.py:_compute_valid_blocks` no longer needs its
+`is_infinite = sym.n_values() is None` split: the closed-form branch generalises to every
+abelian symmetry and the two branches **collapse into one**. The
+`ProductSymmetry(Z2, U1) → None → U(1) formula on packed charges` defect disappears rather
+than being patched. The same substitution removes the two `% n_values()` misuses in
+`_tensor_utils.py:204` and `symmetry.py:178`.
+
+`n_values()` keeps its name and meaning as a **cardinality** — used for sizing, never as a
+modulus. This is documented on the method.
+
+### 3. Canonicalisation at construction
+
+The involution holds only if stored sectors are canonical. `TensorIndex.__post_init__`
+therefore canonicalises `sectors` and **merges duplicates**, so the precondition holds by
+construction rather than by discipline. Every construction path — `from_charges`, `dual`,
+`flip_flow`, direct construction — funnels through `__post_init__`, so this repairs the
+`dual()` non-uniqueness in Severity 5 as a side effect.
+
+Merging is not optional: canonicalising Z2 `[-1, 0, 1]` yields `[1, 0, 1]`, which must
+become sectors `[0, 1]` with multiplicities `[1, 2]`. The steps are:
+
+1. `sectors ← symmetry.canonicalize(sectors)`
+2. group equal sectors, summing their multiplicities
+3. re-sort ascending
+4. canonicalise `_charges_cache` the same way when present, so `charges`,
+   `from_dense`/`todense` orderings stay consistent with `sectors`
+
+Under the guiding principle this rewrite is free: it changes representatives, not physics.
+It is the only part of this design that touches a constructor.
+
+### 4. Staging
+
+Four PRs, each independently landable, each with its own regression gate.
+
+| PR | Scope | Behaviour change | Gate |
+|---|---|---|---|
+| 1 | `flow_charge`, `canonicalize`, `net_charge`; rewrite the dead `is_conserved` to use them | none (pure addition) | unit tests per symmetry, including `ProductSymmetry`: `flow_charge` involution, `fuse(q, dual(q)) == identity`, `canonicalize` idempotent |
+| 2 | `core/tensor.py` (`_validate`, `_compute_valid_blocks`, `TensorIndex.__post_init__`) and `linalg.py` (lines 80, 121, 605, 2109) | **Z_n bond labels canonicalise**; updates `test_zn_same_flow_bonds_carry_the_library_s_own_representative` | full symmetric-tensor suite; new test asserting `svd` gives identical bond sectors with the left leg IN and OUT, for U(1), Z2, Z3 |
+| 3 | `contraction/contractor.py:427`, `dmrg.py:3124` | **fixes Z_n `contract` returning all zeros** | the verified 5.824 → 0.0 repro becomes a regression test |
+| 4 | `ProductSymmetry` enablement; `_tensor_utils.py:204` | mixed-flow `ProductSymmetry` tensors work for the first time | construction, `svd`, `contract` round-trips on `ProductSymmetry(Z2, U1)` and `(Z2, Z3)`; lift the refusal in `_ctm_root_implicit_sym_sectors.py` |
+
+Ordering rationale: PR 1 is behaviourally inert, making it a safe merge-queue warm-up. PR 2
+must land `_validate` and `_group_blocks_by_bond_charge` together — fixing either alone
+leaves the two conventions inconsistent. PRs 2 and 3 each carry a Severity-1 fix, so
+neither waits on PR 4.
+
+## Testing
+
+Per-symmetry parametrised tests over `U1Symmetry`, `ZnSymmetry(2)`, `ZnSymmetry(3)`,
+`FermionParity`, `FermionicU1`, `ProductSymmetry(Z2, U1)`, `ProductSymmetry(Z2, Z3)`:
+
+- `flow_charge(OUT, flow_charge(OUT, q)) == q` for canonical `q`
+- `fuse(q, dual(q)) == identity()` for every sector
+- `canonicalize` is idempotent, and `canonicalize(sectors)` equals `sectors` for any index
+  built through `TensorIndex`
+- `svd` produces the same bond sectors with the left leg IN and with it OUT (the
+  regression test named in #733)
+- `contract` of a Z3 network matches the dense `einsum` reference in norm — the 5.824/0.0
+  repro
+- `TensorIndex` with duplicate representatives merges: Z2 `[-1,0,1]` gives
+  `sectors=[0,1]`, `multiplicities=[1,2]`, `dim=3`
+- `TensorIndex.dual()` is an involution
+
+## Risks
+
+- **Regression surface.** 15 test files touch block keys or sectors; 17 assertions pin
+  them. Only one pins a negative Z_n representative
+  (`tests/test_ctm_root_implicit_sym_sectors.py:454`), which anticipates its own update.
+- **Silent-zero class of bug.** Because the failure mode being fixed is *silent*, absence
+  of new test failures is weak evidence. PR 3's gate must compare against a dense
+  reference in norm, not merely assert that a contraction succeeds.
+- **`_charges_cache` consistency.** Canonicalising `sectors` without canonicalising the
+  cached dense charges would desynchronise `charges` from `sectors`. Step 4 of §3 is
+  load-bearing, not cosmetic.
+- **Fermionic paths.** `FermionParity` is self-dual (`dual(q) == q`), so `flow_charge` is
+  the identity map there and Koszul-sign logic is untouched. This is asserted, not assumed.
+
+## Out of scope
+
+- `tdvp.py:251/270` element-as-scalar. Correct today; tracked separately as a robustness
+  note, not a bug.
+- Renaming or deprecating `n_values()`.
+- Making `.blocks` private. The principle argues for it, but nothing in `src/tenax` or the
+  README currently abuses it, so there is no defect to fix.
+- Non-abelian symmetries. `flow_charge` gives them a place to hook in later; no F/R-symbol
+  machinery is introduced here.

--- a/src/tenax/core/index.py
+++ b/src/tenax/core/index.py
@@ -14,6 +14,7 @@ contracted when contract() or TensorNetwork.contract() is called.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import IntEnum
 
@@ -337,3 +338,44 @@ class TensorIndex:
             f"n_sectors={self.n_sectors}, flow={self.flow.name}, "
             f"label={self.label!r})"
         )
+
+
+def net_charge(
+    indices: Sequence[TensorIndex],
+    key: Sequence[int],
+) -> int:
+    """Return the net fused charge of a block key, as a Python int.
+
+    This is the only sanctioned way to evaluate a block's conservation law: a
+    block is valid exactly when ``net_charge(indices, key) == symmetry.identity()``.
+
+    ``sum(int(idx.flow) * int(q) for ...)`` is **not** equivalent. It assumes the
+    group inverse is integer negation and the group operation is integer
+    addition — true for U(1), accidentally true for ``Z_n`` whenever two or more
+    legs fuse afterwards, and false for the bit-packed charges of
+    :class:`~tenax.core.symmetry.ProductSymmetry` (#734).
+
+    The fusion is seeded with ``identity()`` so that a rank-1 tensor is reduced
+    exactly like a rank-N one. Without the seed, ``fuse_many`` of a single array
+    returns it unreduced and a lone OUT leg yields a non-canonical
+    representative (#733).
+
+    Args:
+        indices: Tensor indices, one per leg.
+        key:     One charge per leg, in the same order.
+
+    Returns:
+        The fused net charge.
+
+    Raises:
+        ValueError: If ``indices`` is empty.
+    """
+    if len(indices) == 0:
+        raise ValueError("net_charge requires at least one index")
+    sym = indices[0].symmetry
+    effective = [np.array([sym.identity()], dtype=np.int32)]
+    effective.extend(
+        sym.flow_charge(idx.flow, np.array([int(q)], dtype=np.int32))
+        for idx, q in zip(indices, key)
+    )
+    return int(sym.fuse_many(effective)[0])

--- a/src/tenax/core/index.py
+++ b/src/tenax/core/index.py
@@ -34,8 +34,12 @@ class FlowDirection(IntEnum):
     OUT (-1): Outgoing leg — corresponds to a "bra" index, arrow pointing
               out of the tensor. Positive charge flows out.
 
-    Conservation law: sum_i(flow_i * charge_i) == symmetry.identity()
-    for any valid block of a symmetric tensor.
+    Conservation law: for any valid block of a symmetric tensor, fusing each
+    leg's flow-weighted charge (``symmetry.flow_charge(flow_i, charge_i)``,
+    i.e. the charge itself on an IN leg and its group inverse on an OUT leg)
+    must yield ``symmetry.identity()``.  See :func:`_net_charge`, which is the
+    one place that evaluates it.  This is *not* the same as
+    ``sum_i(flow_i * charge_i)``, which only coincides for U(1) (#734).
     """
 
     IN = 1
@@ -340,14 +344,14 @@ class TensorIndex:
         )
 
 
-def net_charge(
+def _net_charge(
     indices: Sequence[TensorIndex],
     key: Sequence[int],
 ) -> int:
     """Return the net fused charge of a block key, as a Python int.
 
     This is the only sanctioned way to evaluate a block's conservation law: a
-    block is valid exactly when ``net_charge(indices, key) == symmetry.identity()``.
+    block is valid exactly when ``_net_charge(indices, key) == sym.identity()``.
 
     ``sum(int(idx.flow) * int(q) for ...)`` is **not** equivalent. It assumes the
     group inverse is integer negation and the group operation is integer
@@ -355,10 +359,9 @@ def net_charge(
     legs fuse afterwards, and false for the bit-packed charges of
     :class:`~tenax.core.symmetry.ProductSymmetry` (#734).
 
-    The fusion is seeded with ``identity()`` so that a rank-1 tensor is reduced
-    exactly like a rank-N one. Without the seed, ``fuse_many`` of a single array
-    returns it unreduced and a lone OUT leg yields a non-canonical
-    representative (#733).
+    This is a thin adapter: it reads the flow off each index and delegates the
+    arithmetic to :meth:`~tenax.core.symmetry.BaseSymmetry.net_charge`, so that
+    no charge is ever inverted or combined outside the symmetry class.
 
     Args:
         indices: Tensor indices, one per leg.
@@ -368,14 +371,12 @@ def net_charge(
         The fused net charge.
 
     Raises:
-        ValueError: If ``indices`` is empty.
+        ValueError: If ``indices`` is empty, or if ``key`` has a different
+            length than ``indices``.
     """
     if len(indices) == 0:
-        raise ValueError("net_charge requires at least one index")
-    sym = indices[0].symmetry
-    effective = [np.array([sym.identity()], dtype=np.int32)]
-    effective.extend(
-        sym.flow_charge(idx.flow, np.array([int(q)], dtype=np.int32))
-        for idx, q in zip(indices, key)
+        raise ValueError("_net_charge requires at least one index")
+    pairs = list(zip(indices, key, strict=True))
+    return indices[0].symmetry.net_charge(
+        [q for _, q in pairs], [idx.flow for idx, _ in pairs]
     )
-    return int(sym.fuse_many(effective)[0])

--- a/src/tenax/core/symmetry.py
+++ b/src/tenax/core/symmetry.py
@@ -102,17 +102,26 @@ class BaseSymmetry(ABC):
         ``q = flow_charge(flow, fuse(target, dual(partial)))`` a valid closed
         form for the last leg of a conservation law in any abelian group.
 
+        The default implementation assumes abelian fusion (a single fusion
+        outcome per pair); a future ``BaseNonAbelianSymmetry`` subclass must
+        override it.
+
+        Note:
+            ``np.asarray(charges, dtype=np.int32)`` silently wraps on int64
+            overflow rather than raising.
+
         Args:
             flow:    ``+1`` (IN) or ``-1`` (OUT); a ``FlowDirection`` works too.
             charges: Integer charge array.
 
         Returns:
-            Effective charge array of the same shape.
+            Effective charge array of the same shape.  On an IN leg this may
+            **alias** ``charges``, so the result must be treated as read-only.
         """
         charges = np.asarray(charges, dtype=np.int32)
         return charges if int(flow) > 0 else self.dual(charges)
 
-    def canonicalize(self, charges: np.ndarray) -> np.ndarray:
+    def canonicalize_charges(self, charges: np.ndarray) -> np.ndarray:
         """Return the canonical representative of each charge.
 
         Fusing against the identity applies whatever reduction the group
@@ -122,14 +131,18 @@ class BaseSymmetry(ABC):
         is *not* free is letting two representatives of one sector coexist,
         because label equality is how blocks are paired during contraction.
 
+        The default implementation assumes abelian fusion; a future
+        ``BaseNonAbelianSymmetry`` subclass must override it.
+
         Args:
             charges: Integer charge array.
 
         Returns:
-            Canonical charge array of the same shape.
+            Canonical charge array of the same shape.  Overrides may **alias**
+            ``charges``, so the result must be treated as read-only.
         """
         charges = np.asarray(charges, dtype=np.int32)
-        return self.fuse(np.full_like(charges, self.identity()), charges)
+        return self.fuse(np.int32(self.identity()), charges)
 
     @property
     def braiding_style(self) -> BraidingStyle:
@@ -198,6 +211,44 @@ class BaseSymmetry(ABC):
         """
         return 1.0
 
+    def net_charge(
+        self,
+        charges_per_leg: list[int],
+        flows: list[int],
+    ) -> int:
+        """Fuse one charge per leg, weighted by that leg's flow.
+
+        This is the only sanctioned way to evaluate a conservation law: a block
+        is valid exactly when ``net_charge(...) == identity()``.
+
+        ``sum(int(f) * int(q) for ...)`` is **not** equivalent. It assumes the
+        group inverse is integer negation and the group operation is integer
+        addition — true for U(1), accidentally true for ``Z_n`` whenever two or
+        more legs fuse afterwards, and false for the bit-packed charges of
+        :class:`ProductSymmetry` (#734).
+
+        The fusion is seeded with ``identity()`` so that a rank-1 tensor is
+        reduced exactly like a rank-N one. Without the seed, ``fuse_many`` of a
+        single array returns it unreduced and a lone OUT leg yields a
+        non-canonical representative (#733).
+
+        Args:
+            charges_per_leg: One scalar charge per leg.
+            flows: ``+1`` (IN) or ``-1`` (OUT) per leg, in the same order.
+
+        Returns:
+            The fused net charge, as a Python int.
+
+        Raises:
+            ValueError: If the two sequences have different lengths.
+        """
+        effective = [np.array([self.identity()], dtype=np.int32)]
+        effective.extend(
+            self.flow_charge(f, np.array([int(q)], dtype=np.int32))
+            for f, q in zip(flows, charges_per_leg, strict=True)
+        )
+        return int(self.fuse_many(effective)[0])
+
     def is_conserved(
         self,
         charges_per_leg: list[np.ndarray],
@@ -216,14 +267,9 @@ class BaseSymmetry(ABC):
         """
         if target is None:
             target = self.identity()
-        effective = [np.array([self.identity()], dtype=np.int32)]
-        effective.extend(
-            self.flow_charge(f, np.array([int(q)], dtype=np.int32))
-            for f, q in zip(flows, charges_per_leg)
-        )
-        net = int(self.fuse_many(effective)[0])
-        want = int(self.canonicalize(np.array([int(target)], dtype=np.int32))[0])
-        return net == want
+        net = self.net_charge(charges_per_leg, flows)
+        want = self.canonicalize_charges(np.array([int(target)], dtype=np.int32))
+        return net == int(want[0])
 
 
 class U1Symmetry(BaseSymmetry):
@@ -247,8 +293,13 @@ class U1Symmetry(BaseSymmetry):
     def identity(self) -> int:
         return 0
 
-    def canonicalize(self, charges: np.ndarray) -> np.ndarray:
-        # Every integer is its own canonical U(1) representative.
+    def canonicalize_charges(self, charges: np.ndarray) -> np.ndarray:
+        """Identity map: every integer is its own canonical U(1) representative.
+
+        Returns:
+            The input viewed as int32.  This may **alias** ``charges``, so the
+            result must be treated as read-only.
+        """
         return np.asarray(charges, dtype=np.int32)
 
     def n_values(self) -> None:
@@ -292,6 +343,17 @@ class ZnSymmetry(BaseSymmetry):
 
     def identity(self) -> int:
         return 0
+
+    def canonicalize_charges(self, charges: np.ndarray) -> np.ndarray:
+        """Reduce each charge into ``[0, n)``.
+
+        Equivalent to the base implementation, but skips fusing against a
+        broadcast identity — this runs on every index construction.
+
+        Returns:
+            Canonical charge array of the same shape (read-only by contract).
+        """
+        return np.asarray(charges, dtype=np.int32) % self.n
 
     def n_values(self) -> int:
         return self.n
@@ -390,6 +452,17 @@ class FermionParity(BaseSymmetry):
     def identity(self) -> int:
         return 0
 
+    def canonicalize_charges(self, charges: np.ndarray) -> np.ndarray:
+        """Reduce each charge into ``{0, 1}``.
+
+        Equivalent to the base implementation, but skips fusing against a
+        broadcast identity — this runs on every index construction.
+
+        Returns:
+            Canonical charge array of the same shape (read-only by contract).
+        """
+        return np.asarray(charges, dtype=np.int32) % 2
+
     def n_values(self) -> int:
         return 2
 
@@ -471,8 +544,13 @@ class FermionicU1(BaseSymmetry):
     def identity(self) -> int:
         return 0
 
-    def canonicalize(self, charges: np.ndarray) -> np.ndarray:
-        # Every integer is its own canonical U(1) representative.
+    def canonicalize_charges(self, charges: np.ndarray) -> np.ndarray:
+        """Identity map: every integer is its own canonical U(1) representative.
+
+        Returns:
+            The input viewed as int32.  This may **alias** ``charges``, so the
+            result must be treated as read-only.
+        """
         return np.asarray(charges, dtype=np.int32)
 
     def n_values(self) -> None:

--- a/src/tenax/core/symmetry.py
+++ b/src/tenax/core/symmetry.py
@@ -86,6 +86,51 @@ class BaseSymmetry(ABC):
             result = self.fuse(result, c)
         return result
 
+    def flow_charge(self, flow: int, charges: np.ndarray) -> np.ndarray:
+        """Return the flow-weighted effective charge of a leg.
+
+        An IN leg (flow ``+1``) contributes its charge unchanged; an OUT leg
+        (flow ``-1``) contributes the group inverse.
+
+        This is the only sanctioned way to weight a charge by a flow.
+        ``int(flow) * charge`` hard-codes "the group inverse is integer
+        negation": true for U(1), true for ``Z_n`` only because ``fuse``
+        reduces mod ``n`` afterwards, and meaningless for the bit-packed
+        charges of :class:`ProductSymmetry` (#734).
+
+        On canonical representatives this is an involution, which is what makes
+        ``q = flow_charge(flow, fuse(target, dual(partial)))`` a valid closed
+        form for the last leg of a conservation law in any abelian group.
+
+        Args:
+            flow:    ``+1`` (IN) or ``-1`` (OUT); a ``FlowDirection`` works too.
+            charges: Integer charge array.
+
+        Returns:
+            Effective charge array of the same shape.
+        """
+        charges = np.asarray(charges, dtype=np.int32)
+        return charges if int(flow) > 0 else self.dual(charges)
+
+    def canonicalize(self, charges: np.ndarray) -> np.ndarray:
+        """Return the canonical representative of each charge.
+
+        Fusing against the identity applies whatever reduction the group
+        defines — ``% n`` for ``Z_n``, component-wise reduction for
+        :class:`ProductSymmetry`, nothing for U(1).  Charge representatives are
+        a basis convention and not observable, so rewriting them is free; what
+        is *not* free is letting two representatives of one sector coexist,
+        because label equality is how blocks are paired during contraction.
+
+        Args:
+            charges: Integer charge array.
+
+        Returns:
+            Canonical charge array of the same shape.
+        """
+        charges = np.asarray(charges, dtype=np.int32)
+        return self.fuse(np.full_like(charges, self.identity()), charges)
+
     @property
     def braiding_style(self) -> BraidingStyle:
         """Exchange statistics of this symmetry (bosonic by default)."""
@@ -162,7 +207,7 @@ class BaseSymmetry(ABC):
         """Check if a single charge combination satisfies conservation.
 
         Args:
-            charges_per_leg: List of scalar-or-array charge values per leg.
+            charges_per_leg: List of scalar charge values per leg.
             flows: List of +1 (IN) or -1 (OUT) per leg.
             target: Required net charge; defaults to identity().
 
@@ -171,12 +216,14 @@ class BaseSymmetry(ABC):
         """
         if target is None:
             target = self.identity()
-        net = sum(int(f) * int(q) for f, q in zip(flows, charges_per_leg))
-        # For modular groups we need to reduce the net charge
-        n = self.n_values()
-        if n is not None:
-            net = net % n
-        return net == target
+        effective = [np.array([self.identity()], dtype=np.int32)]
+        effective.extend(
+            self.flow_charge(f, np.array([int(q)], dtype=np.int32))
+            for f, q in zip(flows, charges_per_leg)
+        )
+        net = int(self.fuse_many(effective)[0])
+        want = int(self.canonicalize(np.array([int(target)], dtype=np.int32))[0])
+        return net == want
 
 
 class U1Symmetry(BaseSymmetry):
@@ -199,6 +246,10 @@ class U1Symmetry(BaseSymmetry):
 
     def identity(self) -> int:
         return 0
+
+    def canonicalize(self, charges: np.ndarray) -> np.ndarray:
+        # Every integer is its own canonical U(1) representative.
+        return np.asarray(charges, dtype=np.int32)
 
     def n_values(self) -> None:
         return None
@@ -419,6 +470,10 @@ class FermionicU1(BaseSymmetry):
 
     def identity(self) -> int:
         return 0
+
+    def canonicalize(self, charges: np.ndarray) -> np.ndarray:
+        # Every integer is its own canonical U(1) representative.
+        return np.asarray(charges, dtype=np.int32)
 
     def n_values(self) -> None:
         return None

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -3,8 +3,8 @@
 import numpy as np
 import pytest
 
-from tenax.core.index import FlowDirection, TensorIndex
-from tenax.core.symmetry import U1Symmetry, ZnSymmetry
+from tenax.core.index import FlowDirection, TensorIndex, net_charge
+from tenax.core.symmetry import ProductSymmetry, U1Symmetry, ZnSymmetry
 
 
 class TestFlowDirection:
@@ -290,3 +290,47 @@ class TestTensorIndexSectors:
         # U(1) dual negates: [-1,0,1] → [1,0,-1], sorted → [-1,0,1]
         np.testing.assert_array_equal(d.sectors, np.array([-1, 0, 1]))
         np.testing.assert_array_equal(d.multiplicities, np.array([1, 1, 1]))
+
+
+def test_net_charge_reduces_a_single_out_leg():
+    """The #733 case: one OUT leg, nothing to fuse against, so no reduction ran."""
+    sym = ZnSymmetry(2)
+    idx = TensorIndex.from_charges(
+        sym, np.array([0, 1], dtype=np.int32), FlowDirection.OUT, label="a"
+    )
+    assert net_charge((idx,), (1,)) == 1  # not -1
+
+
+def test_net_charge_agrees_between_one_leg_and_two_legs():
+    sym = ZnSymmetry(3)
+    out = TensorIndex.from_charges(
+        sym, np.array([0, 1, 2], dtype=np.int32), FlowDirection.OUT, label="a"
+    )
+    trivial = TensorIndex.from_charges(
+        sym, np.array([0], dtype=np.int32), FlowDirection.IN, label="b"
+    )
+    for q in (0, 1, 2):
+        assert net_charge((out,), (q,)) == net_charge((out, trivial), (q, 0))
+
+
+def test_net_charge_is_identity_for_a_conserving_product_symmetry_block():
+    ps = ProductSymmetry(ZnSymmetry(2), U1Symmetry())
+    q = ProductSymmetry.encode(1, 1)
+    secs = np.array([ProductSymmetry.encode(0, 0), q], dtype=np.int32)
+    a = TensorIndex.from_charges(ps, secs, FlowDirection.IN, label="a")
+    b = TensorIndex.from_charges(ps, secs, FlowDirection.OUT, label="b")
+    assert net_charge((a, b), (q, q)) == ps.identity()
+
+
+def test_net_charge_matches_plain_summation_for_u1():
+    """U(1) is the case the old hand-rolled arithmetic got right; keep it right."""
+    sym = U1Symmetry()
+    a = TensorIndex.from_charges(
+        sym, np.array([-1, 0, 1], dtype=np.int32), FlowDirection.IN, label="a"
+    )
+    b = TensorIndex.from_charges(
+        sym, np.array([-1, 0, 1], dtype=np.int32), FlowDirection.OUT, label="b"
+    )
+    for qa in (-1, 0, 1):
+        for qb in (-1, 0, 1):
+            assert net_charge((a, b), (qa, qb)) == qa - qb

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from tenax.core.index import FlowDirection, TensorIndex, net_charge
+from tenax.core.index import FlowDirection, TensorIndex, _net_charge
 from tenax.core.symmetry import ProductSymmetry, U1Symmetry, ZnSymmetry
 
 
@@ -298,7 +298,7 @@ def test_net_charge_reduces_a_single_out_leg():
     idx = TensorIndex.from_charges(
         sym, np.array([0, 1], dtype=np.int32), FlowDirection.OUT, label="a"
     )
-    assert net_charge((idx,), (1,)) == 1  # not -1
+    assert _net_charge((idx,), (1,)) == 1  # not -1
 
 
 def test_net_charge_agrees_between_one_leg_and_two_legs():
@@ -310,7 +310,7 @@ def test_net_charge_agrees_between_one_leg_and_two_legs():
         sym, np.array([0], dtype=np.int32), FlowDirection.IN, label="b"
     )
     for q in (0, 1, 2):
-        assert net_charge((out,), (q,)) == net_charge((out, trivial), (q, 0))
+        assert _net_charge((out,), (q,)) == _net_charge((out, trivial), (q, 0))
 
 
 def test_net_charge_is_identity_for_a_conserving_product_symmetry_block():
@@ -319,7 +319,7 @@ def test_net_charge_is_identity_for_a_conserving_product_symmetry_block():
     secs = np.array([ProductSymmetry.encode(0, 0), q], dtype=np.int32)
     a = TensorIndex.from_charges(ps, secs, FlowDirection.IN, label="a")
     b = TensorIndex.from_charges(ps, secs, FlowDirection.OUT, label="b")
-    assert net_charge((a, b), (q, q)) == ps.identity()
+    assert _net_charge((a, b), (q, q)) == ps.identity()
 
 
 def test_net_charge_matches_plain_summation_for_u1():
@@ -333,4 +333,26 @@ def test_net_charge_matches_plain_summation_for_u1():
     )
     for qa in (-1, 0, 1):
         for qb in (-1, 0, 1):
-            assert net_charge((a, b), (qa, qb)) == qa - qb
+            assert _net_charge((a, b), (qa, qb)) == qa - qb
+
+
+def test_net_charge_rejects_a_rank_mismatch():
+    """Without ``strict=True`` a short key silently returns a plausible wrong int."""
+    sym = U1Symmetry()
+    a = TensorIndex.from_charges(
+        sym, np.array([0, 1], dtype=np.int32), FlowDirection.IN, label="a"
+    )
+    b = TensorIndex.from_charges(
+        sym, np.array([0, 1], dtype=np.int32), FlowDirection.OUT, label="b"
+    )
+    assert _net_charge((a, b), (1, 1)) == 0  # the correct answer
+
+    with pytest.raises(ValueError):
+        _net_charge((a, b), (1,))  # missing leg — used to return 1
+    with pytest.raises(ValueError):
+        _net_charge((a,), (1, 1))  # extra charge — used to return 1
+
+
+def test_net_charge_rejects_empty_indices():
+    with pytest.raises(ValueError, match="at least one index"):
+        _net_charge((), ())

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -259,33 +259,51 @@ class TestBaseNonAbelianSymmetry:
         assert sym.allowed_fusions(1, 1) == [0, 2]
 
 
-_BOUNDARY_CASES = [
-    ("U1", U1Symmetry(), [-2, -1, 0, 1, 2]),
-    ("Z2", ZnSymmetry(2), [0, 1]),
-    ("Z3", ZnSymmetry(3), [0, 1, 2]),
-    ("Z4", ZnSymmetry(4), [0, 1, 2, 3]),
-    ("FermionParity", FermionParity(), [0, 1]),
-    ("FermionicU1", FermionicU1(), [-2, -1, 0, 1, 2]),
+_E = ProductSymmetry.encode
+
+# (name, symmetry, canonical sectors, non-canonical input, its canonical form).
+#
+# The non-canonical column is what makes the canonicalize_charges tests bite: on
+# canonical sectors the method is the identity map, so asserting f(x) == x there
+# is satisfied by a stubbed-out implementation too.  U(1) and FermionicU1 have no
+# non-canonical representative at all, so for them the mapping *is* the identity
+# and that itself is the claim under test.
+_CHARGE_CASES = [
+    ("U1", U1Symmetry(), [-2, -1, 0, 1, 2], [-5, 7, 12345], [-5, 7, 12345]),
+    ("Z2", ZnSymmetry(2), [0, 1], [-1, -2, 3, -7], [1, 0, 1, 1]),
+    ("Z3", ZnSymmetry(3), [0, 1, 2], [-1, -2, 5, -6], [2, 1, 2, 0]),
+    ("Z4", ZnSymmetry(4), [0, 1, 2, 3], [-1, -3, 9, -8], [3, 1, 1, 0]),
+    ("FermionParity", FermionParity(), [0, 1], [-1, -2, 3, 4], [1, 0, 1, 0]),
+    ("FermionicU1", FermionicU1(), [-2, -1, 0, 1, 2], [-9, 11, 400], [-9, 11, 400]),
     (
         "Prod(Z2,U1)",
         ProductSymmetry(ZnSymmetry(2), U1Symmetry()),
-        [ProductSymmetry.encode(a, b) for a in (0, 1) for b in (-2, -1, 0, 1, 2)],
+        [_E(a, b) for a in (0, 1) for b in (-2, -1, 0, 1, 2)],
+        [_E(-1, 3), _E(-2, -4), _E(3, 5)],
+        [_E(1, 3), _E(0, -4), _E(1, 5)],
     ),
     (
         "Prod(Z2,Z3)",
         ProductSymmetry(ZnSymmetry(2), ZnSymmetry(3)),
-        [ProductSymmetry.encode(a, b) for a in (0, 1) for b in (0, 1, 2)],
+        [_E(a, b) for a in (0, 1) for b in (0, 1, 2)],
+        [_E(-1, -1), _E(2, 4), _E(-3, -2)],
+        [_E(1, 2), _E(0, 1), _E(1, 1)],
     ),
 ]
-_BOUNDARY_IDS = [c[0] for c in _BOUNDARY_CASES]
+_BOUNDARY_CASES = [(name, sym, secs) for name, sym, secs, _, _ in _CHARGE_CASES]
+_BOUNDARY_IDS = [c[0] for c in _CHARGE_CASES]
 
 
 @pytest.mark.parametrize("name,sym,sectors", _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
-def test_canonicalize_fixes_canonical_sectors_and_is_idempotent(name, sym, sectors):
+def test_canonicalize_charges_fixes_canonical_sectors_and_is_idempotent(
+    name, sym, sectors
+):
     secs = np.array(sectors, dtype=np.int32)
-    once = sym.canonicalize(secs)
+    once = sym.canonicalize_charges(secs)
     assert np.array_equal(once, secs), f"{name}: canonical input was rewritten"
-    assert np.array_equal(sym.canonicalize(once), once), f"{name}: not idempotent"
+    assert np.array_equal(sym.canonicalize_charges(once), once), (
+        f"{name}: not idempotent"
+    )
 
 
 @pytest.mark.parametrize("name,sym,sectors", _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
@@ -320,9 +338,40 @@ def test_closed_form_solves_the_last_leg_charge(name, sym, sectors):
                 assert got == int(t[0]), f"{name}: flow={flow} partial={partial}"
 
 
-def test_canonicalize_maps_negative_zn_representatives():
+@pytest.mark.parametrize(
+    "name,sym,sectors,raw,expected", _CHARGE_CASES, ids=_BOUNDARY_IDS
+)
+def test_canonicalize_charges_rewrites_noncanonical_input(
+    name, sym, sectors, raw, expected
+):
+    """The non-vacuous half: assert the mapping off the fixed points of the map."""
+    got = sym.canonicalize_charges(np.array(raw, dtype=np.int32))
+    want = np.array(expected, dtype=np.int32)
+    assert np.array_equal(got, want), (
+        f"{name}: {raw} -> {got.tolist()}, want {expected}"
+    )
+
+
+@pytest.mark.parametrize(
+    "name,sym,sectors,raw,expected", _CHARGE_CASES, ids=_BOUNDARY_IDS
+)
+def test_canonicalize_charges_override_agrees_with_base(
+    name, sym, sectors, raw, expected
+):
+    """A fast override that silently disagrees with the generic fusion is the risk."""
+    for label, values in (("canonical", sectors), ("non-canonical", raw)):
+        x = np.array(values, dtype=np.int32)
+        got = sym.canonicalize_charges(x)
+        base = BaseSymmetry.canonicalize_charges(sym, x)
+        assert np.array_equal(got, base), (
+            f"{name}: override diverges from BaseSymmetry on {label} input "
+            f"{values}: {got.tolist()} != {base.tolist()}"
+        )
+
+
+def test_canonicalize_charges_maps_negative_zn_representatives():
     sym = ZnSymmetry(3)
-    got = sym.canonicalize(np.array([-1, -2, 0], dtype=np.int32))
+    got = sym.canonicalize_charges(np.array([-1, -2, 0], dtype=np.int32))
     assert np.array_equal(got, np.array([2, 1, 0], dtype=np.int32))
 
 
@@ -332,3 +381,22 @@ def test_is_conserved_accepts_a_conserving_product_symmetry_block():
     q = ProductSymmetry.encode(1, 1)
     assert ps.is_conserved([q, q], [1, -1])
     assert not ps.is_conserved([q, ProductSymmetry.encode(0, 1)], [1, -1])
+
+
+def test_is_conserved_canonicalizes_a_noncanonical_target():
+    """``-2 == 1 (mod 3)``, so the old raw ``net == target`` compare said False."""
+    sym = ZnSymmetry(3)
+    assert sym.is_conserved([1], [1], target=1)
+    assert sym.is_conserved([1], [1], target=-2)
+    assert not sym.is_conserved([1], [1], target=-1)
+
+
+def test_net_charge_rejects_a_rank_mismatch():
+    """Without ``strict=True`` a short flows list silently drops a leg."""
+    sym = U1Symmetry()
+    assert sym.net_charge([1, 1], [1, -1]) == 0
+
+    with pytest.raises(ValueError):
+        sym.net_charge([1, 1], [1])
+    with pytest.raises(ValueError):
+        sym.net_charge([1], [1, -1])

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -9,6 +9,9 @@ from hypothesis.extra import numpy as hnp
 from tenax.core.symmetry import (
     BaseNonAbelianSymmetry,
     BaseSymmetry,
+    FermionicU1,
+    FermionParity,
+    ProductSymmetry,
     U1Symmetry,
     ZnSymmetry,
 )
@@ -254,3 +257,78 @@ class TestBaseNonAbelianSymmetry:
         sym = ConcreteNonAbelian()
         assert sym.identity() == 0
         assert sym.allowed_fusions(1, 1) == [0, 2]
+
+
+_BOUNDARY_CASES = [
+    ("U1", U1Symmetry(), [-2, -1, 0, 1, 2]),
+    ("Z2", ZnSymmetry(2), [0, 1]),
+    ("Z3", ZnSymmetry(3), [0, 1, 2]),
+    ("Z4", ZnSymmetry(4), [0, 1, 2, 3]),
+    ("FermionParity", FermionParity(), [0, 1]),
+    ("FermionicU1", FermionicU1(), [-2, -1, 0, 1, 2]),
+    (
+        "Prod(Z2,U1)",
+        ProductSymmetry(ZnSymmetry(2), U1Symmetry()),
+        [ProductSymmetry.encode(a, b) for a in (0, 1) for b in (-2, -1, 0, 1, 2)],
+    ),
+    (
+        "Prod(Z2,Z3)",
+        ProductSymmetry(ZnSymmetry(2), ZnSymmetry(3)),
+        [ProductSymmetry.encode(a, b) for a in (0, 1) for b in (0, 1, 2)],
+    ),
+]
+_BOUNDARY_IDS = [c[0] for c in _BOUNDARY_CASES]
+
+
+@pytest.mark.parametrize("name,sym,sectors", _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
+def test_canonicalize_fixes_canonical_sectors_and_is_idempotent(name, sym, sectors):
+    secs = np.array(sectors, dtype=np.int32)
+    once = sym.canonicalize(secs)
+    assert np.array_equal(once, secs), f"{name}: canonical input was rewritten"
+    assert np.array_equal(sym.canonicalize(once), once), f"{name}: not idempotent"
+
+
+@pytest.mark.parametrize("name,sym,sectors", _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
+def test_flow_charge_is_an_involution_on_canonical_sectors(name, sym, sectors):
+    secs = np.array(sectors, dtype=np.int32)
+    twice = sym.flow_charge(-1, sym.flow_charge(-1, secs))
+    assert np.array_equal(twice, secs), f"{name}: OUT twice is not the identity map"
+    assert np.array_equal(sym.flow_charge(1, secs), secs), f"{name}: IN altered charges"
+
+
+@pytest.mark.parametrize("name,sym,sectors", _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
+def test_fuse_with_dual_gives_identity(name, sym, sectors):
+    secs = np.array(sectors, dtype=np.int32)
+    assert np.all(sym.fuse(secs, sym.dual(secs)) == sym.identity()), name
+
+
+@pytest.mark.parametrize("name,sym,sectors", _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
+def test_closed_form_solves_the_last_leg_charge(name, sym, sectors):
+    """``q = flow_charge(flow, fuse(target, dual(partial)))`` inverts conservation.
+
+    This is the property that lets ``_compute_valid_blocks`` drop its
+    ``n_values() is None`` split: it holds for every abelian group, not just U(1).
+    """
+    secs = np.array(sectors, dtype=np.int32)
+    for flow in (1, -1):
+        for partial in secs:
+            for target in secs:
+                p = np.array([partial], dtype=np.int32)
+                t = np.array([target], dtype=np.int32)
+                q_last = sym.flow_charge(flow, sym.fuse(t, sym.dual(p)))
+                got = int(sym.fuse(p, sym.flow_charge(flow, q_last))[0])
+                assert got == int(t[0]), f"{name}: flow={flow} partial={partial}"
+
+
+def test_canonicalize_maps_negative_zn_representatives():
+    sym = ZnSymmetry(3)
+    got = sym.canonicalize(np.array([-1, -2, 0], dtype=np.int32))
+    assert np.array_equal(got, np.array([2, 1, 0], dtype=np.int32))
+
+
+def test_is_conserved_accepts_a_conserving_product_symmetry_block():
+    """The IN/OUT pair that ``int(flow) * q`` rejects for bit-packed charges."""
+    ps = ProductSymmetry(ZnSymmetry(2), U1Symmetry())
+    q = ProductSymmetry.encode(1, 1)
+    assert ps.is_conserved([q, q], [1, -1])
+    assert not ps.is_conserved([q, ProductSymmetry.encode(0, 1)], [1, -1])


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

**PR 1 of 4** for #734. Stack: **PR1** → PR2 → PR3 → PR4. Merge in order.

## What

Adds the charge-arithmetic boundary to `BaseSymmetry`. **Behaviourally inert** — pure addition plus a rewrite of a method that had zero production call sites.

| added | purpose |
|---|---|
| `BaseSymmetry.flow_charge(flow, charges)` | `charges` if IN, else `dual(charges)` |
| `BaseSymmetry.canonicalize_charges(charges)` | canonical representative; overridden in `U1Symmetry`/`FermionicU1` (no-ops) and `ZnSymmetry`/`FermionParity` (`% n`) |
| `BaseSymmetry.net_charge(charges_per_leg, flows)` | the seeded fusion loop |
| `core/index.py` `_net_charge(indices, key)` | thin adapter reading `idx.flow` per index |

## Why

Eight sites in `src/tenax` computed a block's conservation law as `sum(int(idx.flow) * int(q))`, encoding two assumptions true **only for U(1)**: that the group inverse is integer negation, and that the group operation is integer addition. For `Z_n` they are accidentally true whenever two or more legs fuse afterwards (`fuse` applies `% n`) and fail when nothing fuses. For `ProductSymmetry`, whose charges are bit-packed as `(q2 << 16) | (q1 & 0xFFFF)`, they never hold.

Seeding the fusion with `identity()` is what fixes #733: there is no longer a path where zero fusions happen, so the single-leg and multi-leg cases agree by construction.

`is_conserved` — the one method that already reduced correctly — had **zero call sites**. A sanctioned abstraction existed, was dead, and eight sites reimplemented a worse version of it.

## Load-bearing property

**`flow_charge` is an involution on canonical representatives.** PR 2 relies on it to replace `_compute_valid_blocks`'s `n_values() is None` branch split with a single closed form valid for any abelian group. Verified across U1, Z2, Z3, Z4, FermionParity, FermionicU1 and both `ProductSymmetry` variants, along with `canonicalize_charges` idempotence, `fuse(q, dual(q)) == identity`, and the closed form over all flows and all (partial, target) pairs.

## Review-driven changes

- **`zip(..., strict=True)`** in both conservation helpers. A rank mismatch previously returned a plausible wrong integer instead of raising — the exact bug class this boundary exists to close.
- **`canonicalize` → `canonicalize_charges`.** "Canonicalize" already means MPS *gauge* form here (`FiniteMPS.canonicalize`, `left_canonicalize`). The method had no production callers, so the rename was nearly free.
- **The first round of tests was vacuous.** They asserted `f(x) == x` on the fixed points of `f`, so stubbing `canonicalize_charges` to the identity function left **27 of 28 passing**. They now assert non-canonical inputs map to their canonical form and that every override agrees with the base implementation; under the same stub, **8 fail**.
- Perf, since PR 2 puts this on every `TensorIndex` construction: broadcast the identity scalar instead of `np.full_like`, plus the `ZnSymmetry`/`FermionParity` overrides.

## Verification

`pytest -m core`: **1213 passed, 8 skipped, 1555 deselected** (baseline 1193 + 20 new).

Refs #734.
