### PR TITLE
fix(#813): promote operands before multi-operand einsum so CUDA can lower it

### DIFF
--- a/src/tenax/algorithms/_einsum_compat.py
+++ b/src/tenax/algorithms/_einsum_compat.py
@@ -1,0 +1,52 @@
+"""``jnp.einsum`` with operands promoted to a common dtype first (#813).
+
+Multi-operand contractions that mix real and complex operands crash on CUDA::
+
+    INTERNAL: GEMM is not supported by cublasLt and legacy cublas fallback
+    is removed.
+
+The cause is not the mixed dtypes themselves but *where* JAX puts the
+promotion.  Given ``einsum("ab,buc,ce->aue", C1, T1, C2)`` with only ``C2``
+complex, the emitted jaxpr is::
+
+    a:f64[8,8]  b:f64[8,4,8]  c:c128[8,8]
+    d:c128[4,8,8] = dot_general[preferred_element_type=complex128] b a
+    e:c128[4,8,8] = dot_general[preferred_element_type=complex128] d c
+
+The *first* ``dot_general`` contracts two **real** operands while carrying the
+final complex result type.  XLA is therefore asked for a real-by-real GEMM
+with a complex output, cuBLASLt has no such kernel, and the legacy cuBLAS
+fallback that used to absorb it has been removed (jaxlib 0.10.2).
+
+Binary contractions never hit this -- JAX promotes the two operands directly,
+so each ``dot_general`` sees operands matching its output type.  It takes three
+or more operands for a real-by-real intermediate to inherit a complex result
+type, which is why it surfaced in the RDM builders rather than anywhere simpler.
+
+Promoting up front restores that invariant for every intermediate.  This is
+semantically identical to calling ``jnp.einsum`` directly -- einsum promotes
+anyway -- and the cast is a no-op when the dtypes already agree, so all-real
+contractions stay real and pay nothing.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+__all__ = ["einsum_promoted"]
+
+
+def einsum_promoted(subscripts, *operands, **kwargs):
+    """``jnp.einsum`` with every operand cast to their common dtype first.
+
+    Drop-in replacement for ``jnp.einsum``.  See the module docstring for why
+    this is needed on CUDA for three-or-more-operand mixed-dtype contractions.
+
+    All-real operands remain real: ``jnp.result_type`` returns the real dtype
+    and ``astype`` is then a no-op, so nothing is promoted to complex
+    needlessly.
+    """
+    if len(operands) > 1:
+        dtype = jnp.result_type(*operands)
+        operands = tuple(jnp.asarray(op).astype(dtype) for op in operands)
+    return jnp.einsum(subscripts, *operands, **kwargs)

--- a/src/tenax/algorithms/ipeps_excitations.py
+++ b/src/tenax/algorithms/ipeps_excitations.py
@@ -22,6 +22,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from tenax.algorithms._ctm_tensor_energy import _normalise_rdm
+from tenax.algorithms._einsum_compat import einsum_promoted
 from tenax.algorithms.ipeps_config import CTMEnvironment
 from tenax.core.tensor import SymmetricTensor, Tensor
 
@@ -237,8 +238,8 @@ def _rdm2x1_with_open_tensors(
     LL = jnp.einsum("gi,idj->gdj", C4, T3)
     LR = jnp.einsum("jdk,mk->jdm", T3, C3)
 
-    Lenv = jnp.einsum("auc,axg,gdj->ucxdj", UL, T4, LL)
-    Renv = jnp.einsum("cuf,frm,jdm->curjd", UR, T2, LR)
+    Lenv = einsum_promoted("auc,axg,gdj->ucxdj", UL, T4, LL)
+    Renv = einsum_promoted("cuf,frm,jdm->curjd", UR, T2, LR)
 
     Lenv_ao1 = jnp.einsum("ucxdj,udxrst->crjst", Lenv, ao1)
     Renv_ao2 = jnp.einsum("curjd,udlrtv->cjltv", Renv, ao2)
@@ -269,15 +270,15 @@ def _rdm1x2_with_open_tensors(
     """
     C1, C2, C3, C4, T1, T2, T3, T4 = env
 
-    top_row = jnp.einsum("ab,buc,ce->aue", C1, T1, C2)
-    env_row1 = jnp.einsum("aue,alf,erg->ulfrg", top_row, T4, T2)
+    top_row = einsum_promoted("ab,buc,ce->aue", C1, T1, C2)
+    env_row1 = einsum_promoted("aue,alf,erg->ulfrg", top_row, T4, T2)
     site1 = jnp.einsum("ulfrg,udlrst->dfgst", env_row1, ao1)
 
     T4_ao2 = jnp.einsum("fmh,pqmnwx->fhpqnwx", T4, ao2)
     site12 = jnp.einsum("abcst,bhaqnwx->chqnstwx", site1, T4_ao2)
     site12_r = jnp.einsum("chqnstwx,cni->hqistwx", site12, T2)
 
-    bot_row = jnp.einsum("hj,jqk,ik->hqi", C4, T3, C3)
+    bot_row = einsum_promoted("hj,jqk,ik->hqi", C4, T3, C3)
     rdm = jnp.einsum("hqistwx,hqi->stwx", site12_r, bot_row)
 
     rdm_mat = rdm.reshape(d * d, d * d)

--- a/src/tenax/algorithms/ipeps_rdm.py
+++ b/src/tenax/algorithms/ipeps_rdm.py
@@ -10,6 +10,7 @@ import jax
 import jax.numpy as jnp
 
 from tenax.algorithms._ctm_tensor_energy import _normalise_rdm
+from tenax.algorithms._einsum_compat import einsum_promoted
 from tenax.algorithms.ipeps_config import (
     CTMEnvironment,
     SplitCTMEnvironment,
@@ -67,12 +68,12 @@ def _rdm2x1(A: jax.Array, env: CTMEnvironment, d: int) -> jax.Array:
 
     # Left env: UL[a,u1,c] · T4[a,l1,g] · LL[g,d1,j]
     # Contract a between UL and T4, g between T4 and LL
-    Lenv = jnp.einsum("auc,axg,gdj->ucxdj", UL, T4, LL)
+    Lenv = einsum_promoted("auc,axg,gdj->ucxdj", UL, T4, LL)
     # shape: (D2, chi, D2, D2, chi) → (u1, c, l1, d1, j)
 
     # Right env: UR[c,u2,f] · T2[f,r2,m] · LR[j,d2,m]
     # Contract f between UR and T2, m between T2 and LR
-    Renv = jnp.einsum("cuf,frm,jdm->curjd", UR, T2, LR)
+    Renv = einsum_promoted("cuf,frm,jdm->curjd", UR, T2, LR)
     # shape: (chi, D2, D2, chi, D2) → (c, u2, r2, j, d2)
 
     # Contract Lenv with ao1[u1, d1, l1, r1, s, sp]:
@@ -123,12 +124,12 @@ def _rdm1x2(A: jax.Array, env: CTMEnvironment, d: int) -> jax.Array:
     a_open = _build_double_layer_open(A)
 
     # Top row: C1·T1·C2 → (chi, D2, chi)  indices: (a, u, e)
-    top_row = jnp.einsum("ab,buc,ce->aue", C1, T1, C2)
+    top_row = einsum_promoted("ab,buc,ce->aue", C1, T1, C2)
 
     # Contract top_row with T4 (site-1 left) and T2 (site-1 right):
     # top_row[a, u1, e]  T4[a, l1, f]  T2[e, r1, g]
     # Contract a, e → env_row1[u1, l1, f, r1, g]
-    env_row1 = jnp.einsum("aue,alf,erg->ulfrg", top_row, T4, T2)
+    env_row1 = einsum_promoted("aue,alf,erg->ulfrg", top_row, T4, T2)
     # (D2, D2, chi, D2, chi) → (u1, l1, f, r1, g)
 
     # Contract with ao1[u1, d1, l1, r1, s, sp]:  match u1, l1, r1
@@ -153,7 +154,7 @@ def _rdm1x2(A: jax.Array, env: CTMEnvironment, d: int) -> jax.Array:
     # (chi, D2, chi, d, d, d, d) → (h, q=d2, i, s1, s1', s2, s2')
 
     # Bottom row: C4·T3·C3 → (chi, D2, chi)  indices: (h, d2, i)
-    bot_row = jnp.einsum("hj,jqk,ik->hqi", C4, T3, C3)
+    bot_row = einsum_promoted("hj,jqk,ik->hqi", C4, T3, C3)
 
     # Final: contract site12_r with bot_row  match h, q=d2, i
     rdm = jnp.einsum("hqistwx,hqi->stwx", site12_r, bot_row)
@@ -225,12 +226,12 @@ def _rdm2x1_2site(
     # Left boundary from env_A
     UL = jnp.einsum("ab,buc->auc", env_A.C1, env_A.T1)
     LL = jnp.einsum("gi,idj->gdj", env_A.C4, env_A.T3)
-    Lenv = jnp.einsum("auc,axg,gdj->ucxdj", UL, env_A.T4, LL)
+    Lenv = einsum_promoted("auc,axg,gdj->ucxdj", UL, env_A.T4, LL)
 
     # Right boundary from env_B
     UR = jnp.einsum("cuf,fg->cug", env_B.T1, env_B.C2)
     LR = jnp.einsum("jdk,mk->jdm", env_B.T3, env_B.C3)
-    Renv = jnp.einsum("cuf,frm,jdm->curjd", UR, env_B.T2, LR)
+    Renv = einsum_promoted("cuf,frm,jdm->curjd", UR, env_B.T2, LR)
 
     # Contract left env with ao_A
     Lenv_ao = jnp.einsum("ucxdj,udxrst->crjst", Lenv, ao_A)
@@ -269,9 +270,9 @@ def _rdm1x2_2site(
     ao_B = _build_double_layer_open(B)
 
     # Top row from env_A
-    top_row = jnp.einsum("ab,buc,ce->aue", env_A.C1, env_A.T1, env_A.C2)
+    top_row = einsum_promoted("ab,buc,ce->aue", env_A.C1, env_A.T1, env_A.C2)
     # Env row 1: contract with T4_A (left) and T2_A (right)
-    env_row1 = jnp.einsum("aue,alf,erg->ulfrg", top_row, env_A.T4, env_A.T2)
+    env_row1 = einsum_promoted("aue,alf,erg->ulfrg", top_row, env_A.T4, env_A.T2)
     # Contract with ao_A
     site1 = jnp.einsum("ulfrg,udlrst->dfgst", env_row1, ao_A)
 
@@ -282,7 +283,7 @@ def _rdm1x2_2site(
     # Contract T2_B
     site12_r = jnp.einsum("chqnstwx,cni->hqistwx", site12, env_B.T2)
     # Bottom row from env_B
-    bot_row = jnp.einsum("hj,jqk,ik->hqi", env_B.C4, env_B.T3, env_B.C3)
+    bot_row = einsum_promoted("hj,jqk,ik->hqi", env_B.C4, env_B.T3, env_B.C3)
     # Final
     rdm = jnp.einsum("hqistwx,hqi->stwx", site12_r, bot_row)
     # Transpose from (s1_ket, s1_bra, s2_ket, s2_bra) to

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,11 @@ _FILE_MARKERS = {
     # CTM gauge the sweep does not fix, so they belong in the *required* gate
     # rather than the unwatched full suite; unregistered, all 80 of them were
     # deselected by ``-m core`` and ran only on push to main.
+    # Multi-operand mixed-dtype einsum must not emit a real-by-real GEMM with
+    # a complex output (#813).  Jaxpr inspection + an AST scan, so it is
+    # microseconds and -- critically -- backend-independent: the crash it
+    # guards only reproduces on CUDA, and the required gate is CPU-only.
+    "test_einsum_mixed_dtype.py": "core",
     "test_ipeps_rdm_gauge.py": "core",
     "test_ipeps_excitations_gauge.py": "core",
     "test_ctm_honeycomb_energy_gauge.py": "core",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,14 +80,16 @@ _FILE_MARKERS = {
     # CTM gauge the sweep does not fix, so they belong in the *required* gate
     # rather than the unwatched full suite; unregistered, all 80 of them were
     # deselected by ``-m core`` and ran only on push to main.
-    # Multi-operand mixed-dtype einsum must not emit a real-by-real GEMM with
-    # a complex output (#813).  Jaxpr inspection + an AST scan, so it is
-    # microseconds and -- critically -- backend-independent: the crash it
-    # guards only reproduces on CUDA, and the required gate is CPU-only.
-    "test_einsum_mixed_dtype.py": "core",
     "test_ipeps_rdm_gauge.py": "core",
     "test_ipeps_excitations_gauge.py": "core",
     "test_ctm_honeycomb_energy_gauge.py": "core",
+    # Multi-operand mixed-dtype einsum must not emit a real-by-real GEMM with
+    # a complex output (#813).  Jaxpr inspection + an AST scan, so it is
+    # microseconds and -- critically -- backend-independent: the crash it
+    # guards only reproduces on CUDA, and the required gate is CPU-only.  The
+    # two gauge files above are what it actually protects: they are already
+    # ``core``, CI ran them green, and they still died on GPU.
+    "test_einsum_mixed_dtype.py": "core",
     # ``_normalise_rdm``'s zero-matrix branch must stay differentiable: the
     # excitation H_eff/N are built by differentiating the norm at ``B = 0``, so
     # a NaN cotangent there is as fatal as a NaN value.  Milliseconds for the

--- a/tests/test_einsum_mixed_dtype.py
+++ b/tests/test_einsum_mixed_dtype.py
@@ -1,0 +1,137 @@
+"""Multi-operand mixed-dtype contractions must not emit a real-by-real GEMM
+with a complex output type (#813).
+
+On CUDA that lowering dies with::
+
+    INTERNAL: GEMM is not supported by cublasLt and legacy cublas fallback
+    is removed.
+
+It took out 22 gauge tests, which *looked* like a gauge-invariance regression
+in the #748 family and was not -- the error is raised before any assertion
+runs.
+
+These tests are deliberately **backend-independent**: they inspect the emitted
+jaxpr rather than executing the contraction, because the crash only reproduces
+on CUDA and CI is CPU-only.  A GPU-only test would guard nothing in the
+required gate.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+from tenax.algorithms._einsum_compat import einsum_promoted
+
+_SPEC = "ab,buc,ce->aue"
+_CHI, _D2 = 8, 4
+
+
+def _operands(*complex_flags):
+    rng = np.random.RandomState(0)
+    shapes = [(_CHI, _CHI), (_CHI, _D2, _CHI), (_CHI, _CHI)]
+    out = []
+    for shape, is_c in zip(shapes, complex_flags):
+        a = rng.standard_normal(shape)
+        out.append(jnp.asarray(a * np.exp(0.7j) if is_c else a))
+    return out
+
+
+def _bad_dots(jaxpr):
+    """dot_general equations with all-real operands but a complex output.
+
+    This is the exact shape cuBLASLt refuses: XLA is asked for a real-by-real
+    GEMM that must produce complex output, because JAX propagated the final
+    result type onto an intermediate whose own operands are both real.
+    """
+    bad = []
+    for eqn in jaxpr.eqns:
+        if eqn.primitive.name != "dot_general":
+            continue
+        ins = [v.aval.dtype for v in eqn.invars if hasattr(v, "aval")]
+        out = eqn.outvars[0].aval.dtype
+        if np.issubdtype(out, np.complexfloating) and not any(
+            np.issubdtype(d, np.complexfloating) for d in ins
+        ):
+            bad.append((ins, out))
+    return bad
+
+
+def test_plain_einsum_emits_the_unsupported_dot():
+    """Pins the defect itself, so the fix below is not guarding a phantom.
+
+    If a future JAX stops propagating the complex result type onto a real
+    intermediate, this fails and ``einsum_promoted`` can be retired.
+    """
+    a, b, c = _operands(False, False, True)
+    jaxpr = jax.make_jaxpr(lambda x, y, z: jnp.einsum(_SPEC, x, y, z))(a, b, c)
+    assert _bad_dots(jaxpr.jaxpr), (
+        "expected jnp.einsum to emit a real-by-real dot_general with a complex "
+        "output; if it no longer does, #813's workaround is obsolete"
+    )
+
+
+def test_promoted_einsum_emits_no_unsupported_dot():
+    """The fix: every dot_general sees operands matching its output type."""
+    a, b, c = _operands(False, False, True)
+    jaxpr = jax.make_jaxpr(lambda x, y, z: einsum_promoted(_SPEC, x, y, z))(a, b, c)
+    assert _bad_dots(jaxpr.jaxpr) == [], (
+        f"real-by-real dot_general with complex output survived: "
+        f"{_bad_dots(jaxpr.jaxpr)}"
+    )
+
+
+@pytest.mark.parametrize(
+    "flags", [(False, False, True), (True, False, False), (True, True, True)]
+)
+def test_promoted_einsum_matches_jnp_einsum_numerically(flags):
+    """Promotion must be a pure lowering change, never a numerical one."""
+    ops = _operands(*flags)
+    got = einsum_promoted(_SPEC, *ops)
+    ref = np.einsum(_SPEC, *[np.asarray(o) for o in ops])
+    assert np.max(np.abs(np.asarray(got) - ref)) < 1e-12
+
+
+def test_all_real_operands_are_not_promoted_to_complex():
+    """A blanket cast-to-complex would double flops and memory on every
+    real-valued contraction in the RDM builders.  Common-dtype promotion is a
+    no-op when the operands already agree."""
+    ops = _operands(False, False, False)
+    assert einsum_promoted(_SPEC, *ops).dtype == jnp.float64
+
+
+def _multi_operand_jnp_einsums(path: Path) -> list[int]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return [
+        n.lineno
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "einsum"
+        and isinstance(n.func.value, ast.Name)
+        and n.func.value.id == "jnp"
+        and len(n.args) >= 4  # subscripts + 3 operands
+    ]
+
+
+@pytest.mark.parametrize("mod", ["ipeps_rdm.py", "ipeps_excitations.py"])
+def test_rdm_builders_do_not_reintroduce_raw_multi_operand_einsum(mod):
+    """The 15 converted sites must stay converted.
+
+    Only these two modules are pinned: they are the ones the #813 failures
+    actually exercised.  Other modules still hold multi-operand einsums and
+    remain exposed -- see the issue.
+    """
+    path = Path(__file__).resolve().parents[1] / "src" / "tenax" / "algorithms" / mod
+    offenders = _multi_operand_jnp_einsums(path)
+    assert offenders == [], (
+        f"{mod} has raw multi-operand jnp.einsum at lines {offenders}; use "
+        "einsum_promoted (#813) or these crash on CUDA with mixed dtypes"
+    )


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

22 gauge tests failed on GPU while passing on CPU **and in CI**. They looked like a gauge-invariance regression in the #748 family. They were not — every one raised before any assertion ran:

```
INTERNAL: GEMM is not supported by cublasLt and legacy cublas fallback is removed.
```

## The actual mechanism

Not "mixed dtypes" — that description is wrong, and it matters. For `einsum("ab,buc,ce->aue", C1, T1, C2)` with only `C2` complex:

```
a:f64[8,8]  b:f64[8,4,8]  c:c128[8,8]
d:c128[4,8,8] = dot_general[preferred_element_type=complex128] b a   <-- both operands REAL
e:c128[4,8,8] = dot_general[preferred_element_type=complex128] d c
```

JAX propagates the **final** complex result type onto the **first** contraction — which contracts two **real** operands. XLA is asked for a real-by-real GEMM with a complex output type. cuBLASLt has no such kernel, and the legacy cuBLAS fallback that used to absorb it was removed in jaxlib 0.10.2.

This explains what "mixed dtype" cannot:

- **binary contractions never fail** — JAX promotes the two operands directly, so each `dot_general` matches its output type. Verified: 2D real@complex, 3D real@2D complex, and both orders all lower fine.
- **it takes three operands** for a real-by-real intermediate to inherit a complex result type.
- **the failure pattern tracked position, not phase** — `C1`/`T1`/`T4` passed, `C2`/`C3`/`C4`/`T2`/`T3` failed. Complex in the *first* operand is fine; complex in a *later* one is not.
- **it is not a contraction-path artifact** — reproduces under `optimize` = `optimal`, `greedy`, `True` and `False`.

## The fix

`einsum_promoted` casts operands to their common dtype first, restoring the invariant that every `dot_general` sees operands matching its output type. Semantically identical to `jnp.einsum` (which promotes anyway), and **a no-op when dtypes already agree** — all-real contractions stay `f64` and pay nothing. A blanket cast-to-complex would have doubled flops and memory on every real contraction in the RDM builders; there is a test pinning that it does not.

Applied to the **15 multi-operand sites in the two modules the failures actually exercised** — `ipeps_rdm` (10) and `ipeps_excitations` (5) — selected by **AST**, not regex.

## Verification

| | |
|---|---|
| **GPU**, both gauge files | **52 passed** (was **22 failed**) |
| **CPU**, gauge + honeycomb gauge + `normalise_rdm_zero_grad` + new file | **96 passed** |
| numerical equivalence vs `np.einsum` | < 1e-12, across three dtype mixes |
| `ruff check` / `format` | clean |

The new tests are **backend-independent by construction** — they inspect the emitted jaxpr and the AST rather than executing the contraction. The crash reproduces only on CUDA and the required gate is CPU-only, so a GPU-marked test would guard *nothing* in CI. That is the whole reason this defect survived: both gauge files are already `core`, CI ran them, and they passed.

One test deliberately **pins the defect in `jnp.einsum` itself**. If a future JAX stops propagating the complex result type onto a real intermediate, that test fails and this workaround can be retired rather than cargo-culted forever.

Mutation-verified, each killing exactly its own test:

| mutation | kills |
|---|---|
| helper stops promoting | the no-unsupported-dot test |
| revert one converted call site | the AST scan test |

## Scope left open

Other modules still hold multi-operand einsums — `pess.py` (15), `ad_utils.py` (9), `_ctm_root_implicit_asym.py` (7), `ipeps_ctm_moves.py` (6), and others. They are **not** converted here: nothing demonstrates they can receive mixed dtypes, and each edit is a chance to introduce a bug in code no test currently exercises that way. The AST scan pins only the two modules with reproduced failures. Noted on the issue so the remaining exposure is not forgotten.

Refs #813.


---

Closes #813
