### PR TITLE
fix(#816): refuse an MPS and MPO that disagree on the physical basis

### DIFF
--- a/src/tenax/algorithms/dmrg.py
+++ b/src/tenax/algorithms/dmrg.py
@@ -452,6 +452,54 @@ def _run_symmetric_jit_executor(
     )
 
 
+def _validate_physical_basis(mps_tensors, mpo_tensors) -> None:
+    """Reject an MPS and MPO whose physical legs use different charge orders.
+
+    Symmetric contraction pairs sectors by *charge value*, so a run whose MPS
+    and MPO list the same physical charges in a different order still converges
+    to the correct state and reports the correct energy -- and then returns an
+    MPS whose dense physical index is permuted relative to the caller's
+    convention.  Everything read off that state (occupations, correlators,
+    entanglement across an orbital cut) is silently in the wrong basis while
+    the energy check that would normally catch it passes (#816).
+
+    The failure is *not* specific to fermions or Jordan-Wigner: it needs only a
+    ground state that is not invariant under the relabelling.  An XXZ chain
+    hides it (its Sz=0 ground state is spin-flip symmetric); adding a single
+    on-site field exposes the same 4.9e-01 mismatch with no fermions in sight.
+
+    Only ``build_auto_mpo`` MPOs paired with ``p{i}``-labelled MPS tensors are
+    checked, so a hand-built network is never rejected on a label heuristic.
+    """
+    import numpy as _np
+
+    for site, (mps_t, mpo_t) in enumerate(zip(mps_tensors, mpo_tensors)):
+        mps_ix = next((ix for ix in mps_t.indices if str(ix.label) == f"p{site}"), None)
+        mpo_ix = next(
+            (ix for ix in mpo_t.indices if str(ix.label) == f"mpo_top_{site}"), None
+        )
+        if mps_ix is None or mpo_ix is None:
+            continue
+        mps_q = _np.asarray(mps_ix.charges)
+        mpo_q = _np.asarray(mpo_ix.charges)
+        if mps_q.shape == mpo_q.shape and _np.array_equal(mps_q, mpo_q):
+            continue
+        raise ValueError(
+            f"MPS and MPO disagree on the physical basis at site {site}: the "
+            f"MPS physical leg carries charges {mps_q.tolist()} but the MPO's "
+            f"carries {mpo_q.tolist()}.\n"
+            "Symmetric contraction pairs sectors by charge value, so this "
+            "would still converge and report the correct energy -- while "
+            "returning an MPS whose dense physical index is permuted relative "
+            "to the MPO's. Occupations, correlators and entanglement read off "
+            "that state would be in the wrong basis, silently (#816).\n"
+            "Build both with the same phys_charges: pass the same array to "
+            "build_auto_mpo(phys_charges=...) and to the MPS builder "
+            "(build_random_symmetric_mps(phys_charges=...) or "
+            "FiniteMPS.random)."
+        )
+
+
 def dmrg(
     hamiltonian: TensorNetwork,
     initial_mps: FiniteMPS | TensorNetwork,
@@ -509,6 +557,7 @@ def dmrg(
 
     if all_mps_sym and all_mpo_sym:
         use_symmetric = True
+        _validate_physical_basis(mps_tensors, mpo_tensors)
         ops = _symmetric_ops(config)
     elif all_mps_dense and all_mpo_dense:
         use_symmetric = False
@@ -2937,6 +2986,7 @@ def build_random_symmetric_mps(
     dtype: Any = jnp.float64,
     seed: int = 42,
     target_charge: int = 0,
+    phys_charges: np.ndarray | None = None,
 ) -> TensorNetwork:
     """Build a random block-sparse MPS with U(1) charge conservation.
 
@@ -2984,8 +3034,23 @@ def build_random_symmetric_mps(
 
     sym = U1Symmetry()
 
-    # Physical: spin up = +1, spin down = −1
-    phys_charges = np.array([1, -1], dtype=np.int32)
+    # Physical: spin up = +1, spin down = −1.  The *order* is caller-visible:
+    # it fixes which dense physical index means which charge, and it must match
+    # whatever was handed to ``build_auto_mpo(phys_charges=...)`` or the
+    # returned MPS is permuted relative to the MPO (#816).  Overridable for
+    # exactly that reason; the virtual-sector construction below assumes the
+    # charges are ±1, so only a reordering is accepted.
+    if phys_charges is None:
+        phys_charges = np.array([1, -1], dtype=np.int32)
+    else:
+        phys_charges = np.asarray(phys_charges, dtype=np.int32)
+        if sorted(phys_charges.tolist()) != [-1, 1]:
+            raise ValueError(
+                f"phys_charges must be a reordering of [1, -1], got "
+                f"{phys_charges.tolist()}. This builder distributes virtual "
+                "sectors assuming each site contributes ±1; for other physical "
+                "charges use FiniteMPS.random."
+            )
     trivial_zero = np.array([0], dtype=np.int32)
 
     # Virtual bond: include charge sectors compatible with target propagation.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,11 @@ _FILE_MARKERS = {
     # CTM convergence, so it is milliseconds.  The production-run case it
     # also carries is explicitly @slow (#772).
     "test_root_implicit_wiring.py": "core",
+    # MPS/MPO physical-basis agreement (#816).  A mismatched charge ORDER
+    # still converges and reports the correct energy while returning a
+    # permuted state, so the energy check that normally catches everything
+    # passes.  Small L=6 DMRG runs, a few seconds.
+    "test_dmrg_phys_basis.py": "core",
     # Knobs the root-implicit path accepted and then ignored (#792).  Mostly
     # config validation and one warning: milliseconds, no CTM.  The masked-
     # gradient convergence-flag test does converge one final D=2/chi=4 env

--- a/tests/test_dmrg_phys_basis.py
+++ b/tests/test_dmrg_phys_basis.py
@@ -1,0 +1,153 @@
+"""MPS and MPO must agree on the physical basis, not just on charge values (#816).
+
+Symmetric contraction pairs sectors by *charge value*, so an MPS and MPO that
+list the same physical charges in a different **order** still converge to the
+right state and report the right energy -- and then hand back an MPS whose dense
+physical index is permuted relative to the caller's convention.  Every quantity
+read off that state (occupations, correlators, entanglement across an orbital
+cut) is silently in the wrong basis, while the energy check that would normally
+catch it passes.
+
+The reporter isolated this to the fermionic / Jordan-Wigner path.  It is not
+fermionic: a plain XXZ chain hides it only because its Sz=0 ground state is
+spin-flip symmetric, so the relabelling maps that state to itself.  Break that
+symmetry with one on-site field and a pure spin model fails identically --
+``test_the_failure_is_not_fermion_specific`` pins exactly that, so the fix is
+never re-scoped to the fermionic path.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tenax.algorithms import DMRGConfig, build_auto_mpo
+from tenax.algorithms.auto_mpo import fermion_site_ops, spin_half_ops
+from tenax.algorithms.dmrg import build_random_symmetric_mps
+from tenax.algorithms.dmrg import dmrg as run_dmrg
+
+L = 6
+
+
+def _mpo(terms, site_ops, fermionic_ops, phys_charges):
+    return build_auto_mpo(
+        terms,
+        L=L,
+        d=2,
+        site_ops=site_ops,
+        fermionic_ops=fermionic_ops,
+        symmetric=True,
+        phys_charges=np.array(phys_charges),
+        compress=True,
+        compress_tol=1e-10,
+    )
+
+
+def _cfg():
+    return DMRGConfig(
+        max_bond_dim=16,
+        num_sweeps=4,
+        target_charge=0,
+        numpy_blockwise=True,
+        svd_trunc_err=1e-9,
+        convergence_tol=1e-14,
+    )
+
+
+def _rayleigh(mps, mpo):
+    """<psi|H|psi>/<psi|psi> read off the returned MPS in the MPO's basis."""
+    w = [np.asarray(mpo.get_tensor(i).todense()) for i in range(L)]
+    env = np.zeros((1, 1, 1), dtype=complex)
+    env[0, 0, 0] = 1.0
+    for i, x in enumerate(w):
+        a = np.asarray(mps.get_tensor(i).todense())
+        env = np.einsum("awb,apc,wpqx,bqd->cxd", env, a.conj(), x, a, optimize=True)
+    n = np.ones((1, 1), dtype=complex)
+    for i in range(L):
+        a = np.asarray(mps.get_tensor(i).todense())
+        n = np.einsum("ab,apc,bpd->cd", n, a.conj(), a, optimize=True)
+    return float(env.ravel()[0].real) / float(n.ravel()[0].real)
+
+
+_XXZ = [
+    t
+    for j in range(L - 1)
+    for t in (
+        (0.5, "Sp", j, "Sm", j + 1),
+        (0.5, "Sm", j, "Sp", j + 1),
+        (1.0, "Sz", j, "Sz", j + 1),
+    )
+]
+_TV = [
+    t
+    for j in range(L - 1)
+    for t in (
+        (-1.0, "Cd", j, "C", j + 1),
+        (-1.0, "Cd", j + 1, "C", j),
+        (2.0, "N", j, "N", j + 1),
+    )
+]
+
+
+def test_a_mismatched_physical_basis_is_refused():
+    """The reporter's exact configuration: MPO [-1, 1] vs the builder's [1, -1].
+
+    Previously this ran to completion and returned a particle-hole-flipped
+    state alongside a correct energy.
+    """
+    mpo = _mpo(_TV, fermion_site_ops(), {"C", "Cd"}, [-1, 1])
+    mps0 = build_random_symmetric_mps(L=L, bond_dim=8, seed=1, target_charge=0)
+    with pytest.raises(ValueError, match="physical basis"):
+        run_dmrg(mpo, mps0, _cfg())
+
+
+def test_matching_the_basis_makes_the_returned_state_the_reported_one():
+    """With the bases aligned, the returned MPS *is* the state whose energy
+    was reported -- the property #816 found violated."""
+    mpo = _mpo(_TV, fermion_site_ops(), {"C", "Cd"}, [-1, 1])
+    mps0 = build_random_symmetric_mps(
+        L=L, bond_dim=8, seed=1, target_charge=0, phys_charges=np.array([-1, 1])
+    )
+    res = run_dmrg(mpo, mps0, _cfg())
+    reported = float(res.energies_per_sweep[-1])
+    assert abs(reported - _rayleigh(res.mps, mpo)) < 1e-8
+
+
+def test_the_default_pairing_is_not_refused():
+    """Both builders default to [1, -1], so the default path must stay legal.
+
+    This is the regression the guard is most likely to introduce.
+    """
+    mpo = _mpo(_TV, fermion_site_ops(), {"C", "Cd"}, [1, -1])
+    mps0 = build_random_symmetric_mps(L=L, bond_dim=8, seed=1, target_charge=0)
+    res = run_dmrg(mpo, mps0, _cfg())
+    assert abs(float(res.energies_per_sweep[-1]) - _rayleigh(res.mps, mpo)) < 1e-8
+
+
+def test_the_failure_is_not_fermion_specific():
+    """A pure spin model with the flip symmetry broken fails identically.
+
+    XXZ alone cannot show this: its Sz=0 ground state is invariant under
+    Sz -> -Sz, so the permuted state equals the original. One on-site field
+    removes that accident. Without this test the fix invites re-scoping to
+    the Jordan-Wigner path, where the bug does not live.
+    """
+    terms = [*_XXZ, (0.7, "Sz", 0)]
+    mpo = _mpo(terms, spin_half_ops(), None, [-1, 1])
+    mps0 = build_random_symmetric_mps(L=L, bond_dim=8, seed=1, target_charge=0)
+    with pytest.raises(ValueError, match="physical basis"):
+        run_dmrg(mpo, mps0, _cfg())
+
+    aligned = build_random_symmetric_mps(
+        L=L, bond_dim=8, seed=1, target_charge=0, phys_charges=np.array([-1, 1])
+    )
+    res = run_dmrg(mpo, aligned, _cfg())
+    assert abs(float(res.energies_per_sweep[-1]) - _rayleigh(res.mps, mpo)) < 1e-8
+
+
+def test_builder_rejects_charges_it_cannot_honour():
+    """The virtual-sector construction assumes +-1 per site."""
+    with pytest.raises(ValueError, match="reordering of"):
+        build_random_symmetric_mps(
+            L=L, bond_dim=8, seed=1, target_charge=0, phys_charges=np.array([2, -2])
+        )


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Reproduced the reporter's script exactly (mismatch `8.62e-01`, matching the issue digit for digit).

## Root cause: charge *order*, not fermionic signs

`build_random_symmetric_mps` hardcoded `phys_charges = [1, -1]` with **no way to override it**; `build_auto_mpo` takes `phys_charges` from the caller, and the reporter passed `[-1, 1]`.

Symmetric contraction pairs sectors by charge **value**, so DMRG converged to the true ground state and reported its true energy. Only the returned MPS's *dense* physical index was ordered by the MPS convention rather than the caller's — index 0 meaning "occupied" in the MPS and "empty" in the MPO.

Two independent pieces of evidence:

```
sorted |amplitudes| vs exact GS            : match to 3.9e-16
|<gs | particle-hole flip of returned psi>| : 1.000000
```

It was the exact ground state with occupation 0↔1 relabelled. Changing **only** the MPO's `phys_charges` order:

| MPO `phys_charges` | mismatch |
|---|---|
| `[-1, 1]` (reporter's) | 8.62e-01 |
| `[1, -1]` (matches the builder) | **3.11e-15** |

## The issue's isolation to the fermionic path is a red herring

The XXZ control passes not because it is non-fermionic, but because its Sz=0 ground state is **invariant under Sz → −Sz**, so the relabelling maps that state to itself. Break that accident with a single on-site field and a pure spin model — no fermions, no Jordan-Wigner — fails identically:

| case | mismatch |
|---|---|
| XXZ (flip-symmetric GS), `phys=[-1,1]` | 1.78e-15 ✓ |
| **XXZ + 0.7·Sz(site 0)**, `phys=[-1,1]` | **4.88e-01** ✗ |
| XXZ + 0.7·Sz(site 0), `phys=[1,-1]` | 5.33e-15 ✓ |

`test_the_failure_is_not_fermion_specific` pins this, so the fix cannot later be re-scoped to the JW path where the bug does not live.

## Fix — two halves, both required

1. **`dmrg()` validates the contract**: the MPS `p{i}` leg and the MPO `mpo_top_{i}` leg must carry the same charge array, and it raises naming both. Only `build_auto_mpo`-labelled networks are checked, so a hand-built MPO is never rejected on a label heuristic.
2. **`build_random_symmetric_mps` gained `phys_charges`.** Without it the error is *unactionable* — the caller had no way to align the two. Restricted to a reordering of `[1, -1]`, since the virtual-sector construction assumes ±1 per site.

**The default pairing is unaffected**: both builders default to `[1, -1]`, so this only ever fires for callers who passed an explicit order. `test_the_default_pairing_is_not_refused` covers the regression this guard is most likely to introduce.

## Verification

- **127 passed** across `test_dmrg`, `test_auto_mpo`, `test_observables` and the new file — no existing configuration is rejected
- Mutation-verified, and the two mutations are **complementary**:

| mutation | kills |
|---|---|
| drop the guard call | the two "refused" tests |
| builder ignores `phys_charges` | the three tests needing the remedy |

The first proves the *detection* is load-bearing, the second that the *remedy* is. Detection without a remedy would have been a dead end.

## Not addressed

`FiniteMPS.norm()` returning `0.0` for these symmetric MPS, flagged in the issue as possibly related. Left untouched — it is a separate contraction, and folding it in would blur this fix. Worth its own issue as the reporter suggested.

Refs #816.


---

Closes #816
