### PR TITLE
fix(#747): make the D=8 driver runnable off the A100 box

### DIFF
--- a/docs/superpowers/handoffs/2026-08-04-747-rerun-handover.md
+++ b/docs/superpowers/handoffs/2026-08-04-747-rerun-handover.md
@@ -76,16 +76,82 @@ export CUDA_VISIBLE_DEVICES=0        # check nvidia-smi first
 
 ## Run 1 — D=8 split arm at 2x2 (the invalid physics result)
 
-```bash
-uv run python examples/heisenberg_d8_chi_scaling.py --path split \
-    --outdir runs/d8_rerun_2x2          # add --allow-non-a100 off the A100 box
-```
-
 **No code change needed.** PR #768 made `ctm_split_tensor` default to
 `recipe="2x2"`, so the driver now runs the correct recipe by construction.
 There is no `--gs-recipe` here and none is needed: this driver's `A_opt` comes
 from the SU seed, not from a `gs_*` optimization, so the collapsed-environment
 contamination that Run 2 has to undo never applied to it.
+
+### Commands
+
+**Step 0 — smoke first.** Five minutes, and it exercises the whole
+orchestrator → worker → aggregate path including `corner_rank` recording. Do
+not skip it on new hardware; it is how you find a device-guard or driver
+problem before burning the real ladder.
+
+```bash
+uv run python examples/heisenberg_d8_chi_scaling.py --path split \
+    --outdir runs/d8_rerun_2x2 --smoke        # writes runs/d8_rerun_2x2_smoke/
+```
+
+`--smoke` shrinks to `chi_su=8`, 20 imaginary-time steps, χ ladder `8,12`,
+single device. Check `results.csv` shows `corner_rank > 1` before continuing.
+
+**Step 1 — the real run.** On the A100 box:
+
+```bash
+uv run python examples/heisenberg_d8_chi_scaling.py --path split \
+    --outdir runs/d8_rerun_2x2
+```
+
+On an H100 or any other ≥40 GB card, add the opt-out — see the device-guard
+note above for why the run otherwise stalls 30 minutes and aborts:
+
+```bash
+uv run python examples/heisenberg_d8_chi_scaling.py --path split \
+    --outdir runs/d8_rerun_2x2 --allow-non-a100
+```
+
+Useful adjustments: `--chi-ladder` (default
+`64,96,112,128,192,256,320,384,448`) to stop short of the wall or extend past
+it; `--path both` to re-measure the dense arm alongside, at roughly double the
+wall-clock — **not needed for the physics**, since the audit already cleared
+dense; `--cell-timeout-s` (default 2400) if a large-χ cell needs a longer wall.
+
+**Resume is automatic and free.** Each cell writes
+`runs/d8_rerun_2x2/D8_chi<χ>_n<n>_split.json`, and a re-run loads whatever is
+already there instead of recomputing it. If the run stops — GPU contention,
+timeout, ctrl-C — just issue the same command again. The SU phase likewise
+skips when `A_opt.pkl` exists.
+
+**Escape hatch: drive the cells yourself.** If GPU selection misbehaves (a
+scheduler that hands you devices, an unusual `nvidia-smi`), bypass the
+orchestrator's picker entirely by running the workers directly. Pin devices
+with `CUDA_VISIBLE_DEVICES` and use exactly these filenames, or the aggregation
+step won't find them:
+
+```bash
+export CUDA_VISIBLE_DEVICES=0
+export TENAX_ALLOW_NON_A100=1        # only if not on an A100
+D=examples/heisenberg_d8_chi_scaling.py
+O=runs/d8_rerun_2x2
+
+uv run python $D --cell --phase su --outdir $O --n-devices 1 \
+    --out $O/su_status.json
+for chi in 64 96 112 128 192 256 320 384 448; do
+  uv run python $D --cell --phase scan --outdir $O --chi $chi \
+      --n-devices 1 --path split --out $O/D8_chi${chi}_n1_split.json
+done
+uv run python $D --path split --outdir $O    # aggregates the cached cells
+```
+
+The final orchestrator call needs no GPU: every cell JSON already exists, so it
+loads them and writes `results.csv` / `convergence.md` without launching a
+worker.
+
+**Reusing an outdir from an earlier attempt?** Delete `A_opt.pkl` and the
+per-cell JSONs first — both are treated as cache and would be silently reused,
+which is how a stale run masquerades as a fresh one.
 
 ### What to check, in order
 

--- a/docs/superpowers/handoffs/2026-08-04-747-rerun-handover.md
+++ b/docs/superpowers/handoffs/2026-08-04-747-rerun-handover.md
@@ -45,12 +45,26 @@ Requires x64 (the drivers set `jax_enable_x64` themselves) and one GPU with
 
 **Device guard.** Both drivers refuse to start if any visible device is under
 40 GB. That exists to stop a run silently landing on a display GPU — the
-original machine has a 4 GB DGX Display card at index 3, which is why. On
-different hardware:
+original machine has a 4 GB DGX Display card at index 3, which is why. Pass
+`--allow-non-a100` on either driver to disable it; it prints the visible
+devices and continues.
 
-- ≥40 GB A100/H100 → passes unchanged, do nothing.
-- Anything smaller, or a deliberate small-scale smoke test → pass
-  `--allow-non-a100`. It prints the visible devices and continues.
+**The D=8 driver has a second, stricter gate**, and it is not the 40 GB one.
+Its orchestrator picks GPUs from `nvidia-smi` by matching the literal string
+`A100` in the device *name*, so **H100s are rejected too** — "≥40 GB" is not
+the criterion there. `--allow-non-a100` drops that vendor-string requirement
+as well (busy devices and anything named `Display` stay excluded on every
+path, since landing on a display card is a failure on any machine).
+
+So, on different hardware:
+
+- A100 box → passes unchanged, do nothing.
+- H100 or any other ≥40 GB card → pass `--allow-non-a100`. **Without it Run 1
+  does not fail fast**: `_wait_for_free_a100s` polls every 30 s for
+  `--gpu-wait-s` (default 1800 s), gives up, and the run aborts with
+  `[abort] SU produced no A_opt.pkl` — half an hour to discover the hardware
+  was never eligible.
+- Anything smaller, or a deliberate small-scale smoke test → same flag.
 
 Pin devices explicitly rather than relying on index order:
 
@@ -64,11 +78,14 @@ export CUDA_VISIBLE_DEVICES=0        # check nvidia-smi first
 
 ```bash
 uv run python examples/heisenberg_d8_chi_scaling.py --path split \
-    --outdir runs/d8_rerun_2x2
+    --outdir runs/d8_rerun_2x2          # add --allow-non-a100 off the A100 box
 ```
 
 **No code change needed.** PR #768 made `ctm_split_tensor` default to
 `recipe="2x2"`, so the driver now runs the correct recipe by construction.
+There is no `--gs-recipe` here and none is needed: this driver's `A_opt` comes
+from the SU seed, not from a `gs_*` optimization, so the collapsed-environment
+contamination that Run 2 has to undo never applied to it.
 
 ### What to check, in order
 

--- a/examples/heisenberg_d8_chi_scaling.py
+++ b/examples/heisenberg_d8_chi_scaling.py
@@ -86,24 +86,40 @@ def _parse_nvidia_smi(text):
     return rows
 
 
-def select_free_a100s(rows, n, mem_threshold_mib=2048, util_threshold=50):
+def select_free_a100s(rows, n, mem_threshold_mib=2048, util_threshold=50,
+                      allow_non_a100=None):
     """The n most-idle 80 GB A100 indices from parsed nvidia-smi rows.
 
     Idle = an A100 (never the DGX Display GPU) with memory.used and
     utilization below the thresholds. Sorted by (memory.used, index) so the
     most-idle device comes first; deterministic tiebreak by index. Raises
     RuntimeError if fewer than n idle A100s are available (so a row stops
-    rather than landing on a busy or display GPU)."""
+    rather than landing on a busy or display GPU).
+
+    *allow_non_a100* drops the A100 vendor-string requirement so the driver
+    runs on other >=40 GB hardware (H100 etc.) — the #747 re-runs move to
+    another machine. It defaults to the ``TENAX_ALLOW_NON_A100`` environment
+    variable, which is how ``--allow-non-a100`` reaches the spawned per-cell
+    workers (they inherit the environment, not kwargs). The display-GPU
+    exclusion and the idle thresholds are NOT relaxed: landing on a 4 GB
+    display card is the failure this guard exists to prevent, and it is a
+    failure on every machine, not just the origin box."""
+    if allow_non_a100 is None:
+        allow_non_a100 = os.environ.get("TENAX_ALLOW_NON_A100") == "1"
     free = [
         r for r in rows
-        if "A100" in r[1] and "Display" not in r[1]
+        if (allow_non_a100 or "A100" in r[1]) and "Display" not in r[1]
         and r[2] <= mem_threshold_mib and r[3] <= util_threshold
     ]
     free.sort(key=lambda r: (r[2], r[0]))
     if len(free) < n:
+        kind = "idle GPUs" if allow_non_a100 else "idle A100s"
         raise RuntimeError(
-            f"need {n} idle A100s, found {len(free)}: "
+            f"need {n} {kind}, found {len(free)}: "
             + ", ".join(f"gpu{r[0]}({r[2]}MiB,{r[3]}%)" for r in free)
+            + ("" if allow_non_a100 else
+               " [non-A100 devices are excluded; pass --allow-non-a100 to "
+               "run on other >=40 GB hardware]")
         )
     return [r[0] for r in free[:n]]
 
@@ -243,6 +259,12 @@ def _build_argparser():
                    help="max seconds to wait for n idle A100s before a cell "
                         "(shared box: transient contention); then stop "
                         "gracefully and aggregate completed cells")
+    p.add_argument("--allow-non-a100", dest="allow_non_a100", action="store_true",
+                   help="run on non-A100 hardware (H100 etc.): drops the A100 "
+                        "vendor-string requirement in GPU selection and the "
+                        ">=40 GB device guard. Display GPUs and busy devices "
+                        "are still excluded. Sets TENAX_ALLOW_NON_A100=1 so "
+                        "spawned per-cell workers inherit it")
     return p
 
 
@@ -609,10 +631,22 @@ def main(args):
     _aggregate8(results, outdir)
 
 
+def _apply_device_opt_out(args):
+    """Publish ``--allow-non-a100`` into the environment. Called before dispatch
+    so it covers both entry points: the orchestrator (whose spawned workers
+    inherit the environment, not kwargs) and a worker invoked directly with
+    ``--cell``, which never reaches ``main()``. Returns whether it was set."""
+    if getattr(args, "allow_non_a100", False):
+        os.environ["TENAX_ALLOW_NON_A100"] = "1"
+        return True
+    return False
+
+
 if __name__ == "__main__":
     _args = _build_argparser().parse_args()
     if _args.smoke:
         _apply_smoke(_args)
+    _apply_device_opt_out(_args)
     if _args.cell:
         _run_worker(_args)
     else:

--- a/tests/test_heisenberg_d8_chi_scaling.py
+++ b/tests/test_heisenberg_d8_chi_scaling.py
@@ -57,6 +57,85 @@ def test_select_free_a100s_excludes_busy_a100():
         d8.select_free_a100s(rows, 4)
 
 
+# A non-A100 box (the #747 re-runs move to other hardware): H100s plus the same
+# kind of small display GPU the A100-only guard exists to avoid.
+_SMI_H100 = (
+    "0, NVIDIA H100 80GB HBM3, 12, 0\n"
+    "1, NVIDIA H100 80GB HBM3, 40, 0\n"
+    "2, NVIDIA DGX Display, 7, 0\n"
+)
+
+
+def test_select_free_a100s_refuses_non_a100_by_default():
+    """Default stays strict: the vendor-string filter is what stops a run from
+    landing on the origin box's display GPU."""
+    rows = d8._parse_nvidia_smi(_SMI_H100)
+    with pytest.raises(RuntimeError):
+        d8.select_free_a100s(rows, 1)
+
+
+def test_select_free_a100s_honours_the_opt_out_argument():
+    rows = d8._parse_nvidia_smi(_SMI_H100)
+    assert d8.select_free_a100s(rows, 2, allow_non_a100=True) == [0, 1]
+
+
+def test_select_free_a100s_honours_the_opt_out_env_var(monkeypatch):
+    """`--allow-non-a100` reaches the selector through the environment, since
+    the orchestrator pins GPUs in a spawned worker that inherits env, not args."""
+    rows = d8._parse_nvidia_smi(_SMI_H100)
+    monkeypatch.setenv("TENAX_ALLOW_NON_A100", "1")
+    assert d8.select_free_a100s(rows, 2) == [0, 1]
+
+
+def test_opt_out_still_never_picks_the_display_gpu():
+    """Relaxing the A100 requirement must not relax the display-GPU exclusion —
+    that is the failure the guard was built for."""
+    rows = d8._parse_nvidia_smi(_SMI_H100)
+    assert 2 not in d8.select_free_a100s(rows, 2, allow_non_a100=True)
+    with pytest.raises(RuntimeError):
+        d8.select_free_a100s(rows, 3, allow_non_a100=True)
+
+
+def test_opt_out_still_excludes_busy_devices():
+    rows = d8._parse_nvidia_smi(
+        "0, NVIDIA H100 80GB HBM3, 12, 0\n1, NVIDIA H100 80GB HBM3, 9000, 97\n"
+    )
+    assert d8.select_free_a100s(rows, 1, allow_non_a100=True) == [0]
+    with pytest.raises(RuntimeError):
+        d8.select_free_a100s(rows, 2, allow_non_a100=True)
+
+
+def test_d8_parser_accepts_allow_non_a100():
+    """The handover doc points operators at this flag; before this change the
+    D=8 driver rejected it with argparse exit 2."""
+    args = d8._build_argparser().parse_args(["--path", "split", "--allow-non-a100"])
+    assert args.allow_non_a100 is True
+    assert d8._build_argparser().parse_args(["--path", "split"]).allow_non_a100 is False
+
+
+def test_allow_non_a100_flag_reaches_the_environment(monkeypatch):
+    """The selector runs inside spawned workers, so the flag has to travel as
+    an env var; a worker started directly with --cell never reaches main()."""
+    monkeypatch.delenv("TENAX_ALLOW_NON_A100", raising=False)
+    args = d8._build_argparser().parse_args(["--path", "split", "--allow-non-a100"])
+    assert d8._apply_device_opt_out(args) is True
+    import os
+
+    assert os.environ["TENAX_ALLOW_NON_A100"] == "1"
+    # and the selector, called with no explicit argument, now honours it
+    rows = d8._parse_nvidia_smi(_SMI_H100)
+    assert d8.select_free_a100s(rows, 1) == [0]
+
+
+def test_allow_non_a100_absent_leaves_environment_untouched(monkeypatch):
+    monkeypatch.delenv("TENAX_ALLOW_NON_A100", raising=False)
+    args = d8._build_argparser().parse_args(["--path", "split"])
+    assert d8._apply_device_opt_out(args) is False
+    import os
+
+    assert "TENAX_ALLOW_NON_A100" not in os.environ
+
+
 def test_parse_nvidia_smi_skips_malformed_and_na_lines():
     text = (
         "0, NVIDIA A100-SXM4-80GB, 56, 0\n"


### PR DESCRIPTION
Stacked on #774 (still in the merge queue), because the handover doc this corrects only exists on that branch. Once #774 lands this reduces to a single commit; if #774 is ejected, this carries its commit until then.

#774 made the re-runs portable for the **D=4** driver only. Run 1 — the D=8 split arm, the invalid physics result #747 exists to replace — is still pinned to A100 hardware, and the handover doc sends operators to an escape hatch that driver doesn't have.

## Two gates, only one documented

- **`--allow-non-a100` wasn't an argument on this driver.** The command in the handover doc dies with argparse exit 2.
- **The orchestrator matches the literal string `A100` in the nvidia-smi device *name***, so H100s are refused too — "≥40 GB" is not the criterion there. `TENAX_ALLOW_NON_A100=1` did not reach it: that env var is read by `_assert_only_a100s`, which runs later, inside the worker. The doc's "≥40 GB A100/H100 → passes unchanged" was wrong for exactly the machine class a handover targets.

Verified before the fix, with the env var set:

```
H100 box (env opt-out SET): REFUSED -> need 1 idle A100s, found 0
D=8 parser, --allow-non-a100: REJECTED by argparse, exit 2
```

The failure is slow and quiet rather than loud: `_wait_for_free_a100s` polls every 30 s for `--gpu-wait-s` (default **1800 s**), gives up, and the run aborts with `[abort] SU produced no A_opt.pkl` — half an hour to learn the hardware was never eligible.

## What changed

- `select_free_a100s` takes `allow_non_a100`, defaulting to the `TENAX_ALLOW_NON_A100` env var — that's how the flag reaches spawned per-cell workers, which inherit environment but not kwargs.
- `_apply_device_opt_out` publishes the flag before dispatch, so a worker started directly with `--cell` is covered too, not just the orchestrator path.
- The refusal message now names the constraint and points at the flag.
- **The display-GPU exclusion and idle thresholds are deliberately NOT relaxed.** Landing on a 4 GB display card is the failure this guard was built for, and it's a failure on every machine, not just the origin box.
- Handover doc: corrects the H100 claim, documents the second gate and the 30-minute failure mode, and notes that `--gs-recipe` is absent here by design — this driver's `A_opt` comes from the SU seed, not a `gs_*` optimization, so Run 2's contamination never applied to it.

## Verification

8 new tests; **38 passed** across `test_heisenberg_d8_chi_scaling.py` + `test_heisenberg_d4_chi_scaling.py`. The file is marked `core` in `conftest.py`, so required CI gates it.

Mutation count **4/4** — each mutation is caught:

| mutation | tests failing |
|---|---|
| drop the opt-out from the filter | 5 |
| drop the display exclusion | 4 |
| flag never sets the env var | 1 |
| env fallback ignored | 2 |

Ruff on the changed example is unchanged at 7 pre-existing errors (`examples/` is outside CI's lint scope, checked before and after); `ruff check src/ tests/` passes.

Refs #747.

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.