### PR TITLE
fix(#740): propagate the #710 corner convention to the split-CTM absorbs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
     branches: [main]
   merge_group:
+  # Daily full-suite run on main (#740).  The required checks run only
+  # ``pytest -m core``; everything else executes on push-to-main or behind the
+  # ``run-full-tests`` label, so a non-core regression could sit red for weeks
+  # with nothing reporting it (#740 found 8 such failures at once).  This gives
+  # the non-core buckets a standing daily signal.  GitHub disables scheduled
+  # workflows after 60 days of repository inactivity and emails the repo owner
+  # when a scheduled run fails.
+  schedule:
+    - cron: "0 7 * * *"  # 07:00 UTC daily
+  workflow_dispatch:
 
 jobs:
   test:
@@ -78,6 +88,8 @@ jobs:
     if: |
       always() &&
       ((github.event_name == 'push' && needs.changes.outputs.code == 'true') ||
+       github.event_name == 'schedule' ||
+       github.event_name == 'workflow_dispatch' ||
        contains(github.event.pull_request.labels.*.name, 'run-full-tests'))
     runs-on: ${{ matrix.os }}
     strategy:

--- a/src/tenax/algorithms/_split_ctm_tensor_moves.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_moves.py
@@ -332,6 +332,16 @@ def _compute_split_plaquette_projector_pair(
 # ------------------------------------------------------------------ #
 # 2x2 split absorption (four directional twins of the fused            #
 # _ctm_tensor_absorb_*_2plaq, on ket/bra split edges)                  #
+#                                                                      #
+# These four kernels must track the corner label convention of their   #
+# fused counterparts in _ctm_tensor_moves.py exactly -- the corner     #
+# read pairing, the _apply_proj_unfused env leg, and the output        #
+# relabels.  They are separate code, so a convention change there does #
+# NOT propagate here: #710 fixed the fused RIGHT/TOP/BOTTOM corners and #
+# left these stale, which silently transposed C1/C2/C3/C4 on the split #
+# path until #740.  test_split_absorb_bitidentical_on_shared_env is    #
+# the convergence-independent guard; it compares both kernels on one   #
+# shared env, so it catches any future drift immediately.              #
 # ------------------------------------------------------------------ #
 
 
@@ -429,7 +439,7 @@ def _split_ctm_absorb_bottom_2plaq(
         FlowDirection.IN,
     )
     C4_new = _apply_proj_unfused(P_bot_left, C4g, "c4_u", "l2")
-    C4_new = C4_new.relabels({"chi_new": "c4_r", "t4k_d": "c4_u"})
+    C4_new = C4_new.relabels({"chi_new": "c4_u", "t4k_d": "c4_r"})  # #710
 
     C3g = _grow_split_corner_2x2(
         env_src.C3,
@@ -445,7 +455,7 @@ def _split_ctm_absorb_bottom_2plaq(
         FlowDirection.OUT,
     )
     C3_new = _apply_proj_unfused(P_top_curr, C3g, "c3_l", "r2")
-    C3_new = C3_new.relabels({"chi_new": "c3_u", "t2k_u": "c3_l"})
+    C3_new = C3_new.relabels({"chi_new": "c3_l", "t2k_u": "c3_u"})  # #710
 
     T3g = _grow_split_edge_2x2(
         env_src.T3_ket,
@@ -573,11 +583,11 @@ def _split_ctm_absorb_right_2plaq(
         FlowDirection.IN,
     )
     C2_new = _apply_proj_unfused(P_top_above, C2g, "c2_d", "u2")
-    C2_new = C2_new.relabels({"chi_new": "c2_l", "t1k_l": "c2_d"})
+    C2_new = C2_new.relabels({"chi_new": "c2_d", "t1k_l": "c2_l"})  # #710
 
     C3g = _grow_split_corner_2x2(
         env_src.C3,
-        "c3_u",
+        "c3_l",  # #710: pair c3_l <-> t3_l, leaving c3_u as the surviving leg
         "t3b_l",
         env_src.T3_bra,
         env_src.T3_ket,
@@ -588,7 +598,7 @@ def _split_ctm_absorb_right_2plaq(
         "d2",
         FlowDirection.OUT,
     )
-    C3_new = _apply_proj_unfused(P_bot_curr, C3g, "c3_l", "d2")
+    C3_new = _apply_proj_unfused(P_bot_curr, C3g, "c3_u", "d2")  # #710
     C3_new = C3_new.relabels({"chi_new": "c3_u", "t3k_r": "c3_l"})
 
     T2g = _grow_split_edge_2x2(
@@ -645,7 +655,7 @@ def _split_ctm_absorb_top_2plaq(
         FlowDirection.IN,
     )
     C1_new = _apply_proj_unfused(P_top_left, C1g, "c1_r", "l2")
-    C1_new = C1_new.relabels({"chi_new": "c1_d", "t4b_u": "c1_r"})
+    C1_new = C1_new.relabels({"chi_new": "c1_r", "t4b_u": "c1_d"})  # #710
 
     C2g = _grow_split_corner_2x2(
         env_src.C2,

--- a/tests/test_ipeps_ad_adjoint_methods.py
+++ b/tests/test_ipeps_ad_adjoint_methods.py
@@ -37,16 +37,67 @@ def _random_peps(seed=2026, D=2, d=2):
 
 
 @pytest.mark.algorithm
-def test_fixed_point_matches_gmres_at_chi8():
-    """``adjoint_method`` choice must not change the optimization outcome.
+def test_fixed_point_matches_gmres_gradient():
+    """``adjoint_method`` must not change the GRADIENT.
 
-    Both Neumann iteration and eager GMRES solve the same linear system
-    to the same tolerance.  Running ``optimize_gs_ad`` from the same
-    seed under both methods must yield matching energies and tensors.
+    ``adjoint_method`` only selects the *backward* linear solver; both methods
+    see the identical forward fixed point and therefore solve the identical
+    system ``(I - J^T) λ = dE/denv``.  Compared at a single gradient evaluation
+    the two agree to well inside ``gmres_tol`` (measured: cos = 1.000000000000,
+    relative L2 difference 1.9e-7), so this is gated tightly.
+
+    Why not compare ``optimize_gs_ad`` end states (issue #740)?  Because that
+    measures chaos amplification through the CTM fixed point, not the solver.
+    Since #710 restored ket-bra Z2 at the fixed point, the projector singular
+    values come in exact degenerate pairs whose LAPACK basis choice is
+    platform- and version-dependent, so a sub-solver-tolerance difference at
+    step 1 explodes across subsequent steps.  Measured on the old fixture
+    (D=2, chi=8, lr=1e-2, seed 2026):
+
+        steps   |dE|       max|dA|
+        1       2.2e-09    1.3e-08
+        2       5.3e-06    3.8e-03    <- what this test used to assert on
+        3       5.2e-03    5.0e-02
+
+    ~3 orders of magnitude per step.  The old 2-step assertion passed only
+    before #710 (verified: green at 3f25688^, red at 3f25688) because the
+    pre-#710 transposed convention broke the degeneracy.  A single step is
+    still stable, so the production path is covered by the second half below.
     """
     H = _heisenberg_gate()
-    A_init = _random_peps()
+    A = _wrap_as_dense_tensor(_random_peps())
 
+    def grad_with(method):
+        def loss(A_):
+            return ctm_energy_implicit(
+                {(0, 0): A_},
+                SINGLE_SITE_NEIGHBORS,
+                H,
+                chi=8,
+                max_iter=40,
+                conv_tol=1e-8,
+                gmres_tol=1e-6,
+                gmres_maxiter=200,
+                adjoint_method=method,
+            )
+
+        g = jax.grad(loss)(A)
+        return np.asarray(g.todense() if hasattr(g, "todense") else g).ravel()
+
+    g_fp = grad_with("fixed_point")
+    g_gmres = grad_with("gmres")
+
+    n_fp, n_gmres = np.linalg.norm(g_fp), np.linalg.norm(g_gmres)
+    assert n_fp > 1e-8 and n_gmres > 1e-8, "gradient collapsed to zero"
+
+    rel = float(np.linalg.norm(g_fp - g_gmres) / n_fp)
+    assert rel < 1e-5, (
+        f"adjoint_method changed the gradient beyond the solver tolerance: "
+        f"rel={rel:.3e} (|g_fp|={n_fp:.6e}, |g_gmres|={n_gmres:.6e})"
+    )
+
+    # Production path: one optimizer step is still below the amplification
+    # threshold, so the two methods must agree there element-wise.
     def make_config(method: str) -> iPEPSConfig:
         return iPEPSConfig(
             max_bond_dim=2,
@@ -56,30 +107,20 @@ def test_fixed_point_matches_gmres_at_chi8():
                 conv_tol=1e-8,
                 adjoint_method=method,
             ),
-            gs_num_steps=2,
+            gs_num_steps=1,
             gs_learning_rate=1e-2,
             su_init=False,
             gs_metric_precond=False,
         )
 
+    A_init = _random_peps()
     A_fp, _, E_fp = optimize_gs_ad(H, A_init, make_config("fixed_point"))
     A_gmres, _, E_gmres = optimize_gs_ad(H, A_init, make_config("gmres"))
 
-    # The two backward solvers do NOT converge to the same tolerance: GMRES
-    # solves its linear system to ``gmres_tol`` (1e-6) while the Neumann
-    # fixed-point loop targets ``adjoint_tol`` (1e-8). Their gradients can
-    # therefore differ at the ~``gmres_tol`` level, which after two optimizer
-    # steps (lr=1e-2) shows up as an energy/tensor disagreement of order 1e-5.
-    # A 1e-6 match is thus tighter than the solvers themselves and fails on
-    # some platforms' BLAS (observed CI diff ≈ 1.8e-5). Assert agreement at the
-    # solver-tolerance scale instead — still tight enough to catch a genuine
-    # method discrepancy (which would be orders of magnitude larger).
-    assert abs(float(E_fp) - float(E_gmres)) < 1e-4, (
-        f"Energies should match within solver tolerance: "
-        f"fixed_point={float(E_fp)}, gmres={float(E_gmres)}, "
-        f"diff={abs(float(E_fp) - float(E_gmres))}"
+    assert abs(float(E_fp) - float(E_gmres)) < 1e-6, (
+        f"one-step energies should match: fixed_point={float(E_fp)}, "
+        f"gmres={float(E_gmres)}, diff={abs(float(E_fp) - float(E_gmres))}"
     )
-
     A_fp_arr = np.asarray(A_fp.todense() if hasattr(A_fp, "todense") else A_fp)
     A_gmres_arr = np.asarray(
         A_gmres.todense() if hasattr(A_gmres, "todense") else A_gmres
@@ -87,9 +128,9 @@ def test_fixed_point_matches_gmres_at_chi8():
     np.testing.assert_allclose(
         A_fp_arr,
         A_gmres_arr,
-        rtol=1e-3,
-        atol=1e-5,
-        err_msg=("Final tensors should match element-wise within solver tolerance"),
+        rtol=1e-5,
+        atol=1e-6,
+        err_msg="one-step tensors should match within solver tolerance",
     )
 
 


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Closes #740.

## What #740's 7 failures actually were

Root-caused each one; they are three unrelated causes, not one.

| Failures | Cause | Action |
|---|---|---|
| `test_split_absorb_bitidentical_on_shared_env` ×3 | **Real bug** — #710 fixed the fused corner convention and left the split twins stale | Fixed here |
| `test_fixed_point_matches_gmres_at_chi8` | **Test asserts the wrong quantity** — broken by #710, which documents the mechanism | Test rewritten |
| `test_ctm_sharding_backward`, `test_reduced_corner_qr` ×2 | **Stale local `.venv` only** — `uv.lock` is gitignored, CI already resolves jax fresh | Nothing to change |

## 1. Split-CTM corner convention (the real bug)

PR #710 (#702) fixed the 2x2 corner label convention in `_ctm_tensor_absorb_{right,top,bottom}_2plaq` and their fermionic twins. It did not touch the split-CTM twins in `_split_ctm_tensor_moves.py`, written earlier (#684, 2026-07-03) — separate code, so the convention change did not propagate. The split path kept writing C1/C2/C3/C4 transposed.

The failing set matches #710's own summary exactly — *"the TOP move's C1, the RIGHT move's C2, and the BOTTOM move's C4+C3"* — which is why LEFT was the one direction that stayed green.

Six line-targeted edits, the split-file analogue of #710: four transposed corner writes, plus the RIGHT move's C3 read pairing (`c3_l <-> t3_l`) and its projector env leg.

**Evidence.** `_one_minus_fidelity(split, fused)` on one shared env and one shared projector pair:

| sweeps | left | right | top | bottom |
|---|---|---|---|---|
| 0 (before) | 0 | 7.3e-1 | 8.2e-1 | 5.5e-1 |
| 1 (before) | 0 | 5.1e-1 | 6.4e-1 | 1.6e-1 |
| 5 (before) | 0 | 1.9e-3 | 3.5e-3 | 1.3e-2 |
| **any (after)** | **≤4.4e-16** | **≤4.4e-16** | **≤4.4e-16** | **≤4.4e-16** |

The error used to shrink as the env converged — a converged env is nearly symmetric, so a transposed corner nearly agrees. That is why it read as a small numerical discrepancy instead of a wrong contraction. The parity is convergence-independent again, as the test docstring claims.

**Second, independent confirmation:** dense split-CTM implicit-vs-explicit AD parity (the #687 repro) improves from `rel 5.5e-4` to `2.9e-14` — machine-exact.

## 2. Adjoint-method test

Bisect: green at `3f25688^`, red at `3f25688`. #710 broke it, and #710's own message predicts this — restoring ket-bra Z2 at the fixed point makes the projector singular values exactly degenerate, so their LAPACK basis choice is trajectory-, platform- and jax-version-dependent.

`adjoint_method` only selects the *backward* solver; both methods see the identical forward, so the invariant is **gradient equality**. Measured at a single evaluation: `cos = 1.000000000000`, `rel = 1.9e-7` — well inside `gmres_tol`. The old test instead compared `optimize_gs_ad` end states after 2 steps, which measures amplification:

| steps | \|dE\| | max\|dA\| |
|---|---|---|
| 1 | 2.2e-09 | 1.3e-08 |
| 2 | 5.3e-06 | **3.8e-03** ← old assertion point |
| 3 | 5.2e-03 | 5.0e-02 |

Now gates the gradient directly (`rel < 1e-5`) plus a one-step `optimize_gs_ad` parity for the production path. Runtime drops from minutes to ~16 s.

## 3. jax versions — no repo change needed

`uv.lock` is gitignored (`.gitignore:39`, deliberate: tenax is a published library) and CI runs a bare `uv sync`, so **CI already resolves jax fresh** to 0.10.2 / 0.11.0. The 0.9.2 pin was purely a stale local `.venv`. Verified all three tests pass on jax 0.10.2 (py3.11) and 0.11.0 (py3.12). Refreshing the local environment is the whole fix.

## 4. Daily full-suite run

Required checks run only `pytest -m core`; everything else runs on push-to-main or behind the `run-full-tests` label, with nothing reporting it. Adds a 07:00 UTC schedule plus `workflow_dispatch`, reusing the existing bucket matrix. Note this adds a daily macOS bucket run to the billing footprint.

## Verification

- `pytest -m core`: **1290 passed, 8 skipped** (required gate)
- All 7 tests from #740: **pass** (28 passed in the affected files)
- Split-CTM + integration suite: **147 passed, 1 failed**

The one remaining failure is `test_kagome_cg_split_energy_matches_shim` (8.9e-3 vs a 1e-9 gate). It reproduces **bit-identically** on pristine HEAD and at `67e6752` (#740's own baseline), so it is pre-existing and untouched by this PR. It is `@pytest.mark.slow`, which is why #740's `-m "not slow"` scan never saw it — **the `slow` bucket was never scanned at all**. Filed separately.

Also added a comment block above the split absorb section explaining that these four kernels must track their fused counterparts, so the next convention change does not repeat this.