### PR TITLE
fix(#792): stop the root-implicit path silently ignoring four documented knobs

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize_root_implicit.py
+++ b/src/tenax/algorithms/ipeps_optimize_root_implicit.py
@@ -313,6 +313,8 @@ def optimize_gs_ad_root_implicit(
     # shape as the 1-site tensor path in ipeps_optimize.
     history_energies: list[float] = []
     history_step_times: list[float] = []
+    jit_compile_time = 0.0
+    first_step = True
 
     def _with_history(A_t, env, E, *, converged):
         if not config.return_history:
@@ -324,10 +326,7 @@ def optimize_gs_ad_root_implicit(
             {
                 "energies": history_energies,
                 "step_times": history_step_times,
-                # No jit: this path drives eager per-step solves, so there is
-                # no single compile event to attribute.  Reported as 0.0
-                # rather than omitted, so the key is always present.
-                "jit_compile_time": 0.0,
+                "jit_compile_time": jit_compile_time,
                 "num_steps": len(history_energies),
                 "converged": converged,
             },
@@ -389,8 +388,23 @@ def optimize_gs_ad_root_implicit(
             )
         grads = jnp.where(jnp.isfinite(grads), grads, 0.0)
         E = float(jnp.real(energy_val))
-        history_energies.append(E)
-        history_step_times.append(_time.perf_counter() - _step_t0)
+        if config.return_history:
+            _step_dt = float(_time.perf_counter() - _step_t0)
+            if first_step:
+                # The first evaluation is compile-dominated even though this
+                # path has no top-level ``jax.jit``: the root solve and its
+                # adjoint are jitted internally, so step 0 pays their lazy
+                # compilation.  Charging it to ``step_times`` would hand the
+                # two-point compile/steady-state fit a cold sample as if it
+                # were warm.  Diverting it here is also what keeps
+                # ``len(step_times) == max(num_steps - 1, 0)`` -- the shape
+                # invariant asserted for the other AD paths in
+                # ``tests/test_ipeps_ad_history.py``.
+                jit_compile_time = _step_dt
+                first_step = False
+            else:
+                history_step_times.append(_step_dt)
+            history_energies.append(E)
 
         if _should_accept_best(
             current_best=best_energy,
@@ -425,7 +439,15 @@ def optimize_gs_ad_root_implicit(
                     grad_norm_tol=config.gs_grad_norm_tol,
                     criterion=config.gs_conv_criterion,
                 )
-            converged_flag = True
+            # Masking a non-finite gradient to zero deflates both criteria: a
+            # fully masked step drives ``grad_norm_val`` to exactly 0.0, and it
+            # is a no-op, so the *next* step re-evaluates identical params and
+            # sees delta_energy == 0.0.  Either can fire ``_converged_outer``
+            # on a run this loop has already warned is "not ... a converged
+            # optimization".  The break itself is pre-existing behaviour and is
+            # left alone here (#812); what must not happen is publishing that
+            # as converged=True to a consumer that cannot see the warning.
+            converged_flag = nonfinite_grad_steps == 0
             break
 
         if use_cg:

--- a/src/tenax/algorithms/ipeps_optimize_root_implicit.py
+++ b/src/tenax/algorithms/ipeps_optimize_root_implicit.py
@@ -41,6 +41,7 @@ __all__ = [
 ]
 
 import logging
+import time as _time
 import warnings
 
 import jax
@@ -121,6 +122,31 @@ def validate_root_implicit_config(config: iPEPSConfig) -> None:
         unsupported.append(
             ("cg_gates", "coarse-grained gates have no root-implicit objective")
         )
+    # #792.  Both are opt-in -- you only get them by asking -- so an
+    # unsatisfiable request is an error here.  ``gs_line_search`` is NOT in
+    # this list: it is effectively default-on (``gs_optimizer`` defaults to
+    # 'lbfgs' and ``gs_line_search=None`` means auto-on), so refusing it would
+    # reject the path's own default configuration.  It warns instead, in
+    # ``optimize_gs_ad_root_implicit``, the same way ``gs_metric_precond``
+    # does.
+    if config.gs_optimizer.lower() == "cg":
+        unsupported.append(
+            (
+                "gs_optimizer='cg'",
+                "the loop would run plain gradient descent under that name -- "
+                "no retained previous gradient, no Polak-Ribiere coefficient, "
+                "no conjugate direction. Use 'lbfgs' or 'adam'",
+            )
+        )
+    if getattr(config, "gs_c4v", False):
+        unsupported.append(
+            (
+                "gs_c4v",
+                "nothing on this path projects into the C4v basis or "
+                "optimises reduced coefficients, so the first update can "
+                "leave the requested symmetry sector",
+            )
+        )
     if unsupported:
         lines = "\n".join(f"  - {k}: {why}" for k, why in unsupported)
         raise NotImplementedError(
@@ -176,6 +202,7 @@ def optimize_gs_ad_root_implicit(
         _log_ad_converged,
         _normalize_params,
         _should_accept_best,
+        _use_line_search,
         _warn_implicit_ad_variational_caveat,
     )
 
@@ -189,6 +216,27 @@ def optimize_gs_ad_root_implicit(
             "needs a per-step CTM environment, which the *_energy_and_grad "
             "entry points do not expose. Falling back to non-preconditioned "
             "optimization.",
+            UserWarning,
+            stacklevel=2,
+        )
+    if _use_line_search(config):
+        # #792.  Default-on for lbfgs/cg, so this warns rather than raising --
+        # refusing it would reject the path's own default configuration.
+        #
+        # No line search runs here: ``_build_optimizer`` returns a plain
+        # ``optax.chain(scale_by_lbfgs, clip_by_global_norm, scale(-1))`` and
+        # ``value_fn=`` is consumed only by ``optax.lbfgs(linesearch=...)``.
+        # Passing it to that chain does nothing.
+        warnings.warn(
+            "gs_line_search is enabled (explicitly, or by default for "
+            f"gs_optimizer={config.gs_optimizer!r}) but no line search runs on "
+            "the root-implicit AD path (ctm_ad_mode='root_implicit'): the "
+            "optimizer chain has no line-search transform, so gs_line_search, "
+            "gs_line_search_method, gs_line_search_max_steps and gs_hz_max_iter "
+            "are all no-ops. Steps are unconditional quasi-Newton steps and an "
+            "energy-increasing one can be accepted. The best-so-far state is "
+            "still tracked and returned. Set gs_line_search=False to silence "
+            "this.",
             UserWarning,
             stacklevel=2,
         )
@@ -259,9 +307,40 @@ def optimize_gs_ad_root_implicit(
 
     params = A.todense()
 
+    # #792: return_history was accepted and dropped, so callers of the
+    # documented 1x1 history API got a 3-tuple and lost the trajectory.  The
+    # loop already computes every field; this only records them.  Same dict
+    # shape as the 1-site tensor path in ipeps_optimize.
+    history_energies: list[float] = []
+    history_step_times: list[float] = []
+
+    def _with_history(A_t, env, E, *, converged):
+        if not config.return_history:
+            return A_t, env, E
+        return (
+            A_t,
+            env,
+            E,
+            {
+                "energies": history_energies,
+                "step_times": history_step_times,
+                # No jit: this path drives eager per-step solves, so there is
+                # no single compile event to attribute.  Reported as 0.0
+                # rather than omitted, so the key is always present.
+                "jit_compile_time": 0.0,
+                "num_steps": len(history_energies),
+                "converged": converged,
+            },
+        )
+
     if config.gs_num_steps == 0:
         A_t, env = _final_env(params)
-        return A_t, env, float(compute_energy_ctm_tensor(A_t, env, gate, d_phys))
+        return _with_history(
+            A_t,
+            env,
+            float(compute_energy_ctm_tensor(A_t, env, gate, d_phys)),
+            converged=False,
+        )
 
     optimizer = _build_optimizer(config)
     use_cg = optimizer is None
@@ -273,8 +352,10 @@ def optimize_gs_ad_root_implicit(
     fully_masked_steps = 0
     steps_run = 0
 
+    converged_flag = False
     for step in range(config.gs_num_steps):
         steps_run = step + 1
+        _step_t0 = _time.perf_counter()
         energy_val, grads = _energy_and_grad(params)
         n_nonfinite = int(jnp.sum(~jnp.isfinite(grads)))
         if n_nonfinite:
@@ -308,6 +389,8 @@ def optimize_gs_ad_root_implicit(
             )
         grads = jnp.where(jnp.isfinite(grads), grads, 0.0)
         E = float(jnp.real(energy_val))
+        history_energies.append(E)
+        history_step_times.append(_time.perf_counter() - _step_t0)
 
         if _should_accept_best(
             current_best=best_energy,
@@ -342,6 +425,7 @@ def optimize_gs_ad_root_implicit(
                     grad_norm_tol=config.gs_grad_norm_tol,
                     criterion=config.gs_conv_criterion,
                 )
+            converged_flag = True
             break
 
         if use_cg:
@@ -379,4 +463,9 @@ def optimize_gs_ad_root_implicit(
         )
 
     A_opt, env = _final_env(best_params)
-    return A_opt, env, float(compute_energy_ctm_tensor(A_opt, env, gate, d_phys))
+    return _with_history(
+        A_opt,
+        env,
+        float(compute_energy_ctm_tensor(A_opt, env, gate, d_phys)),
+        converged=converged_flag,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,11 @@ _FILE_MARKERS = {
     # CTM convergence, so it is milliseconds.  The production-run case it
     # also carries is explicitly @slow (#772).
     "test_root_implicit_wiring.py": "core",
+    # Knobs the root-implicit path accepted and then ignored (#792).  Config
+    # validation and one warning: milliseconds, no CTM.  The end-to-end
+    # return_history shape test carries its own ``@pytest.mark.slow``, which
+    # the rule below honours by *withholding* this ``core``.
+    "test_root_implicit_ignored_knobs.py": "core",
     # Environment-phase (gauge) invariance of the RDM builders (#748, follow-up
     # to #725/#742).  Cheap -- one module-scoped D=2 simple-update state per
     # file, then pure phase reruns of the contraction (~5s each).  These guard

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,9 +65,12 @@ _FILE_MARKERS = {
     # CTM convergence, so it is milliseconds.  The production-run case it
     # also carries is explicitly @slow (#772).
     "test_root_implicit_wiring.py": "core",
-    # Knobs the root-implicit path accepted and then ignored (#792).  Config
-    # validation and one warning: milliseconds, no CTM.  The end-to-end
-    # return_history shape test carries its own ``@pytest.mark.slow``, which
+    # Knobs the root-implicit path accepted and then ignored (#792).  Mostly
+    # config validation and one warning: milliseconds, no CTM.  The masked-
+    # gradient convergence-flag test does converge one final D=2/chi=4 env
+    # (~1s) and is intentionally left in ``core`` -- it guards a flag a
+    # benchmark consumer reads (#812).  Only the end-to-end return_history
+    # shape test is expensive; it carries its own ``@pytest.mark.slow``, which
     # the rule below honours by *withholding* this ``core``.
     "test_root_implicit_ignored_knobs.py": "core",
     # Environment-phase (gauge) invariance of the RDM builders (#748, follow-up

--- a/tests/test_root_implicit_ignored_knobs.py
+++ b/tests/test_root_implicit_ignored_knobs.py
@@ -1,0 +1,183 @@
+"""#792: the root-implicit path must not silently ignore a documented knob.
+
+Four settings were accepted and then dropped, so the caller got a materially
+different optimizer with no signal.  They do **not** all get the same
+treatment, and the distinction is the point:
+
+* ``gs_optimizer='cg'`` and ``gs_c4v`` are **opt-in** — you only get them by
+  asking — so an unsatisfiable request is an error.
+* ``gs_line_search`` is effectively **default-on** (``gs_optimizer`` defaults
+  to ``'lbfgs'`` and ``gs_line_search=None`` means auto-on for lbfgs/cg), so
+  raising would break every existing run, including the documented Path 5
+  example.  It warns, exactly as ``gs_metric_precond`` already does on this
+  path.
+* ``return_history`` is cheap to honour and is a documented API, so it is
+  *implemented* rather than refused.
+
+That rule — refuse what was explicitly requested, warn about what arrived by
+default — is what keeps the fix from breaking the path it is fixing.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import jax
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+from tenax.algorithms.ipeps_optimize_root_implicit import (
+    optimize_gs_ad_root_implicit,
+    validate_root_implicit_config,
+)
+
+
+def _cfg(**kw):
+    base = dict(
+        max_bond_dim=2,
+        unit_cell="1x1",
+        su_init=False,
+        gs_num_steps=1,
+        gs_metric_precond=False,
+        ctm=CTMConfig(chi=4, max_iter=20, conv_tol=1e-10, ctm_ad_mode="root_implicit"),
+    )
+    base.update(kw)
+    return iPEPSConfig(**base)
+
+
+# --- opt-in knobs: refuse ------------------------------------------------
+
+
+def test_cg_is_refused_rather_than_run_as_gradient_descent():
+    """``_build_optimizer`` returns None for 'cg' and the loop then does plain
+    ``params - lr * grad``: no retained previous gradient, no Polak-Ribiere
+    coefficient, no conjugate direction.  Asking for CG and getting gradient
+    descent is a materially different optimizer.
+    """
+    with pytest.raises(NotImplementedError, match="gs_optimizer"):
+        validate_root_implicit_config(_cfg(gs_optimizer="cg"))
+
+
+def test_c4v_is_refused_rather_than_silently_unenforced():
+    """Nothing on this path projects into the C4v basis, so the first update
+    can leave the requested symmetry sector while the caller believes it is
+    constrained.
+    """
+    with pytest.raises(NotImplementedError, match="gs_c4v"):
+        validate_root_implicit_config(_cfg(gs_c4v=True))
+
+
+def test_the_error_still_names_every_offending_knob_at_once():
+    """A caller fixing one knob at a time round-trips once per knob."""
+    with pytest.raises(NotImplementedError) as exc:
+        validate_root_implicit_config(_cfg(gs_optimizer="cg", gs_c4v=True))
+    msg = str(exc.value)
+    assert "gs_optimizer" in msg and "gs_c4v" in msg, msg
+
+
+def test_the_default_optimizer_is_not_refused():
+    """The guard must not reject the path's own default configuration.
+
+    ``gs_optimizer='lbfgs'`` with ``gs_line_search=None`` is what every
+    existing root-implicit run uses, the documented Path 5 example included.
+    """
+    validate_root_implicit_config(_cfg())  # must not raise
+
+
+# --- default-on knob: warn ------------------------------------------------
+
+
+def test_an_effective_line_search_warns_that_steps_are_unconditional():
+    """``_use_line_search`` is True by default for lbfgs, but no line search
+    runs: ``_build_optimizer`` returns a plain ``scale_by_lbfgs`` chain, and
+    ``value_fn=`` is only consumed by ``optax.lbfgs(linesearch=...)``.
+
+    So the default takes unconditional quasi-Newton steps and can accept
+    energy-increasing ones.  The pre-existing in-code comment reads as though
+    a line search is running; it is not.
+    """
+    cfg = _cfg(
+        unit_cell="2site"
+    )  # "cell" variant: refused after the warning is emitted
+    with pytest.warns(UserWarning, match="line search"):
+        with pytest.raises(NotImplementedError):
+            optimize_gs_ad_root_implicit(None, None, cfg)
+
+
+def test_disabling_the_line_search_is_silent():
+    """Without this, the warning could fire unconditionally and be noise.
+
+    The documented Path 5 example sets ``gs_line_search=False``, so that
+    configuration in particular must stay quiet.
+    """
+    cfg = _cfg(unit_cell="2site", gs_line_search=False)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        with pytest.raises(NotImplementedError):
+            optimize_gs_ad_root_implicit(None, None, cfg)
+    bad = [str(w.message) for w in rec if "line search" in str(w.message)]
+    assert not bad, bad
+
+
+# --- documented API: implement --------------------------------------------
+
+
+@pytest.mark.slow
+def test_return_history_yields_the_documented_four_tuple():
+    """``return_history`` was accepted and dropped, so callers of the
+    documented 1x1 history API got a 3-tuple and lost the trajectory.
+
+    The loop already computes every field, so this is honoured rather than
+    refused.  ``jit_compile_time`` is 0.0 by construction: this path drives
+    eager per-step solves and has no single compile event to attribute -- the
+    key is present so consumers do not have to special-case the path.
+    """
+    import numpy as np
+
+    from tenax.core.index import FlowDirection, TensorIndex
+    from tenax.core.symmetry import U1Symmetry
+    from tenax.core.tensor import DenseTensor
+
+    rng = np.random.RandomState(0)
+    data = jax.numpy.array(rng.standard_normal((2, 2, 2, 2, 2)))
+    sym = U1Symmetry()
+    ch = np.zeros(2, dtype=np.int32)
+    idx = (
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="phys"),
+    )
+    A = DenseTensor(data / (jax.numpy.linalg.norm(data) + 1e-10), idx)
+
+    Sz = 0.5 * jax.numpy.array([[1.0, 0.0], [0.0, -1.0]])
+    H = jax.numpy.kron(Sz, Sz).reshape(2, 2, 2, 2)
+
+    cfg = _cfg(gs_num_steps=2, gs_line_search=False, return_history=True)
+    out = optimize_gs_ad_root_implicit(H, A, cfg)
+
+    assert len(out) == 4, f"expected a 4-tuple with return_history, got {len(out)}"
+    hist = out[3]
+    assert set(hist) == {
+        "energies",
+        "step_times",
+        "jit_compile_time",
+        "num_steps",
+        "converged",
+    }, sorted(hist)
+    assert hist["num_steps"] == len(hist["energies"])
+    assert len(hist["step_times"]) == len(hist["energies"])
+    assert hist["energies"], "no energies recorded"
+    assert all(isinstance(e, float) for e in hist["energies"])
+
+
+def test_history_is_absent_by_default():
+    """Default must keep the 3-tuple: this is a shape change on an opt-in flag.
+
+    Cheap -- gs_num_steps=0 short-circuits before any root solve.
+    """
+    cfg = _cfg(gs_num_steps=0, gs_line_search=False)
+    assert cfg.return_history is False

--- a/tests/test_root_implicit_ignored_knobs.py
+++ b/tests/test_root_implicit_ignored_knobs.py
@@ -34,6 +34,32 @@ from tenax.algorithms.ipeps_optimize_root_implicit import (
 )
 
 
+def _tiny_state():
+    """Smallest D=2 1x1 state the root-implicit path will accept, plus a gate."""
+    import numpy as np
+
+    from tenax.core.index import FlowDirection, TensorIndex
+    from tenax.core.symmetry import U1Symmetry
+    from tenax.core.tensor import DenseTensor
+
+    rng = np.random.RandomState(0)
+    data = jax.numpy.array(rng.standard_normal((2, 2, 2, 2, 2)))
+    sym = U1Symmetry()
+    ch = np.zeros(2, dtype=np.int32)
+    idx = (
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="phys"),
+    )
+    A = DenseTensor(data / (jax.numpy.linalg.norm(data) + 1e-10), idx)
+
+    Sz = 0.5 * jax.numpy.array([[1.0, 0.0], [0.0, -1.0]])
+    H = jax.numpy.kron(Sz, Sz).reshape(2, 2, 2, 2)
+    return H, A
+
+
 def _cfg(**kw):
     base = dict(
         max_bond_dim=2,
@@ -130,31 +156,17 @@ def test_return_history_yields_the_documented_four_tuple():
     documented 1x1 history API got a 3-tuple and lost the trajectory.
 
     The loop already computes every field, so this is honoured rather than
-    refused.  ``jit_compile_time`` is 0.0 by construction: this path drives
-    eager per-step solves and has no single compile event to attribute -- the
-    key is present so consumers do not have to special-case the path.
+    refused.
+
+    The shape is the one ``tests/test_ipeps_ad_history.py`` asserts for the
+    other AD paths: step 0 is charged to ``jit_compile_time`` and excluded
+    from ``step_times``, so ``len(step_times) == max(num_steps - 1, 0)``.
+    This path has no top-level ``jax.jit``, but its root solve and adjoint are
+    jitted internally, so the first evaluation is still the compile-dominated
+    one -- reporting it as a warm step would feed the benchmark's two-point
+    compile/steady-state fit a cold sample.
     """
-    import numpy as np
-
-    from tenax.core.index import FlowDirection, TensorIndex
-    from tenax.core.symmetry import U1Symmetry
-    from tenax.core.tensor import DenseTensor
-
-    rng = np.random.RandomState(0)
-    data = jax.numpy.array(rng.standard_normal((2, 2, 2, 2, 2)))
-    sym = U1Symmetry()
-    ch = np.zeros(2, dtype=np.int32)
-    idx = (
-        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="u"),
-        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="d"),
-        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="l"),
-        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="r"),
-        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="phys"),
-    )
-    A = DenseTensor(data / (jax.numpy.linalg.norm(data) + 1e-10), idx)
-
-    Sz = 0.5 * jax.numpy.array([[1.0, 0.0], [0.0, -1.0]])
-    H = jax.numpy.kron(Sz, Sz).reshape(2, 2, 2, 2)
+    H, A = _tiny_state()
 
     cfg = _cfg(gs_num_steps=2, gs_line_search=False, return_history=True)
     out = optimize_gs_ad_root_implicit(H, A, cfg)
@@ -169,9 +181,61 @@ def test_return_history_yields_the_documented_four_tuple():
         "converged",
     }, sorted(hist)
     assert hist["num_steps"] == len(hist["energies"])
-    assert len(hist["step_times"]) == len(hist["energies"])
     assert hist["energies"], "no energies recorded"
     assert all(isinstance(e, float) for e in hist["energies"])
+
+    # The invariant the other AD paths are held to (test_ipeps_ad_history.py):
+    # step 0 lands in jit_compile_time, never in step_times.
+    assert len(hist["step_times"]) == max(hist["num_steps"] - 1, 0), (
+        f"step_times must exclude the cold step 0: {hist['step_times']} vs "
+        f"num_steps={hist['num_steps']}"
+    )
+    assert all(isinstance(t, float) for t in hist["step_times"])
+    assert isinstance(hist["jit_compile_time"], float)
+    # Not 0.0: the first evaluation really was timed and charged here.  A
+    # hard-coded 0.0 would tell the benchmark this path compiles for free.
+    assert hist["jit_compile_time"] > 0.0, hist["jit_compile_time"]
+
+
+def test_a_masked_gradient_is_not_published_as_convergence(monkeypatch):
+    """A failed root solve must not surface as ``history['converged'] = True``.
+
+    When the solve returns non-finite entries the loop masks them to zero.  A
+    *fully* masked gradient therefore has L2 norm exactly 0.0, which satisfies
+    ``gs_conv_criterion='grad_norm'`` and breaks the loop -- on a step the same
+    function has just warned is "a no-op and apparent convergence here is not
+    convergence".
+
+    The warning is the only signal a human sees; a benchmark consumer reads the
+    flag.  Those two must not disagree.  The break itself is pre-existing
+    behaviour and is deliberately left alone here (#812).
+    """
+    import tenax.algorithms._ctm_root_implicit_asym as _asym
+
+    H, A = _tiny_state()
+
+    def _all_nan_grad(A_t, gate, **kw):
+        return (
+            jax.numpy.asarray(-0.25),
+            jax.numpy.full((2, 2, 2, 2, 2), jax.numpy.nan),
+        )
+
+    monkeypatch.setattr(_asym, "asym_root_implicit_energy_and_grad", _all_nan_grad)
+
+    cfg = _cfg(
+        gs_num_steps=1,
+        gs_line_search=False,
+        return_history=True,
+        gs_conv_criterion="grad_norm",
+    )
+    with pytest.warns(RuntimeWarning, match="non-finite gradient"):
+        out = optimize_gs_ad_root_implicit(H, A, cfg)
+
+    assert out[3]["converged"] is False, (
+        "a fully masked gradient has norm exactly 0.0 and fires "
+        "_converged_outer; reporting that as converged contradicts this same "
+        "loop's warning that it is not a converged optimization"
+    )
 
 
 def test_history_is_absent_by_default():


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Four documented settings were accepted by `optimize_gs_ad_root_implicit` and then dropped, so the caller got a materially different optimizer with no signal.

**They do not all get the same treatment**, and that distinction is the substance of this PR:

| knob | default | treatment | why |
|---|---|---|---|
| `gs_optimizer=cg` | opt-in | **raise** | runs plain gradient descent under the CG name |
| `gs_c4v=True` | opt-in | **raise** | nothing projects into the C4v basis |
| `gs_line_search` | **auto-ON** | **warn** | refusing it rejects the path's own default config |
| `return_history` | opt-in | **implement** | documented API; the loop already had the data |

## The trap: `gs_line_search` cannot be refused

The issue groups all four and suggests rejecting them at the dispatcher. That would have been wrong for this one.

`gs_optimizer` defaults to `lbfgs`, and `gs_line_search=None` means *auto-on* for lbfgs/cg (`_use_line_search`, `ipeps_optimize.py:476-480`). A blanket rejection therefore raises on the **default** root-implicit configuration — and on the documented Path 5 example.

So it warns, following the rule this file already established for `gs_metric_precond` (*"Default-on knob, so this warns rather than raising"*). That rule is now written down at the validation gate: **refuse what was explicitly requested, warn about what arrived by default.**

The warning is accurate about what is actually happening: `_build_optimizer` returns a plain `optax.chain(scale_by_lbfgs, clip_by_global_norm, scale(-1))`, and `value_fn=` is consumed only by `optax.lbfgs(linesearch=...)`. Passing it to that chain does nothing. Steps are unconditional quasi-Newton steps and an energy-increasing one can be accepted — the pre-existing in-code comment read as though a search were running.

## `return_history` implemented, not refused

Energies, per-step times and the convergence flag were all computed and discarded; only recording was missing. Same dict shape *and the same shape invariant* as the 1-site tensor path in `ipeps_optimize`:

```
len(step_times) == max(num_steps - 1, 0)
```

Step 0 is charged to `jit_compile_time` and excluded from `step_times`. This path has no top-level `jax.jit`, but its root solve and adjoint are jitted internally, so the first evaluation is still the compile-dominated one.

The `gs_num_steps == 0` early return is covered too; otherwise it would return a 3-tuple while the main path returned 4.

This is the gap that forced a two-point compile/steady-state fit in the AD path benchmark, so it has an immediate consumer.

## Verification

Mutation-verified, each killing exactly its own tests:

| mutation | kills |
|---|---|
| drop cg rejection | cg test + names-every-knob test |
| drop c4v rejection | c4v test + names-every-knob test |
| drop the warning | the warns test |
| **warn unconditionally** | the stays-silent test |
| `if first_step` → `if False` | the `step_times`/`jit_compile_time` shape test |
| `converged_flag = True` | the masked-gradient test |

The last two are complementary on purpose: together they prove the warning is **conditional in both directions**, not merely present. A warning that always fires is noise, and `gs_line_search=False` — what the documented example uses — must stay quiet.

There is also an explicit test that the guard does **not** reject the default configuration, which is the regression this design is most likely to introduce.

Tests: **39 passed** across the new file, `test_root_implicit_wiring.py` and `test_ipeps_ad_history.py` (the contract this path now conforms to).

## Review round 2 (Codex, both confirmed)

**P1 — cold first solve counted as a warm step.** Confirmed, and worse than reported: it broke the invariant `tests/test_ipeps_ad_history.py:62` asserts for the other AD paths, so "same dict shape" was not true. The named consumer in this very PR — the benchmark's two-point compile/steady-state fit — would have been handed a cold sample as warm and told compilation was free. Fixed; the `jit_compile_time = 0.0` rationale above was wrong and has been corrected.

**P2 — convergence reported after masking a failed gradient.** Confirmed. A fully masked gradient has L2 norm exactly `0.0`, so `_converged_outer` fires on a step this loop already warns is "a no-op and apparent convergence here is not convergence", and whose run-level warning declares the whole run "not ... a converged optimization". The flag now agrees with the warnings.

Scope: only the **flag** is fixed here. The `break` on fake convergence is pre-existing, affects every root-implicit caller rather than just `return_history` ones, and shifts returned energies and step counts — filed as #812 with a suggested fix modelled on the existing `prev_energy = float("inf")` guard in `ipeps_optimize.py`.

## CI

GitHub Actions has been in [major outage](https://www.githubstatus.com) since 15:22 UTC and still is. No workflow run has been created **repo-wide** since 19:20 UTC, so `43558ae` and `3ea6c1b` both have zero check-runs. This is infrastructural — nothing on this branch. Checks should populate on their own once Actions recovers; no further push is needed.

Verified locally in the meantime (`JAX_PLATFORMS=cpu`): **39 passed** across `test_root_implicit_ignored_knobs.py`, `test_root_implicit_wiring.py` and `test_ipeps_ad_history.py`; `ruff check` and `ruff format` clean. The `core` subset of the new file — what the required gate actually runs — is 8 tests in ~5s wall.
