### PR TITLE
fix(#819): symmetric FiniteMPS.norm() returned exactly 0.0

### DIFF
--- a/src/tenax/core/mps.py
+++ b/src/tenax/core/mps.py
@@ -307,7 +307,15 @@ class FiniteMPS:
         env = None
         for i in range(self.L):
             ket = other[i]
-            bra = self[i].conj()
+            # ``bar()``, not ``conj()``: the bra must have *opposite flows* so
+            # its legs can contract, while keeping identical charges so blocks
+            # still match by equality.  ``conj()`` only conjugates the data and
+            # leaves the flows alone, so on a SymmetricTensor every physical
+            # pairing is OUT-against-OUT, no block matches, and the whole
+            # overlap collapses to exactly 0j -- see #819.  ``dagger()`` flips
+            # the flows but also duals the charges, which reintroduces the
+            # charge mismatch ``bar()`` was written to avoid.
+            bra = self[i].bar()
 
             # Relabel bra's virtual bond labels to avoid collision with ket.
             # Physical labels (p{i}) stay the same so they contract.
@@ -349,8 +357,42 @@ class FiniteMPS:
         Returns:
             The norm as a non-negative real number.
         """
+        # Fast path, following ITensor: with a known orthogonality center every
+        # other site is an isometry, so <t|t> is just the center tensor's
+        # Frobenius norm squared.  O(chi^2 d) instead of O(L chi^3) -- and it
+        # cannot be corrupted by a bug in the transfer-matrix contraction,
+        # which is exactly how #819 went unnoticed.
+        if self.orth_center is not None:
+            centre = float(self.tensors[self.orth_center].norm())
+            return float(jnp.exp(self.log_norm) * centre)
+
         raw = self._raw_overlap(self)
-        return float(jnp.exp(self.log_norm) * jnp.sqrt(jnp.abs(raw)))
+        # <t|t> is a positive real by construction.  Anything else means the
+        # contraction is broken, and the old ``jnp.abs(raw)`` laundered exactly
+        # that into a plausible non-negative float: #819 returned 0.0 for a
+        # perfectly good state and nothing complained.  Fail instead.
+        raw_c = complex(raw)
+        scale = abs(raw_c)
+        if scale > 0.0 and abs(raw_c.imag) > 1e-8 * scale:
+            raise ValueError(
+                f"<psi|psi> came back complex ({raw_c!r}); the norm of a state "
+                "is a positive real, so the overlap contraction is wrong. This "
+                "is a bug in tenax, not in your state (#819)."
+            )
+        if raw_c.real < 0.0:
+            raise ValueError(
+                f"<psi|psi> came back negative ({raw_c.real!r}); the norm of a "
+                "state is a positive real, so the overlap contraction is wrong. "
+                "This is a bug in tenax, not in your state (#819)."
+            )
+        if raw_c.real == 0.0 and any(float(t.norm()) > 0.0 for t in self.tensors):
+            raise ValueError(
+                "<psi|psi> came back exactly 0 for an MPS whose site tensors "
+                "are not all zero, so the overlap contraction is wrong rather "
+                "than the state being null (#819). A genuinely zero state "
+                "would have zero tensors."
+            )
+        return float(jnp.exp(self.log_norm) * jnp.sqrt(raw_c.real))
 
     def entanglement_entropy(self, bond: int) -> float:
         """Compute the Von Neumann entanglement entropy at a bond.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,6 +136,9 @@ _FILE_MARKERS = {
     "test_observables.py": "algorithm",
     "test_cbe_validation.py": "algorithm",
     "test_mps.py": "core",
+    # FiniteMPS.norm() vs an explicit contraction (#819).  Neither backend had
+    # such a test, which is how an exactly-zero symmetric norm survived.
+    "test_mps_norm.py": "core",
     "test_blas_plan.py": "core",
     "test_padded_block_array.py": "core",
     "test_jit_sweep.py": "core",

--- a/tests/test_mps_norm.py
+++ b/tests/test_mps_norm.py
@@ -1,0 +1,125 @@
+"""``FiniteMPS.norm()`` must agree with an explicit contraction (#819).
+
+Three separate defects, one symptom:
+
+1. ``_raw_overlap`` built the bra with ``conj()``, which conjugates the data but
+   leaves the flows alone.  On a ``SymmetricTensor`` every physical pairing was
+   then OUT-against-OUT, no block matched, and the overlap collapsed to exactly
+   ``0j`` -- so ``norm()`` returned ``0.0`` for a perfectly good state.
+2. ``norm()`` took ``jnp.abs()`` of a quantity that is a positive real by
+   construction, laundering that ``0j`` into a plausible float instead of
+   failing.
+3. ``norm()`` always ran the full O(L*chi^3) contraction even with a known
+   orthogonality centre, where the answer is local and free.
+
+Neither backend had a test comparing ``norm()`` against an explicit
+contraction, which is why an exactly-zero norm survived.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import jax
+import numpy as np
+import pytest
+
+from tenax.algorithms.dmrg import build_random_symmetric_mps
+from tenax.core.mps import FiniteMPS
+
+L = 6
+
+
+def _explicit_tensor_norm(mps) -> float:
+    """sqrt(<t|t>) from a plain dense contraction of the site tensors."""
+    n = np.ones((1, 1), dtype=complex)
+    for i in range(len(mps)):
+        a = np.asarray(mps[i].todense())
+        n = np.einsum("ab,apc,bpd->cd", n, a.conj(), a, optimize=True)
+    return float(n.ravel()[0].real) ** 0.5
+
+
+def _symmetric_mps() -> FiniteMPS:
+    m = build_random_symmetric_mps(L=L, bond_dim=8, seed=1, target_charge=0)
+    return FiniteMPS.from_tensors([m.get_tensor(i) for i in range(L)])
+
+
+def test_symmetric_norm_is_not_zero():
+    """The #819 bug: a normalizable symmetric MPS reported norm exactly 0.0."""
+    f = _symmetric_mps()
+    assert f.orth_center is None, "this test must exercise the contraction path"
+    got = f.norm()
+    assert got > 0.0, "symmetric MPS reported a zero norm"
+    assert abs(got - _explicit_tensor_norm(f)) < 1e-9
+
+
+def test_dense_norm_matches_explicit_contraction_times_log_norm():
+    """Dense was never broken -- pin it so the fix does not regress it.
+
+    ``norm() == exp(log_norm) * sqrt(<t|t>)`` is the documented contract; the
+    tensors are normalized by ``right_canonicalize`` and the scale lives in
+    ``log_norm``.
+    """
+    d = FiniteMPS.random(L=L, d=2, chi=8, key=jax.random.PRNGKey(0))
+    expected = float(np.exp(d.log_norm)) * _explicit_tensor_norm(d)
+    assert abs(d.norm() - expected) < 1e-12
+
+
+@pytest.mark.parametrize("symmetric", [False, True])
+def test_orthogonality_centre_fast_path_agrees_with_the_contraction(symmetric):
+    """The fast path must be an optimization, never a different answer."""
+    mps = (
+        _symmetric_mps()
+        if symmetric
+        else FiniteMPS.random(L=L, d=2, chi=8, key=jax.random.PRNGKey(0))
+    )
+    if mps.orth_center is None:
+        pytest.skip("no orthogonality centre to exercise the fast path")
+    slow = dataclasses.replace(mps, orth_center=None).norm()
+    assert abs(mps.norm() - slow) < 1e-9
+
+
+def test_the_fast_path_does_not_touch_the_contraction(monkeypatch):
+    """Prove the orthogonality-centre path is actually *taken*.
+
+    Comparing fast against slow cannot show this -- delete the fast path and
+    both sides simply run the contraction and still agree.  Making
+    ``_raw_overlap`` explode is what pins it, and it is also the property that
+    matters: with a centre, ``norm()`` must be immune to a contraction bug.
+    """
+    d = FiniteMPS.random(L=L, d=2, chi=8, key=jax.random.PRNGKey(0))
+    assert d.orth_center is not None
+
+    def _boom(self, other):
+        raise AssertionError("_raw_overlap must not be called with a centre set")
+
+    monkeypatch.setattr(FiniteMPS, "_raw_overlap", _boom)
+    assert d.norm() > 0.0
+
+
+def test_a_zero_overlap_from_nonzero_tensors_raises(monkeypatch):
+    """The laundering fix: abs() turned a broken contraction into a number.
+
+    A state whose site tensors are not all zero cannot have <t|t> == 0, so this
+    is a contraction bug and must surface as one rather than as ``0.0``.
+    """
+    f = _symmetric_mps()
+    monkeypatch.setattr(FiniteMPS, "_raw_overlap", lambda self, other: 0j)
+    with pytest.raises(ValueError, match="exactly 0"):
+        f.norm()
+
+
+def test_a_negative_overlap_raises(monkeypatch):
+    """<psi|psi> < 0 is impossible; abs() previously hid it."""
+    f = _symmetric_mps()
+    monkeypatch.setattr(FiniteMPS, "_raw_overlap", lambda self, other: -4.0 + 0j)
+    with pytest.raises(ValueError, match="negative"):
+        f.norm()
+
+
+def test_a_complex_overlap_raises(monkeypatch):
+    """<psi|psi> with a nonzero imaginary part is impossible; abs() hid it."""
+    f = _symmetric_mps()
+    monkeypatch.setattr(FiniteMPS, "_raw_overlap", lambda self, other: 1.0 + 0.5j)
+    with pytest.raises(ValueError, match="complex"):
+        f.norm()


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Three defects, one symptom. All three are fixed, because **each one alone would have let this ship again**.

## 1. The bug

`_raw_overlap` built the bra with `conj()`, which conjugates the data and leaves the flows alone. On a `SymmetricTensor` every physical pairing was then OUT-against-OUT, no block matched, and the overlap collapsed to exactly `0j`:

| | |
|---|---|
| manual `<t\|t>` | **19.829362** |
| `_raw_overlap` via `conj()` | **0j** |
| `_raw_overlap` via `bar()` | **19.829362** |

`bar()` is the correct bra operation and says so in its own docstring — *opposite flows so the legs contract, identical charges so blocks still match by equality*. `dagger()` also flips flows but **duals the charges**, reintroducing precisely the mismatch `bar()` was written to avoid.

## 2. The laundering

```python
return float(jnp.exp(self.log_norm) * jnp.sqrt(jnp.abs(raw)))
```

`<t|t>` is a positive real **by construction**. `abs()` there is not defensive — it converts a broken contraction into a plausible `0.0`. A complex or negative overlap now raises, and so does an exact zero from tensors that are not all zero (a genuinely null state has null tensors).

This is why the bug was silent rather than loud, and it is the same family as #801 and #812: a value that lies instead of failing.

## 3. The unnecessary work

`norm()` always ran the full O(L·χ³) contraction — even with a known orthogonality centre, where every other site is an isometry and the answer is just the centre tensor's Frobenius norm. It now uses the centre when there is one: **O(χ²d)**, and immune to a contraction bug.

This follows ITensor, where *"if the MPS has a well defined orthogonality center, computing the norm reduces to the norm of the orthogonality center tensor"*.

## What was **not** broken

**The dense path.** My original issue claimed it was off by ~125x; that was wrong and I have corrected the issue. `norm() == exp(log_norm) * sqrt(<t|t>)` is the documented contract, `FiniteMPS.random` returns `right_canonicalize()`, and the scale legitimately lives in `log_norm`. Dense numbers are unchanged, and a test pins that.

**`log_norm` itself.** It came from Ian McCulloch's (MPToolkit) design review in #163/#169 and is well-precedented. Only `norm()`'s *use* of it changes.

## Verification

**Mutation-verified, each killing exactly its own tests:**

| mutation | kills |
|---|---|
| `bar()` → `conj()` | the symmetric-norm test |
| restore `abs()` | the three "must raise" tests |
| drop the fast path | the fast-path test |

The fast-path test asserts `_raw_overlap` is **never called** when a centre is set. Comparing fast against slow *cannot* catch its removal — both sides would just run the contraction and agree. That test only exists because I checked whether the mutation would be caught, and it would not have been.

Tests: **203 passed** across `test_mps`, `test_dmrg`, `test_idmrg`, `test_observables` and the new file.

Neither backend previously had a test comparing `norm()` against an explicit contraction — which is how an exactly-zero norm survived.

Refs #819. Found via #816, where the reporter reached for `norm()` to sanity-check a suspect state and could not use it.


---

Closes #819
