### PR TITLE
test(#730): gate the Phase 2 cell-shift tables in required CI; fix two stale #715 docstrings

### DIFF
--- a/src/tenax/algorithms/_ctm_root_implicit_asym.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_asym.py
@@ -24,23 +24,40 @@ environment of Eq. 65 and ``U_a = U*_a + U_perp,a u_a``,
     R_S = diag(U† M Vh†) - λ_S S                 (Eq. 79)
     R_v = S*^-1 (U† M Vh_perp†) - λ_S v          (Eq. 80)
 
-Where this stands (#715 Phase 1, incomplete)
--------------------------------------------
+Where this stands (#715 Phase 1, complete)
+-----------------------------------------
+Phase 1 is done for the dense asymmetric 1x1 cell, real and complex.  Measured
+gradient parity against finite differences is ``< 1e-5`` real
+(``test_gradient_parity_needs_the_modified_variables``) and ``< 1e-9`` complex
+(``test_gradient_parity_for_a_complex_state``), with ``||F(y*)|| = 2.5e-16``.
+
+Two ingredients get it there, and both were arrived at the hard way, so neither
+is worth re-litigating from the equations alone:
+
 ``S`` is a general complex chi x chi matrix, and the projectors use a genuine
 matrix inverse square root (Denman-Beavers, so no decomposition enters ``F``).
-That much is required, not optional: with a *diagonal* ``S`` the in-space
-rotation of the isometries has nowhere to go, the projector closure breaks at
-first order, and Eq. 88's null-space restriction then discards a physical
+That is required, not optional: with a *diagonal* ``S`` the in-space rotation
+of the isometries has nowhere to go, the projector closure breaks at first
+order, and Eq. 88's null-space restriction then discards a physical
 contribution instead of a gauge one — the gradient came out 120% wrong.
-Promoting ``S`` brings it to 1-2.5%.
+Promoting ``S`` alone brings it to 1-2.5%.
 
-Still missing is the rest of Eqs. 73-82: the modified corners and edges that
-carry ``s`` explicitly on the bonds, and the quartic roots
-``s^L = (S S†)^-1/4``, ``s^R = (S† S)^-1/4`` on the *cut legs* of that
-environment.  Putting those roots inside the projectors instead was tried and
-is worse (20%): they are equivariant under independent left/right rotations,
-but their product is not ``S^-1``, so the closure breaks for a non-diagonal
-``S``.  See ``docs/plans/2026-07-29-715-phase1-modified-variables.md``.
+The rest of Eqs. 73-82 closes that residual: the modified corners and edges
+carrying ``s`` explicitly on the bonds (:func:`_modified_env`) and the quartic
+roots ``s^L = (S S†)^-1/4``, ``s^R = (S† S)^-1/4`` on the *cut legs* of that
+environment (:func:`_quartic_root`, :func:`_inv_quartic_root`), assembled by
+:func:`asym_characteristic_residual_covariant`.  Putting those roots inside the
+projectors instead was tried and is worse (20%): they are equivariant under
+independent left/right rotations, but their product is not ``S^-1``, so the
+closure breaks for a non-diagonal ``S``.  See
+``docs/plans/2026-07-29-715-phase1-modified-variables.md``.
+
+What is *not* done is #715 as a whole: none of this is wired into the
+production gradient path.  ``optimize_gs_ad`` still differentiates the CTM
+fixed point through :mod:`tenax.algorithms._ctm_energy_ad`, SVD backward and
+all.  Phase 3 (:mod:`tenax.algorithms._ctm_root_implicit_symmetric`) is the
+phase that would pay off #566/#687 and is blocked on #731 (8.4 GB peak in the
+GMRES solve at D=2, chi=4).
 
 Complex states (#721)
 ---------------------

--- a/src/tenax/algorithms/_ctm_root_implicit_sym_sectors.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_sym_sectors.py
@@ -2,10 +2,9 @@
 
 Nothing here knows about CTM.  It knows about charge sectors: how a chi bond
 is split across them, how to decompose a block-diagonal matrix sector by
-sector, and how to get back to a :class:`SymmetricTensor`.  A future CTM
-layer (``_ctm_root_implicit_symmetric``, not yet written) will call into this
-at the cut and nowhere else; the decomposition/reassembly helpers implied by
-that split are forthcoming and not part of this module yet.
+sector, and how to get back to a :class:`SymmetricTensor`.  The CTM layer
+that consumes it is :mod:`tenax.algorithms._ctm_root_implicit_symmetric`
+(#715 Phase 3, shipped in #729); it calls in at the cut and nowhere else.
 
 The split exists because the two halves fail differently.  A bug here is a
 wrong *shape* or a wrong charge and shows up as an exception; a bug in the CTM

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,17 @@ _FILE_MARKERS = {
     # full CTM convergence plus finite-difference reruns.
     "test_ctm_c4v_root_implicit.py": "algorithm",
     "test_ctm_root_implicit_asym.py": "algorithm",
+    # Multisite root-implicit AD (#715 Phase 2): the Appendix-F cell-shift
+    # index tables are the whole risk of this phase -- a wrong shift still
+    # yields a well-conditioned Jacobian and a plausible root, then a silently
+    # wrong gradient (#700 / #702 failure shape).  Pinning them costs 0.14s for
+    # 13 tests, so they belong in the required gate.  The root/gradient tests
+    # in the same file each converge a 2x2 CTM plus finite-difference reruns
+    # and carry their own explicit ``@pytest.mark.slow``, which the rule below
+    # honours by *withholding* this ``core``; see ``pytest_collection_modifyitems``.
+    # Previously absent from this table entirely, so all 33 tests were
+    # deselected by ``-m core`` and never ran in a required check (#730).
+    "test_ctm_root_implicit_multisite.py": "core",
     "test_ctm_root_implicit_sym_sectors.py": "core",
     # Symmetric root-implicit AD (#715 Phase 3): the structural half of this
     # file is cheap and belongs in the required gate, but the gradient tests

--- a/tests/test_ctm_root_implicit_multisite.py
+++ b/tests/test_ctm_root_implicit_multisite.py
@@ -240,6 +240,7 @@ def test_shifts_are_genuinely_periodic():
 # ------------------------------------------------------------------ #
 
 
+@pytest.mark.slow
 def test_enlarged_corner_at_1x1_reproduces_the_phase1_quadrant():
     """A 1x1 unit cell must reproduce Phase 1's rotate-and-reuse quadrant.
 
@@ -297,6 +298,7 @@ def _gate(delta=1.0):
     return H.reshape(2, 2, 2, 2)
 
 
+@pytest.mark.slow
 def test_multisite_forward_at_1x1_matches_the_phase1_energy():
     """The 1x1 smoke test for the forward sweep.
 
@@ -333,6 +335,7 @@ def test_multisite_forward_at_1x1_matches_the_phase1_energy():
     assert rel < 1e-10, f"E_phase1={E1!r} E_multisite={E2!r} rel={rel:.3e}"
 
 
+@pytest.mark.slow
 def test_multisite_forward_runs_on_a_2x2_cell_of_different_tensors():
     """A 2x2 cell of *different* tensors — the configuration a wrong cell
     shift can actually be seen in.  Only asserts the forward is well formed;
@@ -363,6 +366,7 @@ def test_multisite_forward_runs_on_a_2x2_cell_of_different_tensors():
     assert meta["converged"], meta
 
 
+@pytest.mark.slow
 def test_the_unit_cell_is_not_secretly_uniform():
     """Guards the guard: if a 2x2 cell of different tensors converged to four
     identical environments, every cell-shift test built on it would be
@@ -390,6 +394,7 @@ def test_the_unit_cell_is_not_secretly_uniform():
     assert spread > 1e-3, f"cells are effectively identical (spread {spread:.3e})"
 
 
+@pytest.mark.slow
 def test_the_1x1_energy_gate_is_load_bearing(monkeypatch):
     """Guards the gate: break the gluing partner and the 1x1 energy must move.
 
@@ -459,16 +464,19 @@ def _root_residual(cell, nrows, ncols, chi=4, polish_steps=3):
     return residual
 
 
+@pytest.mark.slow
 def test_characteristic_equations_vanish_at_a_1x1_root():
     assert _root_residual({(0, 0): _site_tensor()}, 1, 1) < 1e-11
 
 
+@pytest.mark.slow
 def test_characteristic_equations_vanish_at_a_2x2_root():
     """The Phase 2 gate: all 20 equations per cell hold at the converged root
     of a 2x2 cell of different tensors."""
     assert _root_residual(_cell_2x2(), 2, 2) < 1e-11
 
 
+@pytest.mark.slow
 def test_every_block_of_F_vanishes_not_just_the_norm():
     """A single dominant block could hide four broken ones behind a small
     total, so check R_C, R_E, R_u, R_S and R_v separately."""
@@ -488,6 +496,7 @@ def test_every_block_of_F_vanishes_not_just_the_norm():
         assert norm < 1e-11, f"{name} = {norm:.3e}"
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "table",
     ["proj_sinv_indices", "leftvec_invfroot_indices", "rightvec_invfroot_indices"],
@@ -515,6 +524,7 @@ def test_each_cell_shift_table_is_load_bearing(monkeypatch, table):
     assert _root_residual(_cell_2x2(), 2, 2) > 1e-3
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "table",
     ["proj_sinv_indices", "leftvec_invfroot_indices", "rightvec_invfroot_indices"],
@@ -590,12 +600,14 @@ def _fd_parity(cell, nrows, ncols, chi=4, h=1e-5, seed=0):
     return ad, fd
 
 
+@pytest.mark.slow
 def test_gradient_matches_finite_differences_at_1x1():
     ad, fd = _fd_parity({(0, 0): _site_tensor()}, 1, 1)
     rel = abs(ad - fd) / max(abs(fd), 1e-30)
     assert rel < 1e-8, f"AD={ad!r} FD={fd!r} rel={rel:.3e}"
 
 
+@pytest.mark.slow
 def test_gradient_matches_finite_differences_on_a_2x2_cell():
     """The Phase 2 gate (#715).
 
@@ -609,6 +621,7 @@ def test_gradient_matches_finite_differences_on_a_2x2_cell():
     assert rel < 1e-6, f"AD={ad!r} FD={fd!r} rel={rel:.3e}"
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "table",
     ["proj_sinv_indices", "leftvec_invfroot_indices", "rightvec_invfroot_indices"],
@@ -633,6 +646,7 @@ def test_a_wrong_cell_shift_breaks_the_2x2_gradient(monkeypatch, table):
     assert rel > 1e-3, f"wrong {table} still matched FD (rel={rel:.3e})"
 
 
+@pytest.mark.slow
 def test_the_two_site_energy_is_gauge_dependent_on_a_nonuniform_cell():
     """Records why the parity objective is a one-site observable.
 


### PR DESCRIPTION
Fixes #730. Also corrects two stale status docstrings in the same `#715` root-implicit family.

## #730 — the Phase 2 tests never ran in a required check

`tests/test_ctm_root_implicit_multisite.py` was absent from `conftest.py`'s `_FILE_MARKERS`, so all 33 tests were unmarked and deselected by `pytest -m core`. They had never run in a required check since Phase 2 merged in #728. They landed in the non-required `fast-other` bucket instead — the bucket already known to be chronically red, so a failure there would not have read as new.

### Why not just mark the file `core`

20 of the 33 tests converge a 2×2 CTM and rerun finite differences. Marking the file `core` puts all of that in the required gate on every PR × 3 jobs. The other 13 pin the **Appendix-F cell-shift index tables** and cost **0.14 s total** — and those are the ones worth gating on, because a wrong shift still produces a well-conditioned Jacobian and a plausible-looking root, then a *silently wrong gradient*. That is the #700 / #702 failure shape.

So this follows the pattern already established for `test_ctm_root_implicit_symmetric.py`: file marker `core`, with explicit `@pytest.mark.slow` on the expensive tests, which `pytest_collection_modifyitems` honours by withholding `core` from them.

### Resulting partition (verified by collection)

| selector | tests |
|---|---|
| `-m core` | **13** (0.14 s, all passing) |
| `-m slow` | 20 |
| `-m "not core and not slow"` | 0 |

13 + 20 = 33 — nothing orphaned by the split.

## Two stale docstrings

Both described a world that stopped being true when later phases landed, in the direction that makes the work look *less* finished than it is:

* **`_ctm_root_implicit_asym.py`** was headed "Phase 1, **incomplete**" and said the rest of Eqs. 73–82 (modified corners/edges, quartic roots on the cut legs) was "still missing", gradient at 1–2.5%. All of it is present — `_modified_env`, `_quartic_root`, `_inv_quartic_root`, `_covariant_pieces`, `asym_characteristic_residual_covariant` — and measured parity is **<1e-5 real / <1e-9 complex**. I re-ran both parity tests to confirm before editing rather than trusting either the docstring or the tests' tolerances.
* **`_ctm_root_implicit_sym_sectors.py`** called its consumer `_ctm_root_implicit_symmetric` "not yet written" and its helpers "forthcoming". That module shipped in #729 and imports `BondLayout`, `SectorSVD`, `bond_index_from_layout` from this one.

Both retain the hard-won negative results — diagonal `S` giving a 120% wrong gradient, quartic roots inside the projectors being worse (20%) — since those explain why the current arrangement looks the way it does.

The asym header now also records what is genuinely **not** done, which is what a reader actually needs: none of #715 is wired into the production gradient path (`optimize_gs_ad` still goes through `_ctm_energy_ad`, SVD backward and all), and Phase 3 is blocked on #731.

## Verification

* `-m core` subset: **13 passed in 0.14 s**.
* Marker partition: verified by collection, as tabled above.
* ruff + ruff-format clean.
* The 20 `slow` tests are unchanged in logic — this adds a marker and touches no test body. A local run of that bucket is in progress; **labeled `run-full-tests` so CI's `slow` bucket exercises them here**, which matters because this PR is what moves them into that bucket.

No source behaviour changes: the two `src/` edits are docstring-only.

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)