### PR TITLE
fix(#828): delete the stale duplicate of arnoldi_spectral_radius

### DIFF
--- a/src/tenax/algorithms/ad_utils.py
+++ b/src/tenax/algorithms/ad_utils.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import logging
 import math
 import warnings
-from collections.abc import Callable
 from functools import partial
 
 import jax
@@ -44,6 +43,9 @@ from tenax.algorithms._ad_primitives import (
 )
 from tenax.algorithms._ad_primitives import (
     truncated_svd_symmetric_ad as truncated_svd_symmetric_ad,
+)
+from tenax.algorithms._arnoldi import (
+    arnoldi_spectral_radius as arnoldi_spectral_radius,
 )
 from tenax.algorithms._ctm_tensor import (
     CTMTensorEnv,
@@ -187,52 +189,6 @@ def _transfer_matrix_leading_eigvec(T_dense: jax.Array, n_iter: int = 30) -> jax
         v = v / (jnp.linalg.norm(v) + 1e-30)
 
     return v.real.reshape(chi, chi)
-
-
-def arnoldi_spectral_radius(
-    matvec: Callable[[jnp.ndarray], jnp.ndarray],
-    v0: jnp.ndarray,
-    n_iter: int = 20,
-) -> float:
-    """Estimate the spectral radius of a linear operator via Arnoldi iteration.
-
-    Builds an (n_iter x n_iter) upper Hessenberg matrix H from the Krylov
-    subspace {v0, A v0, A^2 v0, ...} using Modified Gram-Schmidt, then
-    returns max |eigenvalue(H)| as an approximation to rho(A).
-
-    Args:
-        matvec: Function applying the operator (e.g. J^T) to a flat vector.
-        v0: Initial vector (typically the gradient g, flattened).
-        n_iter: Number of Arnoldi iterations (default 20).
-
-    Returns:
-        Estimated spectral radius rho(A).
-    """
-    n = v0.shape[0]
-    k = min(n_iter, n)
-    Q = jnp.zeros((n, k + 1))
-    H = jnp.zeros((k + 1, k))
-
-    q = v0 / (jnp.linalg.norm(v0) + 1e-30)
-    Q = Q.at[:, 0].set(q)
-
-    actual_k = k
-    for j in range(k):
-        v = matvec(Q[:, j])
-        for i in range(j + 1):
-            h = jnp.dot(Q[:, i], v)
-            H = H.at[i, j].set(h)
-            v = v - h * Q[:, i]
-        h_next = jnp.linalg.norm(v)
-        H = H.at[j + 1, j].set(h_next)
-        if h_next < 1e-14:
-            actual_k = j + 1
-            break
-        Q = Q.at[:, j + 1].set(v / h_next)
-
-    H_k = H[:actual_k, :actual_k]
-    eigenvalues = jnp.linalg.eigvals(H_k)
-    return float(jnp.max(jnp.abs(eigenvalues)))
 
 
 def _sigma_gauge_fix_ctm_tensor(env_new, env_old):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,13 @@ _FILE_MARKERS = {
     # The bucket guard itself (#805). Pure filesystem inspection, microseconds,
     # and it must run in the gate it protects or it protects nothing.
     "test_bucket_registry.py": "core",
+    # Arnoldi spectral-radius estimator: the divergence precheck for the
+    # explicit-AD CTM backward (``if rho >= threshold: raise``).  Pure linear
+    # algebra on 3x3 matrices, ~1s for the file.  Bucketed out of
+    # _UNBUCKETED_LEGACY because #828 was a live defect here -- a stale
+    # duplicate under-reported rho on complex input, so the guard passed a
+    # divergent adjoint -- and a guard that runs in no required job is not one.
+    "test_arnoldi.py": "core",
     # The adjoint-convergence gate on the DEFAULT iPEPS AD gradient path
     # (#801, first raised on #341).  An unconverged adjoint yields a gradient
     # that is wrong, finite, and indistinguishable downstream -- the exact
@@ -244,7 +251,6 @@ _UNBUCKETED_LEGACY = {
     "test_ad_primitives_rank_aware.py",
     "test_apply_chi_bump.py",
     "test_architecture_imports.py",
-    "test_arnoldi.py",
     "test_block_sparse_ctm_ad.py",
     "test_c4v_reference_ad.py",
     "test_chi_ramp_chi_auto_bump_deprecation.py",

--- a/tests/test_arnoldi.py
+++ b/tests/test_arnoldi.py
@@ -49,3 +49,38 @@ def test_pytree_matvec():
     v0 = (jnp.ones(3), jnp.ones(4))
     rho = arnoldi_spectral_radius_pytree(matvec, v0, n_iter=20)
     assert 0.85 < rho < 0.95, f"Expected rho ~ 0.9, got {rho}"
+
+
+# --- #828: there must be exactly one implementation ------------------------
+
+
+def test_ad_utils_reexports_the_reviewed_implementation():
+    """``ad_utils`` must not carry its own copy of this function.
+
+    It did, and the copy was wrong on complex input: real Krylov buffers and an
+    unconjugated ``jnp.dot`` for the Gram-Schmidt projection.  The explicit-AD
+    CTM backward calls it as a *divergence precheck* -- ``if rho >= threshold:
+    raise CTMRGGradientError`` -- so under-reporting rho passes a divergent
+    adjoint through the guard that exists to catch it.
+
+    Pinned as an identity rather than a value check: a future edit that
+    reintroduces a local definition fails here even if it happens to be
+    correct, because two copies is the defect (#828, and #829 the same week).
+    """
+    from tenax.algorithms import _arnoldi, ad_utils
+
+    assert ad_utils.arnoldi_spectral_radius is _arnoldi.arnoldi_spectral_radius
+
+
+def test_the_explicit_ad_entry_point_is_correct_on_complex_input():
+    """The symptom #828 was filed for, at the name the backward actually calls.
+
+    ``diag(2i, 1, 0.5)`` has rho = 2 unambiguously.  The stale copy returned
+    0.972 -- below even the rho >= 1 divergence line.
+    """
+    from tenax.algorithms.ad_utils import arnoldi_spectral_radius as rho_fn
+
+    A = jnp.diag(jnp.array([2j, 1.0 + 0j, 0.5 + 0j]))
+    v0 = jnp.array([1.0 + 1j, 0.3 - 0.2j, 0.1 + 0.4j])
+    rho = rho_fn(lambda v: A @ v, v0, n_iter=3)
+    assert abs(rho - 2.0) < 1e-9, f"expected rho = 2.0, got {rho}"


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Fixes #828. `arnoldi_spectral_radius` existed **twice**, and the explicit-AD backward called the wrong one.

| | buffers | orthogonalisation | called by |
|---|---|---|---|
| `algorithms/_arnoldi.py` | `dtype=v0.dtype` | `jnp.vdot` | implicit AD |
| `algorithms/ad_utils.py` | `jnp.zeros(...)` — **real** | `jnp.dot` — **unconjugated** | explicit AD |

```
true rho (diag(2i, 1, 0.5))  = 2.0
_arnoldi.py                  = 2.000000000000
ad_utils.py                  = 0.972398244785

ComplexWarning: Casting complex values to real discards the imaginary part
FutureWarning: ... In future JAX releases this will result in an error.
```

Real inputs were unaffected (`jnp.zeros` is fine, `dot == vdot` when everything is real), which is exactly why it survived — every real-tensor run exercised it correctly.

## Why it mattered

That call site is the divergence precheck for `_ctm_tensor_converge_bwd`:

```python
rho = arnoldi_spectral_radius(_flat_matvec, g_flat, n_iter=20)
if rho >= arnoldi_threshold:
    raise CTMRGGradientError(spectral_radius=rho)
```

`adjoint_arnoldi_precheck` defaults to `True`. So on complex tensors the guard whose job is to refuse a divergent adjoint was under-reporting `rho` past its own `rho >= 1` line. Complex `DenseTensor` support was fixed rather than gated (#722 via #724), so this was reachable, not theoretical.

## Deleted, not patched

Two copies **is** the defect. The unconjugated `dot` is the same class as #235/#330, which #802 records as *closed*:

> `_tree_dot` is now Hermitian and tangent projection uses `jnp.vdot` — the complex-inner-product cluster (#235, #330) is closed.

It was closed in `ipeps_optimize.py` and `pess_optimize.py`. Nobody grepped for a third implementation. Patching both would have left the next fix the same trap, so `ad_utils` now re-exports `_arnoldi`'s and there is one implementation.

`_arnoldi.py` is also the better-reviewed one independently: it guards Krylov breakdown with `jnp.where` rather than a Python `break` on a traced value, and forces `eigvals` to CPU because cuSOLVER `geev` fails on small complex matrices.

## Tests

Two new, **mutation count 2/2** (both fail with the stale copy restored):

- `test_ad_utils_reexports_the_reviewed_implementation` — asserts the two names are the **same object**, so a future local redefinition fails here *even if it happens to be correct*. The defect is the duplication, not the arithmetic.
- `test_the_explicit_ad_entry_point_is_correct_on_complex_input` — the symptom, at the name the backward actually calls.

Behaviour-preserving where it already worked: real-input agreement measured at rel 6.6e-16 / 1.7e-15 / 6.2e-16 across three sizes.

**92 passed, 1 skipped, 3 xfailed** across `test_arnoldi`, `test_ad_utils`, `test_adjoint_convergence_gate`, `test_ctm_energy_implicit`, `test_complex128_ad`, `test_bucket_registry`.

## Also

`test_arnoldi.py` moves out of `_UNBUCKETED_LEGACY` into `core` (#805). It is ~1s of 3×3 linear algebra, and a guard for a live gradient-path defect that runs in no required job is not a guard.

A sibling instance of the same duplicate-implementation pattern is #829, found in the same sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
