### PR TITLE
feat(#715): wire root implicit AD behind ctm_ad_mode="root_implicit"

### DIFF
--- a/src/tenax/algorithms/ipeps_ad_policy.py
+++ b/src/tenax/algorithms/ipeps_ad_policy.py
@@ -127,6 +127,19 @@ def use_reference_c4v_path(config: iPEPSConfig) -> bool:
     )
 
 
+def use_root_implicit_path(config: iPEPSConfig) -> bool:
+    """Return ``True`` when ``ctm_ad_mode`` selects a root-implicit engine (#715).
+
+    Mirrors :func:`use_reference_c4v_path`.  Unlike that gate this does *not*
+    require ``gs_c4v`` or a particular unit cell -- the variant is chosen from
+    the unit cell inside ``ipeps_optimize_root_implicit.root_implicit_variant``.
+    """
+    return getattr(config.ctm, "ctm_ad_mode", None) in (
+        "root_implicit",
+        "root_implicit_symmetric",
+    )
+
+
 def build_ad_ctm_config(config: iPEPSConfig) -> CTMConfig:
     """Return the effective CTMConfig used by iPEPS AD optimizers.
 

--- a/src/tenax/algorithms/ipeps_config.py
+++ b/src/tenax/algorithms/ipeps_config.py
@@ -118,7 +118,15 @@ class CTMConfig:
     # — explicit user choice is preserved.  See ipeps_ad_paths.md.
     forward_gauge: str = "phase"
     # Optional reference-mode implicit AD mode (App. C-F) for dense 1-site C4v.
-    ctm_ad_mode: str | None = None  # None or "c4v_reference"
+    # None | "c4v_reference" | "root_implicit" | "root_implicit_symmetric".
+    # The root-implicit modes (#715) drive arXiv:2607.15030 characteristic
+    # equations instead of back-propagating the CTM sweep, so no SVD/eigh
+    # backward appears in the gradient path.  See
+    # ``ipeps_optimize_root_implicit`` -- notably that they own their CTM
+    # convergence and reject warm-start-dependent knobs rather than
+    # silently ignoring them, and that they are a stability/accuracy
+    # lever, not a speed one.
+    ctm_ad_mode: str | None = None
     adjoint_solver: str = "bicgstab"  # "bicgstab" or "gmres"
     adjoint_maxiter: int = 50
     adjoint_tol: float = 1e-8
@@ -261,7 +269,12 @@ class CTMConfig:
     ctm_chunk_size: int | None = None
 
     def __post_init__(self):
-        valid_modes = {None, "c4v_reference"}
+        valid_modes = {
+            None,
+            "c4v_reference",
+            "root_implicit",
+            "root_implicit_symmetric",
+        }
         if self.ctm_ad_mode not in valid_modes:
             raise ValueError(
                 f"ctm_ad_mode must be one of {valid_modes}, got {self.ctm_ad_mode!r}"

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -21,6 +21,7 @@ from tenax.algorithms.ipeps_ad_policy import (
     build_ad_ctm_config,
     resolve_projector_backward,
     use_reference_c4v_path,
+    use_root_implicit_path,
 )
 from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
 from tenax.core.index import FlowDirection, TensorIndex
@@ -925,6 +926,18 @@ def optimize_gs_ad(
             "unit_cell='2site' or '1x1' (non-C4v-reference, incl. cg_gates). "
             "Multisite / C4v-reference checkpoint wiring is a follow-up (#497)."
         )
+
+    # Root implicit AD (#715).  Placed ahead of the unit-cell branches because
+    # the variant (dense 1x1 vs dense cell vs symmetric) is selected from the
+    # unit cell *inside* that dispatcher, and its own validator decides what it
+    # can honour -- routing through the ordinary branches first would apply
+    # warm-start machinery the entry points cannot use.
+    if use_root_implicit_path(config):
+        from tenax.algorithms.ipeps_optimize_root_implicit import (
+            optimize_gs_ad_root_implicit,
+        )
+
+        return optimize_gs_ad_root_implicit(hamiltonian_gate, A_init, config)
 
     if isinstance(config.unit_cell, Lattice):
         return _optimize_gs_ad_multisite(hamiltonian_gate, A_init, config)

--- a/src/tenax/algorithms/ipeps_optimize_root_implicit.py
+++ b/src/tenax/algorithms/ipeps_optimize_root_implicit.py
@@ -1,0 +1,333 @@
+"""Ground-state optimization driven by root implicit AD (#715).
+
+Wires the root-implicit ``*_energy_and_grad`` entry points into
+``optimize_gs_ad`` behind ``CTMConfig.ctm_ad_mode="root_implicit"``.
+
+Root implicit differentiation (arXiv:2607.15030) characterises the converged
+environment as the root of an *algebraic* equation ``F(y, p) = 0`` and gets the
+gradient from a single un-nested linear solve.  No SVD or eigh backward appears
+anywhere in the gradient path, which is the point: #566 (block-sparse AD
+compile wall) and #687 (symmetric CTM AD accuracy floor) are specifically those
+VJPs inside the compiled backward.
+
+.. important::
+    **This is not a speed optimization.**  Per #715's own cost/benefit, the
+    crossover where implicit beats fixed-point appears only at large ``D²χ``;
+    at ``D = 3-4``, ``chi = 16-24`` we are on the wrong side of it, and our
+    fixed-point baseline is *better* than the one the paper benchmarks against
+    (they pay a nested Sylvester solve for sparse SVDs; we take a thin SVD with
+    JAX's closed-form VJP).  The reasons to use this path are **stability**
+    (it removes the degenerate-singular-value failure class outright) and
+    block-sparse accuracy/compile cost.
+
+Architectural note -- why this is a separate optimizer loop rather than a
+backward swap.  The ``*_energy_and_grad`` entry points replace the *whole*
+``value_and_grad``, not just the backward: each runs its own CTM convergence
+(``max_iter``, ``conv_tol``, ``min_iter``, ``polish_steps``) and takes **no
+warm-start environment**.  So every optimizer step reconverges CTM from cold,
+and the knobs that ride on a warm-started environment -- chi auto-bump,
+chi ramping, environment checkpointing -- have nothing to attach to.  Those
+hard-error in :func:`validate_root_implicit_config` rather than silently
+no-op; this codebase has been burned repeatedly by silent inapplicability
+(#723, #760, #762).
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "optimize_gs_ad_root_implicit",
+    "root_implicit_variant",
+    "validate_root_implicit_config",
+]
+
+import logging
+import warnings
+
+import jax
+import jax.numpy as jnp
+
+from tenax.algorithms.ipeps_config import iPEPSConfig
+from tenax.core.tensor import DenseTensor, Tensor
+
+_logger = logging.getLogger(__name__)
+
+# ``ctm_ad_mode`` values handled here.  "root_implicit" auto-selects among the
+# *dense* variants from the unit cell; the symmetric variant must be asked for
+# by name so nobody lands on the 8.4 GB GMRES path (#731) by accident.  C4v
+# (Phase 0) is deliberately not exposed -- it exists to validate the
+# characteristic equations, not to run production.
+ROOT_IMPLICIT_MODES = ("root_implicit", "root_implicit_symmetric")
+
+
+def root_implicit_variant(config: iPEPSConfig) -> str:
+    """Return which root-implicit engine ``config`` selects.
+
+    ``"asym"`` (dense 1x1), ``"cell"`` (dense multisite) or ``"symmetric"``.
+    """
+    mode = getattr(config.ctm, "ctm_ad_mode", None)
+    if mode == "root_implicit_symmetric":
+        return "symmetric"
+    if mode != "root_implicit":
+        raise ValueError(f"not a root-implicit mode: {mode!r}")
+    return "asym" if config.unit_cell == "1x1" else "cell"
+
+
+def validate_root_implicit_config(config: iPEPSConfig) -> None:
+    """Reject configurations the root-implicit path cannot honour.
+
+    Every rejection here is a knob that would otherwise be **silently
+    ignored**, because the ``*_energy_and_grad`` entry points own their CTM
+    convergence and accept no warm-start environment.  Failing loudly at
+    config time is the same policy as ``validate_split_ctm_config``.
+
+    ``gs_metric_precond`` is deliberately *not* in this list even though it is
+    equally unhonourable here (the metric inner product needs a per-step
+    environment).  It defaults to ``True``, so rejecting it would make
+    ``ctm_ad_mode="root_implicit"`` unusable without an unrelated opt-out.  It
+    warns and falls back instead, which is exactly what the split-CTM path does
+    with the same knob for the same reason.
+    """
+    ctm = config.ctm
+    unsupported: list[tuple[str, str]] = []
+
+    if ctm.chi_auto_bump:
+        unsupported.append(
+            ("chi_auto_bump", "the entry points converge their own environment")
+        )
+    if getattr(ctm, "ctmrg_heuristic_increase_chi", False):
+        unsupported.append(
+            (
+                "ctmrg_heuristic_increase_chi",
+                "in-CTM chi growth needs the forward loop this path replaces",
+            )
+        )
+    if getattr(ctm, "chi_ramp", None) is not None:
+        unsupported.append(("chi_ramp", "chi is fixed for the lifetime of the solve"))
+    if not getattr(ctm, "fuse_virtual_legs", True):
+        unsupported.append(
+            (
+                "fuse_virtual_legs=False",
+                "root implicit AD is defined on the fused double layer",
+            )
+        )
+    if config.gs_checkpoint_path is not None:
+        unsupported.append(
+            (
+                "gs_checkpoint_path",
+                "there is no warm-start environment to checkpoint",
+            )
+        )
+    if config.cg_gates is not None:
+        unsupported.append(
+            ("cg_gates", "coarse-grained gates have no root-implicit objective")
+        )
+    if unsupported:
+        lines = "\n".join(f"  - {k}: {why}" for k, why in unsupported)
+        raise NotImplementedError(
+            "ctm_ad_mode='root_implicit' does not support the following "
+            f"settings, which would otherwise be silently ignored:\n{lines}\n"
+            "Unset them, or use the default (fixed-point implicit) AD path."
+        )
+
+
+def _initial_tensor(hamiltonian_gate, A_init, config: iPEPSConfig, gate, d_phys):
+    """Resolve the starting site tensor (explicit / simple-update / random)."""
+    from tenax.algorithms.ipeps import ipeps
+    from tenax.algorithms.ipeps_optimize import _wrap_as_dense_tensor
+
+    if A_init is not None:
+        return A_init if isinstance(A_init, Tensor) else _wrap_as_dense_tensor(A_init)
+    if config.su_init:
+        _E, tensors, _envs = ipeps(gate, None, config)
+        return tensors[0] if isinstance(tensors, (list, tuple)) else tensors
+    D = config.max_bond_dim
+    k1, k2 = jax.random.split(jax.random.PRNGKey(0))
+    data = jax.random.normal(k1, (D, D, D, D, d_phys)) + 1j * jax.random.normal(
+        k2, (D, D, D, D, d_phys)
+    )
+    return _wrap_as_dense_tensor(data)
+
+
+def optimize_gs_ad_root_implicit(
+    hamiltonian_gate,
+    A_init,
+    config: iPEPSConfig,
+):
+    """Optimize a ground state using root-implicit gradients.
+
+    Returns ``(A_opt, env, E_gs)``, matching ``optimize_gs_ad``.
+
+    The returned environment is converged *separately* by the standard forward
+    CTM after optimization finishes: the root-implicit entry points return
+    ``(energy, grad)`` and do not surface the environment they built
+    internally.  It is therefore the environment of ``A_opt``, converged with
+    the ordinary machinery -- not a by-product of the last gradient step.
+    """
+    import optax
+
+    from tenax.algorithms._ctm_python_loop import python_loop_ctm_converge
+    from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
+    from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
+    from tenax.algorithms.ipeps_ad_policy import ctm_converge_kwargs
+    from tenax.algorithms.ipeps_optimize import (
+        _build_optimizer,
+        _converged_outer,
+        _grad_l2_norm,
+        _log_ad_converged,
+        _normalize_params,
+        _should_accept_best,
+        _warn_implicit_ad_variational_caveat,
+    )
+
+    validate_root_implicit_config(config)
+    if getattr(config, "gs_metric_precond", False):
+        # Default-on knob, so this warns rather than raising (see
+        # validate_root_implicit_config).  Mirrors the split-CTM fallback.
+        warnings.warn(
+            "gs_metric_precond=True is not supported on the root-implicit AD "
+            "path (ctm_ad_mode='root_implicit'): the metric inner product "
+            "needs a per-step CTM environment, which the *_energy_and_grad "
+            "entry points do not expose. Falling back to non-preconditioned "
+            "optimization.",
+            UserWarning,
+            stacklevel=2,
+        )
+    variant = root_implicit_variant(config)
+
+    if variant == "cell":
+        raise NotImplementedError(
+            "ctm_ad_mode='root_implicit' currently wires the dense 1x1 "
+            "(asymmetric) engine only; got unit_cell="
+            f"{config.unit_cell!r}. The multisite engine "
+            "(cell_root_implicit_energy_and_grad, #715 Phase 2) is built and "
+            "tested but not yet wired here -- its shifted-cell index tables "
+            "are the whole risk of that phase and a wrong shift yields a "
+            "silently wrong gradient, so it gets its own increment. Use "
+            "unit_cell='1x1'."
+        )
+    if variant == "symmetric":
+        raise NotImplementedError(
+            "ctm_ad_mode='root_implicit_symmetric' is not wired yet: the "
+            "symmetric adjoint peaks at 8.4 GB in the GMRES solve (#731), "
+            "which needs resolving before it can be driven from an optimizer "
+            "loop. The engine itself (sym_root_implicit_energy_and_grad) is "
+            "built and tested."
+        )
+
+    _warn_implicit_ad_variational_caveat(config, path="1-site dense root-implicit")
+
+    from tenax.algorithms._ctm_root_implicit_asym import (
+        asym_root_implicit_energy_and_grad,
+    )
+
+    gate = (
+        hamiltonian_gate.todense()
+        if isinstance(hamiltonian_gate, Tensor)
+        else jnp.asarray(hamiltonian_gate)
+    )
+    d_phys = gate.shape[0]
+
+    A = _initial_tensor(hamiltonian_gate, A_init, config, gate, d_phys)
+    if not isinstance(A, DenseTensor):
+        raise TypeError(
+            "ctm_ad_mode='root_implicit' is dense-only (#715 Phase 3 covers "
+            f"SymmetricTensor); got {type(A).__name__}."
+        )
+    A = A * (1.0 / (A.norm() + 1e-10))
+    indices = A.indices
+    ctm_cfg = config.ctm
+
+    def _energy_and_grad(params):
+        A_t = DenseTensor(params, indices)
+        return asym_root_implicit_energy_and_grad(
+            A_t,
+            gate,
+            chi=ctm_cfg.chi,
+            max_iter=ctm_cfg.max_iter,
+            conv_tol=ctm_cfg.conv_tol,
+            min_iter=ctm_cfg.min_iter,
+        )
+
+    def _final_env(params):
+        """Converge the reported environment with the ordinary forward CTM."""
+        A_t = DenseTensor(params, indices)
+        envs, _info = python_loop_ctm_converge(
+            {(0, 0): A_t}, SINGLE_SITE_NEIGHBORS, **ctm_converge_kwargs(ctm_cfg)
+        )
+        return A_t, envs[(0, 0)]
+
+    params = A.todense()
+
+    if config.gs_num_steps == 0:
+        A_t, env = _final_env(params)
+        return A_t, env, float(compute_energy_ctm_tensor(A_t, env, gate, d_phys))
+
+    optimizer = _build_optimizer(config)
+    use_cg = optimizer is None
+    opt_state = None if optimizer is None else optimizer.init(params)
+    best_energy = float("inf")
+    best_params = params
+    prev_energy = float("inf")
+
+    for step in range(config.gs_num_steps):
+        energy_val, grads = _energy_and_grad(params)
+        grads = jnp.where(jnp.isfinite(grads), grads, 0.0)
+        E = float(jnp.real(energy_val))
+
+        if _should_accept_best(
+            current_best=best_energy,
+            candidate=E,
+            floor=getattr(config, "gs_energy_floor", None),
+        ):
+            best_energy = E
+            best_params = params
+
+        if config.gs_verbose:
+            print(
+                f"[iPEPS-AD:root_implicit] step {step + 1}/{config.gs_num_steps} "
+                f"E={E:.12f}",
+                flush=True,
+            )
+
+        delta_energy = abs(E - prev_energy)
+        prev_energy = E
+        grad_norm_val = (
+            _grad_l2_norm(grads)
+            if config.gs_conv_criterion in ("grad_norm", "both")
+            else None
+        )
+        if _converged_outer(config, delta_energy, grad_norm_val):
+            if config.gs_verbose:
+                _log_ad_converged(
+                    "root_implicit",
+                    step,
+                    delta_energy,
+                    config.gs_conv_tol,
+                    grad_norm=grad_norm_val,
+                    grad_norm_tol=config.gs_grad_norm_tol,
+                    criterion=config.gs_conv_criterion,
+                )
+            break
+
+        if use_cg:
+            params = _normalize_params(params - config.gs_learning_rate * grads)
+        else:
+            assert optimizer is not None
+            if config.gs_optimizer.lower() == "lbfgs":
+                # optax's L-BFGS line search re-evaluates the objective, which
+                # on this path means a full root-implicit solve per probe.
+                # Pass only the value function, never value_and_grad.
+                updates, opt_state = optimizer.update(
+                    grads,
+                    opt_state,
+                    params,
+                    value=energy_val,
+                    grad=grads,
+                    value_fn=lambda p: _energy_and_grad(p)[0],
+                )
+            else:
+                updates, opt_state = optimizer.update(grads, opt_state, params)
+            params = _normalize_params(optax.apply_updates(params, updates))
+
+    A_opt, env = _final_env(best_params)
+    return A_opt, env, float(compute_energy_ctm_tensor(A_opt, env, gate, d_phys))

--- a/src/tenax/tuning/registry.py
+++ b/src/tenax/tuning/registry.py
@@ -318,14 +318,19 @@ _register(
         type_str="str | None",
         category=TuningCategory.METHOD_SELECTION,
         description=(
-            "Opt-in reference-mode implicit AD path for dense 1-site C4v "
-            "(Francuz et al. App. C–F). None disables; 'c4v_reference' "
-            "enables the dense C4v fixed-point backward."
+            "Selects a non-default AD backward. None uses fixed-point implicit "
+            "AD. 'c4v_reference' enables the dense 1-site C4v fixed-point "
+            "backward (Francuz et al. App. C-F). 'root_implicit' and "
+            "'root_implicit_symmetric' drive root implicit differentiation "
+            "(arXiv:2607.15030), which removes every SVD/eigh backward from "
+            "the gradient path -- a stability and block-sparse-accuracy lever, "
+            "NOT a speed one (#715 is on the wrong side of the crossover at "
+            "production D and chi)."
         ),
         hint=TuningHint(
             scale=Scale.CATEGORICAL,
             sensitivity=Sensitivity.HIGH,
-            values=(None, "c4v_reference"),
+            values=(None, "c4v_reference", "root_implicit"),
         ),
         dependencies=(
             Dependency(
@@ -338,10 +343,23 @@ _register(
             ),
             Dependency(
                 name="iPEPSConfig.unit_cell",
-                relation="'c4v_reference' requires unit_cell='1x1'",
+                relation=(
+                    "'c4v_reference' requires unit_cell='1x1'; 'root_implicit' "
+                    "currently wires the dense 1x1 engine only"
+                ),
+            ),
+            Dependency(
+                name="CTMConfig.chi_auto_bump",
+                relation=(
+                    "the root_implicit modes reject chi_auto_bump, chi_ramp, "
+                    "ctmrg_heuristic_increase_chi, gs_checkpoint_path, "
+                    "cg_gates and gs_metric_precond rather than silently "
+                    "ignoring them -- they own their CTM convergence and take "
+                    "no warm-start environment"
+                ),
             ),
         ),
-        references=("arXiv:2311.11894",),
+        references=("arXiv:2311.11894", "arXiv:2607.15030"),
     )
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,10 @@ _FILE_MARKERS = {
     # The #747 collapse detectors themselves. Cheap (D=2, chi=8) and they guard
     # the guard: if these rot, nothing else notices a collapsed environment.
     "test_ctm_collapse_detector.py": "core",
+    # Root-implicit AD wiring (#715): dispatch + guard surface only, no
+    # CTM convergence, so it is milliseconds.  The production-run case it
+    # also carries is explicitly @slow + xfail (#772).
+    "test_root_implicit_wiring.py": "core",
     "test_ctm_tensor.py": "algorithm",
     "test_integration_regression.py": "algorithm",
     "test_krylov.py": "core",

--- a/tests/test_root_implicit_wiring.py
+++ b/tests/test_root_implicit_wiring.py
@@ -1,0 +1,232 @@
+"""Wiring for ``ctm_ad_mode="root_implicit"`` (#715).
+
+These cover the *dispatch and guard* surface, not the characteristic equations
+themselves -- those live in ``test_ctm_root_implicit_asym.py`` and friends.
+
+The guards are the point.  The root-implicit ``*_energy_and_grad`` entry points
+replace the whole ``value_and_grad``: each runs its own CTM convergence and
+takes no warm-start environment, so every knob that rides on a warm-started env
+would be *silently ignored* if it were merely passed through.  This repository
+has been burned by exactly that shape of bug in #723, #760 and #762, so the
+policy is to hard-error at config time.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from tenax.algorithms.ipeps_ad_policy import use_root_implicit_path
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+from tenax.algorithms.ipeps_optimize_root_implicit import (
+    root_implicit_variant,
+    validate_root_implicit_config,
+)
+
+
+def _cfg(**ctm_kw):
+    """A minimal root-implicit config; ``ctm_kw`` overrides CTM fields."""
+    base = dict(chi=4, max_iter=50, conv_tol=1e-10, ctm_ad_mode="root_implicit")
+    base.update(ctm_kw)
+    return iPEPSConfig(max_bond_dim=2, unit_cell="1x1", ctm=CTMConfig(**base))
+
+
+# ------------------------------------------------------------------ #
+# Config surface                                                       #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "mode", ["root_implicit", "root_implicit_symmetric", "c4v_reference", None]
+)
+def test_valid_ctm_ad_modes_are_accepted(mode):
+    iPEPSConfig(max_bond_dim=2, ctm=CTMConfig(chi=4, ctm_ad_mode=mode))
+
+
+def test_unknown_ctm_ad_mode_still_rejected():
+    with pytest.raises(ValueError, match="ctm_ad_mode must be one of"):
+        iPEPSConfig(max_bond_dim=2, ctm=CTMConfig(chi=4, ctm_ad_mode="root"))
+
+
+@pytest.mark.parametrize(
+    "mode,expected",
+    [
+        ("root_implicit", True),
+        ("root_implicit_symmetric", True),
+        ("c4v_reference", False),
+        (None, False),
+    ],
+)
+def test_path_predicate(mode, expected):
+    cfg = iPEPSConfig(max_bond_dim=2, ctm=CTMConfig(chi=4, ctm_ad_mode=mode))
+    assert use_root_implicit_path(cfg) is expected
+
+
+def test_variant_selection_follows_the_unit_cell():
+    """``"root_implicit"`` picks the dense engine from the unit cell."""
+    assert root_implicit_variant(_cfg()) == "asym"
+    cell = dataclasses.replace(_cfg(), unit_cell="2site")
+    assert root_implicit_variant(cell) == "cell"
+    sym = _cfg(ctm_ad_mode="root_implicit_symmetric")
+    assert root_implicit_variant(sym) == "symmetric"
+
+
+def test_variant_rejects_a_non_root_mode():
+    cfg = iPEPSConfig(max_bond_dim=2, ctm=CTMConfig(chi=4, ctm_ad_mode=None))
+    with pytest.raises(ValueError, match="not a root-implicit mode"):
+        root_implicit_variant(cfg)
+
+
+# ------------------------------------------------------------------ #
+# Guards: every one of these would otherwise be silently ignored       #
+# ------------------------------------------------------------------ #
+
+
+def test_a_plain_config_validates():
+    validate_root_implicit_config(_cfg())
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("chi_auto_bump", True),
+        ("chi_ramp", [(4, 10)]),
+        ("fuse_virtual_legs", False),
+    ],
+)
+def test_ctm_knobs_that_cannot_be_honoured_are_rejected(field, value):
+    cfg = _cfg(**{field: value})
+    with pytest.raises(NotImplementedError, match="silently ignored"):
+        validate_root_implicit_config(cfg)
+
+
+def test_in_ctm_chi_bump_is_rejected():
+    """Separate because ``ctmrg_heuristic_increase_chi`` needs ``chi_max`` set
+    at construction, so it cannot ride the parametrised case above."""
+    cfg = _cfg(ctmrg_heuristic_increase_chi=True, chi_max=16)
+    with pytest.raises(NotImplementedError, match="silently ignored"):
+        validate_root_implicit_config(cfg)
+
+
+def test_checkpoint_path_is_rejected():
+    cfg = dataclasses.replace(_cfg(), gs_checkpoint_path="/tmp/ckpt.pkl")
+    with pytest.raises(NotImplementedError, match="silently ignored"):
+        validate_root_implicit_config(cfg)
+
+
+def test_metric_precond_warns_rather_than_rejecting():
+    """It defaults to True, so rejecting it would make the mode unusable.
+
+    Every other unhonourable knob defaults off, so hard-erroring on those costs
+    the user nothing.  ``gs_metric_precond=True`` is the default, and rejecting
+    it would force an unrelated opt-out before root-implicit could be tried at
+    all.  The split-CTM path warns and falls back for the same knob for the
+    same reason; this follows it.
+    """
+    from tenax.algorithms.ipeps_optimize_root_implicit import (
+        optimize_gs_ad_root_implicit,
+    )
+
+    cfg = _cfg(ctm_ad_mode="root_implicit_symmetric")
+    assert cfg.gs_metric_precond is True, "precondition: it defaults on"
+    validate_root_implicit_config(cfg)  # must NOT raise
+
+    # It surfaces as a warning on the way to the (unwired) symmetric refusal.
+    with pytest.warns(UserWarning, match="gs_metric_precond"):
+        with pytest.raises(NotImplementedError):
+            optimize_gs_ad_root_implicit(None, None, cfg)
+
+
+def test_the_error_names_every_offending_knob_at_once():
+    """One run should not require N round-trips to discover N bad settings."""
+    # chi_auto_bump and chi_ramp are mutually exclusive at construction, so
+    # pair the bump with the split-CTM flag instead.
+    cfg = dataclasses.replace(
+        _cfg(chi_auto_bump=True, fuse_virtual_legs=False),
+        gs_checkpoint_path="/tmp/ckpt.pkl",
+    )
+    with pytest.raises(NotImplementedError) as exc:
+        validate_root_implicit_config(cfg)
+    msg = str(exc.value)
+    assert "chi_auto_bump" in msg
+    assert "fuse_virtual_legs" in msg
+    assert "gs_checkpoint_path" in msg
+
+
+# ------------------------------------------------------------------ #
+# Unwired variants must say so rather than run something else          #
+# ------------------------------------------------------------------ #
+
+
+def test_multisite_variant_is_refused_with_a_reason():
+    """Phase 2's shifted-cell tables are the risk; it gets its own increment."""
+    from tenax.algorithms.ipeps_optimize_root_implicit import (
+        optimize_gs_ad_root_implicit,
+    )
+
+    cfg = dataclasses.replace(_cfg(), unit_cell="2site")
+    with pytest.raises(NotImplementedError, match="dense 1x1"):
+        optimize_gs_ad_root_implicit(None, None, cfg)
+
+
+def test_symmetric_variant_is_refused_and_cites_its_blocker():
+    from tenax.algorithms.ipeps_optimize_root_implicit import (
+        optimize_gs_ad_root_implicit,
+    )
+
+    cfg = _cfg(ctm_ad_mode="root_implicit_symmetric")
+    with pytest.raises(NotImplementedError, match="8.4 GB"):
+        optimize_gs_ad_root_implicit(None, None, cfg)
+
+
+# ------------------------------------------------------------------ #
+# The gap that blocks production use (#772)                            #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.slow
+@pytest.mark.xfail(
+    reason=(
+        "#772: the asym engine's covariant characteristic equations fail on a "
+        "physical simple-update state -- covariant residual 1.9e-2 at chi=4 "
+        "and 5.7e+05 with NaN gradients at chi>=6, while being ~1e-14 clean on "
+        "the random tensor its own tests use. Independent of every CTM "
+        "convergence knob. Until that is fixed this path cannot run a "
+        "production optimization."
+    ),
+    strict=False,
+)
+def test_production_heisenberg_run_through_optimize_gs_ad():
+    """The production case this wiring exists for: a real Heisenberg state.
+
+    Left in as an executable record of #772 rather than deleted, so whoever
+    fixes the engine gets an immediate signal here (an XPASS) instead of having
+    to reconstruct the case.
+
+    The failure is at least *loud*: ``on_root_residual="raise"`` (#759) turns a
+    non-vanishing root residual into ``RootResidualError``, so the optimizer
+    stops rather than stepping on a NaN gradient.
+    """
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    from tenax.algorithms.ipeps import heisenberg_gate, sublattice_rotate_gate
+    from tenax.algorithms.ipeps_optimize import optimize_gs_ad
+
+    gate = sublattice_rotate_gate(heisenberg_gate())
+    cfg = iPEPSConfig(
+        max_bond_dim=2,
+        num_imaginary_steps=40,
+        dt=0.05,
+        unit_cell="1x1",
+        su_init=True,
+        gs_num_steps=3,
+        gs_optimizer="adam",
+        gs_learning_rate=1e-2,
+        gs_line_search=False,
+        gs_metric_precond=False,
+        ctm=CTMConfig(chi=6, max_iter=100, conv_tol=1e-10, ctm_ad_mode="root_implicit"),
+    )
+    _A, _env, E = optimize_gs_ad(gate, None, cfg)
+    assert E == pytest.approx(-0.4886, abs=5e-3)


### PR DESCRIPTION
Implements the wiring design approved for #715: the root-implicit `*_energy_and_grad` engines — built and tested since Phases 0–3 — become reachable from `optimize_gs_ad` instead of only from a script.

> **This does not yet enable a production run.** The dense engine returns NaN gradients on a physical simple-update state (#772). Landing this anyway because it is correct, guarded, and is what surfaced that gap; the blocked case ships as an `xfail` that will XPASS when #772 is fixed.

## What's wired

- **New `ipeps_optimize_root_implicit.py`** — `ipeps_optimize.py` is already 5000+ lines. Holds the optimizer loop, `root_implicit_variant()` and `validate_root_implicit_config()`.
- **`ctm_ad_mode`** accepts `"root_implicit"` (dense, auto-selects the engine from the unit cell) and `"root_implicit_symmetric"` (must be named explicitly, so nobody lands on #731's 8.4 GB GMRES path by accident). C4v stays unexposed — Phase 0 exists to validate the characteristic equations, not to run production.
- **`use_root_implicit_path()`** in `ipeps_ad_policy`, mirroring `use_reference_c4v_path`. Dispatch slots in *ahead* of the unit-cell branches so this path picks its own variant rather than inheriting warm-start machinery its entry points cannot use.
- **Tuning registry** updated, including the explicit note that this is a stability/block-sparse-accuracy lever and **not** a speed one.

## The guards are the substance

These entry points replace the whole `value_and_grad` — each runs its own CTM convergence and takes no warm-start environment. So `chi_auto_bump`, `chi_ramp`, `ctmrg_heuristic_increase_chi`, `fuse_virtual_legs=False`, `gs_checkpoint_path` and `cg_gates` would all be **silently ignored** if merely passed through. They hard-error at config time, and the message names every offender at once rather than one per round-trip.

`gs_metric_precond` is the deliberate exception. Writing the tests caught that it **defaults to `True`** — hard-erroring on it would have made the whole mode unusable without an unrelated opt-out. It warns and falls back, which is exactly what the split-CTM path already does with that same knob for the same reason.

## Scope: dense 1×1 only

The approved design said "both dense variants in one PR". Only the **asym (1×1)** engine is wired here. The multisite engine refuses with a reason rather than riding along: its shifted-cell index tables are the whole risk of Phase 2, and a wrong shift yields a *silently* wrong gradient — the exact failure shape of #700/#702. It gets its own increment. Flagging the deviation rather than burying it.

## Why it can't run production yet (#772)

`asym_root_implicit_energy_and_grad` returns NaN gradients on a physical D=2 Heisenberg simple-update state at χ≥6 (covariant residual `5.7e+05`; `1.9e-2` at χ=4), while being `~1e-14` clean on the random tensor its own tests use at every χ. The forward is healthy — the energy is identical throughout — and the *root* residual is fine; it's the *covariant* equations that fail.

Ruled out by measurement: the gate, the flow convention, rank deficiency, near-degenerate singular values (the random state is *more* degenerate and is clean), and CTM convergence (at `conv_tol=1e-11` it reports `converged=1` in 9 iterations and still gives `5.70e+05`).

Root cause of the gap: **no test in the #715 suite uses a physical iPEPS state** — only generic random tensors. Root-implicit AD exists to remove the degenerate-SV failure class, so the SU(2) Heisenberg point is the case that must work.

The failure is **loud, not silent**: `on_root_residual="raise"` (#759) stops the optimizer rather than letting it step on a NaN gradient.

## Tests

21 `core`-marked tests (milliseconds — dispatch and guards only, no CTM convergence) covering the config surface, the path predicate, variant selection, every guard, the multi-knob error message, and the two unwired-variant refusals. Plus `test_production_heisenberg_run_through_optimize_gs_ad`, `@slow` + `xfail`, carrying the #772 case so whoever fixes the engine gets an XPASS instead of reconstructing it.

Verified locally: 95 passed under `-m core` across this file, `test_ipeps_config`, `test_split_ctm_fuse_flag`, and the multisite/sym-sector root-implicit suites.

Refs #715, #772.

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.
