### PR TITLE
fix(#829): union-of-keys in the Cython Lanczos block-array updates

### DIFF
--- a/src/tenax/contraction/_cython_blas.pyx
+++ b/src/tenax/contraction/_cython_blas.pyx
@@ -1052,9 +1052,14 @@ cdef double _ba_norm_impl(dict blocks):
 cdef void _ba_axpy_impl(dict blocks_x, dict blocks_y, double alpha):
     """y[k] += alpha * x[k] for shared keys only, in-place via BLAS.
 
-    Keys in blocks_x but not blocks_y are skipped.  This is safe for the
-    Lanczos use-case: H_eff is block-diagonal in charge sectors, so matvec
-    never introduces keys absent from the initial vector.
+    Keys in ``blocks_x`` but not ``blocks_y`` are skipped.  **Callers that need
+    y += alpha*x must use ``_ba_axpy_union_impl``.**  This variant previously
+    carried a Lanczos-specific safety argument -- H_eff is block-diagonal, so
+    the matvec never introduces keys absent from the initial vector -- which
+    bounds the key set from above and says nothing about ``y`` being *narrower*
+    than ``x``.  That is the direction Lanczos reorthogonalisation hits, and it
+    left w non-orthogonal to a basis vector in every sector w happened to lack
+    (#829).  Only use this where the skip is the intended semantics.
     """
     cdef int n, inc = 1
     cdef double a_d = alpha
@@ -1126,8 +1131,15 @@ cdef void _ba_axpy_union_impl(dict blocks_x, dict blocks_y, double alpha):
 
 
 cdef void _ba_sub_scaled_impl(dict w_blocks, dict q_blocks, double scalar):
-    """w -= scalar * q (calls _ba_axpy_impl with -scalar)."""
-    _ba_axpy_impl(q_blocks, w_blocks, -scalar)
+    """w -= scalar * q, union of keys (calls _ba_axpy_union_impl with -scalar).
+
+    Union, not shared-keys-only: the pure-Python ``ba_sub_scaled`` inserts keys
+    present only in ``q`` (``core/_block_array.py``), and a sector where ``w``
+    is implicitly zero must become ``-scalar * q[k]`` or ``w`` is left
+    non-orthogonal to ``q`` there.  Using the shared-keys form here made the
+    Cython and Python Lanczos paths disagree on the same input (#829).
+    """
+    _ba_axpy_union_impl(q_blocks, w_blocks, -scalar)
 
 
 cdef void _ba_scale_impl(dict blocks, double scalar):
@@ -1961,10 +1973,10 @@ cdef void _lanczos_reorth_impl(list basis_blocks_list, dict w_blocks):
                 with nogil:
                     coeff += _ddot(&n, qp, &inc, wp, &inc)
 
-            # Phase 2: w -= coeff * q via _ba_axpy_impl (safe in-place update)
+            # Phase 2: w -= coeff * q, union of keys (see _ba_sub_scaled_impl).
             if coeff == 0.0:
                 continue
-            _ba_axpy_impl(q_blocks, w_blocks, -coeff)
+            _ba_axpy_union_impl(q_blocks, w_blocks, -coeff)
 
         elif dtype_code == 1:
             # Phase 1: coeff = <q|w> via zdotc (full complex)
@@ -1992,11 +2004,14 @@ cdef void _lanczos_reorth_impl(list basis_blocks_list, dict w_blocks):
             # Phase 2: w -= coeff * q via _ba_axpy_impl (safe in-place update)
             if z_coeff_accum == 0.0:
                 continue
-            # _ba_axpy_impl only takes double alpha; for complex we fall back
+            # _ba_axpy_union_impl only takes double alpha; for complex we fall
+            # back, keeping its union-of-keys semantics (#829).
             for k in q_blocks:
                 wk = w_blocks.get(k)
                 if wk is not None:
                     w_blocks[k] = wk - z_coeff_accum * q_blocks[k]
+                else:
+                    w_blocks[k] = -(z_coeff_accum * q_blocks[k])
 
         elif dtype_code == 2:
             # Phase 1: coeff = <q|w> via cdotc (full complex)
@@ -2028,6 +2043,8 @@ cdef void _lanczos_reorth_impl(list basis_blocks_list, dict w_blocks):
                 wk = w_blocks.get(k)
                 if wk is not None:
                     w_blocks[k] = wk - c_coeff_accum * q_blocks[k]
+                else:
+                    w_blocks[k] = -(c_coeff_accum * q_blocks[k])
 
         else:
             # Fallback: numpy (full complex overlap)
@@ -2043,6 +2060,8 @@ cdef void _lanczos_reorth_impl(list basis_blocks_list, dict w_blocks):
                 wk = w_blocks.get(k)
                 if wk is not None:
                     w_blocks[k] = wk - fb_coeff * q_blocks[k]
+                else:
+                    w_blocks[k] = -(fb_coeff * q_blocks[k])
 
 
 def cython_lanczos_reorth(list basis_blocks_list, dict w_blocks):
@@ -2055,7 +2074,7 @@ def cython_lanczos_reorth(list basis_blocks_list, dict w_blocks):
 # ------------------------------------------------------------------ #
 
 def cython_ba_sub_scaled_inplace(dict w_blocks, dict q_blocks, double scalar):
-    """w[k] -= scalar * q[k] for all shared keys. In-place, no allocation.
+    """w[k] -= scalar * q[k], union of keys.  In-place for shared keys.
 
     Replaces ``ba_sub_scaled`` in the Lanczos hot loop, avoiding dict and
     array creation on every call (~87K calls per DMRG run).
@@ -2136,3 +2155,13 @@ def cython_ba_sub_scaled_inplace(dict w_blocks, dict q_blocks, double scalar):
                     wk = wk.copy()
                     w_blocks[k] = wk
                 wk -= scalar * q_blocks[k]
+
+    # Union of keys.  The four in-place loops above skip sectors absent from
+    # w, because BLAS needs an existing destination buffer; a sector present
+    # only in q must still become -scalar * q[k], or w is left non-orthogonal
+    # there and this diverges from the pure-Python ``ba_sub_scaled`` (#829).
+    # Done as a separate pass so the hot loops stay untouched -- it is a dict
+    # lookup per key and inserts nothing in the common equal-keys case.
+    for k in q_blocks:
+        if w_blocks.get(k) is None:
+            w_blocks[k] = -(scalar * q_blocks[k])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,6 +172,12 @@ _FILE_MARKERS = {
     "test_padded_linalg.py": "core",
     "test_lanczos_np.py": "algorithm",
     "test_block_array.py": "core",
+    # Cython/Python parity for the Lanczos block-array ops (#829).  dmrg.py
+    # picks between the two at import time, so a semantic gap makes the same
+    # input converge differently depending on whether the extension loaded --
+    # and the extension is the default.  Pure numpy on 2-element blocks,
+    # microseconds, so it belongs in the required gate.
+    "test_cython_lanczos_block_keys.py": "core",
     "test_dmrg3s.py": "algorithm",
     "test_dmrg_cython.py": "algorithm",
     "test_ipeps_config.py": "core",

--- a/tests/test_cython_lanczos_block_keys.py
+++ b/tests/test_cython_lanczos_block_keys.py
@@ -1,0 +1,139 @@
+"""The Cython Lanczos block-array ops must agree with the pure-Python ones.
+
+``dmrg.py`` picks between them at import time (``_USE_CYTHON_REORTH`` /
+``_USE_CYTHON_SUB``, gated on ``TENAX_DISABLE_CYTHON_BLAS``), so any semantic
+difference makes the same DMRG input converge differently depending on whether
+the extension loaded -- and the extension is the default.
+
+That is what #829 was: the Cython side skipped keys present in ``q`` but absent
+from ``w`` while ``ba_sub_scaled`` inserts them, so reorthogonalisation left
+``w`` non-orthogonal to a basis vector in every sector ``w`` happened to lack,
+and never created the sector.
+
+These are written as **differential** tests rather than against hardcoded
+vectors: the defect was a divergence between two implementations, and only a
+differential check catches the next one.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tenax.core._block_array import BlockArray, ba_inner, ba_sub_scaled
+
+cython_blas = pytest.importorskip(
+    "tenax.contraction._cython_blas",
+    reason="Cython BLAS extension not built",
+)
+
+
+def _q_two_sectors(dtype=np.float64):
+    """Unit basis vector spanning sectors (0,) and (1,)."""
+    q = {
+        (0,): np.array([1.0, 0.0], dtype=dtype),
+        (1,): np.array([1.0, 0.0], dtype=dtype),
+    }
+    nrm = np.sqrt(sum(float(np.vdot(v, v).real) for v in q.values()))
+    return {k: v / nrm for k, v in q.items()}
+
+
+def _w_one_sector(dtype=np.float64):
+    """Running vector missing sector (1,) -- the case that used to be skipped."""
+    return {(0,): np.array([1.0, 0.0], dtype=dtype)}
+
+
+def _python_reorth(q_blocks, w_blocks):
+    """What ``dmrg.py`` does when the Cython path is disabled."""
+    q = BlockArray(blocks=dict(q_blocks), indices=None)
+    w = BlockArray(blocks=dict(w_blocks), indices=None)
+    return ba_sub_scaled(w, q, ba_inner(q, w)).blocks
+
+
+def _inner(a_blocks, b_blocks):
+    return sum(
+        complex(np.vdot(a_blocks[k], b_blocks[k])) for k in a_blocks if k in b_blocks
+    )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.complex128, np.complex64])
+def test_reorth_matches_python_when_w_lacks_a_sector(dtype):
+    """The #829 case, across every dtype branch of ``_lanczos_reorth_impl``.
+
+    Each dtype takes a different Phase-2 path in the Cython source (BLAS axpy
+    for float64, hand-rolled loops for the complex ones), so a fix applied to
+    one of them is not a fix.
+    """
+    q = _q_two_sectors(dtype)
+
+    w_cy = _w_one_sector(dtype)
+    cython_blas.cython_lanczos_reorth([q], w_cy)
+    w_py = _python_reorth(q, _w_one_sector(dtype))
+
+    assert sorted(w_cy) == sorted(w_py), (
+        f"key sets diverge: cython {sorted(w_cy)} vs python {sorted(w_py)}"
+    )
+    for k in w_py:
+        np.testing.assert_allclose(
+            w_cy[k], w_py[k], rtol=1e-5, atol=1e-6, err_msg=f"sector {k}"
+        )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.complex128, np.complex64])
+def test_reorth_actually_orthogonalises_the_missing_sector(dtype):
+    """The property the divergence broke, stated directly.
+
+    Without this a future implementation could match Python by both being
+    wrong.  ``<q|w>`` must be ~0 afterwards; before the fix it was 0.354.
+    """
+    q = _q_two_sectors(dtype)
+    w = _w_one_sector(dtype)
+    cython_blas.cython_lanczos_reorth([q], w)
+
+    tol = 1e-6 if dtype == np.complex64 else 1e-12
+    assert abs(_inner(q, w)) < tol, f"w is not orthogonal to q: <q|w> = {_inner(q, w)}"
+    assert (1,) in w, "the sector w lacked was never created"
+
+
+def test_sub_scaled_inplace_matches_python_on_a_missing_key():
+    """``_ba_sub_scaled_impl`` is the other half of the Lanczos hot loop.
+
+    ``dmrg.py`` calls it directly for the ``beta`` subtraction, so it needs the
+    same union semantics as the reorthogonalisation above.
+    """
+    q = _q_two_sectors()
+    w_cy = _w_one_sector()
+    scalar = 0.25
+
+    cython_blas.cython_ba_sub_scaled_inplace(w_cy, q, scalar)
+    w_py = ba_sub_scaled(
+        BlockArray(blocks=_w_one_sector(), indices=None),
+        BlockArray(blocks=dict(q), indices=None),
+        scalar,
+    ).blocks
+
+    assert sorted(w_cy) == sorted(w_py), (sorted(w_cy), sorted(w_py))
+    for k in w_py:
+        np.testing.assert_allclose(w_cy[k], w_py[k], rtol=1e-12, atol=1e-14)
+
+
+def test_shared_key_case_is_unchanged():
+    """The fix must not perturb the path that was already correct.
+
+    Union and shared-keys semantics coincide when the key sets match, which is
+    the common case; this pins that the change is inert there.
+    """
+    q = _q_two_sectors()
+    w = {
+        (0,): np.array([0.3, 0.4]),
+        (1,): np.array([-0.2, 0.7]),
+    }
+
+    w_cy = {k: v.copy() for k, v in w.items()}
+    cython_blas.cython_lanczos_reorth([q], w_cy)
+    w_py = _python_reorth(q, w)
+
+    assert sorted(w_cy) == sorted(w_py)
+    for k in w_py:
+        np.testing.assert_allclose(w_cy[k], w_py[k], rtol=1e-12, atol=1e-14)
+    assert abs(_inner(q, w_cy)) < 1e-12

--- a/tests/test_dmrg_cython.py
+++ b/tests/test_dmrg_cython.py
@@ -271,7 +271,19 @@ class TestCythonLanczosReorth:
 
     @staticmethod
     def _sequential_reorth(basis_blocks_list, w_blocks):
-        """Reference implementation: sequential inner + axpy per basis vector."""
+        """Reference implementation: sequential inner + axpy per basis vector.
+
+        Union of keys, matching ``core._block_array.ba_sub_scaled`` -- which is
+        what ``dmrg.py`` runs when the Cython path is disabled, and therefore
+        the only thing this reference may encode.
+
+        It previously skipped keys absent from ``w`` (``if wk is not None``),
+        reproducing the very defect the Cython side had, so
+        ``test_partial_key_overlap`` asserted agreement between two
+        implementations that were wrong in the same way and passed while #829
+        was live.  A hand-rolled reference is only worth having if it is
+        derived from the real one.
+        """
         for q_blocks in basis_blocks_list:
             coeff = 0.0
             for k in q_blocks:
@@ -284,6 +296,8 @@ class TestCythonLanczosReorth:
                 wk = w_blocks.get(k)
                 if wk is not None:
                     w_blocks[k] = wk - coeff * q_blocks[k]
+                else:
+                    w_blocks[k] = -(coeff * q_blocks[k])
 
     def _make_random_blocks(self, rng, keys, shapes, dtype=np.float64):
         """Create a dict of random blocks with given keys and shapes."""
@@ -328,6 +342,9 @@ class TestCythonLanczosReorth:
         cython_lanczos_reorth(basis, w_fused)
         self._sequential_reorth(basis, w_seq)
 
+        # Key sets too, not just the shared values: the sectors a basis vector
+        # has and ``w`` lacks are precisely the ones #829 dropped.
+        assert sorted(w_fused) == sorted(w_seq), (sorted(w_fused), sorted(w_seq))
         for k in w_fused:
             np.testing.assert_allclose(w_fused[k], w_seq[k], rtol=1e-12, atol=1e-14)
 


### PR DESCRIPTION
> 🤖 **AI-generated PR** — written by Claude Code, posted by @yingjerkao.

Fixes #829. The Cython Lanczos ops skipped keys present in `q` but absent from `w`; the pure-Python `ba_sub_scaled` inserts them. `dmrg.py` picks between the two at import time (`_USE_CYTHON_REORTH` / `_USE_CYTHON_SUB`), so the same input reorthogonalised differently depending on whether the extension loaded — and the extension is the default.

```
basis vector spans {(0,), (1,)};  w holds only (0,)

cython : w sectors [(0,)]        <q|w> = +0.353553
python : w sectors [(0,), (1,)]  <q|w> = +1.11e-16
```

`w` was left non-orthogonal to a basis vector in every sector it happened to lack, and never acquired the sector.

## The safety argument it was resting on

`_ba_axpy_impl` justified the skip:

> This is safe for the Lanczos use-case: H_eff is block-diagonal in charge sectors, so matvec never introduces keys absent from the initial vector.

That is an argument about `w` **gaining** keys, and it is correct. The failure needs `w` to **lack** a key an earlier basis vector has — the other direction, which block-diagonality bounds from above and says nothing about. Since reorthogonalisation runs against *every* previous basis vector, `w` need only be narrower than one of them, once. Claim removed rather than reworded.

## Six sites

The semantics are duplicated per dtype, so a fix in one place is not a fix:

- `_ba_sub_scaled_impl` → `_ba_axpy_union_impl`
- `_lanczos_reorth_impl` float64 Phase 2 → `_ba_axpy_union_impl`
- `_lanczos_reorth_impl` complex128 / complex64 / numpy-fallback Phase 2 → inline insert (the union helper takes a `double` alpha, so complex coefficients cannot route through it)
- `cython_ba_sub_scaled_inplace` → one union pass after the dtype dispatch

**That last one is worth flagging.** It is the wrapper `dmrg.py` calls directly for the beta subtraction, it has its own four hand-rolled loops, and it does *not* route through `_ba_sub_scaled_impl`. Patching the impl alone looked like a complete fix and was not — the new differential test caught it. The union pass sits after the hot loops (BLAS needs an existing destination buffer) and inserts nothing in the common equal-keys case.

`_ba_axpy_union_impl` already existed, correct, three lines from the defect, wired to eigenvector reconstruction but not to reorthogonalisation. Same shape as #828, found in the same sweep.

## An existing test was protecting the bug

`TestCythonLanczosReorth::test_partial_key_overlap` failed against this fix, and it should have. Its reference `_sequential_reorth` hand-rolls the reorthogonalisation with the *same* `if wk is not None:` skip:

```python
for k in q_blocks:
    wk = w_blocks.get(k)
    if wk is not None:
        w_blocks[k] = wk - coeff * q_blocks[k]
```

So it compared two implementations that were wrong in identical ways and passed while the defect was live. Its docstring even names the case — *"Handles basis vectors with keys not present in w"*.

The reference now matches `ba_sub_scaled`, and the assertion compares **key sets** rather than only `w`'s original keys: the dropped sectors are exactly the ones the old loop could not see. The lesson generalises — a hand-rolled reference is only worth having if it is derived from the implementation actually shipped on the other path.

## Tests

`tests/test_cython_lanczos_block_keys.py` is differential against the real Python path, across all three dtype branches, plus:

- an orthogonality assertion stated directly, so a future implementation cannot pass by matching Python while both are wrong;
- a shared-key control pinning that the change is **inert** where key sets already match.

**Mutation count 7/8** against the pre-fix extension — all three dtype branches fail without the fix. The eighth is the shared-key control, correctly passing both before and after.

**235 passed** across `test_dmrg`, `test_idmrg`, `test_dmrg3s`, `test_dmrg_cython`, `test_lanczos_np`, `test_block_array`, `test_bucket_registry` and the new file.

Bucketed `core` (#805): microseconds, and it guards a divergence on the default path.

## Not established

An end-to-end DMRG run in which `w` actually loses a sector — that needs a matvec that drops a key. The divergence and the orthogonality violation are demonstrated; the in-situ trigger rate is unmeasured. The fix is unconditional and costs a dict lookup per key either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
