### PR TITLE
chore: align pre-commit hook with CI lint scope

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.15
     hooks:
-      - id: ruff
+      # Scoped to CI's lint scope (`ruff check src/ tests/`). examples/,
+      # benchmarks/ and docs/ have never been held to these rules, so an
+      # unscoped hook reformats ~45 example files on first touch.
+      - id: ruff-check
         args: [--fix]
+        files: ^(src|tests)/
       - id: ruff-format
+        files: ^(src|tests)/


### PR DESCRIPTION
## Problem

The pre-commit hook and CI disagree about what gets linted.

- **CI** runs only `uv run ruff check src/ tests/` (`.github/workflows/ci.yml:44,223`) — it never touches `examples/`, `benchmarks/` or `docs/`, and never runs `ruff format` at all.
- **The hook** ran `ruff` + `ruff-format` unscoped, across the entire repo.

Consequence: `pre-commit run --all-files` on a clean `main` reformats **66 files** (45 under `examples/`, 16 `tests/`, 4 `src/`, 1 `.claude/`) and reports 31 lint errors CI does not gate on. Anyone touching an example file gets an unexpected reformat mid-commit.

## Change

Config-only, one file:

- Scope both hooks to `^(src|tests)/`, matching CI's scope exactly.
- Bump the pin `v0.15.2` → `v0.15.15`, the version the project env actually resolves. Formatter output can shift between patch releases, so a stale pin makes the hook and a manual `uv run ruff format` fight each other.
- `ruff` → `ruff-check`: upstream marks the old id `# Legacy alias` in its manifest and it now prints as `ruff (legacy alias)`.

## Verification

- `uv run ruff check src/ tests/` (CI's exact command) → `All checks passed!` on `main`, before and after. This PR changes only which files the *local* hook visits, not CI.
- Hook skips `examples/`: `pre-commit run --files examples/*.py` → both hooks `Skipped (no files to check)`.
- Hook still catches real violations in scope: a staged probe file in `src/` with an unused import → `ruff check ... Failed`, `Found 1 error (1 fixed)`.

## Deliberately not done

`src/` and `tests/` are lint-clean but **not** format-clean — 21 files would be reformatted, because CI has never run `ruff format`. Formatting them here would conflict with the in-flight `fix/734-*`, `fix/740-*` and friends, so they're left to be reformatted lazily as each file is next touched.

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.