### PR TITLE
fix(#796, #787, #784): make every root-implicit gate fail closed, and let the multisite gate follow its clamp

### DIFF
--- a/src/tenax/algorithms/_ad_primitives.py
+++ b/src/tenax/algorithms/_ad_primitives.py
@@ -21,6 +21,7 @@ Reference: Francuz et al., Phys. Rev. Research 7, 013237 (2025).
 
 from __future__ import annotations
 
+import math
 import warnings
 from functools import partial
 
@@ -72,6 +73,48 @@ def _check_root_residual_policy(on_root_residual: str) -> None:
             f"on_root_residual must be one of {_ROOT_RESIDUAL_POLICIES}, "
             f"got {on_root_residual!r}"
         )
+
+
+def _residual_exceeds(value: float, tolerance: float) -> bool:
+    """``True`` when ``value`` is not provably within ``tolerance``.
+
+    Spelled ``not (value <= tolerance)`` rather than ``value > tolerance``.
+    The two differ only on NaN -- and that is the case that matters: ``nan``
+    compares ``False`` to everything, so the naive form takes the *silent*
+    branch exactly when the quantity is most obviously invalid, and the caller
+    proceeds to build a gradient on a root it could not even measure.  Every
+    root-implicit gate is a guard, so every one of them must fail closed.
+
+    This lives here, next to :func:`_report_root_residual`, because the
+    comparison drifting *away* from the reporter is how the engines diverged in
+    the first place: the asymmetric path was fixed in #791 while the C4v,
+    symmetric and multisite engines kept the fail-open spelling (#796).
+    """
+    return not (value <= tolerance)
+
+
+def _gauge_consistency(tilde_bar, tilde, y_bar_norm: float) -> float:
+    """Largest relative component of the energy cotangent along a phase null direction.
+
+    Returns NaN if any pair is NaN, rather than skipping it.  The obvious
+    ``acc = max(acc, ratio)`` loop is silently wrong here: ``max`` picks by
+    ``>``, and ``nan > 0.0`` is ``False``, so an accumulator starting at 0.0
+    *keeps the 0.0* and the diagnostic reports **perfect** gauge consistency
+    for a NaN cotangent -- silent and inverted, on the one input (#772's NaN
+    cotangent) it exists to catch (#787).
+
+    Note the swallowing is order-dependent -- ``max(nan, 0.0)`` does keep the
+    NaN -- so the accumulator's 0.0 seed is what makes the broken ordering the
+    one that always occurs.  Both orders are pinned by tests.
+    """
+    ratios: list[float] = []
+    for bar, tensor in zip(tilde_bar, tilde):
+        pairing = float(jnp.real(jnp.sum(bar * (1j * tensor))))
+        scale = y_bar_norm * float(jnp.linalg.norm(tensor)) + 1e-300
+        ratios.append(abs(pairing) / scale)
+    if any(math.isnan(r) for r in ratios):
+        return math.nan
+    return max(ratios, default=0.0)
 
 
 def _report_root_residual(

--- a/src/tenax/algorithms/_ctm_c4v_root_implicit.py
+++ b/src/tenax/algorithms/_ctm_c4v_root_implicit.py
@@ -58,6 +58,7 @@ import jax.numpy as jnp
 from tenax.algorithms._ad_primitives import (
     _check_root_residual_policy,
     _report_root_residual,
+    _residual_exceeds,
 )
 from tenax.algorithms._ctm_tensor_c4v import _c4v_sweep, _c4v_to_full_env
 from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
@@ -540,7 +541,7 @@ def c4v_root_implicit_energy_and_grad(
         polish_tol=polish_tol,
     )
 
-    if root_residual > root_residual_warn:
+    if _residual_exceeds(root_residual, root_residual_warn):
         _report_root_residual(
             on_root_residual,
             f"C4v root implicit AD: ‖F(y*)‖ = {root_residual:.3e} exceeds "

--- a/src/tenax/algorithms/_ctm_root_implicit_asym.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_asym.py
@@ -97,7 +97,9 @@ import jax.numpy as jnp
 
 from tenax.algorithms._ad_primitives import (
     _check_root_residual_policy,
+    _gauge_consistency,
     _report_root_residual,
+    _residual_exceeds,
 )
 from tenax.algorithms._ctm_tensor_energy import compute_energy_ctm_tensor
 from tenax.algorithms._ctm_tensor_init import (
@@ -1471,12 +1473,8 @@ def asym_root_implicit_energy_and_grad(
     y_bar_norm = float(
         jnp.sqrt(sum(jnp.sum(jnp.abs(x) ** 2) for x in jax.tree.leaves(y_bar)))
     )
-    gauge_consistency = 0.0
-    for bar, tensor in zip(tilde_bar, tilde):
-        pairing = float(jnp.real(jnp.sum(bar * (1j * tensor))))
-        scale = y_bar_norm * float(jnp.linalg.norm(tensor)) + 1e-300
-        gauge_consistency = max(gauge_consistency, abs(pairing) / scale)
-    if gauge_consistency > 1e-8:
+    gauge_consistency = _gauge_consistency(tilde_bar, tilde, y_bar_norm)
+    if _residual_exceeds(gauge_consistency, 1e-8):
         warnings.warn(
             f"Asymmetric root implicit AD: the energy cotangent has a "
             f"{gauge_consistency:.3e} relative component along an environment "

--- a/src/tenax/algorithms/_ctm_root_implicit_multisite.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_multisite.py
@@ -955,6 +955,7 @@ def cell_root_implicit_energy_and_grad(
     from tenax.algorithms._ad_primitives import (
         _check_root_residual_policy,
         _report_root_residual,
+        _residual_exceeds,
     )
     from tenax.algorithms._ctm_c4v_root_implicit import _solve_root_adjoint
     from tenax.algorithms._ctm_tensor_init import (
@@ -994,7 +995,7 @@ def cell_root_implicit_energy_and_grad(
         polish_steps=polish_steps,
         polish_tol=polish_tol,
     )
-    if root_residual > root_residual_warn:
+    if _residual_exceeds(root_residual, root_residual_warn):
         _report_root_residual(
             on_root_residual,
             f"Multisite root implicit AD: ‖F(y*)‖ = {root_residual:.3e} exceeds "

--- a/src/tenax/algorithms/_ctm_root_implicit_multisite.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_multisite.py
@@ -371,6 +371,40 @@ def all_projectors_multisite(ECs, chi: int, nrows: int, ncols: int, prev=None):
     return out
 
 
+def retained_rank_report_multisite(
+    corners, edges, a_by_cell, chi: int, nrows: int, ncols: int, rel_floor=None
+) -> dict:
+    """How much of the retained spectrum carries real weight, per unit cell.
+
+    ``usable_rank`` is the minimum over *every coordinate* of the count
+    :func:`_rank_capped_spectrum` leaves above the clamp — the worst cut in the
+    cell sets the floor, because a single clamped direction anywhere makes
+    ``y*`` unable to satisfy the equations below the clamp level.  Same
+    aggregation as Phase 1's :func:`retained_rank_report`, which minimises over
+    the four directions.
+
+    ``all_projectors_multisite`` computes this rank and discards it into
+    ``_usable_rank`` (#778 did the same in Phase 1); this is the accessor that
+    makes it reachable, which is what #784 needs to size the gate.
+
+    Costs one SVD per coordinate and runs no adjoint solve, against the
+    hundreds of sweeps the caller has already paid for.
+    """
+    from tenax.algorithms._ctm_root_implicit_asym import _rank_capped_spectrum
+
+    ECs = all_enlarged_corners(corners, edges, a_by_cell, nrows, ncols)
+    rank = int(chi)
+    smin_rtol = float("inf")
+    for co in coordinates(nrows, ncols):
+        M, _A, _B = half_infinite_multisite(ECs, co, nrows, ncols)
+        s = jnp.linalg.svd(M, compute_uv=False)
+        _capped, usable = _rank_capped_spectrum(s, chi, rel_floor=rel_floor)
+        s_k = s[:chi]
+        smin_rtol = min(smin_rtol, float(s_k[-1]) / (float(s_k[0]) + 1e-300))
+        rank = min(rank, int(usable))
+    return {"usable_rank": rank, "retained_smin_rtol": smin_rtol}
+
+
 def _absorbed_edge(edges, a_by_cell, co: Coord, nrows: int, ncols: int):
     """``edge[above(co)]`` with the local double layer absorbed.
 
@@ -958,6 +992,7 @@ def cell_root_implicit_energy_and_grad(
         _residual_exceeds,
     )
     from tenax.algorithms._ctm_c4v_root_implicit import _solve_root_adjoint
+    from tenax.algorithms._ctm_root_implicit_asym import _root_residual_tolerance
     from tenax.algorithms._ctm_tensor_init import (
         _build_double_layer_tensor,
         initialize_ctm_tensor_env,
@@ -995,14 +1030,40 @@ def cell_root_implicit_energy_and_grad(
         polish_steps=polish_steps,
         polish_tol=polish_tol,
     )
-    if _residual_exceeds(root_residual, root_residual_warn):
+    # #784: this engine clamps the numerically-null tail exactly as Phase 1
+    # does, so it inherits the same intrinsic residual floor -- a clamped cut
+    # cannot satisfy the equations below the clamp level however long y* is
+    # polished.  A flat 1e-6 therefore rejects the very states the clamp just
+    # made solvable: the frozen physical D=2 simple-update state reads 8.493e-06
+    # at chi=4 and 1.911e-05 at chi=6, both with finite, usable gradients.
+    # Those are the asymmetric engine's covariant numbers at the same chi, so
+    # the same law applies rather than a new constant.
+    #
+    # rel_floor is None because this engine always uses the *derived* clamp:
+    # all_projectors_multisite calls _rank_capped_spectrum without one.  If a
+    # rel_floor knob is ever threaded through here it must be forwarded to this
+    # call too, or the gate will reject what the wider clamp just permitted.
+    rank_report = retained_rank_report_multisite(
+        corners, edges, a_by_cell, chi, nrows, ncols
+    )
+    usable_rank = rank_report["usable_rank"]
+    residual_tol = _root_residual_tolerance(
+        root_residual_warn,
+        usable_rank,
+        chi,
+        a_by_cell[objective_cell].dtype,
+        rel_floor=None,
+    )
+    if _residual_exceeds(root_residual, residual_tol):
         _report_root_residual(
             on_root_residual,
             f"Multisite root implicit AD: ‖F(y*)‖ = {root_residual:.3e} exceeds "
-            f"{root_residual_warn:.1e}; the implicit-function gradient is "
-            "correspondingly inaccurate (paper Fig. 1).",
+            f"{residual_tol:.1e}, so y* does not solve the characteristic "
+            f"equations (usable_rank={usable_rank} of chi={chi}). Note this "
+            "residual measures whether y* solves the equations, NOT gradient "
+            "accuracy -- it mispredicts in both directions (#785).",
             residual=float(root_residual),
-            tolerance=float(root_residual_warn),
+            tolerance=float(residual_tol),
         )
 
     S_star = root.s

--- a/src/tenax/algorithms/_ctm_root_implicit_symmetric.py
+++ b/src/tenax/algorithms/_ctm_root_implicit_symmetric.py
@@ -21,7 +21,9 @@ import numpy as np
 
 from tenax.algorithms._ad_primitives import (
     _check_root_residual_policy,
+    _gauge_consistency,
     _report_root_residual,
+    _residual_exceeds,
 )
 from tenax.algorithms._ctm_root_implicit_asym import (
     _denman_beavers,
@@ -1954,7 +1956,7 @@ def sym_root_implicit_energy_and_grad(
         polish_steps=polish_steps,
         polish_tol=polish_tol,
     )
-    if root_residual > root_residual_warn:
+    if _residual_exceeds(root_residual, root_residual_warn):
         _report_root_residual(
             on_root_residual,
             f"Symmetric root implicit AD: ‖F(y*)‖ = {root_residual:.3e} exceeds "
@@ -1985,15 +1987,14 @@ def sym_root_implicit_energy_and_grad(
     )
 
     y_bar_norm = _pytree_norm(y_bar)
-    gauge_consistency = 0.0
-    for bar, tensor in zip(tilde_bar, tilde, strict=True):
-        # JAX pairs cotangents unconjugated: ``Re Σ g·δz`` with the tangent
-        # ``δz = i x`` of the phase orbit.  Conjugating instead reports a
-        # violation that is not there.
-        pairing = float(jnp.real(jnp.sum(bar._data * (1j * tensor._data))))
-        scale = y_bar_norm * float(jnp.linalg.norm(tensor._data)) + 1e-300
-        gauge_consistency = max(gauge_consistency, abs(pairing) / scale)
-    if gauge_consistency > 1e-8:
+    # JAX pairs cotangents unconjugated: ``Re Σ g·δz`` with the tangent
+    # ``δz = i x`` of the phase orbit.  Conjugating instead reports a violation
+    # that is not there.  Shared helper so the NaN handling cannot drift from
+    # the asymmetric engine's copy again (#787).
+    gauge_consistency = _gauge_consistency(
+        [b._data for b in tilde_bar], [t._data for t in tilde], y_bar_norm
+    )
+    if _residual_exceeds(gauge_consistency, 1e-8):
         warnings.warn(
             f"Symmetric root implicit AD: the energy cotangent has a "
             f"{gauge_consistency:.3e} relative component along an environment "
@@ -2010,7 +2011,7 @@ def sym_root_implicit_energy_and_grad(
 
     F_at_root, vjp_y = jax.vjp(F_of_y, y_star)
     covariant_residual = _pytree_norm(F_at_root)
-    if covariant_residual > root_residual_warn:
+    if _residual_exceeds(covariant_residual, root_residual_warn):
         _report_root_residual(
             on_root_residual,
             f"Symmetric root implicit AD: the covariant ‖F(y*)‖ = "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,12 @@ _FILE_MARKERS = {
     # no CTM, milliseconds.  They guard a defect class that has now recurred
     # on four engines, so they belong in the required gate.
     "test_root_implicit_nan_gates.py": "core",
+    # The multisite clamped-residual gate (#784).  The rank-report half is one
+    # SVD per coordinate and runs in the gate; the two end-to-end cases each
+    # converge a 300-sweep CTM plus an adjoint solve and carry their own
+    # explicit ``@pytest.mark.slow``, which the rule below honours by
+    # *withholding* this ``core``; see ``pytest_collection_modifyitems``.
+    "test_multisite_clamped_gate.py": "core",
     "test_ctm_tensor.py": "algorithm",
     "test_integration_regression.py": "algorithm",
     "test_krylov.py": "core",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,11 @@ _FILE_MARKERS = {
     # class of defect the required gate exists for.  Cheap: D=2, chi=4, and
     # the starved-budget cases converge in one iteration by construction.
     "test_adjoint_convergence_gate.py": "core",
+    # The root-implicit gates' fail-closed comparison (#796 / #787).  Pure
+    # unit tests on the shared predicate and the gauge_consistency reduction:
+    # no CTM, milliseconds.  They guard a defect class that has now recurred
+    # on four engines, so they belong in the required gate.
+    "test_root_implicit_nan_gates.py": "core",
     "test_ctm_tensor.py": "algorithm",
     "test_integration_regression.py": "algorithm",
     "test_krylov.py": "core",

--- a/tests/test_multisite_clamped_gate.py
+++ b/tests/test_multisite_clamped_gate.py
@@ -1,0 +1,149 @@
+"""The multisite root-implicit gate must follow the clamp that sets its floor.
+
+#784.  The multisite engine imports ``_rank_capped_spectrum`` and clamps the
+numerically-null tail exactly as the asymmetric engine does (#772/#778), but
+kept the pre-#778 flat ``1e-6`` gate.  Clamping leaves an O(``rel_floor``)
+inconsistency in the characteristic equations *by construction*, so a fixed
+tolerance rejects precisely the states the clamp has just made solvable.
+
+Measured on the frozen physical D=2 simple-update state (issue body):
+
+    chi=4   root_residual 8.493e-06   8.5x over the 1e-6 default -> raises
+    chi=6   root_residual 1.911e-05   19x over                   -> raises
+
+and the gradients are *finite* in both cases -- multisite never had the NaN
+half of #772, only the gate.  Those numbers are identical to the asymmetric
+engine's covariant residual at the same chi, which is why the same
+``_root_residual_tolerance`` law applies rather than a new constant.
+"""
+
+from __future__ import annotations
+
+import jax
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from _su_fixtures import physical_su_d2
+
+from tenax.algorithms._ad_primitives import RootResidualError
+from tenax.algorithms._ctm_root_implicit_multisite import (
+    cell_root_implicit_energy_and_grad,
+)
+
+
+def _sz():
+    """A ONE-site operator.
+
+    ``cell_root_implicit_energy_and_grad`` takes a single-site ``(d, d)``
+    observable, not a two-site ``(d, d, d, d)`` gate -- see the ``_sz()`` used
+    throughout ``test_ctm_root_implicit_multisite.py``.  Passing a 2-site gate
+    reaches the adjoint solve and dies there on a cotangent shape mismatch,
+    which looks like an engine bug and is not one.
+    """
+    import jax.numpy as jnp
+
+    return jnp.array([[0.5, 0.0], [0.0, -0.5]])
+
+
+def _random_site(D=2, d=2, seed=42):
+    """Well-conditioned random state: full-rank cut, so the clamp stays inert."""
+    import numpy as np
+
+    from tenax.core.index import FlowDirection, TensorIndex
+    from tenax.core.symmetry import U1Symmetry
+    from tenax.core.tensor import DenseTensor
+
+    rng = np.random.RandomState(seed)
+    data = jax.numpy.array(rng.standard_normal((D, D, D, D, d)))
+    data = data.at[0, 0, 0, 0, 0].set(1.0)
+    data = data / (jax.numpy.linalg.norm(data) + 1e-10)
+    sym = U1Symmetry()
+    ch = np.zeros(D, dtype=np.int32)
+    pch = np.zeros(d, dtype=np.int32)
+    idx = (
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(sym, pch.copy(), FlowDirection.IN, label="phys"),
+    )
+    return DenseTensor(data, idx)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("chi", [4, 6])
+def test_a_clamped_physical_state_is_not_rejected(chi):
+    """The headline of #784: this raised ``RootResidualError`` before the fix.
+
+    ``on_root_residual="raise"`` is the default and is left in place on
+    purpose -- the whole failure is that the default policy aborts on a state
+    the engine handles correctly.
+    """
+    A = physical_su_d2()
+    out = cell_root_implicit_energy_and_grad(
+        {(0, 0): A},
+        _sz(),
+        chi=chi,
+        nrows=1,
+        ncols=1,
+        max_iter=300,
+        conv_tol=1e-13,
+        return_diagnostics=True,
+    )
+    E, grads = out[0], out[1]
+    assert bool(jax.numpy.isfinite(E)), E
+    leaves = jax.tree.leaves(grads)
+    assert leaves, "no gradient returned"
+    assert all(bool(jax.numpy.all(jax.numpy.isfinite(g))) for g in leaves)
+
+
+@pytest.mark.slow
+def test_a_full_rank_state_keeps_the_strict_gate():
+    """The relaxation must be *conditional on the clamp*, not unconditional.
+
+    This is the property that stops the fix becoming "accept anything": when
+    the clamp is inert (``usable_rank == chi``) there is no intrinsic floor,
+    roundoff is reachable -- a well-conditioned random state reads 2.4e-14 per
+    the issue -- so the strict tolerance still applies and still fires.
+
+    Note what this test canNOT be: asking a *clamped* state to honour a
+    stricter ``root_residual_warn``.  ``_root_residual_tolerance`` returns
+    ``max(base_tol, floor)``, so with the clamp active a caller cannot tighten
+    below the floor at all.  That is deliberate -- demanding a residual below
+    the level the equations can even represent is unsatisfiable, not strict --
+    but it means a clamped state can never be driven to raise this way, and a
+    test written that way is testing nothing.
+    """
+    A = _random_site()
+    with pytest.raises(RootResidualError):
+        cell_root_implicit_energy_and_grad(
+            {(0, 0): A},
+            _sz(),
+            chi=4,
+            nrows=1,
+            ncols=1,
+            max_iter=200,
+            conv_tol=1e-13,
+            root_residual_warn=1e-30,
+        )
+
+
+def test_the_rank_report_sees_the_clamp_on_a_physical_state():
+    """``usable_rank < chi`` is what makes the tolerance relax at all.
+
+    Cheap (one SVD per coordinate, no adjoint solve), so this half runs in the
+    required gate while the two end-to-end cases above are slow-only.
+    """
+    from tenax.algorithms._ctm_root_implicit_multisite import (
+        converge_multisite,
+        retained_rank_report_multisite,
+    )
+
+    A = physical_su_d2()
+    corners, edges, _meta, _projs, a_by_cell = converge_multisite(
+        {(0, 0): A}, 6, 1, 1, max_iter=60, conv_tol=1e-12, return_projectors=True
+    )
+    rep = retained_rank_report_multisite(corners, edges, a_by_cell, 6, 1, 1)
+    assert rep["usable_rank"] < 6, rep
+    assert rep["retained_smin_rtol"] < 1.0, rep

--- a/tests/test_root_implicit_nan_gates.py
+++ b/tests/test_root_implicit_nan_gates.py
@@ -1,0 +1,100 @@
+"""Root-implicit gates must fail CLOSED on a non-finite value.
+
+Every one of these gates exists to stop an invalid root or an inconsistent
+adjoint from reaching a gradient.  Written as ``value > tolerance`` they do the
+opposite of their purpose: ``nan > x`` is ``False``, so a NaN takes the
+*non-reporting* branch precisely when the quantity is most obviously broken.
+
+This is a recurring defect in this subsystem, not a one-off — it has now been
+found and fixed on the asymmetric path (#791), on the default iPEPS AD adjoint
+gate (#801/#807), and here on the C4v, symmetric and multisite engines (#796)
+plus the ``gauge_consistency`` diagnostic (#787).  These tests pin the
+comparison itself so the spelling cannot come back.
+"""
+
+from __future__ import annotations
+
+import math
+
+import jax.numpy as jnp
+
+# --- #796: the root/covariant residual gates ------------------------------
+
+
+def test_the_residual_gate_reports_a_nan_residual():
+    """A NaN residual is the strongest possible evidence the root is invalid.
+
+    ``residual > tolerance`` sends it to the silent branch, so the engine
+    proceeds to solve an adjoint at a root it cannot even measure.
+    """
+    from tenax.algorithms._ad_primitives import _residual_exceeds
+
+    assert _residual_exceeds(float("nan"), 1e-6) is True
+    assert _residual_exceeds(float("inf"), 1e-6) is True
+
+
+def test_the_residual_gate_still_accepts_a_good_residual():
+    """Without this, the fix could be ``return True`` and still pass above."""
+    from tenax.algorithms._ad_primitives import _residual_exceeds
+
+    assert _residual_exceeds(1e-9, 1e-6) is False
+    assert _residual_exceeds(1e-3, 1e-6) is True
+    # Exactly at tolerance is inside the gate: the callers' messages all read
+    # "exceeds", and the polish loops accept on ``residual <= tol``.
+    assert _residual_exceeds(1e-6, 1e-6) is False
+
+
+# --- #787: the gauge_consistency diagnostic -------------------------------
+
+
+def _fake_pair(value):
+    """One (bar, tensor) pair whose pairing ratio is controllable.
+
+    The pairing is ``Re(sum(bar * 1j*tensor))``, i.e. the component of the
+    cotangent along the tensor's *phase* direction, so ``bar`` must be
+    imaginary to produce a non-zero ratio -- a real ``bar`` gives
+    ``Re(x * 1j) == 0`` for every ``x`` and the fixture would measure nothing.
+    """
+    return jnp.asarray([[value * 1j]], dtype=jnp.complex128), jnp.asarray(
+        [[1.0]], dtype=jnp.complex128
+    )
+
+
+def test_gauge_consistency_does_not_report_a_nan_as_perfect():
+    """``max(0.0, nan)`` keeps ``0.0`` -- the accumulator swallows the NaN.
+
+    This is the inverted failure: the diagnostic does not merely stay quiet on
+    a NaN cotangent, it reports **0.0**, i.e. *perfect* gauge consistency, on
+    the exact input (#772's NaN cotangent) it was added to catch.
+    """
+    from tenax.algorithms._ctm_root_implicit_asym import _gauge_consistency
+
+    bars, tensors = zip(_fake_pair(float("nan")), _fake_pair(1e-12))
+    out = _gauge_consistency(bars, tensors, 1.0)
+    assert math.isnan(out), f"expected NaN to propagate, got {out!r}"
+
+
+def test_gauge_consistency_is_nan_regardless_of_pair_order():
+    """``max`` is order-dependent on NaN: ``max(nan, 0.0)`` keeps ``nan`` but
+    ``max(0.0, nan)`` keeps ``0.0``.  A fix that happens to work for one
+    ordering is not a fix -- the accumulator starts at 0.0, so the swallowing
+    order is the one that actually occurs.
+    """
+    from tenax.algorithms._ctm_root_implicit_asym import _gauge_consistency
+
+    bars, tensors = zip(_fake_pair(1e-12), _fake_pair(float("nan")))
+    assert math.isnan(_gauge_consistency(bars, tensors, 1.0))
+
+
+def test_gauge_consistency_still_returns_the_max_ratio_when_finite():
+    """The diagnostic must keep measuring what it measured before.
+
+    Without this, ``return nan`` unconditionally passes both tests above.
+    """
+    from tenax.algorithms._ctm_root_implicit_asym import _gauge_consistency
+
+    bars, tensors = zip(_fake_pair(2.0), _fake_pair(0.5))
+    out = _gauge_consistency(bars, tensors, 1.0)
+    # pairing = Re(conj-free sum(bar * 1j*tensor)); the larger |bar| dominates.
+    assert math.isfinite(out)
+    assert out > 0.0


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Three root-implicit gate defects. **Two of the three issues understate their own scope** — verified against the code, not taken from the issue text.

## #796 — the residual gates: four sites, not one

`nan > x` is `False`, so a NaN residual takes the *non-reporting* branch and the engine solves an adjoint at a root it could not even measure. The issue names one site; three more carry the identical spelling:

| file | line | in #796? |
|---|---|---|
| `_ctm_c4v_root_implicit.py` | 543 | yes |
| `_ctm_root_implicit_symmetric.py` | 1957 | **no** |
| `_ctm_root_implicit_symmetric.py` | 2013 | **no** |
| `_ctm_root_implicit_multisite.py` | 997 | **no** |

## #787 — `gauge_consistency`: two sites, not one

The symmetric engine has its own copy of the accumulator loop with the same defect.

Two NaN fail-opens are stacked there and the result is **inverted**, not merely silent: `max` picks by `>`, `nan > 0.0` is `False`, so an accumulator seeded at `0.0` *keeps the 0.0* — reporting **perfect** gauge consistency for a NaN cotangent, on the one input (#772's NaN cotangent) it exists to catch. Then `nan > 1e-8` is `False` too.

The swallowing is **order-dependent** — `max(nan, 0.0)` does keep the NaN. The `0.0` seed is what makes the broken ordering the one that always occurs, so both orders are pinned; a fix verified against one ordering only would look correct.

## #784 — the multisite gate ignored the clamp it inherited

Reproduced before fixing, on the frozen physical D=2 simple-update state:

```
RootResidualError: Multisite root implicit AD: |F(y*)| = 8.493e-06 exceeds 1.0e-06
```

matching the issue's measurement exactly — and the gradient is finite. Multisite never had the NaN half of #772, only the gate.

`all_projectors_multisite` computed `usable_rank` and discarded it into `_usable_rank`, which is what left the gate unable to follow the clamp. `retained_rank_report_multisite` makes it reachable; the gate then uses the existing `_root_residual_tolerance`. Rank is the **minimum over every coordinate** — one clamped direction anywhere stops `y*` satisfying the equations below the clamp level, so the worst cut sets the floor (same aggregation as Phase 1's minimum over four directions).

## Why all three happened

**The shared helper shared the wrong half.** `_report_root_residual` centralised raise-vs-warn but the *comparison* stayed at each call site; `all_projectors_multisite` computed the rank and threw it away. So when #791 fixed the asymmetric path, nothing propagated.

Both the comparison (`_residual_exceeds`) and the reduction (`_gauge_consistency`) now live in `_ad_primitives.py` next to the reporter, and every engine imports them — asserted **by identity** in the tests, not by grep.

## Scope decisions

- **`rel_floor` is not added to multisite.** It always uses the derived clamp, so `rel_floor=None` is correct today; a comment at the call site records that threading the knob later must forward it here. Inventing an untested parameter beside a gate fix is how these paths diverged in the first place.
- **The `polish_tol` loops are left alone.** They keep `residual <= tol`, where a NaN means "do not stop polishing" — already failing closed.
- **#784 rides this branch** rather than its own: it modifies the same multisite gate line `_residual_exceeds` touched, so splitting would only create a dependent-PR chain.
- The `#784` error message no longer claims the gradient is "correspondingly inaccurate" — #785 measured that false in both directions.

## Verification

Mutation-verified, each killing exactly its own tests:

| mutation | kills |
|---|---|
| `not (v <= tol)` → `v > tol` | NaN-residual test only |
| NaN propagation → `max()` accumulator | both gauge tests, incl. ordering |

Regression, all on CPU:

- `test_ctm_c4v_root_implicit` + `test_ctm_root_implicit_asym` — **75 passed**, 1 deselected
- wiring / multisite / sym-sectors / symmetric — **116 passed**, 28 deselected
- `test_multisite_clamped_gate` — **4 passed** (both chi=4 and chi=6 raised before this change)

## One thing that cannot be tested the obvious way

A clamped state can **never** be forced to raise by lowering `root_residual_warn`: `_root_residual_tolerance` returns `max(base_tol, floor)`. That is deliberate — a residual below what the equations can represent is unsatisfiable, not strict — but it means the naive "still rejects bad residuals" test is vacuous. The test instead pins that the relaxation is **conditional on the clamp**: a full-rank random state has no floor, reaches 2.4e-14, and must keep the strict gate. The docstring records why, so the version that cannot work is not written again.

## CI

GitHub Actions is in a [major outage](https://www.githubstatus.com) since 15:22 UTC (queued jobs timing out without a runner), so checks may not start until it recovers.


---

Closes #796, closes #787, closes #784
