### PR TITLE
docs(#747): supersede the D=4 energies produced against a collapsed environment

### DIFF
--- a/docs/benchmarks/d4_chi_scaling/README.md
+++ b/docs/benchmarks/d4_chi_scaling/README.md
@@ -12,11 +12,45 @@ the timing/memory columns at identical `(state, χ)` give the multi-GPU speedup 
 
 All 21 cells (7 χ × 3 device counts) completed `ok` — zero OOM, zero errors.
 
+> ## ⚠️ The energies on this page are superseded — #747
+>
+> The state these numbers describe was optimized against a **collapsed**
+> environment. `gs_recipe` was hard-coded to `1x1`, which drives the CTM
+> environment to rank-1 corners — a `chi_eff = 1` mean-field boundary (#723,
+> #726) — so the `A_opt.pkl` committed here is a badly-optimized state, not the
+> D=4 variational optimum.
+>
+> **The χ-scan itself is sound.** It runs through `python_loop_ctm_converge`,
+> which has defaulted to `recipe="2x2"` since PR #597, so the scan methodology,
+> the device-independence cross-check, and every **multi-GPU timing and memory**
+> finding below are unaffected. What does not survive is the **absolute energy**
+> and any reading of it as a truncation error.
+>
+> **Superseded by Run 2** (#747 comment 4, 2026-08-05), which re-optimized at
+> `gs_recipe="2x2"` and confirmed `corner_rank == χ` in all seven cells:
+>
+> | | this page (`1x1`) | Run 2 (`2x2`) |
+> |---|---|---|
+> | E/site at χ=128 | −0.6633981 | **−0.6639345178** |
+> | err vs QMC | +6.04e-03 | **+5.50e-03** |
+>
+> Run 2's figure is **itself an upper bound**: its optimization was stopped at
+> step 14 with `E_best` flat for ~4 h of wall clock, not run to convergence.
+> Neither number is the D=4 truncation error.
+>
+> The data files here are left unmodified as the historical record. Run 2's
+> artifacts (`runs/d4_rerun_2x2/`) live on the machine that produced them —
+> 2×RTX 4070 Ti SUPER, so its timings are also not comparable to the A100
+> numbers below — and are not committed here.
+
 ## Key findings
 
-- **Convergence:** E/site saturates at **−0.663398 by χ≈32** (flat to 6 digits
-  beyond). The residual **+0.006 vs the QMC reference −0.669437 is the D=4
-  variational floor**, not under-convergence. So χ≈32 is sufficient at D=4.
+- **Convergence:** E/site saturates by **χ≈32** (flat to 6 digits beyond), so
+  **χ≈32 is sufficient at D=4** — that is a property of the scan and it holds.
+  The saturated *value* (−0.663398, +0.006 vs the QMC reference −0.669437) is
+  **superseded**, and that residual is **not** the D=4 variational floor: it
+  mixes iPEPS truncation with a state optimized against a collapsed
+  environment. See the banner above.
 - **Multi-GPU:** numerically exact (ΔE vs 1-GPU ≤ 7e-8, machine-epsilon at large χ)
   but **below the crossover at this scale** — 2-GPU is break-even (0.99–1.01×, flat
   in χ), 4-GPU markedly slower but improving monotonically with χ (0.21× at χ=16 →
@@ -26,6 +60,20 @@ All 21 cells (7 χ × 3 device counts) completed `ok` — zero OOM, zero errors.
   existing above this range rather than with sharding being unusable.
 
 ## Corrections
+
+**#747 (2026-08-09) — the optimized state was produced against a collapsed
+environment, so every energy here is superseded.** The driver hard-coded
+`gs_recipe="1x1"`, whose rank-1 corners give a `chi_eff = 1` mean-field boundary
+(#723/#726, fixed in #749/#765). The recorded energies are therefore the
+energies of a badly-optimized state, and **+6.04e-03 must not be quoted as the
+D=4 truncation error**. Run 2 (#747 comment 4) re-optimized at
+`gs_recipe="2x2"` — now the driver default, with `--gs-recipe` exposed — and
+reports **−0.6639345178 / +5.50e-03**, itself an upper bound (see the banner).
+
+The χ-scan path, the multi-GPU findings and `peak_gb` are **unaffected**: the
+forward scan always ran `2x2` via `python_loop_ctm_converge`. Only the state
+being scanned was bad, so the curve's *shape* and the device-independence
+cross-check stand while its absolute *level* does not.
 
 **#781 (2026-08-06) — the per-sweep timings were inflated up to 3×.** The driver
 divided elapsed time by `CTMLoopResult.iterations`, which on the `plateau_patience`
@@ -52,12 +100,13 @@ the full write-up.
 
 | File | Contents |
 |------|----------|
-| `convergence.md` | E/site vs χ table (vs QMC) |
-| `performance.md` | per-sweep CTM cost, peak GB, speedup vs 1-GPU, grouped by device count |
-| `results.csv` | all 21 cells, machine-readable — `ms_per_sweep`/`n_sweeps` as recorded, i.e. inflated (#781) |
-| `D4_chi{χ}_n{devices}.json` | per-cell raw result (E, timing, memory, convergence flag); same #781 caveat |
-| `*.png` | E-vs-χ (with QMC line), ms/sweep, speedup, peak-GB plots |
-| `A_opt.pkl` | the optimized D=4 tensor (host/numpy leaves) — re-scan without re-optimizing |
+| `convergence.md` | E/site vs χ table (vs QMC) — **energies superseded (#747)** |
+| `performance.md` | per-sweep CTM cost, peak GB, speedup vs 1-GPU, grouped by device count — unaffected by #747 |
+| `results.csv` | all 21 cells, machine-readable — **energies superseded (#747)**; `ms_per_sweep`/`n_sweeps` as recorded, i.e. inflated (#781) |
+| `D4_chi{χ}_n{devices}.json` | per-cell raw result (E, timing, memory, convergence flag); same #747 and #781 caveats |
+| `convergence_E_vs_chi.png` | E-vs-χ with QMC line — **plots the superseded energies (#747)** |
+| `perf_*.png` | ms/sweep, speedup, peak-GB plots — unaffected by #747 |
+| `A_opt.pkl` | the D=4 tensor as optimized **against a collapsed `1x1` environment (#747)** — kept as the record; **do not use it as a D=4 ground state** |
 | `optimize_status.json` | optimize-phase exit status |
 
 Optimizer checkpoints (`ckpt_opt/`, ~1.7 MB binary) and the run log are intentionally
@@ -65,14 +114,27 @@ Optimizer checkpoints (`ckpt_opt/`, ~1.7 MB binary) and the run log are intentio
 
 ## Reproduce
 
+`gs_recipe` now defaults to `2x2`, so a fresh run no longer reproduces the
+collapsed state — it reproduces **Run 2**, not this page.
+
 ```bash
 # Full sweep (optimize once at χ_opt=32, then scan χ × {1,2,4} GPU). ~19 h on 4×A100.
 uv run python examples/heisenberg_d4_chi_scaling.py --outdir runs/d4_chi_scaling
 
-# Re-run the χ-scan only, reusing this committed A_opt.pkl (skips the ~18 h optimize):
-mkdir -p runs/d4_chi_scaling && cp docs/benchmarks/d4_chi_scaling/A_opt.pkl runs/d4_chi_scaling/
-uv run python examples/heisenberg_d4_chi_scaling.py --outdir runs/d4_chi_scaling
-
 # Quick end-to-end validation (tiny):
 uv run python examples/heisenberg_d4_chi_scaling.py --smoke
+```
+
+**Do not seed a new run with the committed `A_opt.pkl`.** The optimize phase
+returns immediately when it finds one, so copying this file in silently scans
+the collapsed-environment state again and reproduces the superseded energies —
+which is exactly how the invalid numbers survived to be published. Reusing it is
+only valid for re-deriving *this page's* record, e.g. the #781 timing
+correction.
+
+To reproduce the page as recorded, or to bisect against it, ask for the old
+recipe explicitly:
+
+```bash
+uv run python examples/heisenberg_d4_chi_scaling.py --gs-recipe 1x1 --outdir runs/d4_1x1_bisect
 ```

--- a/docs/benchmarks/d4_chi_scaling/convergence.md
+++ b/docs/benchmarks/d4_chi_scaling/convergence.md
@@ -2,6 +2,29 @@
 
 QMC reference E/site = -0.669437
 
+> **⚠️ These energies are superseded — #747.** The scanned state was optimized
+> at `gs_recipe="1x1"`, against a CTM environment that collapses to rank-1
+> corners (#723/#726). The scan below is sound — it ran `2x2` throughout — but
+> the state it scans is badly optimized, so **+6.04e-03 is not the D=4
+> truncation error**.
+>
+> Run 2 (#747 comment 4, 2026-08-05) re-optimized at `gs_recipe="2x2"`, with
+> `corner_rank == χ` in all seven cells:
+>
+> | χ | E/site | err vs QMC | sweeps | corner_rank |
+> |---|--------|------------|--------|-------------|
+> | 16 | -0.6638308456 | +5.606e-03 | 54 | 16 |
+> | 24 | -0.6639137982 | +5.523e-03 | 54 | 24 |
+> | 32 | -0.6639289593 | +5.508e-03 | 39 | 32 |
+> | 48 | -0.6639337605 | +5.503e-03 | 42 | 48 |
+> | 64 | -0.6639343531 | +5.503e-03 | 78 | 64 |
+> | 96 | -0.6639345149 | +5.502e-03 | 14 | 96 |
+> | 128 | **-0.6639345178** | **+5.502e-03** | 18 | 128 |
+>
+> That run's `A_opt` was stopped at step 14, so **+5.50e-03 is also an upper
+> bound**, not a converged variational result. Both tables agree that χ≈32
+> saturates the scan; they disagree on the level by 5.4e-04.
+
 > **The `conv` column reads `N` everywhere, and that is a criterion artifact —
 > issue #780.** This run inherited `CTMConfig.ctm_conv_method="elementwise"`,
 > which compares raw environment tensor entries between sweeps. A CTM

--- a/docs/superpowers/handoffs/2026-08-04-747-rerun-handover.md
+++ b/docs/superpowers/handoffs/2026-08-04-747-rerun-handover.md
@@ -179,12 +179,41 @@ instead of corner-pair ones, so the cost profile is different. The *memory*
 claim (χ²·D³·d vs χ²·D⁶, ~12×) is shape-derived and should hold; the χ ceiling
 depends on the new peak and needs the ladder walked again.
 
-Budget: the recorded `1x1` split converge was ~14–21 s per χ. `2x2` measured
-3–6× slower on small cells, so ~1–2 min per χ plus compile, times the ladder.
+**Budget — the estimate below was wrong; raise `--cell-timeout-s`.** The first
+attempt (2026-08-06) died with `"error": "timeout"` at the *first* rung, χ=64,
+against the 2400 s default, and the row-stop rule then killed the rest of the
+ladder. Two things the original estimate missed: `_converge_split` runs the full
+`max_iter=200` converge **twice** (an untimed warm-up compile, then the timed
+one), and the `1x1` per-χ figures it extrapolated from were collapsed-corner
+timings. For scale, the *dense* arm needed 13.6 s/sweep × 33 sweeps at this same
+χ=64. Pass `--cell-timeout-s 21600` so a row stops on a real OOM wall rather
+than the clock — a clock stop is indistinguishable from a χ ceiling in
+`results.csv`, which is exactly the confusion this issue exists to remove.
+
+A timed-out cell is **cached like any other result**, so a plain re-run resumes
+straight past it. Move or delete that cell's JSON before retrying.
+
+Superseded estimate, for the record: `1x1` split converge was ~14–21 s per χ,
+and `2x2` measured 3–6× slower on small cells, suggesting ~1–2 min per χ.
 
 ---
 
-## Run 2 — D=4 re-optimization at `gs_recipe="2x2"`
+## Run 2 — D=4 re-optimization at `gs_recipe="2x2"` — ✅ DONE 2026-08-05
+
+Completed on 2×RTX 4070 Ti SUPER; written up as **#747 comment 4**.
+`corner_rank == χ` in all seven cells, and **E/site = −0.6639345178,
+err vs QMC = +5.50e-03**, superseding +6.04e-3. That figure is itself an upper
+bound: the optimization was stopped at step 14 with `E_best` flat for ~4 h.
+Artifacts stayed on that machine (`runs/d4_rerun_2x2/`); the published
+`docs/benchmarks/d4_chi_scaling/` prose was corrected separately.
+
+Two findings from it that outlive the run: `conv_tol` is **dead code** in this
+configuration (a full re-scan at 1e-8 was bit-identical — every cell exits on
+`plateau_patience=20`, never on tolerance, so `plateau_patience` is the real
+knob), and `CUDA_VISIBLE_DEVICES` on the orchestrator **does not pin the run**
+(`_worker_env` overwrites it with its own most-idle pick).
+
+The original instructions are kept below for reproduction and bisection.
 
 ```bash
 uv run python examples/heisenberg_d4_chi_scaling.py \

--- a/examples/heisenberg_d4_chi_scaling.py
+++ b/examples/heisenberg_d4_chi_scaling.py
@@ -315,9 +315,15 @@ def optimize_once(outdir, chi_opt, opt_steps, n_devices, probe_max_iter=15,
     a chi_eff=1 mean-field environment.  The chi *scan* was always correct
     (it goes through ``python_loop_ctm_converge``, which defaults to 2x2), so
     the recorded convergence data stands -- but the +6.04e-3 vs QMC mixes iPEPS
-    truncation with a badly-optimized state and should not be quoted as a D=4
-    truncation error until this is re-run.  ``"1x1"`` reproduces the old
-    (invalid) behaviour for bisection.  See #747."""
+    truncation with a badly-optimized state and must not be quoted as a D=4
+    truncation error.
+
+    That re-run is done (#747 comment 4, 2026-08-05): at ``gs_recipe="2x2"``,
+    with ``corner_rank == chi`` in all seven cells, E/site = -0.6639345178 and
+    err vs QMC = +5.50e-3, superseding +6.04e-3.  That figure is itself an
+    upper bound -- its optimization was stopped at step 14, not converged.
+
+    ``"1x1"`` reproduces the old (invalid) behaviour for bisection.  See #747."""
     import jax
 
     jax.config.update("jax_enable_x64", True)


### PR DESCRIPTION
Run 2 of #747 completed on 2026-08-05 and is written up as [#747 comment 4](https://github.com/tenax-lab/tenax/issues/747), but the result never propagated to the published benchmark page.

`docs/benchmarks/d4_chi_scaling/README.md` still read:

> The residual **+0.006 vs the QMC reference −0.669437 is the D=4 variational floor**, not under-convergence.

That is precisely the claim the audit ruled out. The scanned state was optimized at `gs_recipe="1x1"`, against a CTM environment that collapses to rank-1 corners (#723/#726), so the residual mixes iPEPS truncation with a badly-optimized state. Nothing in that directory mentioned `747`, `recipe`, `1x1`, `2x2`, `collapse` or `superseded`, so a reader got the wrong number presented as settled physics.

### What changed

| | |
|---|---|
| `README.md` | superseded banner (1x1 vs 2x2 comparison), a #747 `Corrections` entry, "variational floor" replaced by upper-bound framing |
| `README.md` Files table | marks which artifacts carry superseded energies vs which are unaffected |
| `README.md` Reproduce | dropped the "seed from the committed `A_opt.pkl`" step; documents `--gs-recipe 1x1` for bisection |
| `convergence.md` | superseded banner carrying Run 2's full per-χ table |
| `heisenberg_d4_chi_scaling.py` | docstring said "until this is re-run" — it has been, so it now names the result |
| 747 handover | marks Run 2 done; corrects the Run 1 timeout budget |

### The number

| | this page (`1x1`) | Run 2 (`2x2`) |
|---|---|---|
| E/site at χ=128 | −0.6633981 | **−0.6639345178** |
| err vs QMC | +6.04e-03 | **+5.50e-03** |

Run 2 is flagged as *itself* an upper bound — its optimization stopped at step 14 with `E_best` flat for ~4 h, so neither figure is the D=4 truncation error.

### What is explicitly *not* invalidated

The forward χ-scan always ran `2x2` via `python_loop_ctm_converge` (default since #597). Only the state being scanned was bad, so `performance.md`, the multi-GPU findings, `peak_gb` and the curve's *shape* stand — the docs now say which is which instead of leaving it to the reader.

### Notes

- **Data files are unmodified.** `results.csv`, the per-cell JSONs and `A_opt.pkl` are kept as the historical record and labelled, not rewritten. Run 2's artifacts (`runs/d4_rerun_2x2/`) are on the 4070 Ti machine that produced them and are not committed here, so this PR corrects prose only.
- The dropped `cp A_opt.pkl` step matters: `optimize_once` returns immediately when it finds one, so that instruction silently re-scans the collapsed state — the mechanism by which these numbers survived to publication.
- Docs only. No `src/` change, no behaviour change. `examples/` is deliberately outside the ruff hook scope (`src|tests` only), and its 18 pre-existing lint findings are unchanged by the docstring edit.

> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.