### PR TITLE
fix(#801): measure the adjoint residual instead of trusting a flag that lies

### DIFF
--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -10,6 +10,7 @@ __all__ = [
 ]
 
 import logging
+import warnings
 from functools import partial
 
 import jax
@@ -38,6 +39,74 @@ from tenax.algorithms.ad_utils import CTMRGGradientError, _phase_fix_ctm_tensor
 from tenax.contraction.contractor import contract
 
 _GMRES_LOGGER = logging.getLogger("tenax.ctm.gmres")
+
+
+def _adjoint_converged(residual: float, tol: float) -> bool:
+    """Whether an adjoint solve met its tolerance.  Fails **closed**.
+
+    Written as ``residual <= tol`` rather than ``not (residual > tol)`` so that
+    a non-finite residual is reported as *not* converged.  ``nan > tol`` is
+    ``False``, so the naive spelling takes the silent branch exactly when the
+    solve has blown up — the #796 failure shape, and the reason this is a named
+    function with its own test rather than an inline comparison.
+    """
+    return bool(residual <= tol)
+
+
+def _relative_adjoint_residual(matvec, lam, rhs) -> float:
+    """``‖(I - Jᵀ)λ - b‖ / ‖b‖`` for the adjoint system, as a host float.
+
+    Costs one extra matvec per backward.  That is one VJP through a CTM sweep
+    against the ``gmres_maxiter`` (default 200) the solve itself is budgeted,
+    so it is well under a percent of the backward — cheap enough to run
+    unconditionally, which is the point: a diagnostic that has to be switched
+    on does not catch the run that needed it.
+    """
+
+    def _norm(tree) -> float:
+        return float(
+            jax.device_get(
+                jnp.sqrt(sum(jnp.sum(jnp.abs(x) ** 2) for x in jax.tree.leaves(tree)))
+            )
+        )
+
+    resid = jax.tree.map(lambda a, b: a - b, matvec(lam), rhs)
+    b_norm = _norm(rhs)
+    return _norm(resid) / b_norm if b_norm > 0 else _norm(resid)
+
+
+def _warn_if_adjoint_unconverged(
+    matvec, lam, rhs, *, tol: float, maxiter: int, restart: int
+) -> float:
+    """Measure the adjoint residual and warn when the solve did not converge.
+
+    The solver's own status flag cannot do this job:
+    ``jax.scipy.sparse.linalg.gmres`` returns ``info = 0`` whether or not it
+    converged (measured: ``maxiter=1, restart=1`` on a 2x2 system returns
+    ``info = 0`` at residual 0.54).  Both call sites here previously bound that
+    flag and discarded it, so reading it would have looked like a fix and
+    changed nothing.  The residual is therefore measured directly.
+
+    Reports rather than raises: ``λ`` is still the best available solution, and
+    an iPEPS optimization that aborts mid-run on one bad backward is usually
+    worse for the caller than one that continues with a warned-about gradient.
+    The C4v sibling (#716) makes the same choice.
+    """
+    rel = _relative_adjoint_residual(matvec, lam, rhs)
+    if not _adjoint_converged(rel, tol):
+        warnings.warn(
+            f"Implicit-AD CTM: adjoint solve did not converge (relative "
+            f"residual {rel:.3e} > gmres_tol {tol:.1e} after gmres_maxiter="
+            f"{maxiter} iterations of a {restart}-dimensional Krylov space). "
+            "The gradient contracts a λ that does not solve "
+            "(I - Jᵀ)λ = dE/denv, so it is wrong by roughly that relative "
+            "amount and nothing downstream can tell. Raise gmres_maxiter/"
+            "gmres_restart, or loosen gmres_tol if this residual is "
+            "acceptable for your use.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    return rel
 
 
 def _default_energy(site_tensors, envs, gate, coords, neighbors):
@@ -1500,6 +1569,16 @@ def _make_implicit_vjp_fn(
                     maxiter=gmres_maxiter,
                     restart=gmres_restart,
                 )
+                # ``_info`` is not a convergence flag on this solver -- see
+                # _warn_if_adjoint_unconverged.  Measure the residual instead.
+                _F3_LAST_DIAGNOSTICS["adjoint_residual"] = _warn_if_adjoint_unconverged(
+                    _eager_apply_I_minus_Jt,
+                    lam,
+                    rhs,
+                    tol=gmres_tol,
+                    maxiter=gmres_maxiter,
+                    restart=gmres_restart,
+                )
                 lam_leaves = tuple(jax.tree.leaves(lam))
                 _cached["prev_lam_leaves"] = lam_leaves
                 return _jit_chain_rule(
@@ -1539,6 +1618,16 @@ def _make_implicit_vjp_fn(
                 _eager_apply_I_minus_Jt,
                 rhs,
                 x0,
+                tol=gmres_tol,
+                maxiter=gmres_maxiter,
+                restart=gmres_restart,
+            )
+            # ``_info`` is not a convergence flag on this solver -- see
+            # _warn_if_adjoint_unconverged.  Measure the residual instead.
+            _F3_LAST_DIAGNOSTICS["adjoint_residual"] = _warn_if_adjoint_unconverged(
+                _eager_apply_I_minus_Jt,
+                lam,
+                rhs,
                 tol=gmres_tol,
                 maxiter=gmres_maxiter,
                 restart=gmres_restart,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,12 @@ _FILE_MARKERS = {
     # a NaN cotangent there is as fatal as a NaN value.  Milliseconds for the
     # unit half; the reachability test converges one D=2 chi=8 CTM.
     "test_normalise_rdm_zero_grad.py": "core",
+    # The adjoint-convergence gate on the DEFAULT iPEPS AD gradient path
+    # (#801, first raised on #341).  An unconverged adjoint yields a gradient
+    # that is wrong, finite, and indistinguishable downstream -- the exact
+    # class of defect the required gate exists for.  Cheap: D=2, chi=4, and
+    # the starved-budget cases converge in one iteration by construction.
+    "test_adjoint_convergence_gate.py": "core",
     "test_ctm_tensor.py": "algorithm",
     "test_integration_regression.py": "algorithm",
     "test_krylov.py": "core",

--- a/tests/test_adjoint_convergence_gate.py
+++ b/tests/test_adjoint_convergence_gate.py
@@ -1,0 +1,139 @@
+"""The implicit-AD backward must not use an unconverged adjoint silently.
+
+The backward solves ``(I - J^T) λ = dE/denv`` and then contracts ``λ`` into the
+gradient.  If that solve has not converged, the gradient is wrong — finite,
+plausibly scaled, and indistinguishable downstream from a correct one.  The
+C4v root-implicit path already refuses to let that pass silently (#716); this
+pins the same guarantee for the *default* iPEPS AD gradient path (#801, first
+raised on #341).
+
+**Why the convergence flag cannot be the guard.**  Both call sites bind the
+solver's second return value and discard it, and consuming it would not help:
+``jax.scipy.sparse.linalg.gmres`` returns ``info = 0`` whether or not it
+converged --
+
+    >>> gmres(lambda v: A @ v, b, tol=1e-14, atol=1e-14, maxiter=1, restart=1)
+    (Array([...]), Array(0, dtype=int64))   # residual 0.54
+
+-- so a fix that reads ``info`` would look right and change nothing.  The
+residual has to be measured.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._ctm_energy_ad import ctm_energy_implicit
+from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
+from tenax.algorithms.ipeps_optimize import _wrap_as_dense_tensor
+
+
+def _heisenberg_gate():
+    d = 2
+    Sz = 0.5 * jnp.array([[1.0, 0.0], [0.0, -1.0]])
+    Sp = jnp.array([[0.0, 1.0], [0.0, 0.0]])
+    Sm = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+    H = jnp.kron(Sz, Sz) + 0.5 * jnp.kron(Sp, Sm) + 0.5 * jnp.kron(Sm, Sp)
+    return H.reshape(d, d, d, d)
+
+
+def _random_peps(seed=2026, D=2, d=2):
+    key = jax.random.PRNGKey(seed)
+    A = jax.random.normal(key, (D, D, D, D, d))
+    return _wrap_as_dense_tensor(A / (jnp.linalg.norm(A) + 1e-10))
+
+
+def _grad(A, H, *, maxiter, restart, tol, method="gmres"):
+    def loss(A_):
+        return ctm_energy_implicit(
+            {(0, 0): A_},
+            SINGLE_SITE_NEIGHBORS,
+            H,
+            chi=4,
+            max_iter=20,
+            conv_tol=1e-8,
+            gmres_tol=tol,
+            gmres_maxiter=maxiter,
+            gmres_restart=restart,
+            adjoint_method=method,
+        )
+
+    return jax.grad(loss)(A)
+
+
+def test_an_unconverged_gmres_adjoint_warns():
+    """A starved Krylov budget must not return a gradient in silence."""
+    A, H = _random_peps(), _heisenberg_gate()
+    with pytest.warns(RuntimeWarning, match="adjoint solve did not converge"):
+        g = _grad(A, H, maxiter=1, restart=1, tol=1e-14)
+    # The gradient is still returned -- the guard reports, it does not abort.
+    assert bool(jnp.all(jnp.isfinite(g if not hasattr(g, "todense") else g.todense())))
+
+
+def test_a_converged_gmres_adjoint_is_silent():
+    """The guard must not fire on a healthy solve, or it is noise.
+
+    Without this the previous test passes against a helper that warns
+    unconditionally.
+    """
+    A, H = _random_peps(), _heisenberg_gate()
+    import warnings
+
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        _grad(A, H, maxiter=200, restart=20, tol=1e-6)
+    bad = [
+        str(w.message)
+        for w in rec
+        if "adjoint solve did not converge" in str(w.message)
+    ]
+    assert not bad, f"guard fired on a converged solve: {bad}"
+
+
+def test_the_warning_reports_the_residual_and_the_tolerance():
+    """A bare 'did not converge' is not actionable.
+
+    The C4v sibling names the residual, the tolerance and the remedy; this
+    path should too, so a caller can tell a near-miss from a total failure.
+    """
+    A, H = _random_peps(), _heisenberg_gate()
+    with pytest.warns(RuntimeWarning) as rec:
+        _grad(A, H, maxiter=1, restart=1, tol=1e-14)
+    msg = next(
+        str(w.message)
+        for w in rec
+        if "adjoint solve did not converge" in str(w.message)
+    )
+    assert "relative residual" in msg, msg
+    assert "gmres_maxiter" in msg, msg
+
+
+def test_the_default_fixed_point_path_is_covered_too():
+    """``fixed_point`` is the default, so it is the one that matters.
+
+    It does not solve the system itself when the fused Neumann loop fails —
+    it falls back to the same eager GMRES. Starving the budget therefore has
+    to surface through the same guard, or the default gradient path stays
+    silent while only the opt-out is protected.
+    """
+    A, H = _random_peps(), _heisenberg_gate()
+    with pytest.warns(RuntimeWarning, match="adjoint solve did not converge"):
+        _grad(A, H, maxiter=1, restart=1, tol=1e-14, method="fixed_point")
+
+
+def test_the_gate_fails_closed_on_a_nan_residual():
+    """``nan > tol`` is False; the guard must not take the silent branch.
+
+    This is the #796 failure shape, pinned here so the fix cannot be written
+    with the comparison that reintroduces it.
+    """
+    from tenax.algorithms._ctm_energy_ad import _adjoint_converged
+
+    assert _adjoint_converged(1e-9, 1e-6) is True
+    assert _adjoint_converged(1e-3, 1e-6) is False
+    assert _adjoint_converged(float("nan"), 1e-6) is False
+    assert _adjoint_converged(float("inf"), 1e-6) is False


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Closes #801.

## The bug

The implicit-AD backward solves `(I - Jᵀ)λ = dE/denv` and contracts `λ` into the gradient. Both eager-GMRES call sites bound the solver's second return value as `_info` and threw it away:

```python
lam, _info = gmres_pytree_jax(...)      # line 1495
lam, _info = gmres_pytree_jax(...)      # line 1538
```

A solve that never converged therefore produced a gradient that is **wrong, finite, plausibly scaled, and indistinguishable from a correct one** anywhere downstream. This is the *default* iPEPS AD gradient path.

## The part the issue got wrong

#801 proposed "consume `info`". That would not have worked, and this is the reason the fix looks different from the issue:

```python
>>> gmres(lambda v: A @ v, b, tol=1e-14, atol=1e-14, maxiter=1, restart=1)
(Array([...]), Array(0, dtype=int64))     # residual 0.54
```

`jax.scipy.sparse.linalg.gmres` returns `info = 0` **whether or not it converged**. Reading the flag would have looked like a fix, passed a naive test, and changed nothing.

So the residual is measured directly — `‖(I - Jᵀ)λ - b‖ / ‖b‖` — which is also what the C4v sibling does.

## Cost

One extra matvec per backward, against the `gmres_maxiter` (default 200) the solve is already budgeted: under a percent. Cheap enough to run unconditionally, which is the point — a diagnostic gated behind a flag does not catch the run that needed it. The existing `_F3_DIAG_COMPUTE_NORMS` gating exists for exactly that reason and is exactly why this went unnoticed.

## Coverage of the default path

`adjoint_method="fixed_point"` is the default and does **not** solve the system itself when its fused Neumann loop fails — it falls back to this same eager GMRES. Guarding the fallback guards the default path, and there is a test that pins it.

## Fail-closed

The comparison is `residual <= tol`, never `not (residual > tol)`: `nan > tol` is `False`, which takes the silent branch exactly when the solve has blown up. That is the #796 failure shape. `_adjoint_converged` is a named function with its own test so the fix cannot be rewritten into the version that reintroduces it.

Reports rather than raises, matching #716 — `λ` is still the best available solution, and aborting an optimization mid-run on one bad backward is usually worse for the caller than continuing with a warned-about gradient.

## Tests

5 new, **each mutation-verified**, and each mutation kills a different subset — so no test in the file is decoration:

| mutation | tests killed |
|---|---|
| remove the check (back to discarding) | 3 |
| `not (residual > tol)` — the NaN-open comparison | 1 |
| warn unconditionally | 1 |

Registered in `conftest._FILE_MARKERS` as `core`. Unregistered they would carry no marker and `-m core` — the required gate — would never run them; that is the lesson from #788, where 80 gauge tests turned out to be running nowhere.

## Verified, and one thing found on the way

`tests/test_ipeps_ad_adjoint_methods.py`, `test_ipeps_ad_f3_fused_bwd.py`, `test_ctm_chunk_backward_grad.py`, `test_ctm_energy_implicit.py`, `test_frontier_probe.py`: **12 passed, 1 failed**.

That one failure (`test_fixed_point_matches_gmres_gradient`) **reproduces on clean `main`** with identical digits and is not caused by this change. I checked whether it was a symptom of this bug — it is not: measured with the new gate, both solvers converge (gmres residual 2.0e-14, no warning) and their gradients agree to 8 significant figures. The 1.4e-4 gap is one-optimizer-step chaos amplification through a degenerate fixed point, which the test's own docstring describes. Filed separately as **#803**, along with the observation that it is the second red-on-main test hidden by a file that runs in no required job (#790 is the first).

Also noted but not changed: `_jit_gmres_solve` returns an `info` nobody consumes, because the function is never called at all — dead code.
