### PR TITLE
feat(#747): make the re-runs portable + handover doc

### DIFF
--- a/docs/superpowers/handoffs/2026-08-04-747-rerun-handover.md
+++ b/docs/superpowers/handoffs/2026-08-04-747-rerun-handover.md
@@ -1,0 +1,168 @@
+# #747 re-runs — handover to another machine
+
+**Status:** ready to run. Nothing is blocked on code; both drivers carry the
+recipe fix and the collapse detectors. This document is what a fresh operator
+on different hardware needs.
+
+**What this is.** #723/#726 established that the `1x1` CTM recipe collapses the
+environment to rank-1 corners — a `chi_eff = 1` mean-field boundary whose energy
+does not respond to χ, with nothing raising. #747 audited which recorded
+results were produced that way. Two need re-running on GPU.
+
+---
+
+## What already got settled without compute
+
+The audit (comment 1 on #747) resolved most of the issue from code paths, not
+re-runs. The key fact: `python_loop_ctm_converge` has defaulted to
+`recipe="2x2"` since 2026-06-10 (PR #597) and `ctm_converge_kwargs` emits no
+`recipe`, so **anything measured through it was already correct**.
+
+| result | recipe actually run | verdict |
+|---|---|---|
+| D=8 (#650) **dense** arm | `2x2` | **valid — do not re-run** |
+| D=4 (#646) χ-scan | `2x2` | **valid — do not re-run** |
+| D=8 (#650) **split** arm | `1x1` | invalid → **Run 1** |
+| D=4 (#646) `A_opt` state | `1x1` | invalid → **Run 2** |
+| #638 showcase | `1x1` | retired, not re-run (PR #771) |
+
+The D=8 conclusion was **inverted**: the split arm's "χ-invariant E to 13
+digits" was the collapse signature, and the dense arm's "oscillates,
+`converged:false`" was the correct side doing real work.
+
+---
+
+## Environment
+
+```bash
+git clone https://github.com/tenax-lab/tenax.git && cd tenax
+uv sync --extra cuda13          # or --extra cuda12, match the driver
+uv run python -c "import jax; print(jax.devices())"
+```
+
+Requires x64 (the drivers set `jax_enable_x64` themselves) and one GPU with
+**≥40 GB** for Run 1. Run 2 is small (peak ~0.3 GB).
+
+**Device guard.** Both drivers refuse to start if any visible device is under
+40 GB. That exists to stop a run silently landing on a display GPU — the
+original machine has a 4 GB DGX Display card at index 3, which is why. On
+different hardware:
+
+- ≥40 GB A100/H100 → passes unchanged, do nothing.
+- Anything smaller, or a deliberate small-scale smoke test → pass
+  `--allow-non-a100`. It prints the visible devices and continues.
+
+Pin devices explicitly rather than relying on index order:
+
+```bash
+export CUDA_VISIBLE_DEVICES=0        # check nvidia-smi first
+```
+
+---
+
+## Run 1 — D=8 split arm at 2x2 (the invalid physics result)
+
+```bash
+uv run python examples/heisenberg_d8_chi_scaling.py --path split \
+    --outdir runs/d8_rerun_2x2
+```
+
+**No code change needed.** PR #768 made `ctm_split_tensor` default to
+`recipe="2x2"`, so the driver now runs the correct recipe by construction.
+
+### What to check, in order
+
+1. **`corner_rank > 1` at every χ** — recorded per cell in `results.csv` since
+   PR #770. If it is 1, stop: the reroute did not take and nothing downstream
+   is meaningful.
+2. **The driver's own χ-frozen warning stays silent.** It prints a
+   `WARNING: chi-frozen energies detected` block if any two χ return a
+   bit-identical energy, judged per `(D, n_devices, path)`.
+3. **Compare against the dense arm's ≈ −0.6055**, which the audit shows was
+   already correct. Convergence toward it confirms the inversion. A persistent
+   gap is new information and worth its own issue.
+
+> **Judge on `corner_rank`, not on whether the energy moves.** A converged
+> environment is flat in χ too — that is what convergence means. The χ-frozen
+> helper errs in *both* directions (see #747 comment 3): it fires on converged
+> scans, and a collapsed environment is not reliably bit-identical either.
+> Rank is the only sound signal.
+
+### Also re-measure, don't just re-confirm
+
+The recorded "≈50–100× faster" and "single-GPU wall moves χ≈112 → ≈448" were
+measured on the **`1x1`** split forward. `2x2` builds plaquette projectors
+instead of corner-pair ones, so the cost profile is different. The *memory*
+claim (χ²·D³·d vs χ²·D⁶, ~12×) is shape-derived and should hold; the χ ceiling
+depends on the new peak and needs the ladder walked again.
+
+Budget: the recorded `1x1` split converge was ~14–21 s per χ. `2x2` measured
+3–6× slower on small cells, so ~1–2 min per χ plus compile, times the ladder.
+
+---
+
+## Run 2 — D=4 re-optimization at `gs_recipe="2x2"`
+
+```bash
+uv run python examples/heisenberg_d4_chi_scaling.py \
+    --gs-recipe 2x2 --outdir runs/d4_rerun_2x2
+```
+
+`--gs-recipe` is new (this PR); it used to be hard-coded to `1x1`. **2x2 is now
+the default**, so the flag above is explicit rather than required. `1x1`
+reproduces the old, invalid behaviour for bisection.
+
+The D=4 χ *scan* is already correct and unchanged — it goes through
+`python_loop_ctm_converge`. What is contaminated is `A_opt`: it was optimized
+against a collapsed environment. So the recorded **+6.04e-3 vs QMC is an upper
+bound mixing iPEPS truncation with a badly-optimized state**, and must not be
+quoted as a D=4 truncation error until this run replaces it.
+
+This is the cheaper run and the one that produces a genuinely new physics
+number. If only one can be done, do this one.
+
+Reference to beat: QMC E/site = **−0.669437**. The recorded (contaminated)
+scan saturated at **−0.6633981** at χ≥64.
+
+Delete or move `runs/d4_chi_scaling/A_opt.pkl` first if reusing that outdir —
+`optimize_once` returns immediately when it finds one, so a stale `A_opt` from
+the `1x1` run would be silently reused.
+
+---
+
+## Reporting back
+
+Post to #747 with:
+
+- `results.csv` from each run (they carry `corner_rank` per cell).
+- Whether the D=8 split energy converges toward the dense −0.6055.
+- The re-measured D=8 split speed and χ ceiling, flagged as **2x2** numbers so
+  they are not compared against the `1x1` ones.
+- The new D=4 err-vs-QMC, which supersedes +6.04e-3.
+
+If a run shows `corner_rank == 1` anywhere, that is a regression in #723/#746 —
+file it rather than working around it.
+
+---
+
+## Not in scope
+
+- **#638 showcase** — retired, not re-run (PR #771). All 29 recorded cells were
+  `gs_num_steps=6`, `converged=false`, with zero anchor rows, so no recipe fix
+  would make them a physics result.
+- **Frontier (#672)** — both arms ran `1x1`, so its reach claims describe a
+  rank-1 corner; the memory/shape half survives. Lower value than Runs 1–2 and
+  it depends on Run 1's new split cost profile, so it should follow them.
+- **Items 4–7** (chunk×shard gate, QR-CTMRG shard NO-GO, #570 reduced-corner,
+  rSVD NO-GO) — memory-locality and shape results, undisturbed by the audit.
+
+## References
+
+- #747 — the issue; comment 1 is the audit, comment 2 the run queue, comment 3
+  the correction on what the χ-frozen detector can and cannot tell you.
+- #723 / #726 / #746 — the collapse and its two fixes (fused, split).
+- #766 / #767 / #769 — defects the collapse had been masking, found while
+  fixing it. #767 matters here: the split AD forward can return a
+  **non-converged** environment with no flag.
+- PR #770 — `_ctm_diagnostics.py` (`ctm_corner_rank`, `check_ctm_env`,
+  `frozen_chi_pairs`) and the per-cell `corner_rank` recording both runs rely on.

--- a/examples/heisenberg_d4_chi_scaling.py
+++ b/examples/heisenberg_d4_chi_scaling.py
@@ -253,6 +253,13 @@ def _assert_only_a100s():
     mismatch so a run can never silently land on the display GPU."""
     import jax
 
+    if os.environ.get("TENAX_ALLOW_NON_A100") == "1":
+        # Set by --allow-non-a100. Uses an env var rather than a threaded
+        # argument because this runs inside the spawned per-cell workers, which
+        # inherit the environment but not arbitrary kwargs.
+        print("[warn] device guard disabled (--allow-non-a100); visible devices: "
+              + ", ".join(str(d) for d in jax.devices()), flush=True)
+        return
     bad = []
     for dev in jax.devices():
         try:
@@ -280,10 +287,21 @@ def _build_mesh(n_devices):
     return build_ctm_mesh()  # over all visible devices (== the pinned A100s)
 
 
-def optimize_once(outdir, chi_opt, opt_steps, n_devices, probe_max_iter=15):
+def optimize_once(outdir, chi_opt, opt_steps, n_devices, probe_max_iter=15,
+                  gs_recipe="2x2"):
     """Optimize the D=4 state once at χ_opt; cache the optimized tensor to
     `<outdir>/A_opt.pkl`. Resumes from its gs checkpoint; if A_opt.pkl already
-    exists, returns immediately."""
+    exists, returns immediately.
+
+    *gs_recipe* defaults to ``"2x2"``.  It used to be hard-coded to ``"1x1"``,
+    whose corner-pair projector collapses the environment to rank-1 corners
+    (#723/#726), so every A_opt this driver has produced was optimized against
+    a chi_eff=1 mean-field environment.  The chi *scan* was always correct
+    (it goes through ``python_loop_ctm_converge``, which defaults to 2x2), so
+    the recorded convergence data stands -- but the +6.04e-3 vs QMC mixes iPEPS
+    truncation with a badly-optimized state and should not be quoted as a D=4
+    truncation error until this is re-run.  ``"1x1"`` reproduces the old
+    (invalid) behaviour for bisection.  See #747."""
     import jax
 
     jax.config.update("jax_enable_x64", True)
@@ -322,7 +340,7 @@ def optimize_once(outdir, chi_opt, opt_steps, n_devices, probe_max_iter=15):
         unit_cell="1x1",
         gs_c4v=True,                  # removes bond-gauge freedom -> stable backward
         gs_implicit_ad=True,          # variational (true expectation value)
-        gs_recipe="1x1",
+        gs_recipe=gs_recipe,
         gs_optimizer="lbfgs",
         gs_line_search_method="hager_zhang",
         gs_metric_precond=True,
@@ -445,6 +463,7 @@ def _run_worker(args):
             optimize_once(
                 args.outdir, args.chi_opt, args.opt_steps, args.n_devices,
                 probe_max_iter=args.probe_max_iter,
+                gs_recipe=args.gs_recipe,
             )
             res = {"phase": "optimize", "ok": True, "error": None}
         except Exception as e:  # noqa: BLE001
@@ -470,6 +489,16 @@ def _build_argparser():
     p.add_argument("--chi-opt", dest="chi_opt", type=int, default=32)
     p.add_argument("--opt-steps", dest="opt_steps", type=int, default=100)
     p.add_argument("--probe-max-iter", dest="probe_max_iter", type=int, default=15)
+    p.add_argument("--gs-recipe", dest="gs_recipe", default="2x2",
+                   choices=["2x2", "1x1"],
+                   help="optimizer CTM recipe. 2x2 is correct; 1x1 collapses "
+                        "the environment to rank-1 corners and only exists "
+                        "to reproduce the pre-#747 runs (#723/#726/#747).")
+    p.add_argument("--allow-non-a100", dest="allow_non_a100", action="store_true",
+                   help="skip the >=40 GB device guard. For porting the run to "
+                        "other hardware; the guard exists to stop a run "
+                        "silently landing on a small display GPU, so only use "
+                        "this when you know what is visible.")
     p.add_argument("--opt-devices", dest="opt_devices", type=int, default=1,
                    help="GPUs for the one-time optimization. Default 1: multi-GPU "
                         "optimize is blocked by sharded gs-checkpoint pickling "
@@ -503,7 +532,8 @@ def _launch(argv, n_devices, timeout_s):
         return False
 
 
-def _optimize_phase(outdir, chi_opt, opt_steps, opt_devices, probe_max_iter):
+def _optimize_phase(outdir, chi_opt, opt_steps, opt_devices, probe_max_iter,
+                    gs_recipe="2x2"):
     """Run the one-time optimization in a subprocess pinned to opt_devices."""
     if os.path.exists(os.path.join(outdir, "A_opt.pkl")):
         print("[opt] A_opt.pkl present; optimization skipped", flush=True)
@@ -514,6 +544,7 @@ def _optimize_phase(outdir, chi_opt, opt_steps, opt_devices, probe_max_iter):
         "--phase", "optimize", "--outdir", outdir,
         "--chi-opt", str(chi_opt), "--opt-steps", str(opt_steps),
         "--probe-max-iter", str(probe_max_iter),
+        "--gs-recipe", str(gs_recipe),
         "--n-devices", str(opt_devices), "--out", out,
     ]
     # Optimization can be long; allow generous wall-clock (resume-safe anyway).
@@ -632,9 +663,12 @@ def main(args):
     chi_ladder = [int(x) for x in args.chi_ladder.split(",")]
     device_counts = [int(x) for x in args.device_counts.split(",")]
 
+    if getattr(args, "allow_non_a100", False):
+        os.environ["TENAX_ALLOW_NON_A100"] = "1"
+
     # Phase 1: optimize once (pinned to opt_devices GPUs).
     _optimize_phase(outdir, args.chi_opt, args.opt_steps, args.opt_devices,
-                    args.probe_max_iter)
+                    args.probe_max_iter, gs_recipe=args.gs_recipe)
     if not os.path.exists(os.path.join(outdir, "A_opt.pkl")):
         print("[abort] optimization produced no A_opt.pkl; see "
               f"{outdir}/optimize_status.json", flush=True)


### PR DESCRIPTION
The #747 GPU re-runs are moving to another machine. Two infra gaps stood between the drivers and someone else being able to run them, plus a handover doc.

## `--gs-recipe` on the D=4 driver

It hard-coded `gs_recipe="1x1"`, whose corner-pair projector collapses the environment to rank-1 corners (#723/#726) — so **every `A_opt` this driver has produced was optimized against a χ_eff=1 mean-field environment**, and Run 2 of #747 was not expressible without editing the source.

Now a flag, defaulting to the correct `2x2`. `1x1` reproduces the old behaviour for bisection.

Worth being precise about what this does and doesn't invalidate: the χ **scan** was always correct — it goes through `python_loop_ctm_converge`, which has defaulted to `2x2` since #597 — so the recorded convergence data stands. What is contaminated is the *state*. The recorded **+6.04e-3 vs QMC mixes iPEPS truncation with a badly-optimized `A_opt`** and should not be quoted as a D=4 truncation error until re-run.

## `--allow-non-a100`

Both drivers refuse to start if any visible device is under 40 GB — a guard against silently landing on the origin machine's 4 GB DGX Display card at index 3. Correct there, merely an obstacle elsewhere. Now has an explicit opt-out that prints the visible devices when used.

Implemented as an env var (`TENAX_ALLOW_NON_A100`) rather than a threaded argument, because the check runs inside the spawned per-cell workers — they inherit the environment but not kwargs.

## Handover doc

`docs/superpowers/handoffs/2026-08-04-747-rerun-handover.md`. Carries what the audit already settled — **the D=8 dense arm and the D=4 χ-scan were always valid, so only the split arm and `A_opt` need redoing, which halves the work #747 assumed** — then the two commands, environment/device-guard notes, and what to check in order.

The three traps it calls out explicitly:

- **Judge on `corner_rank`, not on whether the energy moves.** The χ-frozen detector errs in *both* directions (#747 comment 3): it fires on converged scans, and a collapsed environment isn't reliably bit-identical either. A re-run showing rank > 1 with a flat energy is convergence, not a failed fix — and under the old framing someone would read it as the latter.
- **Re-*measure* the D=8 split speed and χ ceiling, don't re-confirm them.** Those numbers were taken on the `1x1` forward; #768 changed which recipe runs, so `2x2` builds plaquette projectors instead of corner-pair ones. The memory claim is shape-derived and should hold; the ceiling needs the ladder walked again.
- **Delete a stale `A_opt.pkl` before reusing an outdir** — `optimize_once` returns immediately when it finds one, so a `1x1`-era state would be silently reused.

## Verification

`test_heisenberg_d4_chi_scaling.py` + `test_heisenberg_d8_chi_scaling.py`: 30 passed. `--help` confirms both new flags. The 18 pre-existing ruff errors in `examples/` are unchanged (checked before and after).

Refs #747.

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.
