### PR TITLE
fix(#812): a masked gradient must not end the optimization

### DIFF
--- a/src/tenax/algorithms/ipeps_optimize_root_implicit.py
+++ b/src/tenax/algorithms/ipeps_optimize_root_implicit.py
@@ -428,7 +428,26 @@ def optimize_gs_ad_root_implicit(
             if config.gs_conv_criterion in ("grad_norm", "both")
             else None
         )
-        if _converged_outer(config, delta_energy, grad_norm_val):
+        if n_nonfinite:
+            # #812.  Masking a non-finite gradient to zero is what keeps the
+            # run alive, and it is also what makes the run look converged --
+            # the rescue and the false signal are the same operation.  It
+            # deflates *both* criteria:
+            #
+            #   grad_norm: a fully masked gradient has L2 norm exactly 0.0,
+            #              which is below any tolerance.  Fires here.
+            #   dE:        a fully masked step is a no-op, so the *next* step
+            #              re-evaluates identical params and sees
+            #              delta_energy == 0.0.  Fires one step later, on a
+            #              step whose own gradient is perfectly finite.
+            #
+            # So skipping the test on this step is not enough; ``prev_energy``
+            # has to be reset as well, or the manufactured zero ends the run
+            # anyway.  ``ipeps_optimize`` already does exactly this after a
+            # grad-spike rollback, for the same "re-evaluates the same state
+            # and sees dE == 0" reason.
+            prev_energy = float("inf")
+        elif _converged_outer(config, delta_energy, grad_norm_val):
             if config.gs_verbose:
                 _log_ad_converged(
                     "root_implicit",
@@ -439,14 +458,10 @@ def optimize_gs_ad_root_implicit(
                     grad_norm_tol=config.gs_grad_norm_tol,
                     criterion=config.gs_conv_criterion,
                 )
-            # Masking a non-finite gradient to zero deflates both criteria: a
-            # fully masked step drives ``grad_norm_val`` to exactly 0.0, and it
-            # is a no-op, so the *next* step re-evaluates identical params and
-            # sees delta_energy == 0.0.  Either can fire ``_converged_outer``
-            # on a run this loop has already warned is "not ... a converged
-            # optimization".  The break itself is pre-existing behaviour and is
-            # left alone here (#812); what must not happen is publishing that
-            # as converged=True to a consumer that cannot see the warning.
+            # Run-wide, not just this step (#792): the end-of-run warning below
+            # already declares the *whole* run "not ... a converged
+            # optimization" once any step was contaminated, so reporting
+            # converged=True here would contradict it.
             converged_flag = nonfinite_grad_steps == 0
             break
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,10 @@ _FILE_MARKERS = {
     # shape test is expensive; it carries its own ``@pytest.mark.slow``, which
     # the rule below honours by *withholding* this ``core``.
     "test_root_implicit_ignored_knobs.py": "core",
+    # A masked gradient must not end the optimization (#812).  Scripted
+    # (energy, grad) pairs, so the only real work is one final D=2/chi=4 env
+    # per test (~1s).  Guards control flow a benchmark consumer cannot see.
+    "test_root_implicit_masked_convergence.py": "core",
     # Environment-phase (gauge) invariance of the RDM builders (#748, follow-up
     # to #725/#742).  Cheap -- one module-scoped D=2 simple-update state per
     # file, then pure phase reruns of the contraction (~5s each).  These guard

--- a/tests/test_root_implicit_masked_convergence.py
+++ b/tests/test_root_implicit_masked_convergence.py
@@ -1,0 +1,137 @@
+"""A masked gradient must not end the root-implicit optimization (#812).
+
+When a root solve returns non-finite gradient entries the loop masks them to
+zero so the best-so-far state survives.  That rescue is also what makes the run
+*look* converged, and it corrupts **both** convergence criteria:
+
+* ``gs_conv_criterion='grad_norm'`` -- a fully masked gradient has L2 norm
+  *exactly* ``0.0``, below any tolerance.  Fires on the masked step itself.
+* ``gs_conv_criterion='dE'`` (the current default) -- a fully masked step is a
+  no-op, so the *next* step re-evaluates identical params and sees
+  ``delta_energy == 0.0``.  Fires one step later.
+
+#811 stopped the loop *reporting* that as ``converged=True``.  It still broke
+out of the optimization.  These tests pin the control flow: the loop keeps
+going, and the second test covers the one-step-later variant that a
+per-step-only guard would miss.
+"""
+
+from __future__ import annotations
+
+import jax
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms.ipeps_config import CTMConfig, iPEPSConfig
+from tenax.algorithms.ipeps_optimize_root_implicit import optimize_gs_ad_root_implicit
+
+
+def _tiny_state():
+    """Smallest D=2 1x1 state the root-implicit path will accept, plus a gate."""
+    import numpy as np
+
+    from tenax.core.index import FlowDirection, TensorIndex
+    from tenax.core.symmetry import U1Symmetry
+    from tenax.core.tensor import DenseTensor
+
+    rng = np.random.RandomState(0)
+    data = jax.numpy.array(rng.standard_normal((2, 2, 2, 2, 2)))
+    sym = U1Symmetry()
+    ch = np.zeros(2, dtype=np.int32)
+    idx = (
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="u"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="d"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.OUT, label="l"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="r"),
+        TensorIndex.from_charges(sym, ch.copy(), FlowDirection.IN, label="phys"),
+    )
+    A = DenseTensor(data / (jax.numpy.linalg.norm(data) + 1e-10), idx)
+
+    Sz = 0.5 * jax.numpy.array([[1.0, 0.0], [0.0, -1.0]])
+    H = jax.numpy.kron(Sz, Sz).reshape(2, 2, 2, 2)
+    return H, A
+
+
+def _cfg(**kw):
+    base = dict(
+        max_bond_dim=2,
+        unit_cell="1x1",
+        su_init=False,
+        gs_metric_precond=False,
+        gs_line_search=False,
+        return_history=True,
+        ctm=CTMConfig(chi=4, max_iter=20, conv_tol=1e-10, ctm_ad_mode="root_implicit"),
+    )
+    base.update(kw)
+    return iPEPSConfig(**base)
+
+
+_SHAPE = (2, 2, 2, 2, 2)
+_E = -0.25
+
+
+def _patch(monkeypatch, grad_for_step):
+    """Drive the loop with scripted (energy, grad) pairs, counting calls."""
+    import tenax.algorithms._ctm_root_implicit_asym as _asym
+
+    calls = {"n": 0}
+
+    def _fake(A_t, gate, **kw):
+        i = calls["n"]
+        calls["n"] += 1
+        return jax.numpy.asarray(_E), grad_for_step(i)
+
+    monkeypatch.setattr(_asym, "asym_root_implicit_energy_and_grad", _fake)
+    return calls
+
+
+def test_a_masked_gradient_does_not_end_the_optimization(monkeypatch):
+    """grad_norm criterion: a fully masked gradient has norm exactly 0.0.
+
+    Without the guard the loop exits at step 1 having done nothing, and reports
+    an energy from a state it never optimized.
+    """
+    H, A = _tiny_state()
+    _patch(monkeypatch, lambda i: jax.numpy.full(_SHAPE, jax.numpy.nan))
+
+    cfg = _cfg(gs_num_steps=3, gs_conv_criterion="grad_norm")
+    with pytest.warns(RuntimeWarning, match="non-finite gradient"):
+        out = optimize_gs_ad_root_implicit(H, A, cfg)
+
+    hist = out[3]
+    assert hist["num_steps"] == 3, (
+        "a masked gradient has norm exactly 0.0 and satisfies grad_norm; the "
+        f"loop must not treat that as convergence, got num_steps={hist['num_steps']}"
+    )
+    assert hist["converged"] is False
+
+
+def test_a_masked_step_does_not_false_converge_one_step_later(monkeypatch):
+    """dE criterion -- the default, and the variant a per-step guard misses.
+
+    Step 0 is fully masked, so it is a no-op and step 1 re-evaluates *identical*
+    params.  ``delta_energy`` is then exactly 0.0 through no merit of the
+    optimization, and the ``dE`` criterion fires on a step whose own gradient is
+    perfectly finite.  Guarding only the contaminated step would not catch this;
+    ``prev_energy`` has to be reset too.
+    """
+    H, A = _tiny_state()
+    _patch(
+        monkeypatch,
+        lambda i: (
+            jax.numpy.full(_SHAPE, jax.numpy.nan) if i == 0 else jax.numpy.zeros(_SHAPE)
+        ),
+    )
+
+    cfg = _cfg(gs_num_steps=4, gs_conv_criterion="dE")
+    with pytest.warns(RuntimeWarning, match="non-finite gradient"):
+        out = optimize_gs_ad_root_implicit(H, A, cfg)
+
+    hist = out[3]
+    assert hist["num_steps"] >= 3, (
+        "step 1 saw delta_energy == 0.0 only because the masked step 0 was a "
+        "no-op; prev_energy must be reset so that manufactured zero cannot "
+        f"end the run, got num_steps={hist['num_steps']}"
+    )
+    assert hist["converged"] is False


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Masking non-finite gradient entries to zero is what keeps a failing run alive. It is **also** what makes the run look converged — the rescue and the false signal are the same operation.

## Why one guard is not enough

It deflates **both** criteria, and they fail at different times:

| criterion | mechanism | when it fires |
|---|---|---|
| `grad_norm` | a fully masked gradient has L2 norm **exactly 0.0**, below any tolerance | on the masked step itself |
| `dE` (**the default**) | a fully masked step is a no-op, so the next step re-evaluates *identical* params and sees `delta_energy == 0.0` | **one step later**, on a step whose own gradient is perfectly finite |

So skipping the convergence test on the contaminated step does not close this. `prev_energy` has to be reset as well, or the manufactured zero ends the run anyway.

There is precedent for exactly that: `ipeps_optimize` already resets `prev_energy = float("inf")` after a grad-spike rollback, for the same *"re-evaluates the same state and sees dE == 0"* reason. This applies the same guard to the masking case.

## What changed

#811 fixed the *reported flag*. The loop still broke out of the optimization — returning `converged=False` (honest) from a run it had silently truncated. Now the convergence test is skipped on any step with non-finite gradient entries, and `prev_energy` is reset.

The run-wide flag gate from #792 is unchanged; it just gained a comment explaining why it is run-wide rather than per-step (the end-of-run warning already declares the *whole* run non-converged).

## Verification

TDD — both tests written first and failing:

```
num_steps=1   (grad_norm: exits on the masked step)
num_steps=2   (dE: exits one step later on the manufactured 0.0)
```

That second number is the evidence that a per-step-only guard would have been insufficient.

**Mutation-verified, and the two mutations discriminate:**

| mutation | kills |
|---|---|
| drop the `prev_energy` reset, **keep** the skip | **only** the `dE` test |
| drop the guard entirely | both tests |

The first is the important one: it proves the reset is load-bearing on its own, and that the two tests are not redundant coverage of one behaviour.

Tests: **52 passed** across the new file, `test_root_implicit_wiring.py`, `test_root_implicit_ignored_knobs.py` and `test_ipeps_ad_conv_criterion.py`. `ruff check` / `format` clean. New file registered as `core` in `conftest.py` (#806), and it is ~1s — scripted `(energy, grad)` pairs, so the only real work is one final D=2/chi=4 environment per test.

## Behaviour change worth noting

A contaminated run now uses more of its `gs_num_steps` budget instead of exiting early. That is the intended trade: previously it stopped and reported an energy from a state it had never optimized. The existing `RuntimeWarning`s still fire on every masked step and once more at end of run.

Refs #812, #792, #715.


---

Closes #812
