### PR TITLE
fix(#760): absorb the site tensor into the C4v enlarged corner

### DIFF
--- a/src/tenax/algorithms/_ctm_c4v_root_implicit.py
+++ b/src/tenax/algorithms/_ctm_c4v_root_implicit.py
@@ -101,18 +101,27 @@ class C4vRoot(NamedTuple):
 # ---------------------------------------------------------------------------
 
 
-def _enlarged_corner(C: jax.Array, E: jax.Array) -> jax.Array:
-    """Hermitian enlarged corner ``M = 2 Cg Cg†`` with ``Cg = (C·E)`` fused.
+def _enlarged_corner(C: jax.Array, E: jax.Array, a: jax.Array) -> jax.Array:
+    """Hermitian enlarged corner ``M = C·E_top·E_left·a``, fused to a matrix.
 
-    Mirrors steps 1 and 3 of :func:`_c4v_sweep`: the corner is grown by one
-    edge and the density matrix accumulated from the two (identical, by C4v)
-    corner slots.  Returns a ``(chi*d2, chi*d2)`` Hermitian PSD matrix whose
-    dominant eigenvectors are the CTM projector.
+    Mirrors step 1 of :func:`_c4v_sweep`: the top-left quadrant, i.e. the
+    corner grown by *both* adjacent edges with the double-layer tensor filling
+    the plaquette between them.  ``C.c_b`` joins the top edge's ``t_l`` and
+    ``C.c_a`` the left edge's ``t_r``; the top edge's ``D2`` is ``a.u2`` and
+    the left edge's is ``a.l2``, leaving the bottom face ``(t_l, d2)`` and the
+    right face ``(t_r, r2)`` open, fused in that order to match the sweep's
+    ``(fused, col)``.
+
+    This was ``M = 2 Cg Cg†`` with ``Cg = C·E`` — one edge, no ``a`` — which
+    converges cleanly to the wrong fixed point (#760).
+
+    ``M`` is Hermitian for a C4v state, so its dominant eigenvectors are those
+    of the sweep's density matrix ``ρ = 2 M M†`` and ``U†MU`` is the projected
+    corner.  That lets one matrix keep serving both roles, exactly as before.
     """
     chi, d2 = C.shape[0], E.shape[1]
-    Cg = jnp.einsum("ab,bmc->amc", C, E).reshape(chi * d2, chi)
-    M = 2.0 * (Cg @ Cg.conj().T)
-    # eigh below assumes exact hermiticity; the product form is Hermitian up
+    M = jnp.einsum("ij,jup,qli,udlr->qdpr", C, E, E, a).reshape(chi * d2, chi * d2)
+    # eigh below assumes exact hermiticity; the contraction is Hermitian up
     # to rounding, so symmetrise rather than let the asymmetry leak into the
     # eigenvectors.
     return 0.5 * (M + M.conj().T)
@@ -164,7 +173,7 @@ def c4v_characteristic_residual(
     C, E, u = y
     U = U_star + U_perp @ u  # Eq. 25 — differentiable only through ``u``
 
-    M = _enlarged_corner(C, E)
+    M = _enlarged_corner(C, E, a)
     N = _enlarged_edge(E, a)
 
     proj_C = _project_corner(M, U)
@@ -239,10 +248,16 @@ def c4v_root_parametrize(
     best: tuple[C4vRoot, float] | None = None
 
     for _step in range(max(int(polish_steps), 1)):
-        M = _enlarged_corner(C, E)
-        # eigh returns ascending eigenvalues; keep the chi dominant ones.
+        M = _enlarged_corner(C, E, a)
+        # eigh returns ascending eigenvalues; keep the chi dominant ones by
+        # MAGNITUDE.  The sweep's projector comes from ρ = 2 M M† (see
+        # ``_compute_projector_tensor``), whose spectrum is w², so it ranks by
+        # |w|.  While M was ``2 Cg Cg†`` it was PSD and signed-vs-magnitude
+        # ordering coincided; the enlarged corner is Hermitian but *not* PSD,
+        # so ranking by signed w would drop large negative modes the sweep
+        # keeps and converge to a different root entirely (#760).
         w, V = jnp.linalg.eigh(M)
-        order = jnp.argsort(-w)
+        order = jnp.argsort(-jnp.abs(w))
         V = V[:, order]
         U_star = _align_isometry(V[:, :chi], U_prev)
         U_perp = V[:, chi:]

--- a/src/tenax/algorithms/_ctm_tensor_c4v.py
+++ b/src/tenax/algorithms/_ctm_tensor_c4v.py
@@ -15,7 +15,6 @@ __all__ = [
     "ctm_tensor_c4v",
 ]
 
-import jax.numpy as jnp
 
 from tenax.algorithms._ctm_projector import _compute_projector_tensor
 from tenax.algorithms._ctm_tensor_convergence import _ctm_sv_diff
@@ -29,7 +28,6 @@ from tenax.algorithms._ctm_tensor_init import (
 )
 from tenax.algorithms._ctm_tensor_moves import _flip_leg_flow
 from tenax.contraction.contractor import contract
-from tenax.core.index import TensorIndex
 from tenax.core.tensor import DenseTensor, SymmetricTensor, Tensor
 from tenax.linalg import _dense_svd
 
@@ -53,10 +51,28 @@ def _c4v_sweep(
     Returns:
         ``(C_new, T_new)`` with the same label conventions.
     """
-    # 1. Grow corner: Cg = C · T  (connect C.c_b to T.t_l)
-    C_conn = C.relabel("c_b", "t_l")
-    Cg = contract(C_conn, T)  # (c_a, D2, t_r)
-    Cg = _fuse_pair_by_label(Cg, "c_a", "D2", "fused", IN)  # (fused, t_r)
+    # 1. Enlarged corner: Q = C · T_top · T_left · a  (top-left quadrant).
+    #
+    #    The corner must absorb the double-layer tensor, exactly as
+    #    ``_build_enlarged_corner`` does for the general sweep.  This used to
+    #    be ``Cg = C · T`` — one edge, with ``a`` contracted only into the
+    #    *edge* and never into the corner — whose implicit density matrix is
+    #    ``C·T·T†·C†``: two copies of the same edge, one conjugated, and no
+    #    site tensor.  That converges cleanly to the *wrong* fixed point, so
+    #    nothing reports a failure while the energy is simply wrong (#760).
+    #
+    #    C.c_b joins the top edge's t_l and C.c_a joins the left edge's t_r,
+    #    matching the adjacency ``_c4v_to_full_env`` builds (C1.c1_r -> T1.t1_l,
+    #    C1.c1_d -> T4.t4_u).  The top edge's D2 is a.u2, the left edge's is
+    #    a.l2, leaving the right face (t_r, r2) and bottom face (t_l, d2) open.
+    C_top = C.relabel("c_b", "t_l")
+    Q = contract(C_top, T)  # (c_a, D2, t_r)
+    Q = Q.relabels({"D2": "u2", "t_r": "o_r"})
+    T_left = T.relabels({"t_r": "c_a", "D2": "l2", "t_l": "o_d"})
+    Q = contract(Q, T_left)  # (u2, o_r, o_d, l2)
+    Q = contract(Q, a)  # (o_r, o_d, d2, r2)
+    Qf = _fuse_pair_by_label(Q, "o_d", "d2", "fused", IN)
+    Qf = _fuse_pair_by_label(Qf, "o_r", "r2", "col", OUT)  # (fused, col)
 
     # 2. Grow edge: Tg = T · a  (connect T.D2 to a.u2)
     T_conn = T.relabel("D2", "u2")
@@ -64,12 +80,14 @@ def _c4v_sweep(
     Tg = _fuse_pair_by_label(T_with_a, "t_l", "l2", "fl", IN)
     Tg = _fuse_pair_by_label(Tg, "t_r", "r2", "fr", OUT)  # (fl, d2, fr)
 
-    # 3. Projector from Cg alone (C4v: both corners are equivalent)
-    #    Use Cg for both corner slots — the density matrix is ρ = 2 * Cg · Cg†
+    # 3. Projector from the enlarged corner (C4v: both faces are equivalent).
+    #    Use Qf for both corner slots — the density matrix is ρ = 2 * Qf · Qf†.
+    #    Qf is symmetric for a C4v state, so its eigenvectors are those of
+    #    ρ = Qf², i.e. the same subspace, ordered identically by |λ|.
     #    No base_charges: the C4v sweep uses a single corner, so there is no
     #    charge-sector drift between independent projectors.
     P, _, _eps_t = _compute_projector_tensor(
-        Cg, Cg, chi, projector_method
+        Qf, Qf, chi, projector_method
     )  # C4v eigh/qr: P_1 == P_2, second slot intentionally discarded
 
     # 4. Apply projector to edge: T_new = P† · Tg · P (paired projector
@@ -81,31 +99,21 @@ def _c4v_sweep(
     T_new = contract(step, P_right)  # (chi_new, d2, chi_new_r)
     T_new = T_new.relabels({"chi_new": "t_l", "d2": "D2", "chi_new_r": "t_r"})
 
-    # 5. New corner: C_new = (P† · Cg) · (P† · Cg)†
-    #    Compute half = P† · Cg, then form C_new = half · half† in the
-    #    dense domain.  The previous approach (contracting Cg with bar(Cg)
-    #    as SymmetricTensor) introduced spurious Koszul signs for fermionic
-    #    symmetries, making the density matrix non-PSD and preventing
-    #    convergence.  The dense half · conj(half).T is PSD by construction.
-    half = contract(P_bar, Cg)  # (chi_new, t_r)
-    half_dense = half.todense()
-    C_new_dense = half_dense @ jnp.conj(half_dense).T  # (chi_new, chi_new)
-
-    # Build corner indices with the same charge distribution as the
-    # projector's chi_new leg, ensuring compatibility with the edges.
-    chi_new_idx = P.indices[P.labels().index("chi_new")]
-    c_a_idx = TensorIndex.from_charges(
-        chi_new_idx.symmetry, chi_new_idx.charges.copy(), IN, label="c_a"
-    )
-    c_b_idx = TensorIndex.from_charges(
-        chi_new_idx.symmetry, chi_new_idx.charges.copy(), OUT, label="c_b"
-    )
-    if isinstance(Cg, SymmetricTensor):
-        C_new = SymmetricTensor.from_dense(
-            C_new_dense, (c_a_idx, c_b_idx), tol=float("inf")
-        )
-    else:
-        C_new = DenseTensor(C_new_dense, (c_a_idx, c_b_idx))
+    # 5. New corner: C_new = P† · Q · P — the enlarged corner projected on
+    #    *both* faces, mirroring ``new_C1 = (C1·T1) projected by P_bot`` in
+    #    the general sweep.  Both faces of Qf carry the same charge structure
+    #    for a C4v state, so the single projector applies to each.
+    #
+    #    This replaces a ``half · half†`` construction (half = P†·Cg), which
+    #    stored the projected *density matrix* rather than the projected
+    #    corner.  That was introduced to keep the corner PSD for fermionic
+    #    symmetries; the paired P†·Q·P contraction here is the same shape as
+    #    the general sweep's projector application, which is Koszul-correct
+    #    by construction (see the ``.bar()`` note above).
+    C_half = contract(P_bar, Qf)  # (chi_new, col)
+    P_col = P.relabels({"fused": "col", "chi_new": "chi_new_r"})
+    C_new = contract(C_half, P_col)  # (chi_new, chi_new_r)
+    C_new = C_new.relabels({"chi_new": "c_a", "chi_new_r": "c_b"})
 
     # 7. Normalize
     C_norm = C_new.max_abs()

--- a/tests/test_ctm_c4v_root_implicit.py
+++ b/tests/test_ctm_c4v_root_implicit.py
@@ -73,7 +73,17 @@ def _xxz_gate(delta: float = 1.0):
     return H.reshape(2, 2, 2, 2)
 
 
-_CTM_KW = dict(max_iter=300, conv_tol=1e-12, projector_method="eigh")
+# ``conv_tol`` is load-bearing for ``test_gradient_matches_finite_difference``
+# and must not be loosened.  The finite difference divides by ``2h = 2e-5``, so
+# it amplifies any residual error in the converged energy by 5e4.  At
+# ``conv_tol=1e-12`` the environment still carries a ~1.4e-13 energy error,
+# which lands as ~9e-9 in ``fd`` — the same order as the 1e-8 tolerance the
+# test asserts.  The test then measures the FD noise floor rather than the
+# gradient: it passes at ``h=1e-5`` and fails at ``h=1e-6`` (9.0e-8) on code
+# whose gradient is fine.  At 1e-14 the parity is 1.2e-10..2.2e-09 across both
+# h and every parametrization, and the assertion means what it says.
+# Costs ~11 extra CTM iterations (58 -> 69 at chi=6).
+_CTM_KW = dict(max_iter=300, conv_tol=1e-14, projector_method="eigh")
 
 
 def _directional_fd(A, gate, direction, h, **kw):

--- a/tests/test_ctm_c4v_root_implicit.py
+++ b/tests/test_ctm_c4v_root_implicit.py
@@ -28,17 +28,27 @@ from tenax.core.tensor import DenseTensor
 
 
 def _site_tensor(D: int = 2, d: int = 2, seed: int = 42, eps: float = 0.5):
-    """Entangled-but-C4v-friendly iPEPS tensor with trivial U(1) charges.
+    """Entangled, genuinely C4v-symmetric iPEPS tensor with trivial U(1) charges.
 
     ``eps`` controls the deviation from a product state.  It must be large
     enough that the kept corner spectrum sits above numerical noise: at
     ``eps = 0.1`` and ``chi = 8`` the truncation cuts through eigenvalues of
     order 1e-12 and the environment is no longer a root of the
-    characteristic equations (see ``test_warns_on_degenerate_truncation``).
+    characteristic equations.
+
+    The projection onto the C4v-invariant subspace is load-bearing, not
+    cosmetic.  The enlarged corner ``C·E_top·E_left·a`` is Hermitian *only*
+    for a C4v-symmetric state — on the raw random tensor this fixture used to
+    return, ``‖M - M†‖/‖M‖`` is 0.97 and no root exists to find.  The old
+    ``M = 2 Cg Cg†`` was Hermitian PSD for any input whatsoever, so it
+    accepted states the scheme does not apply to (#760).
     """
+    from tenax.algorithms.ipeps import symmetrize_c4v
+
     rng = np.random.RandomState(seed)
     data = eps * jnp.array(rng.standard_normal((D, D, D, D, d)))
     data = data.at[0, 0, 0, 0, 0].set(1.0)
+    data = symmetrize_c4v(data)
     data = data / (jnp.linalg.norm(data) + 1e-10)
     sym = U1Symmetry()
     charges = np.zeros(D, dtype=np.int32)
@@ -139,7 +149,19 @@ def test_gradient_matches_finite_difference(delta, chi):
     ``delta = 1.0`` is the isotropic Heisenberg point, where the corner
     spectrum is SU(2)-degenerate — the case that floors the truncated-SVD
     backward on the production path at ~5e-4.
+
+    The difference direction is projected onto the C4v-invariant subspace,
+    because that is the manifold the method is defined on: off it the
+    enlarged corner ``C·E_top·E_left·a`` is not Hermitian, so ``A ± h·v``
+    along a generic ``v`` (76% off-manifold for this seed) is not a state the
+    C4v CTM contracts consistently.  Measured at chi=4: generic ``v`` floors
+    at 3.6e-5 while a symmetric one reaches 1.7e-9 — the parity is exact
+    in-manifold, and it was only the old scheme's ``M = 2 Cg Cg†``, Hermitian
+    for *any* input, that made an off-manifold difference look meaningful
+    (#760).
     """
+    from tenax.algorithms.ipeps import symmetrize_c4v
+
     A = _site_tensor(eps=1.0)
     gate = _xxz_gate(delta)
     kw = dict(chi=chi, **_CTM_KW)
@@ -151,11 +173,12 @@ def test_gradient_matches_finite_difference(delta, chi):
 
     rng = np.random.RandomState(7)
     v = jnp.array(rng.standard_normal(A.todense().shape))
+    v = symmetrize_c4v(v)
     v = v / jnp.linalg.norm(v)
 
     ad = float(jnp.sum(grad * v))
     fd = _directional_fd(A, gate, v, 1e-5, **kw)
-    assert abs(fd - ad) / max(abs(fd), 1e-30) < 1e-5, (fd, ad)
+    assert abs(fd - ad) / max(abs(fd), 1e-30) < 1e-8, (fd, ad)
 
 
 def test_gradient_is_finite_on_a_degenerate_spectrum():
@@ -168,11 +191,6 @@ def test_gradient_is_finite_on_a_degenerate_spectrum():
     """
     A = _site_tensor(eps=0.02)
     with warnings.catch_warnings():
-        # A large residual is a legitimate outcome here and is covered by
-        # ``test_raises_on_degenerate_truncation_by_default``; this test is
-        # about the gradient being finite either way, so it opts out of the
-        # default hard failure rather than depending on the residual landing
-        # under the tolerance by luck.
         warnings.simplefilter("ignore", RuntimeWarning)
         _e, grad = c4v_root_implicit_energy_and_grad(
             A, _xxz_gate(1.0), chi=8, on_root_residual="warn", **_CTM_KW
@@ -180,28 +198,47 @@ def test_gradient_is_finite_on_a_degenerate_spectrum():
     assert jnp.all(jnp.isfinite(grad))
 
 
-def test_raises_on_degenerate_truncation_by_default():
-    """Truncating through numerical noise is a hard failure, not a warning.
+def test_raises_on_a_non_vanishing_residual_by_default():
+    """A non-vanishing ``‖F(y*)‖`` is a hard failure, not a warning.
 
     The gradient solves the adjoint of equations ``y*`` does not satisfy, so
     it comes back finite and silently wrong.  An unattended optimizer cannot
     detect that, so the default has to stop rather than report.
+
+    Driven by making the *tolerance* impossible rather than by engineering a
+    degenerate spectrum, matching
+    ``test_ctm_root_implicit_multisite.test_an_unconverged_root_raises_by_default``.
+    This used to truncate a near-product state through numerical noise at
+    ``eps=0.1, chi=8``, but the corrected enlarged corner (#760) no longer
+    produces a collapsing corner spectrum — a sweep of
+    ``eps ∈ {0.02..0.3} × chi ∈ {8,12,16}`` now stays under 1.9e-10
+    throughout, so that trigger is gone and the policy needs a deterministic
+    one.
     """
     from tenax.algorithms._ad_primitives import RootResidualError
 
     A = _site_tensor(eps=0.1)
-    with pytest.raises(RootResidualError, match=r"‖F\(y\*\)‖"):
-        c4v_root_implicit_energy_and_grad(A, _xxz_gate(1.0), chi=8, **_CTM_KW)
+    with pytest.raises(RootResidualError, match=r"‖F\(y\*\)‖") as excinfo:
+        c4v_root_implicit_energy_and_grad(
+            A, _xxz_gate(1.0), chi=8, root_residual_warn=0.0, **_CTM_KW
+        )
+    assert excinfo.value.residual >= 0.0
+    assert excinfo.value.tolerance == 0.0
 
 
-def test_degenerate_truncation_still_warns_under_the_warn_policy():
+def test_a_non_vanishing_residual_still_warns_under_the_warn_policy():
     """The diagnostic itself is not lost -- ``on_root_residual='warn'`` keeps
     the old reporting behaviour for callers that want to inspect the bad
     gradient rather than abort."""
     A = _site_tensor(eps=0.1)
     with pytest.warns(RuntimeWarning, match=r"‖F\(y\*\)‖"):
         c4v_root_implicit_energy_and_grad(
-            A, _xxz_gate(1.0), chi=8, on_root_residual="warn", **_CTM_KW
+            A,
+            _xxz_gate(1.0),
+            chi=8,
+            root_residual_warn=0.0,
+            on_root_residual="warn",
+            **_CTM_KW,
         )
 
 

--- a/tests/test_ctm_tensor_c4v.py
+++ b/tests/test_ctm_tensor_c4v.py
@@ -50,6 +50,39 @@ def small_peps_dense():
 
 
 @pytest.fixture
+def entangled_peps_c4v():
+    """*Entangled* C4v-symmetric iPEPS site tensor, D=2, d=2, trivial U1.
+
+    ``small_peps_dense`` perturbs a product state by 1%, which leaves the
+    corner spectrum so close to rank-1 that a wrong enlarged corner barely
+    moves the energy — that fixture passed throughout #760.  This one is a
+    fully random tensor projected onto the C4v-invariant subspace, so the
+    environment carries real weight beyond the leading eigenvalue and the
+    two CTM schemes have something to disagree about.
+    """
+    from tenax.algorithms.ipeps import symmetrize_c4v
+
+    D, d = 2, 2
+    rng = np.random.RandomState(7)
+    data = jnp.array(rng.standard_normal((D, D, D, D, d)))
+    data = symmetrize_c4v(data)
+    data = data / (jnp.linalg.norm(data) + 1e-10)
+    sym = U1Symmetry()
+    charges = np.zeros(D, dtype=np.int32)
+    phys_charges = np.zeros(d, dtype=np.int32)
+    indices = (
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, charges.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(
+            sym, phys_charges.copy(), FlowDirection.IN, label="phys"
+        ),
+    )
+    return DenseTensor(data, indices)
+
+
+@pytest.fixture
 def heisenberg_gate():
     """Heisenberg 2-site Hamiltonian gate as dense array."""
     d = 2
@@ -103,6 +136,51 @@ class TestC4vCTM:
         )
 
         np.testing.assert_allclose(E_c4v, E_gen, atol=1e-4)
+
+    def test_energy_matches_general_ctm_on_an_entangled_state(
+        self, entangled_peps_c4v, heisenberg_gate
+    ):
+        """#760: two converged CTMs must contract the same state identically.
+
+        The C4v sweep grew its corner as ``C·T`` — one edge, and the
+        double-layer tensor ``a`` absorbed only into the *edge*, never into
+        the corner.  Standard CTMRG enlarges the corner as ``C·T_h·T_v·a``
+        (:func:`_build_enlarged_corner`).  The omission converges cleanly to
+        the *wrong* fixed point, so nothing upstream reports a failure; the
+        energy is simply wrong, by 4.6e-3 at D=2 and 1.8e-2 at D=4 on
+        optimised Heisenberg states, and the gap does **not** close as chi
+        grows.
+
+        Both schemes are run to 1e-12 here, so a converged-vs-converged
+        comparison is exact up to CTM tolerance — no ``atol=1e-4`` slack that
+        a near-product fixture can hide inside.
+        """
+        from tenax.algorithms._ctm_tensor_c4v import ctm_tensor_c4v
+
+        chi = 8
+        env_gen, _ = ctm_tensor(
+            entangled_peps_c4v,
+            chi=chi,
+            max_iter=300,
+            conv_tol=1e-12,
+            projector_method="eigh",
+        )
+        E_gen = float(
+            compute_energy_ctm_tensor(entangled_peps_c4v, env_gen, heisenberg_gate, d=2)
+        )
+
+        env_c4v = ctm_tensor_c4v(
+            entangled_peps_c4v, chi=chi, max_iter=300, conv_tol=1e-12
+        )
+        E_c4v = float(
+            compute_energy_ctm_tensor(entangled_peps_c4v, env_c4v, heisenberg_gate, d=2)
+        )
+
+        assert abs(E_c4v - E_gen) / max(abs(E_gen), 1e-30) < 1e-8, (
+            f"C4v CTM energy {E_c4v!r} != general CTM energy {E_gen!r} "
+            f"(rel {abs(E_c4v - E_gen) / abs(E_gen):.3e}); the two schemes "
+            "converged to different environments (#760)."
+        )
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
Fixes #760.

`_c4v_sweep` grew its corner as `Cg = C·T` — one edge, with the double-layer
tensor `a` contracted into the *edge* and never into the corner. The implicit
density matrix is then `C·T·T†·C†`: two copies of the same edge, one
conjugated, and no site tensor. Standard CTMRG enlarges the corner as
`C·T_top·T_left·a`, which this repo already implements as
`_build_enlarged_corner` for the general sweep.

The omission converges *cleanly* to the wrong fixed point — residual 4e-13,
`converged=True` — so nothing upstream ever reported a failure. The energy was
simply wrong.

## Evidence

Against `ctm_tensor` on AD-optimised Heisenberg states, same observable, same
gate:

| | before | after |
|---|---|---|
| D=2 χ=8 | −4.55e-03 | **−2.44e-15** |
| D=2 χ=32 | −4.79e-03 | **−1.11e-15** |
| D=4 χ=16 | −1.83e-02 | **+1.14e-12** |

The gap did not close as χ grew, which is what indicts it: two convergent
approximations of the same contraction must agree in the limit. `ctm_tensor`
was χ-converged to ten digits (−0.6599411913 at χ=16/32/64), matched the
optimiser's own `E_opt` to eight digits, and matched the published D=2 value
≈−0.6602. The C4v path meanwhile drifted the *wrong way* with χ, at D=4 passing
through the exact bound (−0.687 vs −0.669437/site).

## Changes

Three coupled corrections:

1. **`_c4v_sweep`** builds the true enlarged corner and projects it on both
   faces (`P†·Q·P`), replacing a `half·half†` that stored the projected
   *density matrix* rather than the projected corner.
2. **`_ctm_c4v_root_implicit._enlarged_corner`** is an independent dense copy
   of the same construction, which `c4v_root_parametrize` polishes against;
   corrected identically. Without this the root path keeps re-deriving the old
   fixed point regardless of what the sweep produces.
3. **Eigenvalue ordering** in the polish loop now ranks by `|w|`. While `M` was
   `2 Cg Cg†` it was PSD and signed-vs-magnitude ordering coincided; the true
   enlarged corner is Hermitian but *not* PSD, and the sweep's projector comes
   from `ρ = 2MM†` (spectrum `w²`). Signed ordering silently selected a
   different subspace and converged to a different root — this cost a separate
   debugging pass after (1) and (2) were in.

## Knock-on effects

Root residuals improve from ~1e-9 to **~1e-14**; sweeps converge in **13
iterations instead of 24–63**; and the apparent "χ ceiling" disappears:

* D=2 was valid only to χ=12 and stagnated from χ=16 (unchanged at
  `max_iter=3000`). Now valid through χ=32, and χ=48/64 sit at 7.7e-11 /
  9.5e-09 — valid by the root criterion.
* D=4 had an isolated stall at χ=32 and a failure at χ=4. Now valid at **every**
  χ from 4 to 64, uniformly ~1e-14.

That ceiling was this bug, not a property of the state or the method.

## Blast radius

`_c4v_sweep` backs `ctm_tensor_c4v` (public, in `__all__`), the reference-C4v
AD path in `optimize_gs_ad`, and #715 Phase 0. The root-implicit machinery
itself was never implicated — its residual, adjoint solve and gradient were all
consistent with the environment they were handed; that environment was wrong
upstream.

## Tests

The existing `test_energy_matches_general_ctm` passed throughout #760: its
near-product fixture (1% perturbation) plus `atol=1e-4` cannot see the
difference. The new entangled-state regression fails at **42% relative error**
without this fix.

Four further corrections, each making the tests *stricter*:

* **`_site_tensor` was 75% non-C4v.** The old `2 Cg Cg†` was Hermitian PSD for
  any input, so it accepted states the scheme does not apply to
  (`‖M−M†‖/‖M‖ = 0.97` there). Now projected onto the invariant subspace.
* **The FD parity direction was generic**, 76% off the C4v manifold, where the
  enlarged corner is not Hermitian. In-manifold the gradient is exact — 1.7e-9
  vs 3.6e-5 at χ=4 — so the tolerance tightens **1e-5 → 1e-8**.
* **The parity test's `conv_tol` tightens 1e-12 → 1e-14.** At 1e-12 the test
  measured the finite-difference noise floor, not the gradient. The symmetric
  FD divides by `2h = 2e-5`, amplifying the converged environment's residual
  ~1.4e-13 energy error by 5e4 into ~9e-9 in `fd` — the same order as the 1e-8
  tolerance being asserted. It therefore passed at `h=1e-5` and *failed* at
  `h=1e-6` (9.0e-8) on code whose gradient is fine. At 1e-14 the parity is
  1.2e-10..2.2e-09 across both h and every parametrization.
* **The two degenerate-truncation tests lost their trigger.** The corrected
  spectrum no longer collapses: a sweep of `eps ∈ {0.02…0.3} × χ ∈ {8,12,16}`
  now stays under 1.9e-10. Re-based on the deterministic
  `root_residual_warn=0.0` idiom the multisite tests already use.

Verified: 20 C4v tests, 105 adjacent tests (reference-AD, sublattice rotation,
lorentzian-eigh, multisite, asym), and `pytest -m core`.

## On not calling `_build_enlarged_corner` here

`_c4v_sweep` still open-codes its enlarged corner rather than calling the
general sweep's `_build_enlarged_corner`, which is the fourth copy of the same
contraction (general / C4v / root-implicit dense / split). That duplication is
worth removing, but not in a correctness fix — it is deferred, not justified.

An earlier draft of this PR justified it on a measurement — that delegating to
the helper degraded parity 1.44e-09 → 1.05e-08. **That measurement was an
artifact and the claim is withdrawn.** It was a single sample of the FD noise
floor described above: the two constructions' AD gradients agree *with each
other* to 1.1e-12, the entire gap sat in `fd`, and it reconstructs exactly as
`1.44e-09 + 9.05e-09 = 1.049e-08` from a 1.4e-13 energy difference amplified by
`1/2h`. At `h=1e-6` the ordering reverses — the open-coded path scores 9.04e-08
and the helper 6.46e-10 — and at `conv_tol=1e-14` the two are indistinguishable
(1.51e-09 vs 1.52e-09). Hence the `conv_tol` change above.

Two real differences between the copies were confirmed while checking this, and
they are what any consolidation has to handle. Neither affects the dense C4v
path:

* The helper's `C1.c1_d ↔ T4.t4_d` is the **non-geometric** adjacency (the
  #670/#702 historical label swap, which its own `bottom_left` branch already
  comments on). It agrees with the open-coded form to 1.7e-16 on a C4v fixed
  point *only* because `‖T − T(t_l↔t_r)‖/‖T‖ = 3.2e-16`; on an asymmetric C/T
  the two differ by 137%. The general sweep is self-consistent with the swapped
  convention — flipping `top_left` to geometric breaks its seam relabel — so
  this is convention, not a latent bug.
* That pairing contracts two **same-flow** legs (`c1_d` IN with `t4_d` IN),
  which is why the helper's `chi_B` seam is OUT where the open-coded `o_d` is
  IN. Inert for trivial charges; live bookkeeping for the U(1)/fermionic copies.

## Not addressed

Nothing validates that a caller's input to `ctm_tensor_c4v` is C4v-symmetric.
The path now genuinely requires it — the enlarged corner is Hermitian only on
that manifold — and a non-symmetric input yields a meaningless environment
rather than an error. That is how the test fixture went 75% asymmetric
unnoticed. A guard is a behaviour change beyond this fix; worth a follow-up.

Separately, `_c4v_to_full_env` emits `T1.u2` / `T4.l2` with flow OUT where the
general init has them IN. Noticed while comparing the copies; not investigated.

🤖 **AI-generated** — written by Claude Code, posted by @yingjerkao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
