### PR TITLE
chore: move examples/ driver tests out of the required CI gate

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,9 +159,14 @@ _FILE_MARKERS = {
     # (mesh specs, commit helpers, config default) gate every PR; the heavy
     # subprocess parity sweep (N=2,4 fake CPU devices) is slow-only.
     "test_ctm_sharding.py": "core",
-    "test_showcase_scaling.py": "core",
-    "test_heisenberg_d4_chi_scaling.py": "core",
-    "test_heisenberg_d8_chi_scaling.py": "core",
+    # These three test the orchestration helpers of driver scripts under
+    # examples/, not the library: they path-load the example and exercise its
+    # argument/schedule plumbing, and are jax-free by design.  The required
+    # gate is for library behaviour, so a broken example should not block a
+    # merge -- they still run in the full suite and on push to main.
+    "test_showcase_scaling.py": "algorithm",
+    "test_heisenberg_d4_chi_scaling.py": "algorithm",
+    "test_heisenberg_d8_chi_scaling.py": "algorithm",
     "test_ctm_sharding_parity.py": "slow",
     # Chunked dense-CTM edge absorption (chunk x shard #632 Increment 1): fast
     # mechanism unit tests; collected as core so CI required checks run them.
@@ -177,7 +182,11 @@ _FILE_MARKERS = {
     # #632 frontier benchmark (phase 1): tiny D=2 CPU value_and_grad finite +
     # path-guard checks. Fast; core so CI required checks run them.
     "test_frontier_probe.py": "core",
-    "test_frontier_bench_guard.py": "core",
+    # Stays out of the gate for the same reason as the scaling drivers above:
+    # it only checks the `skip_reason` arithmetic of an examples/ benchmark
+    # script.  (test_frontier_probe.py above is NOT in this group -- it runs a
+    # real D=2 chi=6 CTM energy+gradient, so it is library behaviour.)
+    "test_frontier_bench_guard.py": "algorithm",
 }
 
 


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Four files in the `core` bucket test the orchestration helpers of driver scripts under `examples/`, not the library. They path-load the example and exercise its argument/schedule plumbing, and are jax-free by design.

| file | tests |
|---|---|
| `test_heisenberg_d8_chi_scaling.py` | 27 |
| `test_heisenberg_d4_chi_scaling.py` | 21 |
| `test_showcase_scaling.py` | 7 |
| `test_frontier_bench_guard.py` | 3 (`skip_reason` arithmetic only) |

The required gate exists to decide whether **library behaviour** is safe to merge. A broken example script should not block a merge, so these move to `algorithm`: still collected, still run in the full suite and on push to `main`, just not gating.

Verified both directions — 58 deselected by `-m core`, all 58 still collected by `-m algorithm`. **No coverage is lost.**

## Explicitly not moved

`test_frontier_probe.py` sits directly beside `test_frontier_bench_guard.py` and shares the naming, so it looks like a sibling. It is not — it runs a real `D=2 chi=6` CTM energy+gradient and asserts finiteness, which is library behaviour. It stays in the gate. Moving it on the name pattern would have quietly pulled a genuine gradient regression test out of required CI.

## This does not speed up CI, and is not offered as doing so

The four files run in ~25s against a ~55min gate — under 1%. Being jax-free is what makes them identifiable as example-tests *and* what makes them nearly free. The gate spends its time in the JAX/CTM tests, i.e. the ones where removal has a real safety cost. Profiling that properly (`-m core --durations=0`) is separate work in progress; this PR is a scope change, not a performance one.

## CI note

GitHub Actions is in a [major outage](https://www.githubstatus.com) as of 15:22 UTC today (queued jobs timing out without a runner), so checks here may not start until it recovers.