### PR TITLE
fix(#723): default ctm_tensor to the 2x2 recipe instead of the collapsing 1x1

### DIFF
--- a/src/tenax/algorithms/_ctm_tensor_convergence.py
+++ b/src/tenax/algorithms/_ctm_tensor_convergence.py
@@ -614,6 +614,7 @@ def ctm_tensor(
     projector_method: str = "svd",
     qr_warmup_steps: int = 3,
     projector_backward: str = "auto",
+    recipe: str = "2x2",
 ) -> tuple[CTMTensorEnv, float]:
     """Run standard CTM to convergence using the Tensor protocol.
 
@@ -629,7 +630,26 @@ def ctm_tensor(
         conv_tol:          Convergence tolerance on corner singular values.
         renormalize:       Renormalize environment at each step.
         projector_method:  ``"svd"`` (Fishman, default), ``"eigh"``, or ``"qr"``.
+                           Consulted only on the ``"1x1"`` recipe; the ``"2x2"``
+                           recipe always uses Fishman SVD via
+                           ``_compute_2x2_projector``.
         qr_warmup_steps:   Number of eigh warm-up sweeps before QR kicks in.
+        recipe:            ``"2x2"`` (default) — the variPEPS-style 2x2
+                           plaquette projector, run on a 1-site neighbour map.
+                           ``"1x1"`` — the legacy single-site corner-pair
+                           projector, kept only for regression bisection.
+
+                           **``"1x1"`` collapses the environment to rank-1
+                           corners and must not be used for physics** (#723,
+                           #726, #747).  Its projector comes from
+                           ``M = C1g^H C4g``, which is ``chi x chi`` — the
+                           ``chi * D**2`` seam is summed away, so
+                           ``rank(P) <= rank(C1g)``, and the cold ``chi_init=1``
+                           seed makes rank-1 an absorbing state.  The symptom is
+                           an energy that is bit-identical across a 4x change in
+                           chi.  Switching ``projector_method`` does not help:
+                           ``eigh``/``qr`` escape the rank collapse but are
+                           wildly non-convergent on the same recipe.
 
     Returns:
         ``(env, max_truncation_error)`` where ``env`` is the converged
@@ -673,7 +693,38 @@ def ctm_tensor(
             # Asymmetric virtual charges: densify for compatibility
             A = DenseTensor(A.todense(), A.indices)
 
-    sweep_fn = _ctm_tensor_sweep_paired if use_paired else _ctm_tensor_sweep
+    if recipe not in ("2x2", "1x1"):
+        raise ValueError(f"Unknown recipe={recipe!r}; expected '2x2' or '1x1'.")
+    # Validated here rather than inside the projector: the 2x2 recipe never
+    # consults projector_method, so an unknown value would otherwise be
+    # silently accepted on the default path.
+    if projector_method not in ("eigh", "qr", "svd"):
+        raise ValueError(
+            f"Unknown projector_method={projector_method!r}; "
+            f"expected 'eigh', 'qr', or 'svd'."
+        )
+
+    if recipe == "2x2":
+        # A uniform 1-site lattice is just the multisite path with a
+        # self-referential neighbour map, so the 2x2 plaquette projector
+        # applies verbatim.  Wrapped to keep the single-site convergence loop,
+        # normalisation and ``(env, eps)`` return contract below unchanged.
+        def sweep_fn(
+            env, a, chi, renormalize, projector_method, *, projector_backward="auto"
+        ):
+            envs, eps, _smallest_s = _ctm_tensor_sweep_multisite(
+                {(0, 0): env},
+                {(0, 0): a},
+                SINGLE_SITE_NEIGHBORS,
+                chi,
+                renormalize,
+                projector_method,
+                projector_backward=projector_backward,
+                recipe="2x2",
+            )
+            return envs[(0, 0)], float(eps)
+    else:
+        sweep_fn = _ctm_tensor_sweep_paired if use_paired else _ctm_tensor_sweep
 
     a = _build_double_layer_tensor(A)
     env = initialize_ctm_tensor_env(A, chi)

--- a/tests/test_ctm_700_env_collapse.py
+++ b/tests/test_ctm_700_env_collapse.py
@@ -6,6 +6,9 @@ where chi - D**2 is neither 0 nor a full multiset), while leaving chi=10 and
 chi=18 nonzero.  The collapse was silent (no error, just E=0).  The fix pads the
 chi bonds beyond D**2 with the identity (charge-0) sector, which reproduces the
 pre-regression energy and is chi-independent.
+
+Updated for #723: ``ctm_tensor`` now defaults to ``recipe="2x2"``, so the
+chi-frozen reference energy this test used to pin is gone — see the note below.
 """
 
 import jax
@@ -18,8 +21,19 @@ from tenax import compute_energy_ctm_tensor
 from tenax.algorithms._ctm_tensor import ctm_tensor
 from tenax.algorithms.ipeps import heisenberg_gate_u1sz, heisenberg_u1sz_init_pair
 
-# Pre-#671 reference energy for the raw D=3 init (issue #700).
-_E_REF = -0.061722
+# The former ``_E_REF = -0.061722`` pin is deliberately gone.  It was measured
+# on the legacy ``recipe="1x1"`` path, which collapses the environment to
+# rank-1 corners (#723/#726/#747), and it was a *chi-frozen* value: -0.061721808
+# at chi=10 and bit-identical at chi=12, because a rank-1 corner is a chi_eff=1
+# mean-field boundary that cannot respond to chi at all.  Pinning one energy
+# across chi=10..18 only type-checked because the environment was broken.
+#
+# On the corrected 2x2 recipe the corner has rank 4 and the energy genuinely
+# moves with chi (+0.112962196 at chi=10, +0.113096902 at chi=12), so a single
+# pinned value is the wrong shape for this test.  A corrected reference should
+# be re-pinned as part of the #747 re-run; until then this asserts what #700
+# actually guards — the environment must not go to *exact zero* — plus the
+# anti-collapse invariant that would have caught #723.
 
 
 @pytest.mark.parametrize("chi", [10, 12, 14, 16, 18])
@@ -28,5 +42,10 @@ def test_u1sz_env_does_not_collapse(chi):
     env, _ = ctm_tensor(A, chi=chi, max_iter=30, conv_tol=1e-10)
     c1_norm = float(np.linalg.norm(np.asarray(env.C1._data)))
     assert c1_norm > 1e-6, f"chi={chi}: env collapsed to zero (|C1|={c1_norm})"
+
+    s = np.linalg.svd(np.asarray(env.C1.todense()), compute_uv=False)
+    rank = int((s / (s[0] + 1e-300) > 1e-10).sum())
+    assert rank > 1, f"chi={chi}: env collapsed to a rank-{rank} corner (#723)"
+
     e = float(compute_energy_ctm_tensor(A, env, heisenberg_gate_u1sz()))
-    assert e == pytest.approx(_E_REF, abs=1e-4), f"chi={chi}: E={e} != {_E_REF}"
+    assert np.isfinite(e) and e != 0.0, f"chi={chi}: E={e}"

--- a/tests/test_ctm_723_single_site_collapse.py
+++ b/tests/test_ctm_723_single_site_collapse.py
@@ -1,0 +1,111 @@
+"""Regression: single-site ``ctm_tensor`` must not collapse to a rank-1 env (#723).
+
+The legacy ``1x1`` recipe builds its projector from the corner-pair cross
+product ``M = C1g^H C4g``, which is ``chi x chi`` — the ``chi * D**2`` seam is
+summed away, so ``rank(P) <= rank(C1g)``.  With the cold ``chi_init=1`` seed
+(``_make_rank1_dense_corner`` plus the ``T[0, diag, 0]`` edge) that is 1, and
+rank-1 is an *absorbing* state: the environment can never grow.
+
+The signature is an energy that does not move with chi at all — bit-identical
+across a 4x change — because a rank-1 corner is a chi_eff = 1 mean-field
+boundary rather than a corner transfer matrix.  Nothing raises: the collapsed
+environment is still finite, Hermitian and PSD, so it is silently wrong.
+
+Switching the projector does **not** rescue the ``1x1`` recipe.  Measured on the
+D=2 sublattice-rotated Heisenberg simple-update state, ``2x2`` gives
+``-0.488638504625`` at every chi, while ``1x1`` gives:
+
+===========  ==============  ==============  ==============
+projector    chi=4           chi=8           chi=16
+===========  ==============  ==============  ==============
+``"svd"``    -0.485745       -0.485745       -0.485745      (bit-identical, rank 1)
+``"eigh"``   -0.530886       -0.723684       -0.272534      (full rank, divergent)
+``"qr"``     -0.500077       -0.527835       -0.301451      (full rank, divergent)
+===========  ==============  ==============  ==============
+
+``eigh``/``qr`` escape the rank collapse but are wildly non-convergent, and
+-0.7237 is below the exact ground-state energy of this model.  So the defect is
+the recipe, not the projector, and the fix routes the single-site path through
+the 2x2 plaquette projector that the multisite path already uses.
+
+The oracle here is ``ctm_tensor_2site(A, A)``: a uniform 1-site lattice is
+exactly the checkerboard with both sublattices equal, and the 2x2 recipe is the
+known-good path (#726, #746, #747).
+"""
+
+import jax
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_tensor_convergence import ctm_tensor, ctm_tensor_2site
+from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
+from tenax.algorithms.ipeps import heisenberg_gate, ipeps, sublattice_rotate_gate
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+
+
+@pytest.fixture(scope="module")
+def su_state():
+    """Physical D=2 simple-update Heisenberg state (the #726/#747 reproducer)."""
+    gate = sublattice_rotate_gate(heisenberg_gate())
+    cfg = iPEPSConfig(
+        max_bond_dim=2,
+        num_imaginary_steps=60,
+        dt=0.05,
+        ctm=CTMConfig(chi=8, max_iter=20),
+    )
+    _, (A, _B), _ = ipeps(gate, None, cfg)
+    return A, gate
+
+
+def _corner_rank(env, tol=1e-10):
+    s = np.linalg.svd(np.asarray(env.C1.todense()), compute_uv=False)
+    return int((s / (s[0] + 1e-300) > tol).sum())
+
+
+def test_single_site_env_is_not_rank_one(su_state):
+    """A rank-1 corner is a chi_eff=1 mean-field boundary, not a CTM env."""
+    A, _ = su_state
+    env, _ = ctm_tensor(A, chi=8, max_iter=100, conv_tol=1e-12)
+    rank = _corner_rank(env)
+    assert rank > 1, (
+        f"single-site CTM env collapsed to rank {rank} (#723): the corner "
+        f"spectrum is [1, 0, 0, ...], i.e. a product environment"
+    )
+
+
+def test_single_site_energy_moves_with_chi(su_state):
+    """#747's cheap detector: a chi-frozen energy is a broken environment."""
+    A, gate = su_state
+    e_lo, _ = ctm_tensor(A, chi=4, max_iter=100, conv_tol=1e-12)
+    e_hi, _ = ctm_tensor(A, chi=16, max_iter=100, conv_tol=1e-12)
+    E_lo = float(compute_energy_ctm_tensor(A, e_lo, gate, d=2))
+    E_hi = float(compute_energy_ctm_tensor(A, e_hi, gate, d=2))
+    assert E_lo != E_hi, (
+        f"energy bit-identical across a 4x change in chi ({E_lo!r}); that is the "
+        f"rank-1 collapse signature (#723/#747), not convergence"
+    )
+
+
+def test_single_site_matches_2site_oracle(su_state):
+    """A uniform 1-site lattice IS the checkerboard with both sublattices equal."""
+    A, gate = su_state
+    chi = 8
+    env_1, _ = ctm_tensor(A, chi=chi, max_iter=100, conv_tol=1e-12)
+    env_A, _env_B = ctm_tensor_2site(A, A, chi=chi, max_iter=100, conv_tol=1e-12)
+    E_1 = float(compute_energy_ctm_tensor(A, env_1, gate, d=2))
+    E_2 = float(compute_energy_ctm_tensor(A, env_A, gate, d=2))
+    assert E_1 == pytest.approx(E_2, rel=1e-6), (
+        f"single-site CTM energy {E_1!r} != 2x2 oracle {E_2!r}"
+    )
+
+
+def test_legacy_1x1_recipe_still_reachable(su_state):
+    """``recipe='1x1'`` is kept for regression bisection, and still collapses."""
+    A, _ = su_state
+    env, _ = ctm_tensor(A, chi=8, max_iter=100, conv_tol=1e-12, recipe="1x1")
+    assert _corner_rank(env) == 1, (
+        "the legacy 1x1 recipe is expected to still collapse; if this now "
+        "passes, the 1x1 projector itself was fixed and this test is stale"
+    )

--- a/tests/test_split_ctm_doublelayer_projector.py
+++ b/tests/test_split_ctm_doublelayer_projector.py
@@ -79,7 +79,19 @@ def test_split_matches_fused_lossless_chi_I(D, chi):
     make_site, heisenberg_gate, fused_env_to_split = _oracle()
     A = make_site(D, 2, seed=7)
     gate = heisenberg_gate()
-    fused_env, _ = ctm_tensor(A, chi=chi, max_iter=300, conv_tol=0.0)
+    # ``recipe="1x1"`` is pinned deliberately.  This test asserts a
+    # *representation* claim — that the split double-layer path is an exact
+    # factorization of the fused one at the same chi — so both sides must run
+    # the same projector recipe or the comparison is meaningless.
+    #
+    # ``ctm_tensor`` now defaults to ``recipe="2x2"`` (#723) while
+    # ``ctm_split_tensor`` is still on ``1x1``; rerouting the split path is the
+    # remaining half of #746.  Until that lands, this is the circular oracle
+    # #746 calls out — both sides collapse to rank-1 corners, so agreement here
+    # says nothing about physics, only that the factorization is faithful.
+    # When #746 lands, drop this pin so both sides run 2x2 and the oracle
+    # becomes real.
+    fused_env, _ = ctm_tensor(A, chi=chi, max_iter=300, conv_tol=0.0, recipe="1x1")
     E_fused = float(compute_energy_ctm_tensor(A, fused_env, gate))
     split_env = ctm_split_tensor(A, chi=chi, chi_I=chi * D, max_iter=300, conv_tol=0.0)
     E_split = float(compute_energy_split_ctm_tensor(A, split_env, gate))


### PR DESCRIPTION
Closes #723. Implements the single-site half of #746 for the **fused** path.

## The defect

`ctm_tensor` had **no recipe knob at all** and always ran the legacy `1x1` sweep, whose corner-pair projector collapses the environment to rank-1 corners.

`M = C1g^H C4g` is `chi x chi` — the `chi*D^2` seam is summed away — so `rank(P) <= rank(C1g)`, which is 1 at the cold `chi_init=1` seed (`_make_rank1_dense_corner` plus the `T[0, diag, 0]` edge). Rank-1 is therefore an **absorbing** state: measured rank 1 at init and after 1, 2, 4, 8 and 16 forced sweeps, on every tensor tried.

The symptom is an energy that does not move with chi at all. Nothing raises — the collapsed environment is still finite, Hermitian and PSD.

## Switching the projector does not rescue it

Measured on the D=2 sublattice-rotated Heisenberg simple-update state from #726/#747:

| projector | chi=4 | chi=8 | chi=16 | rank(C1) |
|---|---|---|---|---|
| `"svd"` (default) | -0.485745 | -0.485745 | -0.485745 | **1** — bit-identical |
| `"eigh"` | -0.530886 | -0.723684 | -0.272534 | full, divergent |
| `"qr"` | -0.500077 | -0.527835 | -0.301451 | full, divergent |
| **`recipe="2x2"`** | **-0.488638504625** | same | same | 4–6, nested |

`eigh`/`qr` escape the rank collapse but are wildly non-convergent — `-0.7237` is *below* the exact ground-state energy of this model. So the defect is recipe-level, exactly as #746 concluded, and a projector swap was refuted before this fix was written. The 2x2 value matches the correct reference quoted in #747.

## The fix

Add `recipe: str = "2x2"` to `ctm_tensor`, delegating to `_ctm_tensor_sweep_multisite` with `SINGLE_SITE_NEIGHBORS` — a uniform 1-site lattice *is* the multisite path with a self-referential neighbour map, so the working 2x2 plaquette projector applies verbatim. The existing convergence loop, normalisation and `(env, eps)` return contract are untouched. `recipe="1x1"` is kept for regression bisection and documented as unusable for physics.

`projector_method` is now validated in `ctm_tensor` itself — the 2x2 path never consults it, so unknown values were silently accepted (this is what `test_invalid_projector_method_raises` caught).

**Blast radius is small.** `gs_recipe` already defaults to `"2x2"` (`ipeps_config.py`) and `ad_utils` never passes `recipe`, so it inherits the `"2x2"` default. Only this entry point was stuck on `1x1`.

## Cost

2x2 is **3–6x slower** on the single-site path (D=3 U(1)-Sz, chi=10: 46.6s → 118.5s; chi=12: 27.7s → 160.6s). Several CTM test files go from seconds to minutes. Correctness over speed, and this is the recipe the AD/optimizer path already used, but it is a real CI cost.

## Test changes

`test_ctm_700_env_collapse.py` pinned `_E_REF = -0.061722` across chi=10..18. That was measured on the collapsed path, and one value only covered five chi because the broken environment returned a bit-identical number at every one. Under 2x2:

| chi | E | rank(C1) |
|---|---|---|
| 10 | +0.112962196 | 4/10 |
| 12 | +0.113096902 | 4/12 |
| 14 | +0.085402464 | 5/14 |
| 16 | +0.085402081 | 5/16 |
| 18 | +0.255773158 | 6/18 |

No single pin at `abs=1e-4` is possible. Replaced with what #700 actually guards — the environment must not go to *exact zero* — plus `rank(C1) > 1`, the invariant that would have caught #723. A corrected reference belongs to the #747 re-run. (This state is a random D=3 init, not a ground state, so it is not expected to converge in chi.)

New `tests/test_ctm_723_single_site_collapse.py`: corner is not rank-1; energy moves with chi (#747's cheap detector); energy matches the `ctm_tensor_2site(A, A)` oracle; and the legacy `1x1` still collapses. All four fail on `main`.

## Verification

Passing: `test_ctm_723_single_site_collapse.py` (4), `test_ctm_tensor.py` (33p/2s), `test_ctm_projector.py` + `test_ctm_tensor_init_rank1.py` (19), `test_ctm_paired.py` + `test_ctm_recipe_2x2_consistency.py` + `test_ctm_truncation_error.py` (17), `test_ctm_env_pad.py` + `test_ctm_chi_ramp.py` + `test_ctm_direction_dependent_bonds.py` + `test_ctm_compiled.py` (32), `test_ctm_700_env_collapse.py` (chi=10). Ruff clean.

**Not run locally:** the rest of the core suite — the 3–6x slowdown made full local runs impractical, so CI is the real gate here. Please watch for other tests that pinned collapsed-path references.

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)