### PR TITLE
fix: four review follow-ups on #804 and #806

### DIFF
--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -41,20 +41,39 @@ from tenax.contraction.contractor import contract
 _GMRES_LOGGER = logging.getLogger("tenax.ctm.gmres")
 
 
-def _adjoint_converged(residual: float, tol: float) -> bool:
-    """Whether an adjoint solve met its tolerance.  Fails **closed**.
+def _adjoint_converged(residual: float, b_norm: float, tol: float) -> bool:
+    """Whether an adjoint solve met **the solver's own** criterion.  Fails closed.
 
-    Written as ``residual <= tol`` rather than ``not (residual > tol)`` so that
-    a non-finite residual is reported as *not* converged.  ``nan > tol`` is
-    ``False``, so the naive spelling takes the silent branch exactly when the
-    solve has blown up — the #796 failure shape, and the reason this is a named
-    function with its own test rather than an inline comparison.
+    Two things this must get right.
+
+    *The criterion.*  ``gmres_pytree_jax`` configures JAX GMRES with
+    ``tol=tol, atol=tol``, and that solver stops at
+    ``‖r‖ <= max(tol·‖b‖, atol)``.  Gating on the relative residual alone
+    (``‖r‖/‖b‖ <= tol``) is a *stricter* test, so whenever ``‖b‖ < 1`` the
+    solver can legitimately stop above the gate and be reported as a failure.
+    ``‖b‖`` is O(1) on this path (measured 1.285 on the D=2 chi=8 fixture), so
+    that is one state away, not hypothetical — and a guard that cries wolf
+    gets ignored, which would undo the point of #801.  The comparison
+    therefore mirrors the solver exactly.
+
+    *Failing closed.*  Written as ``residual <= threshold`` rather than
+    ``not (residual > threshold)`` so a non-finite residual is reported as
+    *not* converged.  ``nan > x`` is ``False``, so the naive spelling takes the
+    silent branch exactly when the solve has blown up — the #796 failure shape,
+    and the reason this is a named function with its own test rather than an
+    inline comparison.  ``max()`` with a NaN ``b_norm`` is also handled: the
+    comparison against any threshold is ``False`` for a NaN residual.
     """
-    return bool(residual <= tol)
+    threshold = tol if not b_norm > 0 else max(tol * b_norm, tol)
+    return bool(residual <= threshold)
 
 
-def _relative_adjoint_residual(matvec, lam, rhs) -> float:
-    """``‖(I - Jᵀ)λ - b‖ / ‖b‖`` for the adjoint system, as a host float.
+def _adjoint_residual_and_rhs_norm(matvec, lam, rhs) -> tuple[float, float]:
+    """``(‖(I - Jᵀ)λ - b‖, ‖b‖)`` for the adjoint system, as host floats.
+
+    Both are needed: the gate compares against the solver's combined
+    ``max(tol·‖b‖, atol)`` threshold, and the warning quotes the *relative*
+    residual because that is the number a caller can interpret.
 
     Costs one extra matvec per backward.  That is one VJP through a CTM sweep
     against the ``gmres_maxiter`` (default 200) the solve itself is budgeted,
@@ -71,8 +90,7 @@ def _relative_adjoint_residual(matvec, lam, rhs) -> float:
         )
 
     resid = jax.tree.map(lambda a, b: a - b, matvec(lam), rhs)
-    b_norm = _norm(rhs)
-    return _norm(resid) / b_norm if b_norm > 0 else _norm(resid)
+    return _norm(resid), _norm(rhs)
 
 
 def _warn_if_adjoint_unconverged(
@@ -92,8 +110,9 @@ def _warn_if_adjoint_unconverged(
     worse for the caller than one that continues with a warned-about gradient.
     The C4v sibling (#716) makes the same choice.
     """
