### PR TITLE
test(#756): assert real PSD on a converged env instead of a magic bound

### DIFF
--- a/tests/test_ipeps.py
+++ b/tests/test_ipeps.py
@@ -240,13 +240,44 @@ class TestRDM:
 
     @pytest.fixture
     def peps_env(self):
-        """PEPS tensor and converged CTM environment."""
+        """Random PEPS tensor with a deliberately *approximate* CTM environment.
+
+        ``max_iter=20`` with no convergence check: this is a smoke-test
+        fixture, not a converged state.  Assertions using it must be
+        scale-free (finiteness, hermiticity, trace), never a numeric bound
+        on the spectrum -- see :meth:`test_rdm_eigenvalues_are_finite`.
+        """
         key = jax.random.PRNGKey(55)
         D, d = 2, 2
         A = jax.random.normal(key, (D, D, D, D, d))
         A = A / (jnp.linalg.norm(A) + 1e-10)
         config = CTMConfig(chi=8, max_iter=20)
         env = ctm(A, config)
+        return A, env, d
+
+    @pytest.fixture
+    def converged_peps_env(self):
+        """Weakly-entangled *physical* PEPS with a genuinely converged CTM env.
+
+        A random tensor (the ``peps_env`` fixture) is a pathological CTM
+        input: at ``chi=8`` the environment has not converged, and
+        converging it harder makes the RDM *worse* rather than better --
+        at ``chi>=16`` the norm collapses and ``trace(rdm)`` lands
+        anywhere from ~1e-5 to 0.3 instead of 1.  So a random tensor
+        cannot support a positive-semidefinite assertion at all.
+
+        A product state perturbed towards entanglement is a genuine PEPS
+        state whose CTM fixed point is well conditioned.  Its RDM is PSD
+        to ~1e-9 and agrees between ``chi=8`` and ``chi=16`` to ~1e-11,
+        which is what makes the PSD assertion below both meaningful and
+        platform-stable (#756).
+        """
+        D, d = 2, 2
+        A = jnp.zeros((D, D, D, D, d)).at[0, 0, 0, 0, 0].set(1.0)
+        pert = jax.random.normal(jax.random.PRNGKey(0), (D, D, D, D, d))
+        A = A + 0.2 * pert / jnp.linalg.norm(pert)
+        A = A / jnp.linalg.norm(A)
+        env = ctm(A, CTMConfig(chi=8, max_iter=100, conv_tol=1e-10))
         return A, env, d
 
     def test_rdm_hermitian(self, peps_env):
@@ -260,21 +291,45 @@ class TestRDM:
         assert jnp.allclose(rdm_h_mat, rdm_h_mat.conj().T, atol=1e-10)
         assert jnp.allclose(rdm_v_mat, rdm_v_mat.conj().T, atol=1e-10)
 
-    def test_rdm_positive_semidefinite(self, peps_env):
-        """Eigenvalues of the RDM should be bounded.
+    def test_rdm_positive_semidefinite(self, converged_peps_env):
+        """A converged environment must give a genuinely PSD RDM.
 
-        For a random (non-optimized) PEPS with small chi the CTM
-        environment is approximate, so eigenvalues outside [0,1] are
-        expected.  We check they are not wildly unphysical (> O(10)).
+        This asserts what the test is named after: every eigenvalue in
+        ``[0, 1]`` up to a numerical tolerance, on a state where that is
+        actually expected to hold.
+
+        Previously this ran on the unconverged random fixture and asserted
+        ``abs(eigval) < 10`` -- a magic constant that straddled a platform
+        difference (Linux peaked at 6.43, macOS at 11.73 on the same seed),
+        making it chronically red on macOS while testing nothing (#756).
+        """
+        A, env, d = converged_peps_env
+        rdm_h = _rdm2x1(A, env, d).reshape(d * d, d * d)
+        rdm_v = _rdm1x2(A, env, d).reshape(d * d, d * d)
+
+        # Observed slack is ~1e-9; 1e-6 leaves three orders of margin for
+        # platform LAPACK differences without letting a real regression
+        # through -- a broken normalization moves these by O(0.1) or more.
+        tol = 1e-6
+        for name, rdm in (("horizontal", rdm_h), ("vertical", rdm_v)):
+            eigvals = jnp.linalg.eigvalsh(rdm)
+            assert jnp.all(eigvals > -tol), f"{name} RDM not PSD: {eigvals}"
+            assert jnp.all(eigvals < 1.0 + tol), f"{name} RDM eigenvalue > 1: {eigvals}"
+
+    def test_rdm_eigenvalues_are_finite(self, peps_env):
+        """Smoke test on the approximate environment: no NaN, no inf.
+
+        The unconverged random fixture cannot support a bound on the
+        spectrum (that is what #756 was), but it can still catch a CTM or
+        RDM path that produces non-finite numbers.  Finiteness is
+        scale-free, so it cannot straddle a platform difference.
         """
         A, env, d = peps_env
         rdm_h = _rdm2x1(A, env, d).reshape(d * d, d * d)
         rdm_v = _rdm1x2(A, env, d).reshape(d * d, d * d)
 
-        eigvals_h = jnp.linalg.eigvalsh(rdm_h)
-        eigvals_v = jnp.linalg.eigvalsh(rdm_v)
-        assert jnp.all(jnp.abs(eigvals_h) < 10), f"Unbounded eigenvalues: {eigvals_h}"
-        assert jnp.all(jnp.abs(eigvals_v) < 10), f"Unbounded eigenvalues: {eigvals_v}"
+        assert jnp.all(jnp.isfinite(jnp.linalg.eigvalsh(rdm_h)))
+        assert jnp.all(jnp.isfinite(jnp.linalg.eigvalsh(rdm_v)))
 
     def test_rdm_trace_one(self, peps_env):
         """trace(rdm) should be approximately 1."""


### PR DESCRIPTION
Fixes #756. Also closes out #713, which was closed as a duplicate.

## Problem

`TestRDM::test_rdm_positive_semidefinite` asserted a magic constant on a state its own docstring described as deliberately unconverged:

```python
assert jnp.all(jnp.abs(eigvals_h) < 10), f"Unbounded eigenvalues: {eigvals_h}"
```

On the same seed, max |λ| is **6.43 on Linux** and **11.73 on macOS**. The bound of `10` sits between the two platforms, so the test was permanently red on macOS while asserting nothing about positive semidefiniteness. It sits in a non-required bucket, so it never blocked a merge — which is the real cost: it trains everyone to read `Full tests (macos-latest, Python 3.12, fast-ipeps)` as "red as usual" and stop looking.

## Why the obvious fix does not work

Option 1 in the issue was "assert PSD on a converged environment". That cannot use the existing fixture: a random PEPS is a pathological CTM input, and converging it *harder* makes the RDM **worse**, not better.

| χ (max_iter=200, conv_tol=1e-10) | trace(rdm_h) | max abs eigval |
|---|---|---|
| 8 | 1.000000 | 0.81 |
| 16 | **-0.000056** | 0.0006 |
| 32 | **0.000531** | 0.0012 |
| 64 | **0.281974** | 0.167 |

At χ≥16 the norm collapses and the trace stops being 1, which would break the neighbouring `test_rdm_trace_one`. So the random fixture cannot support a PSD assertion at any χ.

## What this does instead (option 3: split)

A product state perturbed towards entanglement is a genuine PEPS state whose CTM fixed point is well conditioned — min eigenvalue **+3e-10**, max **1.0**, trace **1.0**, agreeing between χ=8 and χ=16 to ~1e-11, stable across seeds 0/1/55.

* **`test_rdm_positive_semidefinite`** — now runs on a new `converged_peps_env` fixture and asserts what its name says: every eigenvalue in `[0, 1]` within `1e-6`. The tolerance sits ~1000× away from the measured slack, instead of within 2× of it as before.
* **`test_rdm_eigenvalues_are_finite`** — keeps a smoke test over the original approximate fixture, asserting finiteness. Scale-free, so it cannot straddle a platform difference.

The `peps_env` docstring also claimed "converged CTM environment", which was never true at `max_iter=20`; corrected.

## Verification

Mutation-tested rather than merely run green — a test that only passes proves nothing:

| injected defect | caught by |
|---|---|
| `rdm *= 1.5` (lost trace normalization) | new upper bound **and** `test_rdm_trace_one` |
| traceless `diag(+0.01, -0.01, 0, 0)` (breaks PSD, preserves trace) | **new PSD assertion alone** — `test_rdm_trace_one` and `test_rdm_hermitian` both pass through it |

The second case is the point: this adds coverage the class did not previously have. Source restored after both mutations; the diff is test-file only.

Full `fast-ipeps` bucket on Linux: **100 passed, 5 deselected, 1 xfailed** (9m30s).

**Labeled `run-full-tests`** — the macOS leg this fixes only runs under that label, so without it CI would not exercise the thing being fixed.

## Caveat

The failure is macOS-only and I verified on Linux, so the macOS result comes from this PR's CI, not from local measurement. The reason it should hold: the old test amplified floating-point noise through an unconverged random fixture, whereas this one is χ-stable to 1e-11 with a 1000× tolerance margin.

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)