### PR TITLE
fix(#747): make --allow-non-a100 work in D=4 worker mode

### DIFF
--- a/docs/superpowers/handoffs/2026-08-04-747-rerun-handover.md
+++ b/docs/superpowers/handoffs/2026-08-04-747-rerun-handover.md
@@ -128,6 +128,43 @@ Delete or move `runs/d4_chi_scaling/A_opt.pkl` first if reusing that outdir —
 `optimize_once` returns immediately when it finds one, so a stale `A_opt` from
 the `1x1` run would be silently reused.
 
+### Choosing the GPU
+
+**`CUDA_VISIBLE_DEVICES` on the orchestrator does not pin the run.** Every
+phase runs in a spawned worker, and `_worker_env` *overwrites*
+`CUDA_VISIBLE_DEVICES` with its own most-idle pick from `nvidia-smi`. An outer
+pin is discarded, so on a shared box the run lands wherever the picker decides.
+
+To choose the device yourself, drive the workers directly — they run in-process
+and keep the environment you give them:
+
+```bash
+export CUDA_VISIBLE_DEVICES=1
+export XLA_PYTHON_CLIENT_PREALLOCATE=false   # so peak_gb is the real high-water mark
+export TENAX_ALLOW_NON_A100=1                # only if not on an A100
+D=examples/heisenberg_d4_chi_scaling.py
+O=runs/d4_rerun_2x2
+
+uv run python $D --cell --phase optimize --outdir $O \
+    --chi-opt 32 --opt-steps 100 --probe-max-iter 15 \
+    --gs-recipe 2x2 --n-devices 1 --out $O/optimize_status.json
+for chi in 16 24 32 48 64 96 128; do
+  uv run python $D --cell --phase scan --outdir $O --chi $chi \
+      --n-devices 1 --out $O/D4_chi${chi}_n1.json
+done
+uv run python $D --gs-recipe 2x2 --allow-non-a100 --device-counts 1 --outdir $O
+```
+
+Filenames must match `cell_result_path()` exactly (`D4_chi<χ>_n<n>.json`) or
+the final call recomputes the cells instead of aggregating them. That call
+launches no workers — the optimize phase skips on an existing `A_opt.pkl` and
+every cell is cached — so nothing can re-pin the device.
+
+Two things this sequence avoids: `--device-counts 1` keeps the n=2/n=4 rows out
+of `results.csv`, since they cannot run against a single visible GPU; and
+`--smoke` is not used, because it overrides `device_counts` to `"1,2"` *after*
+parsing, silently discarding a `--device-counts 1` passed alongside it.
+
 ---
 
 ## Reporting back

--- a/examples/heisenberg_d4_chi_scaling.py
+++ b/examples/heisenberg_d4_chi_scaling.py
@@ -657,14 +657,26 @@ def _aggregate(results, outdir, d_label=4):
     print(f"\n[done] wrote {outdir}/convergence.md, performance.md, results.csv, *.png")
 
 
+def _apply_device_opt_out(args):
+    """Publish ``--allow-non-a100`` into the environment. Called before dispatch
+    so it covers both entry points: the orchestrator (whose spawned workers
+    inherit the environment, not kwargs) and a worker invoked directly with
+    ``--cell``, which never reaches ``main()``. Returns whether it was set.
+
+    This used to live inside ``main()``, which made ``--allow-non-a100 --cell``
+    a silent no-op: the worker never set the variable, so ``_assert_only_a100s``
+    refused non-A100 hardware however the flag was passed (#747)."""
+    if getattr(args, "allow_non_a100", False):
+        os.environ["TENAX_ALLOW_NON_A100"] = "1"
+        return True
+    return False
+
+
 def main(args):
     outdir = args.outdir
     os.makedirs(outdir, exist_ok=True)
     chi_ladder = [int(x) for x in args.chi_ladder.split(",")]
     device_counts = [int(x) for x in args.device_counts.split(",")]
-
-    if getattr(args, "allow_non_a100", False):
-        os.environ["TENAX_ALLOW_NON_A100"] = "1"
 
     # Phase 1: optimize once (pinned to opt_devices GPUs).
     _optimize_phase(outdir, args.chi_opt, args.opt_steps, args.opt_devices,
@@ -689,17 +701,25 @@ def main(args):
     _aggregate(results, outdir)
 
 
-if __name__ == "__main__":
-    _args = _build_argparser().parse_args()
-    if _args.smoke:
-        _args.outdir = _args.outdir + "_smoke"
-        _args.chi_opt = 8
-        _args.opt_steps = 6
-        _args.opt_devices = 1
-        _args.chi_ladder = "8,12"
-        _args.device_counts = "1,2"
-        _args.cell_timeout_s = 1200
-    if _args.cell:
-        _run_worker(_args)
+def _dispatch(args):
+    """Shrink for --smoke, publish the device opt-out, then route to the worker
+    or the orchestrator. Kept out of ``__main__`` so the ordering is testable:
+    the opt-out must be applied BEFORE dispatch, or worker mode silently loses
+    it (#747)."""
+    if args.smoke:
+        args.outdir = args.outdir + "_smoke"
+        args.chi_opt = 8
+        args.opt_steps = 6
+        args.opt_devices = 1
+        args.chi_ladder = "8,12"
+        args.device_counts = "1,2"
+        args.cell_timeout_s = 1200
+    _apply_device_opt_out(args)
+    if args.cell:
+        _run_worker(args)
     else:
-        main(_args)
+        main(args)
+
+
+if __name__ == "__main__":
+    _dispatch(_build_argparser().parse_args())

--- a/tests/test_heisenberg_d4_chi_scaling.py
+++ b/tests/test_heisenberg_d4_chi_scaling.py
@@ -176,3 +176,114 @@ def test_read_json_or_none_handles_missing_corrupt_and_valid(tmp_path):
     good = tmp_path / "good.json"
     good.write_text('{"k": 5}')
     assert d4._read_json_or_none(str(good)) == {"k": 5}
+
+
+# --- device opt-out (#747): --allow-non-a100 must reach worker mode too ------
+#
+# The flag used to be published to the environment inside main(), which a
+# worker started with --cell never reaches -- so `--allow-non-a100 --cell`
+# was silently a no-op and _assert_only_a100s refused non-A100 hardware.
+# This is the same defect fixed for the D=8 driver in #775.
+
+
+class _FakeDevice:
+    def __init__(self, kind, bytes_limit):
+        self.device_kind = kind
+        self._limit = bytes_limit
+
+    def memory_stats(self):
+        return {"bytes_limit": self._limit}
+
+    def __str__(self):
+        return f"fake({self.device_kind})"
+
+
+def _install_fake_jax(monkeypatch, devices):
+    """_assert_only_a100s does `import jax` inside the function, so a stub in
+    sys.modules is enough to exercise it without a GPU or a real backend."""
+    import sys
+    import types
+
+    fake = types.ModuleType("jax")
+    fake.devices = lambda: devices
+    monkeypatch.setitem(sys.modules, "jax", fake)
+
+
+def test_apply_device_opt_out_publishes_the_flag(monkeypatch):
+    monkeypatch.delenv("TENAX_ALLOW_NON_A100", raising=False)
+    args = d4._build_argparser().parse_args(["--allow-non-a100"])
+    assert d4._apply_device_opt_out(args) is True
+    import os
+
+    assert os.environ["TENAX_ALLOW_NON_A100"] == "1"
+
+
+def test_apply_device_opt_out_absent_leaves_environment_untouched(monkeypatch):
+    monkeypatch.delenv("TENAX_ALLOW_NON_A100", raising=False)
+    args = d4._build_argparser().parse_args([])
+    assert d4._apply_device_opt_out(args) is False
+    import os
+
+    assert "TENAX_ALLOW_NON_A100" not in os.environ
+
+
+def test_guard_refuses_small_gpu_without_the_opt_out(monkeypatch):
+    monkeypatch.delenv("TENAX_ALLOW_NON_A100", raising=False)
+    _install_fake_jax(
+        monkeypatch, [_FakeDevice("NVIDIA GeForce RTX 4070 Ti SUPER", 16 * 1000**3)]
+    )
+    with pytest.raises(RuntimeError, match="non-A100"):
+        d4._assert_only_a100s()
+
+
+def test_guard_passes_on_small_gpu_once_the_flag_is_applied(monkeypatch):
+    """The end-to-end contract the worker path depends on: applying the parsed
+    flag is sufficient to make the guard accept non-A100 hardware."""
+    monkeypatch.delenv("TENAX_ALLOW_NON_A100", raising=False)
+    _install_fake_jax(
+        monkeypatch, [_FakeDevice("NVIDIA GeForce RTX 4070 Ti SUPER", 16 * 1000**3)]
+    )
+    args = d4._build_argparser().parse_args(
+        ["--cell", "--phase", "scan", "--allow-non-a100"]
+    )
+    d4._apply_device_opt_out(args)
+    d4._assert_only_a100s()  # must not raise
+
+
+def test_guard_still_refuses_a_display_gpu_without_the_flag(monkeypatch):
+    monkeypatch.delenv("TENAX_ALLOW_NON_A100", raising=False)
+    _install_fake_jax(monkeypatch, [_FakeDevice("NVIDIA DGX Display", 4 * 1000**3)])
+    with pytest.raises(RuntimeError):
+        d4._assert_only_a100s()
+
+
+def test_dispatch_applies_the_opt_out_before_running_the_worker(monkeypatch):
+    """The regression guard: worker mode must see TENAX_ALLOW_NON_A100 already
+    set. Asserting on the environment *at the moment _run_worker is called* is
+    what makes deleting the _apply_device_opt_out call a test failure."""
+    import os
+
+    monkeypatch.delenv("TENAX_ALLOW_NON_A100", raising=False)
+    seen = {}
+    monkeypatch.setattr(
+        d4,
+        "_run_worker",
+        lambda a: seen.update(env=os.environ.get("TENAX_ALLOW_NON_A100")),
+    )
+    monkeypatch.setattr(
+        d4, "main", lambda a: pytest.fail("worker mode must not call main()")
+    )
+    args = d4._build_argparser().parse_args(
+        ["--cell", "--phase", "scan", "--chi", "16", "--allow-non-a100"]
+    )
+    d4._dispatch(args)
+    assert seen["env"] == "1"
+
+
+def test_dispatch_routes_to_the_orchestrator_without_cell(monkeypatch):
+    monkeypatch.delenv("TENAX_ALLOW_NON_A100", raising=False)
+    called = {}
+    monkeypatch.setattr(d4, "main", lambda a: called.update(main=True))
+    monkeypatch.setattr(d4, "_run_worker", lambda a: pytest.fail("not worker mode"))
+    d4._dispatch(d4._build_argparser().parse_args([]))
+    assert called == {"main": True}

--- a/tests/test_heisenberg_d4_chi_scaling.py
+++ b/tests/test_heisenberg_d4_chi_scaling.py
@@ -3,9 +3,32 @@ The example file is path-loaded (it is not an importable package) so these
 tests stay jax-free and fast."""
 
 import importlib.util
+import os
 import pathlib
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_device_opt_out():
+    """Keep TENAX_ALLOW_NON_A100 from leaking between tests.
+
+    ``_apply_device_opt_out`` writes ``os.environ`` directly, and
+    ``monkeypatch.delenv(..., raising=False)`` records *nothing* when the key is
+    absent (pytest returns early), so it cannot undo that write. Without this
+    the flag leaks into every later test in the session -- it broke the D=8
+    driver's strict-default guard, which reads the same variable.
+    """
+    prev = os.environ.get("TENAX_ALLOW_NON_A100")
+    os.environ.pop("TENAX_ALLOW_NON_A100", None)
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("TENAX_ALLOW_NON_A100", None)
+        else:
+            os.environ["TENAX_ALLOW_NON_A100"] = prev
+
 
 _PATH = (
     pathlib.Path(__file__).resolve().parent.parent

--- a/tests/test_heisenberg_d8_chi_scaling.py
+++ b/tests/test_heisenberg_d8_chi_scaling.py
@@ -66,9 +66,16 @@ _SMI_H100 = (
 )
 
 
-def test_select_free_a100s_refuses_non_a100_by_default():
+def test_select_free_a100s_refuses_non_a100_by_default(monkeypatch):
     """Default stays strict: the vendor-string filter is what stops a run from
-    landing on the origin box's display GPU."""
+    landing on the origin box's display GPU.
+
+    Clears the opt-out explicitly rather than trusting the ambient environment,
+    so a variable leaked by another test cannot make this pass or fail for the
+    wrong reason -- which is exactly what happened once (see the isolation
+    fixture in ``test_heisenberg_d4_chi_scaling.py``).
+    """
+    monkeypatch.delenv("TENAX_ALLOW_NON_A100", raising=False)
     rows = d8._parse_nvidia_smi(_SMI_H100)
     with pytest.raises(RuntimeError):
         d8.select_free_a100s(rows, 1)


### PR DESCRIPTION
`--allow-non-a100` published `TENAX_ALLOW_NON_A100` from inside `main()` — which a worker started with `--cell` never reaches. The flag was a **silent no-op in worker mode**, so `_assert_only_a100s` refused non-A100 hardware however it was passed.

Found the hard way, not by reading: it aborted a real Run 2 launch with

```
{"phase": "optimize", "ok": false, "error": "RuntimeError: refusing to run:
 non-A100/display GPU visible: cuda:0 kind='NVIDIA GeForce RTX 4070 Ti SUPER'
 bytes_limit=12513705984"}
```

This is the same defect #775 fixes for the D=8 driver — the D=4 half. #774 added the flag to this driver with **no test coverage at all**.

## The fix

`_apply_device_opt_out` publishes the flag; `_dispatch` calls it before routing to worker or orchestrator. Dispatch moved out of `__main__` **specifically so the ordering is testable** — an unimportable `__main__` is why this shipped unnoticed.

## Docs: choosing the GPU

The handover doc gains a "Choosing the GPU" section for Run 2, prompted by a second finding from the same run:

**`CUDA_VISIBLE_DEVICES` on the orchestrator does not pin the run.** `_worker_env` overwrites it with its own most-idle `nvidia-smi` pick, so an outer pin is discarded. Observed directly — a run launched with `CUDA_VISIBLE_DEVICES=1` executing on GPU 0, confirmed from `/proc/<pid>/environ` (`CUDA_VISIBLE_DEVICES=0`) and `nvidia-smi --query-compute-apps` attributing 510 MiB to that pid on GPU 0's UUID.

The documented worker-mode sequence keeps the pin, and calls out two traps that cost real time here: cell filenames must match `cell_result_path()` exactly or the aggregation step recomputes everything, and `--smoke` overrides `device_counts` *after* parsing, silently discarding a `--device-counts 1` passed with it.

## Verification

7 new tests; **37 passed** across both driver test files. `ruff check src/ tests/` passes; ruff on the changed example is unchanged at 18 pre-existing errors (`examples/` is outside CI's lint scope).

Mutation count **5/5**:

| mutation | tests failing |
|---|---|
| helper never sets the env var | 3 |
| dispatch drops the opt-out call | 1 |
| opt-out applied *after* dispatch (the original bug) | 1 |
| guard ignores the env var | 1 |
| guard accepts any device | 2 |

The dispatch mutation **survived an earlier revision** of these tests — everything passed with the call deleted. That's what prompted extracting `_dispatch` rather than leaving the wiring in `__main__`, and it's the mutation that actually pins the regression.

Refs #747.

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.