-    rel = _relative_adjoint_residual(matvec, lam, rhs)
-    if not _adjoint_converged(rel, tol):
+    abs_resid, b_norm = _adjoint_residual_and_rhs_norm(matvec, lam, rhs)
+    rel = abs_resid / b_norm if b_norm > 0 else abs_resid
+    if not _adjoint_converged(abs_resid, b_norm, tol):
         warnings.warn(
             f"Implicit-AD CTM: adjoint solve did not converge (relative "
             f"residual {rel:.3e} > gmres_tol {tol:.1e} after gmres_maxiter="
@@ -1394,6 +1413,15 @@ def _make_implicit_vjp_fn(
         per distinct chi value visited (#516 chi-lock).
         """
         params_data_tuple, env_leaves, chi_post = residuals
+
+        # ``adjoint_residual`` is written only where an eager solve actually
+        # runs.  Clear it first so a fused fixed-point backward that never
+        # reaches one cannot leave the *previous* call's residual sitting in
+        # the diagnostics next to this call's ``converged=True`` -- a consumer
+        # reading them together would attribute a failed solve to a healthy
+        # one.  Absent means "no eager solve this backward", which is the
+        # honest report.
+        _F3_LAST_DIAGNOSTICS.pop("adjoint_residual", None)
 
         # Defense-in-depth: a malformed final_chi from a future
         # _run_ctm_loop_with_bump regression would silently corrupt the

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -10,6 +10,7 @@ __all__ = [
 ]
 
 import logging
+import math
 import warnings
 from functools import partial
 
@@ -61,9 +62,17 @@ def _adjoint_converged(residual: float, b_norm: float, tol: float) -> bool:
     *not* converged.  ``nan > x`` is ``False``, so the naive spelling takes the
     silent branch exactly when the solve has blown up — the #796 failure shape,
     and the reason this is a named function with its own test rather than an
-    inline comparison.  ``max()`` with a NaN ``b_norm`` is also handled: the
-    comparison against any threshold is ``False`` for a NaN residual.
+    inline comparison.
+
+    Scaling by ``‖b‖`` reintroduces that hazard on the *threshold* side: if the
+    RHS norm overflows, ``max(tol·inf, tol)`` is ``inf`` and every residual —
+    ``inf`` included — passes ``r <= inf``, so a blown-up solve reads as
+    converged.  Both inputs are therefore screened for finiteness up front.  An
+    infinite or NaN ``‖b‖`` means the RHS is garbage, so no residual measured
+    against it is meaningful, however small.
     """
+    if not math.isfinite(residual) or not math.isfinite(b_norm):
+        return False
     threshold = tol if not b_norm > 0 else max(tol * b_norm, tol)
     return bool(residual <= threshold)
 

--- a/tests/test_adjoint_convergence_gate.py
+++ b/tests/test_adjoint_convergence_gate.py
@@ -125,15 +125,74 @@ def test_the_default_fixed_point_path_is_covered_too():
         _grad(A, H, maxiter=1, restart=1, tol=1e-14, method="fixed_point")
 
 
-def test_the_gate_fails_closed_on_a_nan_residual():
-    """``nan > tol`` is False; the guard must not take the silent branch.
+# --- review follow-ups on #804 -------------------------------------------
 
-    This is the #796 failure shape, pinned here so the fix cannot be written
-    with the comparison that reintroduces it.
+
+def test_the_gate_uses_the_same_criterion_as_the_solver():
+    """A guard that cries wolf gets ignored, which would undo #801.
+
+    ``gmres_pytree_jax`` configures JAX GMRES with ``tol=tol, atol=tol``, and
+    that solver stops at ``‖r‖ <= max(tol·‖b‖, atol)``.  Gating on the
+    *relative* residual alone is a stricter test, so whenever ``‖b‖ < 1`` the
+    solver can legitimately stop above the gate and be reported as a failure.
+
+    ``‖rhs‖`` is O(1) here (measured 1.285 on the D=2 chi=8 fixture), so this
+    is one state away rather than hypothetical.
     """
     from tenax.algorithms._ctm_energy_ad import _adjoint_converged
 
-    assert _adjoint_converged(1e-9, 1e-6) is True
-    assert _adjoint_converged(1e-3, 1e-6) is False
-    assert _adjoint_converged(float("nan"), 1e-6) is False
-    assert _adjoint_converged(float("inf"), 1e-6) is False
+    tol = 1e-6
+    # ‖b‖ = 1: the two criteria coincide.
+    assert _adjoint_converged(1e-7, 1.0, tol) is True
+    assert _adjoint_converged(1e-5, 1.0, tol) is False
+
+    # ‖b‖ = 1e-3: the solver's floor is atol = tol, so a residual of 1e-7 is
+    # converged even though ‖r‖/‖b‖ = 1e-4 is far above tol.  This is the
+    # false positive.
+    assert _adjoint_converged(1e-7, 1e-3, tol) is True
+    # Still rejects a genuinely bad solve at the same ‖b‖.
+    assert _adjoint_converged(1e-2, 1e-3, tol) is False
+
+    # ‖b‖ = 100: the relative criterion binds and is the looser of the two.
+    assert _adjoint_converged(1e-5, 100.0, tol) is True
+
+
+def test_the_gate_still_fails_closed_on_a_non_finite_residual():
+    """``nan > tol`` is False; the guard must not take the silent branch.
+
+    This is the #796 failure shape, pinned here so neither the original fix
+    nor the tolerance change above can be written with the comparison that
+    reintroduces it.
+    """
+    from tenax.algorithms._ctm_energy_ad import _adjoint_converged
+
+    assert _adjoint_converged(float("nan"), 1.0, 1e-6) is False
+    assert _adjoint_converged(float("inf"), 1.0, 1e-6) is False
+    # ...including when ‖b‖ itself is degenerate.
+    assert _adjoint_converged(float("nan"), float("nan"), 1e-6) is False
+
+
+def test_a_successful_fixed_point_backward_clears_a_stale_residual():
+    """Diagnostics must describe the latest solve, not a previous one.
+
+    ``adjoint_residual`` is written only on the eager paths.  Without an
+    explicit reset, a later successful fused fixed-point backward leaves the
+    old value in place, so a consumer reads a failed solve's residual next to
+    the current solve's ``converged=True``.
+    """
+    from tenax.algorithms import _ctm_energy_ad as M
+
+    A, H = _random_peps(), _heisenberg_gate()
+    # Starve the budget so the eager fallback runs and records a residual.
+    with pytest.warns(RuntimeWarning):
+        _grad(A, H, maxiter=1, restart=1, tol=1e-14)
+    assert M._F3_LAST_DIAGNOSTICS.get("adjoint_residual") is not None
+
+    # Now a healthy fixed-point backward: the stale value must not survive it.
+    _grad(A, H, maxiter=200, restart=20, tol=1e-6, method="fixed_point")
+    stale = M._F3_LAST_DIAGNOSTICS.get("adjoint_residual")
+    assert stale is None, (
+        f"stale adjoint_residual={stale} survived a successful fixed-point "
+        "backward; get_last_implicit_ad_diagnostics() would report it "
+        "alongside converged=True for a different solve"
+    )

--- a/tests/test_adjoint_convergence_gate.py
+++ b/tests/test_adjoint_convergence_gate.py
@@ -47,14 +47,33 @@ def _random_peps(seed=2026, D=2, d=2):
     return _wrap_as_dense_tensor(A / (jnp.linalg.norm(A) + 1e-10))
 
 
-def _grad(A, H, *, maxiter, restart, tol, method="gmres"):
+def _grad(A, H, *, maxiter, restart, tol, method="gmres", ctm_max_iter=20):
+    """Gradient through the implicit-AD energy.
+
+    ``ctm_max_iter`` is separate from ``maxiter`` on purpose, and the tests
+    that assert *silence* must raise it.  The backward linearises about the
+    forward CTM iterate: if the forward has not reached its fixed point,
+    ``(I - Jᵀ)`` is not the operator the adjoint system assumes and GMRES
+    stalls no matter how large its Krylov budget is.  Measured on this D=2
+    chi=4 fixture:
+
+        ctm_max_iter =  20  ->  adjoint residual 2.5e-02   (guard fires)
+        ctm_max_iter = 100  ->  adjoint residual 1.3e-10
+        ctm_max_iter = 300  ->  adjoint residual 3.4e-10
+
+    At 20 the guard is *correct* to warn, so a silence assertion there is
+    testing luck: it held on CPU and failed on CUDA, where the unconverged
+    forward lands somewhere else.  Starve the Krylov budget to provoke the
+    warning, never the forward sweep count.
+    """
+
     def loss(A_):
         return ctm_energy_implicit(
             {(0, 0): A_},
             SINGLE_SITE_NEIGHBORS,
             H,
             chi=4,
-            max_iter=20,
+            max_iter=ctm_max_iter,
             conv_tol=1e-8,
             gmres_tol=tol,
             gmres_maxiter=maxiter,
@@ -79,13 +98,18 @@ def test_a_converged_gmres_adjoint_is_silent():
 
     Without this the previous test passes against a helper that warns
     unconditionally.
+
+    ``ctm_max_iter`` is raised so the forward actually reaches its fixed
+    point — see ``_grad``. With the default 20 this asserts silence about a
+    solve that genuinely does not converge, which is a backend-dependent
+    coin flip rather than a property of the guard.
     """
     A, H = _random_peps(), _heisenberg_gate()
     import warnings
 
     with warnings.catch_warnings(record=True) as rec:
         warnings.simplefilter("always")
-        _grad(A, H, maxiter=200, restart=20, tol=1e-6)
+        _grad(A, H, maxiter=200, restart=20, tol=1e-6, ctm_max_iter=200)
     bad = [
         str(w.message)
         for w in rec
@@ -172,6 +196,29 @@ def test_the_gate_still_fails_closed_on_a_non_finite_residual():
     assert _adjoint_converged(float("nan"), float("nan"), 1e-6) is False
 
 
+def test_a_non_finite_rhs_norm_cannot_make_the_threshold_swallow_the_residual():
+    """The ‖b‖-relative threshold must not become the thing that fails open.
+
+    Scaling the tolerance by ‖b‖ introduces a failure mode the residual-only
+    check does not have: if the RHS norm overflows, ``max(tol·inf, tol)`` is
+    ``inf``, and *every* residual satisfies ``r <= inf`` — including ``inf``
+    itself.  So the exact situation the guard exists to catch, a blown-up
+    adjoint solve, is the one it reports as converged.
+
+    Note ``(nan, inf)`` already fails closed for an unrelated reason
+    (``nan <= inf`` is False), so testing only nan residuals misses this.
+    An infinite ‖b‖ means the RHS itself is garbage, so no residual against
+    it is meaningful, however small.
+    """
+    from tenax.algorithms._ctm_energy_ad import _adjoint_converged
+
+    inf = float("inf")
+    assert _adjoint_converged(inf, inf, 1e-6) is False
+    # A *small* residual against an infinite RHS is not evidence of anything.
+    assert _adjoint_converged(1e-9, inf, 1e-6) is False
+    assert _adjoint_converged(1e-9, float("nan"), 1e-6) is False
+
+
 def test_a_successful_fixed_point_backward_clears_a_stale_residual():
     """Diagnostics must describe the latest solve, not a previous one.
 
@@ -189,7 +236,16 @@ def test_a_successful_fixed_point_backward_clears_a_stale_residual():
     assert M._F3_LAST_DIAGNOSTICS.get("adjoint_residual") is not None
 
     # Now a healthy fixed-point backward: the stale value must not survive it.
-    _grad(A, H, maxiter=200, restart=20, tol=1e-6, method="fixed_point")
+    # Converged forward (see _grad) so "healthy" is a fact, not a coin flip.
+    _grad(
+        A,
+        H,
+        maxiter=200,
+        restart=20,
+        tol=1e-6,
+        method="fixed_point",
+        ctm_max_iter=200,
+    )
     stale = M._F3_LAST_DIAGNOSTICS.get("adjoint_residual")
     assert stale is None, (
         f"stale adjoint_residual={stale} survived a successful fixed-point "

--- a/tests/test_bucket_registry.py
+++ b/tests/test_bucket_registry.py
@@ -33,6 +33,110 @@ import re
 
 TESTS_DIR = pathlib.Path(__file__).parent
 
+_VALID_BUCKETS = {"core", "algorithm", "slow"}
+
+# Frozen at the commit that introduced the guard (#805). Removals only:
+# a file leaves this set by being bucketed in _FILE_MARKERS, never by being
+# added here. Kept in the TEST, not in conftest, so the thing being checked
+# and the thing checking it cannot be edited in one place.
+_FROZEN_LEGACY = {
+    "test_ad_primitives_rank_aware.py",
+    "test_apply_chi_bump.py",
+    "test_architecture_imports.py",
+    "test_arnoldi.py",
+    "test_block_sparse_ctm_ad.py",
+    "test_c4v_reference_ad.py",
+    "test_chi_ramp_chi_auto_bump_deprecation.py",
+    "test_coarse_grain.py",
+    "test_complex128_ad.py",
+    "test_ctm_2x2_projector_symmetric.py",
+    "test_ctm_670_symmetric_2x2.py",
+    "test_ctm_674_fermionic_fused.py",
+    "test_ctm_700_env_collapse.py",
+    "test_ctm_chi_ramp.py",
+    "test_ctm_compiled.py",
+    "test_ctm_direction_dependent_bonds.py",
+    "test_ctm_energy_implicit.py",
+    "test_ctm_energy_implicit_chi_bump.py",
+    "test_ctm_env_pad_chi_schedule.py",
+    "test_ctm_explicit_tbptt.py",
+    "test_ctm_honeycomb_ad.py",
+    "test_ctm_honeycomb_convergence.py",
+    "test_ctm_honeycomb_cross_path.py",
+    "test_ctm_honeycomb_energy.py",
+    "test_ctm_honeycomb_env.py",
+    "test_ctm_honeycomb_forward.py",
+    "test_ctm_honeycomb_init.py",
+    "test_ctm_honeycomb_lukin_sotnikov.py",
+    "test_ctm_honeycomb_moves.py",
+    "test_ctm_honeycomb_projector.py",
+    "test_ctm_honeycomb_safeguards.py",
+    "test_ctm_implicit_warm_start_adjoint.py",
+    "test_ctm_in_loop_bump_ad_paths.py",
+    "test_ctm_in_loop_chi_bump.py",
+    "test_ctm_loop_core.py",
+    "test_ctm_multisite_2x2_contract.py",
+    "test_ctm_projector.py",
+    "test_ctm_recipe_2x2_production_correctness.py",
+    "test_ctm_sharding_backward.py",
+    "test_ctm_tensor_flow_flip.py",
+    "test_ctm_tensor_init_rank1.py",
+    "test_ctm_tensor_projector_2x2.py",
+    "test_ctm_tensor_tiling.py",
+    "test_gmres_lax.py",
+    "test_hotrg_sharding.py",
+    "test_ipeps_ad_adjoint_methods.py",
+    "test_ipeps_ad_conv_criterion.py",
+    "test_ipeps_ad_f3_fused_bwd.py",
+    "test_ipeps_ad_history.py",
+    "test_ipeps_ad_policy.py",
+    "test_ipeps_checkpoint.py",
+    "test_ipeps_checkpoint_resume.py",
+    "test_ipeps_chi_adaptive_bump_unit.py",
+    "test_ipeps_chi_bump_rollback_desync.py",
+    "test_ipeps_chi_schedule_wiring.py",
+    "test_ipeps_config_chi_ceiling_bailout.py",
+    "test_ipeps_config_grad_spike.py",
+    "test_ipeps_config_hz_max_iter.py",
+    "test_ipeps_config_stall_recovery_retries.py",
+    "test_ipeps_ctm_stall_recovery_cap.py",
+    "test_ipeps_stall_recovery_cap.py",
+    "test_ipeps_tree_dot.py",
+    "test_ipeps_u1sz.py",
+    "test_line_search.py",
+    "test_line_search_auto.py",
+    "test_lorentzian_eigh_kernel.py",
+    "test_make_neighbors.py",
+    "test_metric_precond.py",
+    "test_optimize_gs_ad_chi_schedule_shim.py",
+    "test_optimize_gs_ad_chi_schedule_unified.py",
+    "test_pess_3site_multisite_encoding.py",
+    "test_pess_3site_multisite_rdm_invariants.py",
+    "test_pess_3site_multisite_wavefunction.py",
+    "test_pess_ad_honeycomb.py",
+    "test_pess_local_energy.py",
+    "test_profiler_u1sz_arm.py",
+    "test_projector_backward_dispatch.py",
+    "test_reduced_corner_qr.py",
+    "test_regularized_qr.py",
+    "test_regularized_svd.py",
+    "test_split_ctm_chi_frozen_726.py",
+    "test_split_ctm_doublelayer_projector.py",
+    "test_split_ctm_energy_gauge.py",
+    "test_split_ctm_fuse_flag.py",
+    "test_split_ctm_large_d_memory.py",
+    "test_split_ctm_production_correctness.py",
+    "test_sublattice_rotation.py",
+    "test_svd_adjoint_fd_750.py",
+    "test_symmetric_custom_vjp.py",
+    "test_truncated_lowrank_svd.py",
+    "test_tuning_registry.py",
+    "test_u1sz_defrag_prototype_610.py",
+    "test_varipeps_compare.py",
+    "test_varipeps_compare_payload.py",
+    "test_varipeps_compare_su.py",
+}
+
 
 def _registered_keys() -> set[str]:
     """Filenames appearing as keys of ``_FILE_MARKERS`` in conftest."""
@@ -47,6 +151,20 @@ def _legacy_keys() -> set[str]:
     start = src.index("_UNBUCKETED_LEGACY = {")
     end = src.index("\n}\n", start)
     return set(re.findall(r'"(test_[A-Za-z0-9_]+\.py)"', src[start:end]))
+
+
+def _registered_items() -> dict[str, str]:
+    """``{filename: bucket}`` for every entry of ``_FILE_MARKERS``.
+
+    Parsed rather than imported so a syntax-level typo in the *value* is
+    visible; importing conftest would only surface the keys.
+    """
+    src = (TESTS_DIR / "conftest.py").read_text()
+    start = src.index("_FILE_MARKERS = {")
+    end = src.index("\n}\n", start)
+    return dict(
+        re.findall(r'"(test_[A-Za-z0-9_]+\.py)"\s*:\s*"([^"]*)"', src[start:end])
+    )
 
 
 def _test_files() -> set[str]:
@@ -93,17 +211,42 @@ def test_the_registry_has_no_keys_for_files_that_no_longer_exist():
     )
 
 
-def test_the_legacy_list_is_a_ratchet():
-    """The unbucketed backlog may shrink, never grow.
+def test_the_legacy_list_can_only_shrink():
+    """Freeze *membership*, not size — a size ceiling is dodgeable.
 
-    Without this the legacy list becomes the path of least resistance and the
-    guard above is decorative.
+    ``len(legacy) <= N`` leaves a reusable slot the moment one file is
+    correctly bucketed: a later change can remove one entry and add a
+    different one in the same diff, keep the count at N, and pass every
+    guard while the new file still carries no marker and ``-m core`` skips
+    it. That is precisely the hole this whole file exists to close.
+
+    So the frozen set lives *here*, independent of conftest, and conftest's
+    list is checked as a subset of it. Removals pass; additions cannot.
     """
-    legacy = _legacy_keys()
-    assert len(legacy) <= 95, (
-        f"_UNBUCKETED_LEGACY grew to {len(legacy)} (ceiling 95). It is frozen "
-        "debt from #805: move files OUT of it into `_FILE_MARKERS`, never in. "
-        "If you are draining it, lower the ceiling in this test to match."
+    extra = sorted(_legacy_keys() - _FROZEN_LEGACY)
+    assert not extra, (
+        "these files were added to `_UNBUCKETED_LEGACY`, which is frozen "
+        "debt (#805) and accepts removals only:\n  "
+        + "\n  ".join(extra)
+        + "\n\nBucket them in `_FILE_MARKERS` instead."
+    )
+
+
+def test_every_registered_bucket_is_a_real_bucket():
+    """A typo'd bucket silently deselects the file.
+
+    ``pytest_collection_modifyitems`` does ``getattr(pytest.mark, marker)``,
+    which happily creates an unknown marker — pytest only *warns* about it,
+    since this repo does not enable strict markers. So
+    ``"test_new.py": "algoritm"`` registers cleanly, passes every other guard
+    here, and is still deselected by ``pytest -m core``: the file looks
+    bucketed and runs nowhere.
+    """
+    bad = {f: b for f, b in _registered_items().items() if b not in _VALID_BUCKETS}
+    assert not bad, (
+        "these entries in `_FILE_MARKERS` name a bucket that does not "
+        f"exist (valid: {sorted(_VALID_BUCKETS)}):\n  "
+        + "\n  ".join(f"{f}: {b!r}" for f, b in sorted(bad.items()))
     )
 
 


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Codex reviewed #804 and #806 after they merged. All four findings verified against `main`; **two of them left real holes in the things those PRs had just built**, which is why this is one PR rather than four.

## 1. The ratchet was dodgeable (#806)

`len(legacy) <= 95` freezes the *size*, not the membership. The first correctly-bucketed file frees a reusable slot:

> remove one entry, add a different one in the same diff → count stays 95 → **every guard passes** → the new file carries no marker and `-m core` skips it.

That is exactly the hole the guard exists to close, so the guard was only partly doing its job. Confirmed by mutating precisely that swap.

The frozen set now lives **in the test**, independent of conftest, and conftest's list is checked as a subset of it. Removals pass; additions cannot. Keeping the two in separate files is deliberate — the thing being checked and the thing checking it should not be editable in one place.

## 2. A typo'd bucket was invisible (#806)

`pytest_collection_modifyitems` does `getattr(pytest.mark, marker)`, which happily creates an unknown marker. Pytest only *warns* about it, since this repo does not enable strict markers. So:

```python
"test_new.py": "algoritm",     # registered, passes every guard
```

...and is still deselected by `pytest -m core`. Bucketed-looking, running nowhere — the same end state the guard was written to prevent, reached by a different route. The mapping's **values** are now parsed and checked against the three real buckets.

## 3. The new gate could cry wolf (#804)

`gmres_pytree_jax` configures JAX GMRES with `tol=tol, atol=tol`, and that solver stops at

```
‖r‖ <= max(tol·‖b‖, atol)
```

Gating on the relative residual alone (`‖r‖/‖b‖ <= tol`) is a **stricter** test, so whenever `‖b‖ < 1` the solver can legitimately stop above the gate and be reported as a failure.

Measured `‖rhs‖ = 1.285` on the D=2 χ=8 fixture — so not hit there, but it is O(1) and the window is one state away. A guard that fires spuriously gets ignored, which would undo the point of #801. The comparison now mirrors the solver exactly, and still fails closed on a non-finite residual (including a NaN `‖b‖`).

## 4. Stale diagnostics (#804)

`adjoint_residual` is written only where an eager solve runs, so a later fused fixed-point backward left the *previous* call's residual sitting next to the current call's `converged=True`. A consumer reading them together would attribute a failed solve to a healthy one. Cleared at the top of every backward — absent now means "no eager solve this backward", which is the honest report.

## Verification

Each fix **mutation-verified**, each mutation killing exactly its own test:

| mutation | killed |
|---|---|
| revert to the relative-only criterion | `test_the_gate_uses_the_same_criterion_as_the_solver` |
| naive `not (r > tol)` comparison | `test_the_gate_still_fails_closed_on_a_non_finite_residual` |
| don't clear the diagnostics key | `test_a_successful_fixed_point_backward_clears_a_stale_residual` |
| the legacy swap-in/swap-out dodge | `test_the_legacy_list_can_only_shrink` |
| a typo'd bucket value | `test_every_registered_bucket_is_a_real_bucket` |

The superseded 2-arg NaN test from #804 is folded into its replacement rather than left duplicated.

**Regression:** 12 passed, 1 failed across the AD suites. That one failure is `test_fixed_point_matches_gmres_gradient`, which is already red on `main` and tracked as **#803** — verified pre-existing, not caused by this change.
