### PR TITLE
fix(#726): reject gs_recipe='2x2' on the single-site split path instead of silently running 1x1

### DIFF
--- a/src/tenax/algorithms/ipeps_ad_policy.py
+++ b/src/tenax/algorithms/ipeps_ad_policy.py
@@ -41,7 +41,19 @@ def validate_ctm_for_implicit_ad(ctm_cfg: CTMConfig) -> None:
         )
 
 
-def validate_split_ctm_config(ctm_cfg: CTMConfig, recipe: str) -> None:
+SINGLE_SITE_SPLIT_RECIPE_ERROR = (
+    "The single-site split-CTM path only implements the '1x1' CTM recipe; got "
+    "gs_recipe={recipe!r}. Set gs_recipe='1x1' to opt in explicitly -- but note "
+    "that '1x1' collapses the environment to rank-1 corners and yields a "
+    "chi-independent (mean-field) energy (#726). For a correct single-site "
+    "environment use the fused path (fuse_virtual_legs=True) with "
+    "gs_recipe='2x2'."
+)
+
+
+def validate_split_ctm_config(
+    ctm_cfg: CTMConfig, recipe: str, *, single_site: bool = False
+) -> None:
     """Reject ``CTMConfig`` combinations the split-CTM path cannot honor.
 
     The split (``fuse_virtual_legs=False``) forward is fixed-χ (single-site or
@@ -62,6 +74,15 @@ def validate_split_ctm_config(ctm_cfg: CTMConfig, recipe: str) -> None:
             "fuse_virtual_legs=False (split CTM) supports gs_recipe in "
             f"('1x1', '2x2'); got recipe={recipe!r}."
         )
+    # Branch-specific narrowing (#726).  Must live here, not only in
+    # ``_split_ctm_energy_fn``: the loss is not called at all when
+    # ``gs_num_steps=0`` (evaluate-only) or when a resumed checkpoint starts at
+    # or beyond the final step, and the final ``_eval_fresh`` then reaches
+    # ``_split_forward``/``converge_split_env`` directly.  A guard that only
+    # sits on the loss path lets those configurations through still returning
+    # the 1x1 chi-independent energy under the default gs_recipe='2x2'.
+    if single_site and recipe != "1x1":
+        raise NotImplementedError(SINGLE_SITE_SPLIT_RECIPE_ERROR.format(recipe=recipe))
     if ctm_cfg.ctmrg_heuristic_increase_chi:
         raise NotImplementedError(
             "in-CTM chi auto-bump (ctmrg_heuristic_increase_chi) is not "
@@ -346,14 +367,12 @@ def make_ctm_energy_fn(
         # measured bit-identical from chi=2 to chi=32 on a physical D=2 SU state
         # — i.e. a chi_eff=1 mean-field boundary, not a corner transfer matrix.
         # Fail loudly rather than return that under the default config.
+        # Defence in depth: the dispatcher below also validates with
+        # ``single_site=True`` before the optimization loop, which is what
+        # covers the loss-never-called paths.  Same message, one source.
         if recipe != "1x1":
             raise NotImplementedError(
-                "The single-site split-CTM path only implements the '1x1' CTM "
-                f"recipe; got gs_recipe={recipe!r}. Set gs_recipe='1x1' to opt "
-                "in explicitly -- but note that '1x1' collapses the environment "
-                "to rank-1 corners and yields a chi-independent (mean-field) "
-                "energy (#726). For a correct single-site environment use the "
-                "fused path (fuse_virtual_legs=True) with gs_recipe='2x2'."
+                SINGLE_SITE_SPLIT_RECIPE_ERROR.format(recipe=recipe)
             )
         if use_explicit:
             # The explicit split forward re-initializes internally; no

--- a/src/tenax/algorithms/ipeps_ad_policy.py
+++ b/src/tenax/algorithms/ipeps_ad_policy.py
@@ -331,6 +331,30 @@ def make_ctm_energy_fn(
                 energy_fn=None,
                 envs_init=envs_init,
             )
+        # Single-site split.  Mirror of the 2-site guard above, and for the same
+        # stated reason: accept-then-silently-run-a-different-recipe mislabels
+        # the experiment.  Every single-site split entry point below runs the
+        # ``1x1`` moves unconditionally, so honouring ``gs_recipe="2x2"`` here is
+        # not possible — and "2x2" is the *default*, so without this guard the
+        # default config silently produced 1x1 results.
+        #
+        # That is not a cosmetic mislabel.  The 1x1 corner-pair projector
+        # collapses the environment to rank-1 corners (#726, same root cause as
+        # #723): ``M = C1g† C4g`` is indexed by the outer chi legs only, so the
+        # updated corner's spectrum is sqrt(spec(M)) and rank(C_new) <=
+        # rank(C1g) = 1 at cold init.  The resulting energy is chi-independent —
+        # measured bit-identical from chi=2 to chi=32 on a physical D=2 SU state
+        # — i.e. a chi_eff=1 mean-field boundary, not a corner transfer matrix.
+        # Fail loudly rather than return that under the default config.
+        if recipe != "1x1":
+            raise NotImplementedError(
+                "The single-site split-CTM path only implements the '1x1' CTM "
+                f"recipe; got gs_recipe={recipe!r}. Set gs_recipe='1x1' to opt "
+                "in explicitly -- but note that '1x1' collapses the environment "
+                "to rank-1 corners and yields a chi-independent (mean-field) "
+                "energy (#726). For a correct single-site environment use the "
+                "fused path (fuse_virtual_legs=True) with gs_recipe='2x2'."
+            )
         if use_explicit:
             # The explicit split forward re-initializes internally; no
             # env_init warm-start yet (perf follow-up).

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -1313,7 +1313,12 @@ def _optimize_gs_ad_tensor(
     if use_split:
         # Shared single source of truth for the CTMConfig-level rejects
         # (recipe + the three χ-changing knobs); see validate_split_ctm_config.
-        validate_split_ctm_config(ctm_cfg, config.gs_recipe)
+        # ``single_site=True`` narrows the recipe to '1x1' here rather than only
+        # inside the loss (#726): with gs_num_steps=0, or a resumed checkpoint
+        # already at the final step, the loss never runs and the final
+        # ``_eval_fresh`` -> ``_split_forward`` would otherwise still return the
+        # 1x1 chi-independent energy under the default gs_recipe='2x2'.
+        validate_split_ctm_config(ctm_cfg, config.gs_recipe, single_site=True)
         # iPEPSConfig-level rejects the shared helper can't see.
         if _use_cg:
             raise NotImplementedError(

--- a/tests/test_split_ctm_chi_frozen_726.py
+++ b/tests/test_split_ctm_chi_frozen_726.py
@@ -145,3 +145,35 @@ def test_single_site_split_rejects_the_default_2x2_recipe():
     _E, tensors, _envs = ipeps(gate, None, cfg)
     with pytest.raises(NotImplementedError, match=r"only implements the '1x1'"):
         optimize_gs_ad(gate, tensors[0], cfg)
+
+
+def test_the_guard_survives_when_the_loss_is_never_called():
+    """``gs_num_steps=0`` must reject too -- the loss-path guard is not enough.
+
+    Evaluate-only mode (and a resumed checkpoint already at or beyond the final
+    step) never calls ``loss_fn``, so a guard living only inside
+    ``_split_ctm_energy_fn`` is bypassed: the final ``_eval_fresh`` reaches
+    ``_split_forward`` -> ``converge_split_env`` directly and still returns the
+    1x1 chi-independent energy under the default ``gs_recipe='2x2'``.  The
+    rejection therefore has to happen in ``validate_split_ctm_config``, before
+    the optimization loop.
+
+    Caught by Codex review on PR #749.
+    """
+    from tenax.algorithms.ipeps_config import iPEPSConfig as Cfg
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    gate = sublattice_rotate_gate(heisenberg_gate())
+    cfg = Cfg(
+        max_bond_dim=2,
+        num_imaginary_steps=2,
+        dt=0.05,
+        unit_cell="1x1",
+        gs_num_steps=0,  # evaluate-only: loss_fn is never invoked
+        ctm=CTMConfig(chi=4, max_iter=20, conv_tol=1e-8, fuse_virtual_legs=False),
+    )
+    assert cfg.gs_recipe == "2x2", "precondition: 2x2 is the default recipe"
+
+    _E, tensors, _envs = ipeps(gate, None, cfg)
+    with pytest.raises(NotImplementedError, match=r"only implements the '1x1'"):
+        optimize_gs_ad(gate, tensors[0], cfg)

--- a/tests/test_split_ctm_chi_frozen_726.py
+++ b/tests/test_split_ctm_chi_frozen_726.py
@@ -1,0 +1,147 @@
+"""Detectors for the #726 rank-1 corner collapse on the ``1x1`` CTM recipe.
+
+The ``1x1`` corner-pair (Fishman) projector -- shared *verbatim* by the fused
+and split single-site paths, so this is not a split-CTM defect -- collapses the
+environment to rank-1 corners.  ``_ctm_projector.py`` forms ``M = C1g† C4g``,
+which is ``chi x chi``: the ``chi·D²`` seam is summed away, so ``M`` sees only
+the outer chi legs.  Since ``C1_new = S^{1/2} U^H``, the updated corner's whole
+spectrum is ``sqrt(spec(M))`` and ``rank(C_new) <= rank(C1g)``, which is 1 at
+cold init.  The corner can never grow rank.
+
+The cheapest possible detector for that is **energy frozen in chi**: a genuine
+corner transfer matrix improves as the boundary grows, a chi_eff=1 mean-field
+boundary does not.  On a physical D=2 SU state the ``1x1`` energy is
+bit-identical from chi=2 to chi=32 (delta exactly 0.0), while the ``2x2``
+recipe converges normally over the same range.
+
+Two guards live here:
+
+* ``test_the_2x2_recipe_energy_is_not_frozen_in_chi`` -- the positive control.
+  It must keep passing; if it ever goes chi-frozen, the *working* recipe has
+  regressed into the same failure mode.
+* ``test_single_site_split_rejects_the_default_2x2_recipe`` -- the production
+  guard.  ``gs_recipe="2x2"`` is the default, and the single-site split path
+  runs ``1x1`` moves unconditionally, so before #726 the default config
+  silently returned mean-field numbers.
+
+The ``1x1`` collapse itself is deliberately *not* asserted as expected
+behaviour here.  Three existing tests were shaped around that symptom (see
+#726); pinning it again would entrench the bug.  Fixing the projector is
+tracked separately.
+"""
+
+from __future__ import annotations
+
+import jax
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_tensor_convergence import _ctm_tensor_multisite
+from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
+from tenax.algorithms.ipeps import heisenberg_gate, ipeps, sublattice_rotate_gate
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+
+# A 1-site unit cell expressed as a multisite problem, so the same entry point
+# serves both recipes (``ctm_tensor`` has no ``recipe`` knob -- it is the fused
+# 1x1 path by construction).
+_ORIGIN = (0, 0)
+_NEIGHBORS = {
+    _ORIGIN: {"left": _ORIGIN, "right": _ORIGIN, "top": _ORIGIN, "bottom": _ORIGIN}
+}
+
+
+@pytest.fixture(scope="module")
+def _su_state():
+    """A physical simple-update state -- not a random tensor.
+
+    The collapse is only meaningful on a state with genuine corner structure:
+    the 2x2 spectrum of this one is ``1, 0.128, 0.127, 0.016, 2.1e-3, 2.0e-3``,
+    whose degenerate pairs are the expected Neel structure.
+    """
+    gate = sublattice_rotate_gate(heisenberg_gate())
+    cfg = iPEPSConfig(
+        max_bond_dim=2,
+        num_imaginary_steps=60,
+        dt=0.05,
+        unit_cell="1x1",
+        ctm=CTMConfig(chi=8, max_iter=100, conv_tol=1e-10),
+    )
+    _E, tensors, _envs = ipeps(gate, None, cfg)
+    return tensors[0], heisenberg_gate()
+
+
+def _env_at(A, chi, recipe):
+    envs = _ctm_tensor_multisite(
+        {_ORIGIN: A},
+        _NEIGHBORS,
+        chi=chi,
+        max_iter=200,
+        conv_tol=1e-12,
+        recipe=recipe,
+    )
+    return envs[_ORIGIN]
+
+
+def _energy_at(A, gate, chi, recipe):
+    return float(compute_energy_ctm_tensor(A, _env_at(A, chi, recipe), gate))
+
+
+@pytest.mark.parametrize("chi_lo,chi_hi", [(4, 8), (8, 16)])
+def test_the_2x2_recipe_energy_is_not_frozen_in_chi(chi_lo, chi_hi, _su_state):
+    """Positive control: a working recipe must respond to chi.
+
+    Not an accuracy assertion -- only that the boundary is doing something.  A
+    chi_eff=1 environment returns *bit-identical* energies across any chi range
+    (delta exactly 0.0), which is what this catches.  The real 2x2 movement
+    between chi=4 and chi=8 on this state is ~2.3e-7, so the threshold sits far
+    below it and far above float noise.
+    """
+    A, gate = _su_state
+    E_lo = _energy_at(A, gate, chi_lo, "2x2")
+    E_hi = _energy_at(A, gate, chi_hi, "2x2")
+    assert E_lo != E_hi, (
+        f"2x2 energy is bit-identical at chi={chi_lo} and chi={chi_hi} "
+        f"({E_lo!r}); the working recipe has regressed into the #726 "
+        "chi_eff=1 collapse."
+    )
+
+
+def test_the_2x2_recipe_corner_is_not_rank_1(_su_state):
+    """The direct form of the same check, on the corner itself."""
+    A, _gate = _su_state
+    env = _env_at(A, chi=8, recipe="2x2")
+    s = np.linalg.svd(np.asarray(env.C1.todense()), compute_uv=False)
+    rank = int((s > 1e-10 * s[0]).sum())
+    assert rank > 1, (
+        f"2x2 corner collapsed to rank {rank} (spectrum {s[:6]}); this is the "
+        "#726 signature on the recipe that is supposed to work."
+    )
+
+
+def test_single_site_split_rejects_the_default_2x2_recipe():
+    """The production guard: the default config must not silently run 1x1.
+
+    ``gs_recipe`` defaults to ``"2x2"`` and the single-site split path runs the
+    ``1x1`` moves unconditionally, so before #726 a default-configured
+    ``fuse_virtual_legs=False`` run returned a chi_eff=1 mean-field energy with
+    no indication anything was wrong.  It must now raise instead.
+    """
+    from tenax.algorithms.ipeps_config import iPEPSConfig as Cfg
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    gate = sublattice_rotate_gate(heisenberg_gate())
+    cfg = Cfg(
+        max_bond_dim=2,
+        num_imaginary_steps=2,
+        dt=0.05,
+        unit_cell="1x1",
+        gs_num_steps=1,
+        ctm=CTMConfig(chi=4, max_iter=20, conv_tol=1e-8, fuse_virtual_legs=False),
+    )
+    assert cfg.gs_recipe == "2x2", "precondition: 2x2 is the default recipe"
+
+    _E, tensors, _envs = ipeps(gate, None, cfg)
+    with pytest.raises(NotImplementedError, match=r"only implements the '1x1'"):
+        optimize_gs_ad(gate, tensors[0], cfg)

--- a/tests/test_split_ctm_fuse_flag.py
+++ b/tests/test_split_ctm_fuse_flag.py
@@ -530,10 +530,18 @@ def test_optimize_gs_ad_split_rejects_chi_auto_bump():
 
 
 def test_optimize_gs_ad_split_rejects_unsupported_recipe():
-    """The split optimizer path supports gs_recipe in ('1x1', '2x2').
+    """The shared validator accepts only gs_recipe in ('1x1', '2x2').
 
-    ``'2x2'`` is now accepted by the shared validator (#463 Phase 2); any
-    other recipe must still raise up front via ``validate_split_ctm_config``.
+    ``'2x2'`` is accepted *by the validator* (#463 Phase 2); any other recipe
+    must raise up front via ``validate_split_ctm_config``.
+
+    Note this is the validator's contract, not the dispatcher's: which of the
+    two recipes a given branch will actually run is narrower.  The 2-site
+    branch accepts only ``'2x2'``, and since #726 the single-site branch
+    accepts only ``'1x1'`` -- it runs the 1x1 moves unconditionally, and those
+    collapse the environment to rank-1 corners, so silently honouring the
+    ``'2x2'`` default would return a chi-independent mean-field energy.  See
+    ``tests/test_split_ctm_chi_frozen_726.py``.
     """
     from tenax.algorithms.ipeps_optimize import optimize_gs_ad
 


### PR DESCRIPTION
Refs #726. The real fix is #746; this stops the bleeding.

## The problem

The single-site branch of `_split_ctm_energy_fn` ran the `1x1` CTM moves **unconditionally**, never consulting `recipe`. Since `gs_recipe` defaults to `"2x2"`, a default-configured `fuse_virtual_legs=False` run silently got `1x1`.

That is not a cosmetic mislabel — `1x1` returns a different physical answer. The corner-pair (Fishman) projector collapses the environment to rank-1 corners: `_ctm_projector.py` forms `M = C1g† C4g`, which is χ×χ, so the χ·D² seam is summed away and `M` sees only the outer χ legs. With `C1_new = S^½U^H` the corner's entire spectrum is `√spec(M)`, hence `rank(C_new) ≤ rank(C1g) = 1` at cold init — the corner can never grow rank.

Measured on a physical D=2 SU state, through the D=8 benchmark driver's exact entry points:

```
chi=  2  E=-0.485880315530  corner_rank=1
chi=  4  E=-0.485880315530  corner_rank=1   delta_vs_prev=+0.000e+00
chi=  8  E=-0.485880315530  corner_rank=1   delta_vs_prev=+0.000e+00
chi= 16  E=-0.485880315530  corner_rank=1   delta_vs_prev=+0.000e+00
chi= 32  E=-0.485880315530  corner_rank=1   delta_vs_prev=+0.000e+00
```

Bit-identical across a 16× range in χ, delta exactly zero. That is a χ_eff=1 mean-field boundary, not a corner transfer matrix. The `2x2` recipe on the same state gives `−0.4886385` and converges normally.

## The change

Mirror the guard the 2-site branch already has — and for the reason its own comment gives, that accept-then-silently-run-something-else mislabels the experiment. The single-site branch now raises unless `gs_recipe='1x1'` is passed explicitly, with an error that names #726 and points at the fused path for a correct single-site environment.

**Breaking by design.** `"2x2"` is the default, so callers relying on it now get an exception instead of a number. Those numbers were mean-field; an exception is the better outcome.

## What it breaks: nothing

`test_split_ctm_fuse_flag.py`, `test_split_ctm_tensor.py`, `test_split_ctm_production_correctness.py` → **74 passed, 0 failed**. Every existing single-site split test already sets `gs_recipe='1x1'` explicitly, so the guard is inert for them. I checked this rather than assuming it, since a breaking change to a default is exactly where I'd expect fallout.

## The detector

`tests/test_split_ctm_chi_frozen_726.py` adds the cheapest possible detector for this whole bug class: **energy frozen in χ**. A genuine corner transfer matrix improves as the boundary grows; a χ_eff=1 boundary returns bit-identical numbers. One extra CTM run would have caught this years earlier.

- positive control: the `2x2` energy must respond to χ, and its corner rank must exceed 1
- production guard: the default config must raise

Verified with teeth — the guard test **fails without the guard** and passes with it.

The `1x1` collapse itself is deliberately **not** pinned as expected behaviour. Three existing tests were already shaped around that symptom (see #746, which lists them); re-pinning it would entrench the bug.

Also corrects a now-stale docstring in `test_split_ctm_fuse_flag.py` that described the *validator's* contract as if it were the *dispatcher's* — the validator accepts both recipes, but each branch runs only one.

## Related

- #746 — the real fix: route `1x1` through the working 2×2 plaquette projector
- #747 — the D=8 split-CTM results ran through this path and need re-running
- #723 — same mechanism on the fused path

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.