### PR TITLE
fix(#725, #742): trace-normalise the RDM before symmetrising on the split-CTM and PESS paths

### DIFF
--- a/src/tenax/algorithms/_pess_multisite_energy.py
+++ b/src/tenax/algorithms/_pess_multisite_energy.py
@@ -20,6 +20,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from tenax.algorithms._ctm_tensor_energy import (
+    _normalise_rdm,
     _rdm1x2_tensor_2site,
     _rdm2x1_tensor_2site,
 )
@@ -30,7 +31,6 @@ from tenax.algorithms._ctm_tensor_init import (
 )
 from tenax.algorithms.pess import _site_ops
 from tenax.contraction.contractor import contract
-from tenax.core import EPS
 from tenax.core.tensor import Tensor
 
 __all__ = [
@@ -183,8 +183,7 @@ def _rdm_3site_marginal_vw_row(
     rdm = rdm_t.todense()
     d_phys = rdm.shape[0]
     rdm_mat = rdm.reshape(d_phys * d_phys, d_phys * d_phys)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-    rdm_mat = rdm_mat / (jnp.trace(rdm_mat) + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d_phys, d_phys, d_phys, d_phys)
 
 
@@ -270,8 +269,7 @@ def _rdm_3site_marginal_vw_col(
     rdm = rdm_t.todense()
     d_phys = rdm.shape[0]
     rdm_mat = rdm.reshape(d_phys * d_phys, d_phys * d_phys)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-    rdm_mat = rdm_mat / (jnp.trace(rdm_mat) + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d_phys, d_phys, d_phys, d_phys)
 
 

--- a/src/tenax/algorithms/_split_ctm_tensor_energy.py
+++ b/src/tenax/algorithms/_split_ctm_tensor_energy.py
@@ -18,11 +18,11 @@ __all__ = [
 import jax
 import jax.numpy as jnp
 
+from tenax.algorithms._ctm_tensor_energy import _normalise_rdm
 from tenax.algorithms._ctm_tensor_init import CTMTensorEnv
 from tenax.algorithms._split_ctm_tensor_init import SplitCTMTensorEnv
 from tenax.algorithms._tensor_utils import fuse_indices
 from tenax.contraction.contractor import contract
-from tenax.core import EPS
 from tenax.core.index import FlowDirection
 from tenax.core.tensor import Tensor
 
@@ -178,8 +178,7 @@ def _rdm_1site_split_tensor(A: Tensor, env: SplitCTMTensorEnv) -> jax.Array:
     )  # consumes u_bra, l_bra, r_bra, d_bra
 
     rdm = rdm_t.todense()
-    rdm = 0.5 * (rdm + rdm.conj().T)
-    rdm = rdm / (jnp.trace(rdm) + EPS)
+    rdm = _normalise_rdm(rdm)
     return rdm
 
 
@@ -307,8 +306,7 @@ def _rdm1x2_split_tensor(A: Tensor, env: SplitCTMTensorEnv) -> jax.Array:
     rdm = rdm_t.todense()
     d = rdm.shape[0]
     rdm_mat = rdm.reshape(d * d, d * d)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-    rdm_mat = rdm_mat / (jnp.trace(rdm_mat) + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d, d, d, d)
 
 
@@ -441,8 +439,7 @@ def _rdm2x1_split_tensor(A: Tensor, env: SplitCTMTensorEnv) -> jax.Array:
     rdm = rdm_t.todense()
     d = rdm.shape[0]
     rdm_mat = rdm.reshape(d * d, d * d)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-    rdm_mat = rdm_mat / (jnp.trace(rdm_mat) + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d, d, d, d)
 
 
@@ -665,8 +662,7 @@ def _rdm_diagonal_split_tensor(A: Tensor, env: SplitCTMTensorEnv) -> jax.Array:
     rdm = rdm_t.todense()
     d = rdm.shape[0]
     rdm_mat = rdm.reshape(d * d, d * d)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-    rdm_mat = rdm_mat / (jnp.trace(rdm_mat) + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d, d, d, d)
 
 
@@ -812,13 +808,16 @@ def _rdm1x2_split_tensor_2site(
     rdm = rdm_t.todense()
     d = rdm.shape[0]
     rdm_mat = rdm.reshape(d * d, d * d)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-
     # Trace-floor guard: if the split contraction's trace lands in the
     # catastrophic-cancellation regime, fall back to the shim path so the
     # atol=1e-10 parity tolerance holds.  Eager Python branch — these RDM
     # routines are not jit-traced anywhere in the codebase (energy probes
     # only).  ``.item()`` forces a host sync.
+    #
+    # Guard on the *raw* trace, before symmetrising.  ``tr Herm(R) = Re(tr R)``,
+    # which is not gauge-invariant: an environment phase near pi/2 drives the
+    # real part through zero while ``|tr R|`` stays O(1), so guarding the
+    # symmetrised trace fires the fallback on a perfectly healthy RDM.
     trace_val = jnp.trace(rdm_mat)
     if float(jnp.abs(trace_val).item()) < _MIXED_ENV_RDM_TRACE_FLOOR:
         from tenax.algorithms._ctm_tensor_energy import _rdm1x2_tensor_2site
@@ -830,7 +829,7 @@ def _rdm1x2_split_tensor_2site(
             _split_env_to_tensor_standard(env_B),
         )
 
-    rdm_mat = rdm_mat / (trace_val + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d, d, d, d)
 
 
@@ -967,9 +966,8 @@ def _rdm2x1_split_tensor_2site(
     rdm = rdm_t.todense()
     d = rdm.shape[0]
     rdm_mat = rdm.reshape(d * d, d * d)
-    rdm_mat = 0.5 * (rdm_mat + rdm_mat.conj().T)
-
-    # Trace-floor guard: see :func:`_rdm1x2_split_tensor_2site` for rationale.
+    # Trace-floor guard on the raw trace: see
+    # :func:`_rdm1x2_split_tensor_2site` for rationale.
     trace_val = jnp.trace(rdm_mat)
     if float(jnp.abs(trace_val).item()) < _MIXED_ENV_RDM_TRACE_FLOOR:
         from tenax.algorithms._ctm_tensor_energy import _rdm2x1_tensor_2site
@@ -981,7 +979,7 @@ def _rdm2x1_split_tensor_2site(
             _split_env_to_tensor_standard(env_B),
         )
 
-    rdm_mat = rdm_mat / (trace_val + EPS)
+    rdm_mat = _normalise_rdm(rdm_mat)
     return rdm_mat.reshape(d, d, d, d)
 
 

--- a/tests/test_split_ctm_energy_gauge.py
+++ b/tests/test_split_ctm_energy_gauge.py
@@ -1,0 +1,159 @@
+"""Environment-phase (gauge) invariance of the split-CTM energy path.
+
+Regression guard for #725.  Every environment tensor carries an arbitrary
+complex phase -- a gauge of the CTM, fixed by nothing in the sweep -- so the
+raw RDM network is only ever defined up to an overall complex scalar.  The
+energy ``tr(rho H) / tr(rho)`` is a ratio, so it cancels that scalar and every
+phase is separately a null direction.
+
+Symmetrising the RDM *before* trace-normalising does not survive it.  Writing
+the raw RDM as ``H + K`` with ``H`` Hermitian and ``K`` anti-Hermitian,
+
+    Herm(e^{i.phi} (H + K)) = cos(phi) H + sin(phi) iK,
+
+so the phase rescales the physical part by ``cos(phi)`` and mixes ``K`` in with
+weight ``sin(phi)``.  A converged environment has ``|K|/|H| ~ 1e-14``, which
+hides this at generic angles -- the #725 measurement was 1e-14 of movement at
+phi = 0.7 but 5.4e-3 at phi = pi/2, where the cosine annihilates ``H`` outright
+and the energy is computed entirely from the noise in ``K``.  **pi/2 is the
+angle that catches it; a sweep of generic angles passes either way.**
+
+These paths are only observably broken on a complex state: for real data
+``tr Herm(R) = tr R`` and the two orderings agree identically.  Hence the
+complex site tensor below -- the same construction as
+``tests/test_ctm_root_implicit_asym.py::_complex_site_tensor`` so the numbers
+stay comparable with #721.
+
+Companion to ``test_the_energy_is_invariant_under_every_environment_phase`` in
+``tests/test_ctm_root_implicit_asym.py``, which covers the fused path fixed in
+#721/#724.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._split_ctm_tensor_convergence import ctm_split_tensor
+from tenax.algorithms._split_ctm_tensor_energy import compute_energy_split_ctm_tensor
+from tenax.core.tensor import DenseTensor
+
+
+def _oracle():
+    try:
+        from tests._split_ctm_oracle import heisenberg_gate, make_site
+    except ModuleNotFoundError:
+        from _split_ctm_oracle import heisenberg_gate, make_site
+    return make_site, heisenberg_gate
+
+
+def _complex_site(D=2, d=2, seed=7, imag_seed=7, scale=0.25):
+    """The real split-CTM test state plus an imaginary part, renormalised."""
+    make_site, _ = _oracle()
+    A = make_site(D, d, seed=seed)
+    rng = np.random.RandomState(imag_seed)
+    base = np.asarray(A.todense())
+    data = base + scale * 1j * rng.standard_normal(base.shape)
+    data = jnp.asarray(data / np.linalg.norm(data))
+    return DenseTensor(data, A.indices)
+
+
+# The 12 fields of SplitCTMTensorEnv: 4 corners + ket/bra halves of 4 edges.
+_ENV_FIELDS = (
+    "C1",
+    "C2",
+    "C3",
+    "C4",
+    "T1_ket",
+    "T1_bra",
+    "T2_ket",
+    "T2_bra",
+    "T3_ket",
+    "T3_bra",
+    "T4_ket",
+    "T4_bra",
+)
+
+
+@pytest.fixture(scope="module")
+def _converged():
+    A = _complex_site()
+    _, heisenberg_gate = _oracle()
+    gate = heisenberg_gate()
+    env = ctm_split_tensor(A, chi=4, chi_I=8, max_iter=300, conv_tol=0.0)
+    return A, env, gate
+
+
+def _energy_with_phase(A, env, gate, theta, fields):
+    """Energy with ``exp(i.theta)`` applied to each named environment tensor."""
+    phase = jnp.exp(1j * theta)
+    rotated = env._replace(
+        **{name: phase * getattr(env, name) for name in fields},
+    )
+    return float(jnp.real(compute_energy_split_ctm_tensor(A, rotated, gate)))
+
+
+@pytest.mark.parametrize("field", _ENV_FIELDS)
+def test_split_energy_is_invariant_under_each_environment_phase(field, _converged):
+    """A phase on any single split-env tensor cannot move the energy.
+
+    Each of the 12 tensors is tested on its own: the RDM is one network, so a
+    phase on any tensor in it is an overall complex scalar on ``rho``, and all
+    12 phases are separately free rather than only their sum.
+    """
+    A, env, gate = _converged
+    base = _energy_with_phase(A, env, gate, 0.0, ())
+    assert abs(base) > 1e-3, f"degenerate baseline energy {base}"
+
+    for theta in (0.2, 0.7, float(np.pi / 2)):
+        moved = _energy_with_phase(A, env, gate, theta, (field,))
+        assert abs(moved - base) < 1e-11, (field, theta, moved - base)
+
+
+def test_split_energy_is_invariant_under_a_global_environment_phase(_converged):
+    """The same, with the phase on all 12 tensors at once."""
+    A, env, gate = _converged
+    base = _energy_with_phase(A, env, gate, 0.0, ())
+    for theta in (0.2, 0.7, float(np.pi / 2)):
+        moved = _energy_with_phase(A, env, gate, theta, _ENV_FIELDS)
+        assert abs(moved - base) < 1e-11, (theta, moved - base)
+
+
+def test_pi_over_2_is_the_angle_that_catches_the_bug(_converged):
+    """Guard the guard: pi/2 must be materially harder than a generic angle.
+
+    Without it this suite would pass against the pre-#725 ordering.  Reverting
+    ``_normalise_rdm`` to symmetrise-first moves the energy by ~1e-3 at pi/2 and
+    by ~1e-14 at 0.7, so a test that only swept generic angles would have been
+    green on the bug.  This asserts the *raw* RDM really is non-Hermitian enough
+    for the ordering to matter -- i.e. that the test above has teeth.
+    """
+    A, env, gate = _converged
+    base = _energy_with_phase(A, env, gate, 0.0, ())
+
+    # Reproduce the old (buggy) ordering on the same network: symmetrise the
+    # phased RDM first, then trace-normalise.
+    from tenax.algorithms._split_ctm_tensor_energy import _rdm2x1_split_tensor
+
+    rdm = jnp.asarray(_rdm2x1_split_tensor(A, env))
+    d = rdm.shape[0]
+    mat = rdm.reshape(d * d, d * d)
+
+    def old_order(theta):
+        m = jnp.exp(1j * theta) * mat
+        m = 0.5 * (m + m.conj().T)
+        m = m / (jnp.trace(m) + 1e-30)
+        return jnp.real(jnp.einsum("ijkl,ijkl->", m.reshape(d, d, d, d), gate))
+
+    generic = abs(float(old_order(0.7)) - float(old_order(0.0)))
+    at_pi_2 = abs(float(old_order(float(np.pi / 2))) - float(old_order(0.0)))
+    assert at_pi_2 > 1e3 * max(generic, 1e-16), (
+        "pi/2 no longer distinguishes the two orderings, so the invariance "
+        f"tests above have lost their teeth (generic={generic:.3e}, "
+        f"pi/2={at_pi_2:.3e})"
+    )
+    assert abs(base) > 1e-3


### PR DESCRIPTION
Closes #725. Closes #742.

## These are one bug

#725 reported a latent gauge bug; #742 reported an 8.9e-3 energy disagreement that "means one of the two energy contractions is wrong." They are the same defect, and #742's diagnosis was wrong: **the two contractions are byte-identical.** Comparing the raw pre-normalisation RDMs from both paths on the same `env`:

```
max|raw_split - raw_std| = 8.34e-17        (max|raw| = 7.78e-02)
elementwise |ratio| in [1-1.6e-15, 1+2e-15], phase spread 4.3e-16
```

Not a leg order, missing conjugate, double-counted bond, or supersite error. The entire gap is the RDM normalisation ordering.

## The bug

Every CTM environment tensor carries an arbitrary complex phase — a gauge fixed by nothing in the sweep — so a raw RDM is defined only up to an overall complex scalar. With `R = e^{iφ}(H + K)`, `H` Hermitian and `K` anti-Hermitian:

```
Herm(e^{iφ}(H + K)) = cos(φ)·H + sin(φ)·iK
```

Symmetrising first rescales the physical part by `cos φ` and injects `K` with weight `sin φ`. Trace-normalising first cancels the scalar exactly, and symmetrising a gauge-independent object is gauge-independent in turn.

#721/#724 fixed this on the standard path via `_normalise_rdm`; the split-CTM and PESS modules were never updated. This routes all 8 sites through that helper — 6 in `_split_ctm_tensor_energy.py`, 2 in `_pess_multisite_energy.py`.

## Which order is correct — gauge invariance decides

Phasing `env.C1` by `exp(iφ)`:

| φ | shim | split (fixed) | split (pre-fix) |
|---|---|---|---|
| 0.0000 | −0.346533245356 | −0.346533245356 | −0.355393914491 |
| 1.0000 | −0.346533245356 | −0.346533245356 | −0.331867934154 |
| 1.5708 | −0.346533245356 | −0.346533245356 | **−2.893573306668** |

The shim and fixed split path are invariant to 12 digits; the pre-fix path is off by 8× at π/2. Only a gauge-invariant answer can be the physical energy, so **−0.346533** is correct. Independent corroboration: the historical D=4 χ=32 baseline `−0.347185` is 6.5e-4 from the corrected value and 8.9e-3 from the buggy one.

## Why it hid for so long

`tests/_split_ctm_oracle.py::make_site` is **real**, and for real data `tr Herm(R) = tr R` — both orders agree identically. The kagome PESS state is the first *complex* consumer of the split path (`IPESSState.random` seeds complex, SU never projects back to real; `‖Im A‖/‖A‖ = 0.95`). And `|K|/|H|` here is **0.25–0.66**, not the ~1e-14 of a converged env — so this was a full 1e-2 error, not amplified noise.

## One extra change the issue did not anticipate

#725 lists lines 815 and 970 as having "no trace-normalisation follows." They do — at 833 and 984, behind a `_MIXED_ENV_RDM_TRACE_FLOOR` guard. That guard had a **second instance of the same bug**: it measured `jnp.trace` on the already-symmetrised matrix. Since `tr Herm(R) = Re(tr R)` is not gauge-invariant, a phase near π/2 drives it through zero while `|tr R|` stays O(1) — firing the expensive `χ²·D⁶` shim fallback on a perfectly healthy RDM. The guard now reads the raw trace.

## Verification

`tests/test_split_ctm_energy_gauge.py` phases each of the 12 split-env tensors independently at θ ∈ {0.2, 0.7, **π/2**}:

| source | result |
|---|---|
| unfixed `main` | **13 failed**, 1 passed |
| with fix | **14 passed** |

π/2 is what catches it — generic angles move the energy by ~1e-14 either way — so the file also asserts π/2 stays materially harder than a generic angle, or the suite would have been green on the bug.

- `tests/test_split_ctm_large_d_memory.py` (#742's red test): **2 passed**
- Targeted split/PESS/fPEPS sweep, 20 files, `-m "not slow"`: **208 passed, 0 failed**
- Baseline `test_split_ctm_2site.py` before any change: 27 passed (the 3 pre-existing failures #725 warns about were already fixed by #741 — nothing is being excused)

## Blast radius

**Real-valued states are bit-for-bit unchanged** (mathematically identical). Complex-state energies move — reachable via `compute_energy_cg_split`, `compute_energy_split_ctm_tensor{,_2site,_multisite}`, `_split_ctm_energy_ad.py`, and `_pess_multisite_energy` → `compute_energy_pess_3site_multisite`. No test bakes a magic-number energy around the old value; the split/PESS suites assert variational bounds, not point values.

## Follow-up (not in this PR)

The same symmetrise-first pattern survives in 8 more sites outside split-CTM — `ipeps_rdm.py` (4), `ipeps_excitations.py` (2), `_ctm_honeycomb_energy.py` (2). Filed separately to keep a verified fix from growing an unverified tail.

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.