### PR TITLE
fix(#824): report the adjoint residual on the default (fixed_point) path

### DIFF
--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -120,19 +120,55 @@ def _warn_if_adjoint_unconverged(
     The C4v sibling (#716) makes the same choice.
     """
     abs_resid, b_norm = _adjoint_residual_and_rhs_norm(matvec, lam, rhs)
+    return _warn_unconverged_adjoint_residual(
+        abs_resid,
+        b_norm,
+        tol=tol,
+        budget=(
+            f"after gmres_maxiter={maxiter} iterations of a "
+            f"{restart}-dimensional Krylov space"
+        ),
+        remedy=(
+            "Raise gmres_maxiter/gmres_restart, or loosen gmres_tol if this "
+            "residual is acceptable for your use."
+        ),
+        stacklevel=3,
+    )
+
+
+def _warn_unconverged_adjoint_residual(
+    abs_resid: float,
+    b_norm: float,
+    *,
+    tol: float,
+    budget: str,
+    remedy: str,
+    stacklevel: int = 3,
+) -> float:
+    """Gate an already-measured adjoint residual, warn on a miss, return ``rel``.
+
+    Takes ``(‖r‖, ‖b‖)`` rather than the ratio because the gate and the message
+    need different things: ``_adjoint_converged`` compares the *absolute*
+    residual against the solver's own ``max(tol·‖b‖, tol)`` threshold, while
+    the caller-facing number is the *relative* residual.  Collapsing them early
+    would reintroduce the cry-wolf gate that #807 removed — on this path
+    ``‖b‖`` is O(1) but routinely below it, so a relative-only test flags
+    solves that stopped exactly where they were told to.
+
+    Shared by both adjoint solvers so the two cannot drift apart in wording or
+    in the comparison they use; ``budget`` names what was exhausted and
+    ``remedy`` what to do about it, which is all that differs between them.
+    """
     rel = abs_resid / b_norm if b_norm > 0 else abs_resid
     if not _adjoint_converged(abs_resid, b_norm, tol):
         warnings.warn(
             f"Implicit-AD CTM: adjoint solve did not converge (relative "
-            f"residual {rel:.3e} > gmres_tol {tol:.1e} after gmres_maxiter="
-            f"{maxiter} iterations of a {restart}-dimensional Krylov space). "
+            f"residual {rel:.3e} > gmres_tol {tol:.1e} {budget}). "
             "The gradient contracts a λ that does not solve "
             "(I - Jᵀ)λ = dE/denv, so it is wrong by roughly that relative "
-            "amount and nothing downstream can tell. Raise gmres_maxiter/"
-            "gmres_restart, or loosen gmres_tol if this residual is "
-            "acceptable for your use.",
+            f"amount and nothing downstream can tell. {remedy}",
             RuntimeWarning,
-            stacklevel=2,
+            stacklevel=stacklevel,
         )
     return rel
 
@@ -811,9 +847,17 @@ def set_implicit_ad_norm_diagnostics(enabled: bool) -> bool:
 def get_last_implicit_ad_diagnostics() -> dict:
     """Snapshot of the most recent implicit-AD adjoint solve diagnostics.
 
-    Populated by the fused fixed-point backward (``adjoint_method="fixed_point"``)
-    after every gradient call.  Keys:
+    Populated by the backward after every gradient call, under either
+    ``adjoint_method``.  Keys:
 
+    * ``adjoint_residual`` -- ``||(I - J^T) lam - b|| / ||b||``.  **This is
+      the one that says whether the gradient is trustworthy**; the gradient
+      is wrong by roughly this relative amount.  Prefer it to ``converged``,
+      which reports only that the solver stopped on its own criterion -- a
+      different norm from the gate's, so it can read True at a relative
+      residual of 1e-2 (#824).  Cleared at the start of each backward, so a
+      missing key means the last solve did not measure one, not that it was
+      healthy.
     * ``converged`` -- True if the fixed-point iteration crossed
       ``gmres_tol`` within ``gmres_maxiter``.
     * ``diverged`` -- True if the in-loop divergence guard fired
@@ -1265,6 +1309,25 @@ def _make_implicit_vjp_fn(
             Final adjoint vector, shaped like ``dE_denv``.  Caller caches
             this and passes it back as ``init_lam`` on the next call to
             warm-start the Neumann iteration.
+        abs_resid, b_norm : real scalars
+            ``‖(I - Jᵀ)λ - b‖`` and ``‖b‖``, the pair ``_adjoint_converged``
+            gates on and the two the caller needs to report a relative
+            residual.  Not the loop's ``diff`` criterion, which is absolute
+            and an ℓ1-of-ℓ2 sum over leaves, so it can sit at ``gmres_tol``
+            while the residual the GMRES branch would report is orders larger
+            (#824 measured ``converged=True`` at a relative 1.5e-02).
+
+            Evaluated at ``λ_{k-1}``, one Neumann step behind the returned
+            ``λ_final``, because that is where it is free: the step difference
+            the loop already forms *is* the residual.  Measuring at
+            ``λ_final`` costs a second Jᵀ application, benchmarked at +18% on
+            the whole backward (92.6 -> 109.0 ms median, D=2 χ=8, n_iter=19)
+            against +0.04% for this form — too much for a diagnostic that has
+            to stay on by default to be worth anything.  Under the contraction
+            the loop requires (ρ(Jᵀ) < 1) the residual only shrinks, so this
+            over-reports slightly (measured 1.8x): it can raise a false alarm
+            but cannot hide a bad solve, which is the right direction for a
+            guard.
         """
         gate_ = mutables["gate"]
         energy_fn_ = mutables["energy_fn"]
@@ -1317,31 +1380,46 @@ def _make_implicit_vjp_fn(
         init_diff = jnp.array(jnp.inf, dtype=real_dtype)
         init_k = jnp.array(0, dtype=jnp.int32)
         init_diverged = jnp.array(False)
+        # Fails closed: if the body never runs (gmres_maxiter=0) this stays inf
+        # and ``_adjoint_converged`` reports not-converged rather than nothing.
+        init_resid = jnp.array(jnp.inf, dtype=real_dtype)
 
         tol_arr = jnp.array(gmres_tol, dtype=real_dtype)
         maxiter_arr = jnp.array(gmres_maxiter, dtype=jnp.int32)
 
         def cond_fn(carry):
-            _lam, prev_diff, k, diverged = carry
+            _lam, prev_diff, k, diverged, _resid = carry
             return (k < maxiter_arr) & (~diverged) & (prev_diff > tol_arr)
 
         def body_fn(carry):
-            lam, prev_diff, k, _diverged = carry
+            lam, prev_diff, k, _diverged, _resid = carry
             jt_lam = apply_Jt(lam)
             new_lam = tuple(b + j for b, j in zip(dE_denv, jt_lam))
-            diff = sum(jnp.linalg.norm(n - p) for n, p in zip(new_lam, lam)).astype(
+            delta = tuple(n - p for n, p in zip(new_lam, lam))
+            diff = sum(jnp.linalg.norm(d) for d in delta).astype(real_dtype)
+            # ‖(I - Jᵀ)λ_k - b‖ for free: the Neumann step *is* the residual,
+            #   λ_{k+1} - λ_k = b + Jᵀλ_k - λ_k = b - (I - Jᵀ)λ_k
+            # so this is one L2 over an array already formed, not a second Jᵀ
+            # application.  Kept separate from ``diff``, which is an ℓ1-of-ℓ2
+            # sum over leaves and drives the stopping criterion — the two are
+            # different norms and only this one is what the GMRES branch gates
+            # and reports (#824).
+            resid = jnp.sqrt(sum(jnp.sum(jnp.abs(d) ** 2) for d in delta)).astype(
                 real_dtype
             )
             # Divergence guard: same trigger as F2 Python loop.
             new_diverged = (diff > prev_diff) & (k > jnp.array(5, jnp.int32))
-            return (new_lam, diff, k + jnp.array(1, jnp.int32), new_diverged)
+            return (new_lam, diff, k + jnp.array(1, jnp.int32), new_diverged, resid)
 
-        lam_final, final_diff, n_iter, diverged = jax.lax.while_loop(
+        lam_final, final_diff, n_iter, diverged, abs_resid = jax.lax.while_loop(
             cond_fn,
             body_fn,
-            (init_lam_local, init_diff, init_k, init_diverged),
+            (init_lam_local, init_diff, init_k, init_diverged, init_resid),
         )
         converged = final_diff <= tol_arr
+        b_norm = jnp.sqrt(sum(jnp.sum(jnp.abs(b) ** 2) for b in dE_denv)).astype(
+            real_dtype
+        )
 
         # --- 4. Chain rule: direct dE/dparams + indirect J_p^T @ lam ---
         def energy_from_params(p_tuple):
@@ -1370,7 +1448,7 @@ def _make_implicit_vjp_fn(
         indirect = vjp_sweep_params(lam_final)[0]
 
         total = jax.tree.map(lambda d, ind: g_scalar * (d + ind), direct, indirect)
-        return (total,), diverged, converged, n_iter, lam_final
+        return (total,), diverged, converged, n_iter, lam_final, abs_resid, b_norm
 
     @partial(jax.jit, static_argnames=("chi",))
     def _jit_gmres_solve(params_data_tuple, env_leaves, rhs, *, chi):
@@ -1422,6 +1500,14 @@ def _make_implicit_vjp_fn(
         per distinct chi value visited (#516 chi-lock).
         """
         params_data_tuple, env_leaves, chi_post = residuals
+
+        # Drop the previous backward's residual before any branch can return.
+        # ``_F3_LAST_DIAGNOSTICS`` is module-global, so a path that fails to
+        # publish one would otherwise hand the caller a stale value from an
+        # unrelated solve and read as a healthy adjoint (#824).  Absent beats
+        # wrong: every branch below sets it, and if a future one forgets, the
+        # consumer sees a missing key rather than someone else's number.
+        _F3_LAST_DIAGNOSTICS.pop("adjoint_residual", None)
 
         # ``adjoint_residual`` is written only where an eager solve actually
         # runs.  Clear it first so a fused fixed-point backward that never
@@ -1522,6 +1608,8 @@ def _make_implicit_vjp_fn(
                 _converged,
                 _n_iter,
                 lam_final,
+                _abs_resid,
+                _b_norm,
             ) = _jit_fused_fixed_point_bwd(
                 params_data_tuple, env_leaves, g, init_lam, chi=chi_post
             )
@@ -1529,6 +1617,11 @@ def _make_implicit_vjp_fn(
             _F3_LAST_DIAGNOSTICS["converged"] = bool(jax.device_get(_converged))
             _F3_LAST_DIAGNOSTICS["n_iter"] = int(jax.device_get(_n_iter))
             _F3_LAST_DIAGNOSTICS["warm_start_invalidated"] = invalidated_by_shape
+            _abs_resid = float(jax.device_get(_abs_resid))
+            _b_norm = float(jax.device_get(_b_norm))
+            _F3_LAST_DIAGNOSTICS["adjoint_residual"] = (
+                _abs_resid / _b_norm if _b_norm > 0 else _abs_resid
+            )
             # Adjoint-amplification diagnostic: ||lam_final|| vs ||init_lam||.
             # Large ratios point to (I - J^T) being near-singular (typical at
             # chi-ceiling with degenerate retained SVs in the frozen
@@ -1621,6 +1714,28 @@ def _make_implicit_vjp_fn(
                 return _jit_chain_rule(
                     params_data_tuple, env_leaves, lam_leaves, g, chi=chi_post
                 )
+            # The fused loop stopped on its own criterion, so no fallback ran
+            # and nothing above has checked whether the system was actually
+            # solved.  That criterion is a different norm from the one the
+            # gate uses, so ``converged=True`` does not imply the residual
+            # cleared it (#824: converged=True at a relative 1.5e-02).
+            # Without this the default adjoint path returns a gradient wrong
+            # by percent with no residual, no warning, and a converged flag.
+            _warn_unconverged_adjoint_residual(
+                _abs_resid,
+                _b_norm,
+                tol=gmres_tol,
+                budget=(
+                    f"after {_F3_LAST_DIAGNOSTICS['n_iter']} Neumann "
+                    "iterations of the fused fixed-point loop, which stopped "
+                    "on its own step-size criterion"
+                ),
+                remedy=(
+                    "Raise gmres_maxiter, tighten gmres_tol, or switch to "
+                    "adjoint_method='gmres'."
+                ),
+                stacklevel=2,
+            )
             _cached["prev_lam_leaves"] = tuple(jax.tree.leaves(lam_final))
             return grads_tuple
         else:

--- a/src/tenax/algorithms/_ctm_energy_ad.py
+++ b/src/tenax/algorithms/_ctm_energy_ad.py
@@ -118,57 +118,28 @@ def _warn_if_adjoint_unconverged(
     an iPEPS optimization that aborts mid-run on one bad backward is usually
     worse for the caller than one that continues with a warned-about gradient.
     The C4v sibling (#716) makes the same choice.
+
+    The fused fixed-point branch does not come through here.  It cannot: this
+    *measures* the residual with an extra matvec, and that branch already has
+    the residual for free (its Neumann step is the residual) while an extra
+    matvec would cost it +18% of the backward.  It also does not need the
+    warning — see ``_jit_fused_fixed_point_bwd``, where reaching the caller at
+    all implies the residual already cleared ``tol``.
     """
     abs_resid, b_norm = _adjoint_residual_and_rhs_norm(matvec, lam, rhs)
-    return _warn_unconverged_adjoint_residual(
-        abs_resid,
-        b_norm,
-        tol=tol,
-        budget=(
-            f"after gmres_maxiter={maxiter} iterations of a "
-            f"{restart}-dimensional Krylov space"
-        ),
-        remedy=(
-            "Raise gmres_maxiter/gmres_restart, or loosen gmres_tol if this "
-            "residual is acceptable for your use."
-        ),
-        stacklevel=3,
-    )
-
-
-def _warn_unconverged_adjoint_residual(
-    abs_resid: float,
-    b_norm: float,
-    *,
-    tol: float,
-    budget: str,
-    remedy: str,
-    stacklevel: int = 3,
-) -> float:
-    """Gate an already-measured adjoint residual, warn on a miss, return ``rel``.
-
-    Takes ``(‖r‖, ‖b‖)`` rather than the ratio because the gate and the message
-    need different things: ``_adjoint_converged`` compares the *absolute*
-    residual against the solver's own ``max(tol·‖b‖, tol)`` threshold, while
-    the caller-facing number is the *relative* residual.  Collapsing them early
-    would reintroduce the cry-wolf gate that #807 removed — on this path
-    ``‖b‖`` is O(1) but routinely below it, so a relative-only test flags
-    solves that stopped exactly where they were told to.
-
-    Shared by both adjoint solvers so the two cannot drift apart in wording or
-    in the comparison they use; ``budget`` names what was exhausted and
-    ``remedy`` what to do about it, which is all that differs between them.
-    """
     rel = abs_resid / b_norm if b_norm > 0 else abs_resid
     if not _adjoint_converged(abs_resid, b_norm, tol):
         warnings.warn(
             f"Implicit-AD CTM: adjoint solve did not converge (relative "
-            f"residual {rel:.3e} > gmres_tol {tol:.1e} {budget}). "
+            f"residual {rel:.3e} > gmres_tol {tol:.1e} after gmres_maxiter="
+            f"{maxiter} iterations of a {restart}-dimensional Krylov space). "
             "The gradient contracts a λ that does not solve "
             "(I - Jᵀ)λ = dE/denv, so it is wrong by roughly that relative "
-            f"amount and nothing downstream can tell. {remedy}",
+            "amount and nothing downstream can tell. Raise gmres_maxiter/"
+            "gmres_restart, or loosen gmres_tol if this residual is "
+            "acceptable for your use.",
             RuntimeWarning,
-            stacklevel=stacklevel,
+            stacklevel=2,
         )
     return rel
 
@@ -850,14 +821,15 @@ def get_last_implicit_ad_diagnostics() -> dict:
     Populated by the backward after every gradient call, under either
     ``adjoint_method``.  Keys:
 
-    * ``adjoint_residual`` -- ``||(I - J^T) lam - b|| / ||b||``.  **This is
-      the one that says whether the gradient is trustworthy**; the gradient
-      is wrong by roughly this relative amount.  Prefer it to ``converged``,
-      which reports only that the solver stopped on its own criterion -- a
-      different norm from the gate's, so it can read True at a relative
-      residual of 1e-2 (#824).  Cleared at the start of each backward, so a
-      missing key means the last solve did not measure one, not that it was
-      healthy.
+    * ``adjoint_residual`` -- ``||(I - J^T) lam - b|| / ||b||``, the relative
+      residual of the adjoint solve, on both ``adjoint_method`` values and in
+      the same norm, so the two are comparable.  Roughly how wrong the
+      gradient is.  On the fused fixed-point path it is the residual of the
+      penultimate Neumann iterate (see ``_jit_fused_fixed_point_bwd``) and is
+      always at most ``gmres_tol`` -- read it as the tolerance actually
+      achieved, not as a certificate for the returned ``lam``.  Cleared at
+      the start of each backward, so a missing key means the last solve did
+      not measure one rather than that it was healthy.
     * ``converged`` -- True if the fixed-point iteration crossed
       ``gmres_tol`` within ``gmres_maxiter``.
     * ``diverged`` -- True if the in-loop divergence guard fired
@@ -1310,24 +1282,32 @@ def _make_implicit_vjp_fn(
             this and passes it back as ``init_lam`` on the next call to
             warm-start the Neumann iteration.
         abs_resid, b_norm : real scalars
-            ``‖(I - Jᵀ)λ - b‖`` and ``‖b‖``, the pair ``_adjoint_converged``
-            gates on and the two the caller needs to report a relative
-            residual.  Not the loop's ``diff`` criterion, which is absolute
-            and an ℓ1-of-ℓ2 sum over leaves, so it can sit at ``gmres_tol``
-            while the residual the GMRES branch would report is orders larger
-            (#824 measured ``converged=True`` at a relative 1.5e-02).
+            ``‖(I - Jᵀ)λ_{k-1} - b‖`` and ``‖b‖`` — the loop's own convergence
+            measure, in the plain ℓ2 the GMRES branch reports, so the two
+            solvers' ``adjoint_residual`` diagnostics are comparable.  The
+            loop's ``diff`` is the *same step vector* in an ℓ1-of-ℓ2 sum over
+            leaves; reporting that instead would not be comparable to
+            anything.
 
-            Evaluated at ``λ_{k-1}``, one Neumann step behind the returned
-            ``λ_final``, because that is where it is free: the step difference
-            the loop already forms *is* the residual.  Measuring at
-            ``λ_final`` costs a second Jᵀ application, benchmarked at +18% on
-            the whole backward (92.6 -> 109.0 ms median, D=2 χ=8, n_iter=19)
-            against +0.04% for this form — too much for a diagnostic that has
-            to stay on by default to be worth anything.  Under the contraction
-            the loop requires (ρ(Jᵀ) < 1) the residual only shrinks, so this
-            over-reports slightly (measured 1.8x): it can raise a false alarm
-            but cannot hide a bad solve, which is the right direction for a
-            guard.
+            Free because the Neumann step *is* the residual,
+
+                λ_{k+1} - λ_k = b + Jᵀλ_k - λ_k = b - (I - Jᵀ)λ_k
+
+            so this is one ℓ2 over an array the loop already forms.  It is
+            therefore the residual of ``λ_{k-1}``, one step behind the
+            returned ``λ_final``, whose residual is ``‖Jᵀ(λ_k - λ_{k-1})‖``.
+            **That is not bounded by this one**: ρ(Jᵀ) < 1 gives asymptotic
+            decay, not a monotone norm, and Jᵀ here is non-normal, so a
+            transient-growth step can make the returned iterate's residual
+            larger than the reported one.  Measuring at ``λ_final`` would need
+            a second Jᵀ application, benchmarked at +18% of the whole backward
+            (92.6 -> 109.0 ms median, D=2 χ=8, n_iter=19) against +0.04% for
+            this form.
+
+            Read it as "the tolerance the loop actually achieved", not as a
+            certificate for ``λ_final``.  It is not load-bearing for
+            correctness: nothing gates on it, and the branch that returns it
+            has already met ``diff <= gmres_tol`` (see the caller).
         """
         gate_ = mutables["gate"]
         energy_fn_ = mutables["energy_fn"]
@@ -1714,28 +1694,16 @@ def _make_implicit_vjp_fn(
                 return _jit_chain_rule(
                     params_data_tuple, env_leaves, lam_leaves, g, chi=chi_post
                 )
-            # The fused loop stopped on its own criterion, so no fallback ran
-            # and nothing above has checked whether the system was actually
-            # solved.  That criterion is a different norm from the one the
-            # gate uses, so ``converged=True`` does not imply the residual
-            # cleared it (#824: converged=True at a relative 1.5e-02).
-            # Without this the default adjoint path returns a gradient wrong
-            # by percent with no residual, no warning, and a converged flag.
-            _warn_unconverged_adjoint_residual(
-                _abs_resid,
-                _b_norm,
-                tol=gmres_tol,
-                budget=(
-                    f"after {_F3_LAST_DIAGNOSTICS['n_iter']} Neumann "
-                    "iterations of the fused fixed-point loop, which stopped "
-                    "on its own step-size criterion"
-                ),
-                remedy=(
-                    "Raise gmres_maxiter, tighten gmres_tol, or switch to "
-                    "adjoint_method='gmres'."
-                ),
-                stacklevel=2,
-            )
+            # No convergence warning here, and it would be dead code if there
+            # were one.  Reaching this line means the loop set ``converged``,
+            # i.e. ``diff <= gmres_tol``; ``diff`` is the ell1-of-ell2 sum over
+            # leaves of the same step vector whose plain ell2 is ``_abs_resid``,
+            # and ||v||_2 <= ||v||_1, so ``_abs_resid <= gmres_tol`` always.
+            # The gate's threshold is ``max(tol*||b||, tol) >= tol``, so it can
+            # never fire on this branch.  The fused loop's stopping criterion
+            # *is* a residual criterion -- what it lacked was reporting, not a
+            # guard.  Pinned by
+            # test_the_fused_happy_path_is_residual_gated_by_construction.
             _cached["prev_lam_leaves"] = tuple(jax.tree.leaves(lam_final))
             return grads_tuple
         else:

--- a/src/tenax/algorithms/ipeps_optimize.py
+++ b/src/tenax/algorithms/ipeps_optimize.py
@@ -3413,6 +3413,12 @@ def _optimize_gs_ad_tensor_2site(
                 # amplification so chi-ceiling collapse runs (e.g. v9d/v9h)
                 # have a smoking-gun trace.  Populated by the fused fixed-point
                 # backward; empty dict on the explicit-AD path.
+                #
+                # ``resid`` is the one to read: ``converged`` reports only
+                # that the solver hit its own stopping criterion, which is a
+                # different norm from the gate's and so can be True while the
+                # relative residual is 1e-2 (#824).  Unlike ||lam||/amp it is
+                # not gated on _F3_DIAG_COMPUTE_NORMS, so it is always real.
                 if config.gs_implicit_ad:
                     from tenax.algorithms._ctm_energy_ad import (
                         get_last_implicit_ad_diagnostics,
@@ -3424,6 +3430,7 @@ def _optimize_gs_ad_tensor_2site(
                             f"[iPEPS-AD:2site-tensor] step {step + 1}/{config.gs_num_steps} "
                             f"GMRES n_iter={_diag.get('n_iter', '?')} "
                             f"converged={_diag.get('converged', '?')} "
+                            f"resid={_diag.get('adjoint_residual', float('nan')):.3e} "
                             f"diverged={_diag.get('diverged', '?')} "
                             f"||lam||={_diag.get('lam_norm', float('nan')):.3e} "
                             f"amp={_diag.get('amplification', float('nan')):.3e}",

--- a/tests/test_adjoint_convergence_gate.py
+++ b/tests/test_adjoint_convergence_gate.py
@@ -335,40 +335,35 @@ def test_the_fixed_point_residual_tracks_the_tolerance():
     )
 
 
-def test_the_shared_warning_helper_gates_on_the_solver_criterion():
-    """Both solvers must reach the gate through one code path.
+def test_the_fused_happy_path_is_residual_gated_by_construction():
+    """Why the fused branch carries no convergence warning: it cannot need one.
 
-    The fused branch cannot reuse ``_warn_if_adjoint_unconverged`` — that one
-    *measures* the residual with an extra matvec, which is the +18% the fused
-    path exists to avoid.  It shares the gate instead, so a second copy of the
-    ``max(tol·‖b‖, tol)`` comparison (and of the #796 NaN handling) never gets
-    written.
+    Returning to the caller means the loop set ``converged``, i.e.
+    ``diff <= gmres_tol``.  ``diff`` is the ell1-of-ell2 sum over leaves of the
+    same step vector whose plain ell2 is the published residual, and
+    ``||v||_2 <= ||v||_1``, so the residual is always at most ``gmres_tol``
+    while the gate's threshold is ``max(tol*||b||, tol) >= tol``.  A warning
+    there would be unreachable code that reads like a guard.
+
+    Pinned as a property rather than argued in a comment: if someone changes
+    the loop's stopping criterion so it no longer implies the residual bound,
+    this fails and the branch genuinely does need a gate again.
     """
-    from tenax.algorithms._ctm_energy_ad import (
-        _warn_unconverged_adjoint_residual,
-    )
-
-    kw = {"budget": "after 18 Neumann iterations", "remedy": "x"}
-
-    # Genuine miss: ‖r‖ = 1.5e-2 against ‖b‖ = 1 and tol = 1e-6.
-    with pytest.warns(RuntimeWarning, match="adjoint solve did not converge"):
-        rel = _warn_unconverged_adjoint_residual(1.5e-2, 1.0, tol=1e-6, **kw)
-    assert rel == pytest.approx(1.5e-2)
-
-    # Healthy solve stays silent, or the guard is noise.
-    with warnings.catch_warnings(record=True) as rec:
-        warnings.simplefilter("always")
-        _warn_unconverged_adjoint_residual(1e-9, 1.0, tol=1e-6, **kw)
-    assert not rec, [str(w.message) for w in rec]
-
-    # Small ‖b‖: the solver's atol floor applies, so this is NOT a miss even
-    # though ‖r‖/‖b‖ = 1e-4 exceeds tol.  Sharing the gate is what gets this
-    # right; a relative-only test here would cry wolf (#807).
-    with warnings.catch_warnings(record=True) as rec:
-        warnings.simplefilter("always")
-        _warn_unconverged_adjoint_residual(1e-7, 1e-3, tol=1e-6, **kw)
-    assert not rec, [str(w.message) for w in rec]
-
-    # Fails closed on a non-finite residual, same as the eager branch (#796).
-    with pytest.warns(RuntimeWarning, match="adjoint solve did not converge"):
-        _warn_unconverged_adjoint_residual(float("nan"), 1.0, tol=1e-6, **kw)
+    A, H = _random_peps(), _heisenberg_gate()
+    for tol in (1e-4, 1e-6, 1e-8):
+        _grad(
+            A,
+            H,
+            maxiter=200,
+            restart=20,
+            tol=tol,
+            method="fixed_point",
+            ctm_max_iter=200,
+        )
+        diag = get_last_implicit_ad_diagnostics()
+        assert diag.get("converged") is True, (tol, diag)
+        assert diag["adjoint_residual"] <= tol, (
+            f"published residual {diag['adjoint_residual']:.3e} exceeds "
+            f"gmres_tol {tol:.1e} on the happy path — the branch now needs "
+            "the convergence gate that was removed as unreachable"
+        )

--- a/tests/test_adjoint_convergence_gate.py
+++ b/tests/test_adjoint_convergence_gate.py
@@ -21,13 +21,18 @@ residual has to be measured.
 
 from __future__ import annotations
 
+import warnings
+
 import jax
 import jax.numpy as jnp
 import pytest
 
 jax.config.update("jax_enable_x64", True)
 
-from tenax.algorithms._ctm_energy_ad import ctm_energy_implicit
+from tenax.algorithms._ctm_energy_ad import (
+    ctm_energy_implicit,
+    get_last_implicit_ad_diagnostics,
+)
 from tenax.algorithms._ctm_tensor_convergence import SINGLE_SITE_NEIGHBORS
 from tenax.algorithms.ipeps_optimize import _wrap_as_dense_tensor
 
@@ -105,7 +110,6 @@ def test_a_converged_gmres_adjoint_is_silent():
     coin flip rather than a property of the guard.
     """
     A, H = _random_peps(), _heisenberg_gate()
-    import warnings
 
     with warnings.catch_warnings(record=True) as rec:
         warnings.simplefilter("always")
@@ -219,21 +223,24 @@ def test_a_non_finite_rhs_norm_cannot_make_the_threshold_swallow_the_residual():
     assert _adjoint_converged(1e-9, float("nan"), 1e-6) is False
 
 
-def test_a_successful_fixed_point_backward_clears_a_stale_residual():
+def test_a_successful_fixed_point_backward_replaces_a_stale_residual():
     """Diagnostics must describe the latest solve, not a previous one.
 
-    ``adjoint_residual`` is written only on the eager paths.  Without an
-    explicit reset, a later successful fused fixed-point backward leaves the
-    old value in place, so a consumer reads a failed solve's residual next to
-    the current solve's ``converged=True``.
+    Originally pinned as "the fused path clears the key", because that path
+    measured nothing and absent was the best it could do.  It now measures its
+    own residual (#824), so the same requirement is met more strongly: the
+    value describes *this* solve rather than merely not describing the last
+    one.  The assertion tracks that — what must never happen is the previous
+    solve's number sitting next to this solve's ``converged=True``.
     """
     from tenax.algorithms import _ctm_energy_ad as M
 
     A, H = _random_peps(), _heisenberg_gate()
-    # Starve the budget so the eager fallback runs and records a residual.
+    # Starve the budget so the eager fallback runs and records a bad residual.
     with pytest.warns(RuntimeWarning):
         _grad(A, H, maxiter=1, restart=1, tol=1e-14)
-    assert M._F3_LAST_DIAGNOSTICS.get("adjoint_residual") is not None
+    starved = M._F3_LAST_DIAGNOSTICS.get("adjoint_residual")
+    assert starved is not None and starved > 1e-8, starved
 
     # Now a healthy fixed-point backward: the stale value must not survive it.
     # Converged forward (see _grad) so "healthy" is a fact, not a coin flip.
@@ -246,9 +253,122 @@ def test_a_successful_fixed_point_backward_clears_a_stale_residual():
         method="fixed_point",
         ctm_max_iter=200,
     )
-    stale = M._F3_LAST_DIAGNOSTICS.get("adjoint_residual")
-    assert stale is None, (
-        f"stale adjoint_residual={stale} survived a successful fixed-point "
+    fresh = M._F3_LAST_DIAGNOSTICS.get("adjoint_residual")
+    assert fresh is not None, (
+        "the fused fixed-point backward published no residual at all; a "
+        "consumer cannot distinguish that from a solve it never ran"
+    )
+    assert fresh != starved, (
+        f"stale adjoint_residual={starved} survived a successful fixed-point "
         "backward; get_last_implicit_ad_diagnostics() would report it "
         "alongside converged=True for a different solve"
     )
+    assert fresh < 1e-5, f"healthy solve reported residual {fresh}"
+
+
+# --- #824: the fused fixed-point happy path -------------------------------
+
+
+def test_the_fixed_point_happy_path_publishes_a_residual():
+    """The default solver must report a residual when it *succeeds*, too.
+
+    ``test_the_default_fixed_point_path_is_covered_too`` above only reaches
+    the eager-GMRES fallback — it starves the budget so the fused loop fails.
+    When that loop stops on its own criterion it returns straight to the
+    caller, and before #824 that path measured nothing: no residual, no
+    warning, ``converged=True``.  Since it is the default ``adjoint_method``
+    that was the hole covering the majority of real backward calls, and #824
+    measured it returning a gradient wrong by 3e-3 on CUDA under exactly that
+    clean bill of health.
+    """
+    A, H = _random_peps(), _heisenberg_gate()
+    _grad(
+        A,
+        H,
+        maxiter=200,
+        restart=20,
+        tol=1e-6,
+        method="fixed_point",
+        ctm_max_iter=200,
+    )
+
+    diag = get_last_implicit_ad_diagnostics()
+    assert diag.get("converged") is True, (
+        "precondition: this test must exercise the fused happy path, not the "
+        f"eager fallback (diagnostics={diag})"
+    )
+    assert "adjoint_residual" in diag, (
+        "the fused fixed-point loop returned without publishing a residual; "
+        f"diagnostics={diag}"
+    )
+    assert diag["adjoint_residual"] < 1e-5, diag
+
+
+def test_the_fixed_point_residual_tracks_the_tolerance():
+    """Pins that the number is measured, not a constant.
+
+    A hardcoded ``0.0`` — or an alias of the loop's own ``diff``, which is a
+    different norm — passes the presence check above.  Stopping the Neumann
+    iteration earlier via a looser ``gmres_tol`` has to show up as a *larger*
+    reported residual, which only holds if ``‖(I - Jᵀ)λ - b‖/‖b‖`` is really
+    being evaluated.
+    """
+    A, H = _random_peps(), _heisenberg_gate()
+    seen = {}
+    for tol in (1e-2, 1e-8):
+        _grad(
+            A,
+            H,
+            maxiter=200,
+            restart=20,
+            tol=tol,
+            method="fixed_point",
+            ctm_max_iter=200,
+        )
+        diag = get_last_implicit_ad_diagnostics()
+        assert diag.get("converged") is True, (tol, diag)
+        seen[tol] = diag["adjoint_residual"]
+
+    assert seen[1e-2] > seen[1e-8], (
+        f"residual did not respond to gmres_tol: {seen} — it is not being "
+        "measured at the returned λ"
+    )
+
+
+def test_the_shared_warning_helper_gates_on_the_solver_criterion():
+    """Both solvers must reach the gate through one code path.
+
+    The fused branch cannot reuse ``_warn_if_adjoint_unconverged`` — that one
+    *measures* the residual with an extra matvec, which is the +18% the fused
+    path exists to avoid.  It shares the gate instead, so a second copy of the
+    ``max(tol·‖b‖, tol)`` comparison (and of the #796 NaN handling) never gets
+    written.
+    """
+    from tenax.algorithms._ctm_energy_ad import (
+        _warn_unconverged_adjoint_residual,
+    )
+
+    kw = {"budget": "after 18 Neumann iterations", "remedy": "x"}
+
+    # Genuine miss: ‖r‖ = 1.5e-2 against ‖b‖ = 1 and tol = 1e-6.
+    with pytest.warns(RuntimeWarning, match="adjoint solve did not converge"):
+        rel = _warn_unconverged_adjoint_residual(1.5e-2, 1.0, tol=1e-6, **kw)
+    assert rel == pytest.approx(1.5e-2)
+
+    # Healthy solve stays silent, or the guard is noise.
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        _warn_unconverged_adjoint_residual(1e-9, 1.0, tol=1e-6, **kw)
+    assert not rec, [str(w.message) for w in rec]
+
+    # Small ‖b‖: the solver's atol floor applies, so this is NOT a miss even
+    # though ‖r‖/‖b‖ = 1e-4 exceeds tol.  Sharing the gate is what gets this
+    # right; a relative-only test here would cry wolf (#807).
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        _warn_unconverged_adjoint_residual(1e-7, 1e-3, tol=1e-6, **kw)
+    assert not rec, [str(w.message) for w in rec]
+
+    # Fails closed on a non-finite residual, same as the eager branch (#796).
+    with pytest.warns(RuntimeWarning, match="adjoint solve did not converge"):
+        _warn_unconverged_adjoint_residual(float("nan"), 1.0, tol=1e-6, **kw)


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Closes the *reporting* half of #824: `adjoint_method="fixed_point"` is the **default**, and its fused Neumann loop returned to the caller without publishing any residual. Only the eager-GMRES fallback recorded one, so on the default path `get_last_implicit_ad_diagnostics()` handed back either nothing or — worse — a stale value from an unrelated earlier solve, sitting next to this solve's `converged=True`.

`_adjoint_residual_and_rhs_norm`'s own docstring already states the intent — *"cheap enough to run unconditionally, which is the point: a diagnostic that has to be switched on does not catch the run that needed it."* The fused path just did not honour it.

## Measuring it for free

In a Neumann iteration the step difference **is** the residual:

```
λ_{k+1} − λ_k  =  b + Jᵀλ_k − λ_k  =  b − (I − Jᵀ)λ_k
```

and the loop already forms that difference to test its stopping criterion. One ℓ2 over an existing array, no second Jᵀ.

| | median | min |
|---|---|---|
| baseline (no measurement) | 92.63 ms | 85.40 ms |
| **this PR** | **92.67 ms** | **85.46 ms** |
| measuring at `λ_final` (2nd Jᵀ) | 109.03 ms | 106.95 ms |

**+0.04% instead of +18%** (D=2 χ=8, n_iter=19, 30 reps, matched runs). 18% is half of what F3 was landed to win.

The consequence is that the number is the residual of the *penultimate* iterate. It is documented as **the tolerance the loop achieved**, explicitly not a certificate for the returned λ — see the review thread below; an earlier revision claimed a safety property here that does not hold for a non-normal `Jᵀ`.

## What this does *not* do

**It adds no new guard, because the branch cannot need one.** Reaching the caller requires `converged`, i.e. `diff <= gmres_tol`; `diff` is `Σ_leaves ‖d_i‖₂` while the published residual is the plain ℓ2 of the *same* step vector, and `‖v‖₂ ≤ ‖v‖₁`, so `abs_resid ≤ diff ≤ tol` — against a gate threshold of `max(tol·‖b‖, tol) ≥ tol`.

The first revision of this PR added a warning there anyway. It was unreachable, and Codex caught it. Removed; `test_the_fused_happy_path_is_residual_gated_by_construction` pins the implication instead, so a future change to the stopping criterion that breaks it fails a test rather than silently reopening the hole.

The corollary is worth stating plainly, since it corrects the framing of #824 itself: **the fused loop's stopping criterion already is a residual criterion**, in a different norm and unreported. That branch was never silently returning an unconverged solve.

**It would not have caught #824's CUDA failure.** That is not an unconverged solve — both backends solve their own system accurately, and the systems differ because the GPU environment is rank-deficient. No residual on either path detects that. The primary #824 defect is untouched here.

## Staleness

`adjoint_residual` is now popped at the top of every backward, so a branch that fails to publish reads as *absent* rather than as an unrelated solve's healthy 1e-14.

**This modifies a test that landed in #807.** `test_a_successful_fixed_point_backward_clears_a_stale_residual` pinned "the fused path clears the key" — the best available property when that path measured nothing. It now measures its own, so the requirement is met more strongly: the value describes *this* solve. Renamed to `..._replaces_a_stale_residual`; what must never happen — the previous solve's number next to this solve's `converged=True` — is still pinned.

## Tests

Four new, **mutation count 4/4** against `origin/main`:

- `test_the_fixed_point_happy_path_publishes_a_residual` — the fused success path, which no existing test reached (`test_the_default_fixed_point_path_is_covered_too` starves the budget and so only exercises the fallback).
- `test_the_fixed_point_residual_tracks_the_tolerance` — pins that the number is *measured*. A hardcoded `0.0`, or an alias of `diff`, passes the presence check but fails this.
- `test_the_fused_happy_path_is_residual_gated_by_construction` — the invariant above, across three tolerances.
- the rewritten `..._replaces_a_stale_residual`.

All follow #807's `ctm_max_iter` lesson: tests that assert *health* raise the forward sweep count, so they are not asserting silence about a genuinely unconverged forward — the thing that was CPU-green and CUDA-red.

**Suite: 67 passed, 1 failed.** The failure is the pre-existing CPU bug now tracked as #827, still at `diff=0.0001368256107568966` — byte-identical, confirming no numerics changed. The loop's stopping criterion is untouched. Zero warnings on healthy solves.

## Also

`get_last_implicit_ad_diagnostics()` never documented `adjoint_residual` at all, and the optimizer's per-step log printed `converged=` without it — the one place a human actually watches. Both fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
