### PR TITLE
fix(#689): honour left_labels/right_labels in the block-sparse decompositions

### DIFF
--- a/src/tenax/linalg.py
+++ b/src/tenax/linalg.py
@@ -35,6 +35,27 @@ from tenax.core.tensor import (
 # ---------- Shared helpers ----------
 
 
+def _block_in_decomp_order(block, decomp_perm: tuple[int, ...]):
+    """Transpose a sector block into ``left_axes + right_axes`` order (#689).
+
+    Block-sparse blocks are stored in the tensor's *native* axis order, but the
+    matrix assembled by the decompositions below is indexed by ``left_labels``
+    rows against ``right_labels`` columns.  Reshaping a block without this
+    transpose flattens it in the wrong order whenever the requested split is
+    not the identity permutation of the stored axes, so the decomposition
+    silently operates on a permuted matrix and returns finite but wrong
+    factors.  The dense paths already do the equivalent ``jnp.transpose(dense,
+    left_axes + right_axes)``; this is the block-sparse counterpart.
+
+    Uses the array's own ``.transpose`` so numpy-backed and JAX-backed blocks
+    each keep their type.  Identity permutations return the block untouched, so
+    the common in-order case costs nothing.
+    """
+    if decomp_perm == tuple(range(len(decomp_perm))):
+        return block
+    return block.transpose(decomp_perm)
+
+
 def _dense_svd(
     matrix: jax.Array,
     full_matrices: bool = False,
@@ -336,7 +357,9 @@ def _truncated_svd_symmetric(
             ri = right_subkeys_seen[rk]
             row_start = sum(left_row_sizes[:li])
             col_start = sum(right_col_sizes[:ri])
-            flat_block = block.reshape(left_row_sizes[li], right_col_sizes[ri])
+            flat_block = _block_in_decomp_order(block, decomp_perm).reshape(
+                left_row_sizes[li], right_col_sizes[ri]
+            )
             # Apply Koszul sign for leg reordering (original -> left+right)
             if is_fermionic:
                 full_key = [0] * len(tensor.indices)
@@ -725,7 +748,9 @@ def _truncated_svd_symmetric_traced(
             ri = right_subkeys_seen[rk]
             row_start = sum(left_row_sizes[:li])
             col_start = sum(right_col_sizes[:ri])
-            flat_block = block.reshape(left_row_sizes[li], right_col_sizes[ri])
+            flat_block = _block_in_decomp_order(block, decomp_perm).reshape(
+                left_row_sizes[li], right_col_sizes[ri]
+            )
             if is_fermionic:
                 full_key = [0] * len(tensor.indices)
                 for ax, ch in zip(left_axes, lk):
@@ -1000,7 +1025,7 @@ def _truncated_svd_symmetric_np(
             ri = right_subkeys_seen[rk]
             row_start = sum(left_row_sizes[:li])
             col_start = sum(right_col_sizes[:ri])
-            flat_block = np.asarray(block).reshape(
+            flat_block = _block_in_decomp_order(np.asarray(block), decomp_perm).reshape(
                 left_row_sizes[li], right_col_sizes[ri]
             )
             # Apply Koszul sign for leg reordering (original -> left+right)
@@ -1229,7 +1254,7 @@ def _qr_symmetric_np(
             ri = right_subkeys_seen[rk]
             row_start = sum(left_row_sizes[:li])
             col_start = sum(right_col_sizes[:ri])
-            flat_block = np.asarray(block).reshape(
+            flat_block = _block_in_decomp_order(np.asarray(block), decomp_perm).reshape(
                 left_row_sizes[li], right_col_sizes[ri]
             )
             # Apply Koszul sign for leg reordering (original -> left+right)
@@ -1408,7 +1433,9 @@ def _qr_symmetric(
             ri = right_subkeys_seen[rk]
             row_start = sum(left_row_sizes[:li])
             col_start = sum(right_col_sizes[:ri])
-            flat_block = block.reshape(left_row_sizes[li], right_col_sizes[ri])
+            flat_block = _block_in_decomp_order(block, decomp_perm).reshape(
+                left_row_sizes[li], right_col_sizes[ri]
+            )
             # Apply Koszul sign for leg reordering (original -> left+right)
             if is_fermionic:
                 full_key = [0] * len(tensor.indices)
@@ -1606,7 +1633,9 @@ def _eigh_symmetric(
             ri = right_subkeys_seen[rk]
             row_start = sum(left_row_sizes[:li])
             col_start = sum(right_col_sizes[:ri])
-            flat_block = block.reshape(left_row_sizes[li], right_col_sizes[ri])
+            flat_block = _block_in_decomp_order(block, decomp_perm).reshape(
+                left_row_sizes[li], right_col_sizes[ri]
+            )
             # Apply Koszul sign for leg reordering (original -> left+right)
             if is_fermionic:
                 full_key = [0] * len(tensor.indices)
@@ -2001,7 +2030,9 @@ def _rsvd_symmetric(
             ri = right_subkeys_seen[rk]
             row_start = sum(left_row_sizes[:li])
             col_start = sum(right_col_sizes[:ri])
-            flat_block = block.reshape(left_row_sizes[li], right_col_sizes[ri])
+            flat_block = _block_in_decomp_order(block, decomp_perm).reshape(
+                left_row_sizes[li], right_col_sizes[ri]
+            )
             if is_fermionic:
                 full_key = [0] * len(tensor.indices)
                 for ax, ch in zip(left_axes, lk):

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -933,3 +933,200 @@ def test_svd_bond_labels_are_canonical_for_either_left_leg_flow(name, sym, secto
     assert seen["OUT"] == canon(sym.dual(np.array(seen["IN"], dtype=np.int32))), (
         f"{name}: mirrored bond labels are not the canonical dual: {seen}"
     )
+
+
+# ------------------------------------------------------------------ #
+# #689 — block-sparse decompositions must honour left/right label      #
+# order rather than the tensor's native stored axis order.             #
+# ------------------------------------------------------------------ #
+
+
+@pytest.fixture
+def u1_sym_tensor_3leg_mult2():
+    """3-leg U(1) tensor whose every charge sector has multiplicity 2.
+
+    Multiplicity matters here: with multiplicity 1 on every charge, each sector
+    block is 1x1x1 and reshaping it in native versus ``left+right`` axis order
+    gives the identical matrix — so a multiplicity-1 fixture cannot detect #689
+    at all.  Repeating each charge twice makes the blocks 2x2x2, where the two
+    orders genuinely differ.
+    """
+    sym = U1Symmetry()
+    pl = np.array([0, 0, 1, 1], dtype=np.int32)  # phys / left: charges {0,1} x2
+    r = np.array([0, 0, 1, 1, 2, 2], dtype=np.int32)  # right: {0,1,2} x2
+    indices = (
+        TensorIndex.from_charges(sym, pl, IN, label="phys"),
+        TensorIndex.from_charges(sym, pl, IN, label="left"),
+        TensorIndex.from_charges(sym, sym.dual(r), OUT, label="right"),
+    )
+    return SymmetricTensor.random_normal(indices, jax.random.PRNGKey(7))
+
+
+def _reference_in_split_order(tensor, left_labels, right_labels):
+    """``tensor`` densified and transposed to ``left_labels + right_labels``."""
+    stored = list(tensor.labels())
+    perm = tuple(stored.index(lbl) for lbl in list(left_labels) + list(right_labels))
+    return np.asarray(tensor.todense()).transpose(perm)
+
+
+def _contract_over_bond(left_factor, right_factor, scale=None):
+    """Contract ``(left..., bond)`` against ``(bond, right...)``, optionally
+    scaling the bond by ``scale`` (the singular values)."""
+    lf = np.asarray(left_factor.todense())
+    rf = np.asarray(right_factor.todense())
+    if scale is not None:
+        lf = lf * np.asarray(scale).reshape((1,) * (lf.ndim - 1) + (-1,))
+    return np.tensordot(lf, rf, axes=([lf.ndim - 1], [0]))
+
+
+class TestBlockSparseDecompLabelOrder:
+    """``svd``/``qr``/``eigh`` accept ``left_labels``/``right_labels``, but the
+    block-sparse path reshaped each sector block in its *native* stored axis
+    order — silently decomposing a permuted matrix (#689).
+
+    Each case requests a split whose ``left + right`` concatenation is NOT the
+    identity permutation of the stored axes, on a fixture with multiplicity 2,
+    which is exactly when the two orders disagree.  The dense path already
+    transposes to ``left_axes + right_axes`` before reshaping, so it defines
+    the contract.  Reconstruction is gauge-free, so it holds for any correct
+    decomposition regardless of basis choice.
+    """
+
+    LEFT = ["left"]
+    RIGHT = ["phys", "right"]  # stored order is (phys, left, right)
+
+    def test_qr_reconstructs_under_permuted_label_split(self, u1_sym_tensor_3leg_mult2):
+        """Q·R == T when left_labels+right_labels reorders the stored axes."""
+        from tenax.linalg import qr
+
+        T = u1_sym_tensor_3leg_mult2
+        Q, R = qr(T, left_labels=self.LEFT, right_labels=self.RIGHT)
+        np.testing.assert_allclose(
+            _contract_over_bond(Q, R),
+            _reference_in_split_order(T, self.LEFT, self.RIGHT),
+            atol=1e-12,
+        )
+
+    def test_svd_reconstructs_under_permuted_label_split(
+        self, u1_sym_tensor_3leg_mult2
+    ):
+        """U·diag(S)·Vh == T when the requested split reorders the stored axes."""
+        from tenax.linalg import svd
+
+        T = u1_sym_tensor_3leg_mult2
+        U, S, Vh, _ = svd(T, left_labels=self.LEFT, right_labels=self.RIGHT)
+        np.testing.assert_allclose(
+            _contract_over_bond(U, Vh, scale=S),
+            _reference_in_split_order(T, self.LEFT, self.RIGHT),
+            atol=1e-12,
+        )
+
+    def test_qr_symmetric_matches_dense_under_permuted_split(
+        self, u1_sym_tensor_3leg_mult2
+    ):
+        """Block-sparse QR reconstructs the same tensor as the dense path."""
+        from tenax.linalg import qr
+
+        T = u1_sym_tensor_3leg_mult2
+        T_dense = DenseTensor(T.todense(), T.indices)
+        np.testing.assert_allclose(
+            _contract_over_bond(*qr(T, self.LEFT, self.RIGHT)),
+            _contract_over_bond(*qr(T_dense, self.LEFT, self.RIGHT)),
+            atol=1e-12,
+        )
+
+    def test_rsvd_reconstructs_under_permuted_label_split(
+        self, u1_sym_tensor_3leg_mult2
+    ):
+        """Randomized SVD also assembles its blocks in the requested order.
+
+        ``rank`` exceeds the true per-sector rank, so HMT randomized SVD is
+        essentially exact here and reconstruction is still the right invariant.
+        """
+        from tenax.linalg import rsvd
+
+        T = u1_sym_tensor_3leg_mult2
+        U, S, Vh = rsvd(
+            T, left_labels=self.LEFT, right_labels=self.RIGHT, rank=8, oversampling=6
+        )
+        np.testing.assert_allclose(
+            _contract_over_bond(U, Vh, scale=S),
+            _reference_in_split_order(T, self.LEFT, self.RIGHT),
+            atol=1e-8,
+        )
+
+
+@pytest.fixture
+def u1_hermitian_4leg_mult2():
+    """4-leg U(1) tensor, Hermitian under the ``(a,b) | (c,d)`` bipartition.
+
+    Multiplicity 2 on every charge so the sector blocks are 2x2x2x2, where
+    native-order and ``left+right``-order flattening genuinely differ (#689).
+    """
+    sym = U1Symmetry()
+    c = np.array([0, 0, 1, 1], dtype=np.int32)
+    indices = (
+        TensorIndex.from_charges(sym, c, IN, label="a"),
+        TensorIndex.from_charges(sym, c, IN, label="b"),
+        TensorIndex.from_charges(sym, sym.dual(c), OUT, label="c"),
+        TensorIndex.from_charges(sym, sym.dual(c), OUT, label="d"),
+    )
+    # Project onto the allowed sectors FIRST, then symmetrize.  Legs c/d are
+    # the duals of a/b in the same index order, so the charge condition is
+    # invariant under (a,b) <-> (c,d) and symmetrizing keeps the result inside
+    # the allowed sectors.  Symmetrizing a dense random matrix instead would
+    # leave most of its weight outside them.
+    T0 = SymmetricTensor.random_normal(indices, jax.random.PRNGKey(11))
+    M = np.asarray(T0.todense()).reshape(16, 16)
+    M = M + M.T
+    return SymmetricTensor.from_dense(jnp.asarray(M.reshape(4, 4, 4, 4)), indices)
+
+
+def test_eigh_reconstructs_under_permuted_label_split(u1_hermitian_4leg_mult2):
+    """``eigh``: V·diag(w)·V^dag == T when the split reorders the stored axes.
+
+    Rows and columns are permuted consistently (``b,a | d,c``) so the matrix
+    stays Hermitian; the permutation ``(1,0,3,2)`` is still non-identity, which
+    is what #689 turns on.
+    """
+    T = u1_hermitian_4leg_mult2
+    left, right = ["b", "a"], ["d", "c"]
+    V, w = eigh(T, left_labels=left, right_labels=right)
+    Vd = np.asarray(V.todense()).reshape(16, -1)
+    recon = (Vd * np.asarray(w)[None, :]) @ Vd.conj().T
+    ref = _reference_in_split_order(T, left, right).reshape(16, 16)
+    np.testing.assert_allclose(recon, ref, atol=1e-10)
+
+
+def test_traced_svd_honors_permuted_label_split(u1_sym_tensor_3leg_mult2):
+    """The traced (jit/AD) SVD path assembles blocks in the requested order too.
+
+    ``_truncated_svd_symmetric_traced`` is a separate implementation reached
+    when the blocks are tracers, so it needs its own guard against #689.
+
+    The probe is the nuclear norm ``sum(s)``, which depends on *how* the tensor
+    is folded into a matrix.  (``sum(s**2)`` — what the other traced-SVD tests
+    use — is the Frobenius norm and is invariant under any reshuffling of
+    elements, so it cannot detect a mis-ordered block assembly.)
+
+    The reference is computed densely from the correctly folded matrix, NOT
+    from the eager block-sparse path: both block-sparse paths shared the same
+    defect, so comparing them against each other agrees while both are wrong.
+    Per-sector singular values are the singular values of the block-diagonal
+    matrix, so the two nuclear norms are equal for a correct implementation.
+    """
+    T = u1_sym_tensor_3leg_mult2
+    left, right = ["left"], ["phys", "right"]
+    leaves, treedef = jax.tree_util.tree_flatten(T)
+    x0 = leaves[0]
+
+    def loss(x):
+        Tx = jax.tree_util.tree_unflatten(treedef, [x])
+        _, s, _, _ = svd(Tx, left, right, max_singular_values=None)
+        return jnp.sum(s)
+
+    folded = _reference_in_split_order(T, left, right).reshape(4, 24)
+    expected = float(np.linalg.svd(folded, compute_uv=False).sum())
+
+    # jit forces the blocks to be tracers -> _truncated_svd_symmetric_traced.
+    np.testing.assert_allclose(float(jax.jit(loss)(x0)), expected, rtol=1e-10)

--- a/tests/test_linalg_np.py
+++ b/tests/test_linalg_np.py
@@ -197,3 +197,69 @@ class TestQrSymmetricNp:
             np.asarray(recon_jax.todense()),
             atol=1e-12,
         )
+
+
+# ------------------------------------------------------------------ #
+# #689 — the numpy block-sparse variants must honour left/right label  #
+# order rather than the tensor's native stored axis order.             #
+# ------------------------------------------------------------------ #
+
+
+@pytest.fixture
+def sym_3leg_mult2():
+    """3-leg U(1) tensor with multiplicity 2 in every charge sector.
+
+    Multiplicity is what makes #689 detectable: with multiplicity 1 each sector
+    block is 1x1x1 and reshaping it in native versus ``left+right`` axis order
+    yields the same matrix, so a multiplicity-1 fixture cannot see the bug.
+    """
+    sym = U1Symmetry()
+    pl = np.array([0, 0, 1, 1], dtype=np.int32)
+    r = np.array([0, 0, 1, 1, 2, 2], dtype=np.int32)
+    indices = (
+        TensorIndex.from_charges(sym, pl, IN, label="phys"),
+        TensorIndex.from_charges(sym, pl, IN, label="left"),
+        TensorIndex.from_charges(sym, sym.dual(r), OUT, label="right"),
+    )
+    return SymmetricTensor.random_normal(indices, jax.random.PRNGKey(7))
+
+
+def _split_order_reference(tensor, left_labels, right_labels):
+    """``tensor`` densified and transposed to ``left_labels + right_labels``."""
+    stored = list(tensor.labels())
+    perm = tuple(stored.index(lbl) for lbl in list(left_labels) + list(right_labels))
+    return np.asarray(tensor.todense()).transpose(perm)
+
+
+def test_qr_symmetric_np_honors_permuted_label_split(sym_3leg_mult2):
+    """``_qr_symmetric_np``: Q·R == T when the split reorders the stored axes.
+
+    Stored order is ``(phys, left, right)``; requesting ``left | phys, right``
+    makes ``left_axes + right_axes`` a non-identity permutation, which is
+    exactly when native-order reshaping decomposes the wrong matrix (#689).
+    """
+    T = sym_3leg_mult2
+    left, right = ["left"], ["phys", "right"]
+    Q_ba, R_ba = _qr_symmetric_np(T, left, right, "bond")
+    Q = np.asarray(ba_to_symmetric(Q_ba).todense())
+    R = np.asarray(ba_to_symmetric(R_ba).todense())
+    recon = np.tensordot(Q, R, axes=([Q.ndim - 1], [0]))
+    np.testing.assert_allclose(
+        recon, _split_order_reference(T, left, right), atol=1e-12
+    )
+
+
+def test_truncated_svd_symmetric_np_honors_permuted_label_split(sym_3leg_mult2):
+    """``_truncated_svd_symmetric_np``: U·diag(s)·Vh == T under a permuted split."""
+    T = sym_3leg_mult2
+    left, right = ["left"], ["phys", "right"]
+    U_ba, s, Vh_ba, _ = _truncated_svd_symmetric_np(
+        T, left, right, None, None, "bond", False
+    )
+    U = np.asarray(ba_to_symmetric(U_ba).todense())
+    Vh = np.asarray(ba_to_symmetric(Vh_ba).todense())
+    U = U * np.asarray(s).reshape((1,) * (U.ndim - 1) + (-1,))
+    recon = np.tensordot(U, Vh, axes=([U.ndim - 1], [0]))
+    np.testing.assert_allclose(
+        recon, _split_order_reference(T, left, right), atol=1e-12
+    )


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Closes #689.

## The defect

The block-sparse `svd`/`qr`/`eigh`/`rsvd` accept `left_labels` and `right_labels`, but reshaped each charge-sector block in the tensor's **native** stored axis order:

```python
flat_block = block.reshape(left_row_sizes[li], right_col_sizes[ri])
```

`left_row_sizes` is computed from the *requested* axes while `block` is still in *stored* order, so the two agree only when `left_axes + right_axes` is the identity permutation. Otherwise the assembled matrix is a scrambled fold and the decomposition returns finite but wrong factors.

The dense paths already do `jnp.transpose(dense, left_axes + right_axes)` before reshaping, so they define the contract. This adds the block-sparse counterpart (`_block_in_decomp_order`) at all **seven** assembly sites:

| | |
|---|---|
| `_truncated_svd_symmetric` | `_truncated_svd_symmetric_np` |
| `_truncated_svd_symmetric_traced` | `_qr_symmetric_np` |
| `_qr_symmetric` | `_rsvd_symmetric` |
| `_eigh_symmetric` | |

Identity permutations return the block untouched, so the common in-order case is unchanged and costs nothing. The helper uses the array's own `.transpose`, so the `_np` variants keep numpy arrays and the JAX variants keep JAX arrays.

**Bonus fix:** `_koszul_sign(parities, decomp_perm)` was already being applied for a leg reordering the data never underwent — the comment literally reads *"Apply Koszul sign for leg reordering (original -> left+right)"*. Sign and permutation now agree.

## Tests — 8 new, all mutation-checked

Every one fails with the fix reverted and passes with it (verified by stashing `linalg.py`), one per code path.

**Multiplicity is why this went unnoticed.** With multiplicity 1, each sector block is `1x1x...x1` and both orders give the same matrix — the existing fixtures *cannot* see the bug. My first attempt used `u1_sym_tensor_3leg` and two of three tests passed against known-broken code. The new fixtures use multiplicity 2.

**The traced-path test needed particular care.** Comparing the traced result against the eager one passes even with the fix reverted, because both paths shared the defect — so it is checked against a dense reference instead. Its probe is the nuclear norm `sum(s)`, which depends on how the tensor is folded; `sum(s**2)`, used by the neighbouring traced-SVD tests, is the Frobenius norm and is invariant under any reshuffle, so it cannot detect this at all.

## Verification

| suite | result |
|---|---|
| `pytest -m core` | **1298 passed**, 8 skipped (1290 baseline + 8 new) |
| linalg + linalg_np | 63 passed |
| fermionic ×5 files | 140 passed — highest risk, since the Koszul sign now pairs with a real permutation |
| DMRG / iDMRG / symmetric-CTM projectors / split-CTM symmetric / symmetry / tensor | 354 passed |

## Relationship to #687

**Independent.** I re-ran #687's repro before and after: `sym-vs-dense` stays at `rel 1.7e-2`, bit-for-bit. The split-CTM callers pre-canonicalise their leg order, so the traced path there was already receiving identity permutations. #687's block-sparse SVD-backward floor is a separate defect.

Those caller-side workarounds (`_canonical_split_corner`, the explicit transpose in `_svd_split_edge_tensor`) are now redundant but harmless. Removing them is deliberately left to a separate change rather than folded into this one.