### PR TITLE
docs: retitle Unreleased as v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-*(Becomes v0.8.3. Staying in the v0.8.x patch line per the versioning strategy —
-approaching v1.0.0 as a coherent milestone.)*
+## v0.8.3 (2026-08-09)
 
 A correctness release. The headline feature is root implicit AD for CTMRG
 (#715), but the reason to upgrade is the set of silent-wrong-answer defects


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

`v0.8.3` was tagged at `8440b98`, whose `CHANGELOG.md` still read `## Unreleased`. This retitles that section to `## v0.8.3 (2026-08-09)` and opens a fresh `## Unreleased` above it, matching the convention of the `v0.8.2` entry.

Cosmetic only — `publish.yml` derives the version from the git tag, so the published artifact is unaffected. The tagged tree keeps the old heading; this fixes it going forward.

Docs only.